### PR TITLE
 Data Source: `tencentcloud_kubernetes_clusters`add new arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-## 1.40.2 (August 08, 2020)
+## 1.40.3 (Unreleased) 
 
 ENHANCEMENTS:
 
 * Data Source: `tencentcloud_kubernetes_clusters`add new arguments `cluster_as_enabled`,`node_name_type`,`cluster_extra_args`,`network_type`,`is_non_static_ip_mode`,`kube_proxy_mode`,`service_cidr`,`eni_subnet_ids`,`claim_expired_seconds` and
 `deletion_protection`.
+
+## 1.40.2 (August 08, 2020)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ENHANCEMENTS:
 
-* Data Source: `tencentcloud_kubernetes_clusters`add new arguments `cluster_as_enabled`,`node_name_type`,`cluster_extra_args`,`network_type`,`is_non_static_ip_mode`,`kube_proxy_mode`,`service_cidr`,`eni_subnet_ids`,`claim_expired_seconds` and
-`deletion_protection`.
+* Data Source: `tencentcloud_kubernetes_clusters`add new attributes `cluster_as_enabled`,`node_name_type`,`cluster_extra_args`,`network_type`,`is_non_static_ip_mode`,`kube_proxy_mode`,`service_cidr`,`eni_subnet_ids`,`claim_expired_seconds` and `deletion_protection`.
 
 ## 1.40.2 (August 08, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.40.2 (August 08, 2020)
 
+ENHANCEMENTS:
+
+* Data Source: `tencentcloud_kubernetes_clusters`add new arguments `cluster_as_enabled`,`node_name_type`,`cluster_extra_args`,`network_type`,`is_non_static_ip_mode`,`kube_proxy_mode`,`service_cidr`,`eni_subnet_ids`,`claim_expired_seconds` and
+`deletion_protection`.
+
 BUG FIXES:
 
 * Resource: `tencentcloud_instance` fix accidentally fail to delete prepaid instance ([#485](https://github.com/tencentcloudstack/terraform-provider-tencentcloud/issues/485)).

--- a/tencentcloud/data_source_tc_kubernetes_clusters.go
+++ b/tencentcloud/data_source_tc_kubernetes_clusters.go
@@ -92,6 +92,79 @@ func tkeClusterInfo() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "The maximum number of services in the cluster.",
 		},
+		"cluster_as_enabled": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether to enable cluster node auto scaler.",
+		},
+		"node_name_type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Node name type of Cluster.",
+		},
+		"cluster_extra_args": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"kube_apiserver": {
+						Type:        schema.TypeList,
+						Computed:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Description: "The customized parameters for kube-apiserver.",
+					},
+					"kube_controller_manager": {
+						Type:        schema.TypeList,
+						Computed:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Description: "The customized parameters for kube-controller-manager.",
+					},
+					"kube_scheduler": {
+						Type:        schema.TypeList,
+						Computed:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Description: "The customized parameters for kube-scheduler.",
+					},
+				},
+			},
+			Description: "Customized parameters for master component.",
+		},
+		"network_type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Cluster network type.",
+		},
+		"is_non_static_ip_mode": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether static ip mode is enabled.",
+		},
+		"kube_proxy_mode": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Cluster kube-proxy mode.",
+		},
+		"service_cidr": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The network address block of the cluster.",
+		},
+		"eni_subnet_ids": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Subnet Ids for cluster with VPC-CNI network mode.",
+		},
+		"claim_expired_seconds": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "The expired seconds to recycle ENI.",
+		},
+		"deletion_protection": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether cluster deletion protection is enabled.",
+		},
 		"cluster_node_num": {
 			Type:        schema.TypeInt,
 			Computed:    true,
@@ -227,7 +300,12 @@ LOOP:
 		infoMap["cluster_ipvs"] = info.Ipvs
 		infoMap["cluster_as_enabled"] = info.AsEnabled
 		infoMap["node_name_type"] = info.NodeNameType
-		infoMap["cluster_extra_args"] = info.ExtraArgs
+
+		infoMap["cluster_extra_args"] = []map[string]interface{}{{
+			"kube_apiserver":          info.ExtraArgs.KubeAPIServer,
+			"kube_controller_manager": info.ExtraArgs.KubeControllerManager,
+			"kube_scheduler":          info.ExtraArgs.KubeScheduler,
+		}}
 		infoMap["network_type"] = info.NetworkType
 		infoMap["is_non_static_ip_mode"] = info.IsNonStaticIpMode
 		infoMap["deletion_protection"] = info.DeletionProtection

--- a/tencentcloud/service_tencentcloud_tke.go
+++ b/tencentcloud/service_tencentcloud_tke.go
@@ -3,11 +3,11 @@ package tencentcloud
 import (
 	"context"
 	"fmt"
-	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	tke "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke/v20180525"
 	"github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity"
 	"github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper"

--- a/website/docs/d/kubernetes_clusters.html.markdown
+++ b/website/docs/d/kubernetes_clusters.html.markdown
@@ -37,10 +37,16 @@ In addition to all arguments above, the following attributes are exported:
 
 * `list` - An information list of kubernetes clusters. Each element contains the following attributes:
   * `certification_authority` - The certificate used for access.
+  * `claim_expired_seconds` - The expired seconds to recycle ENI.
+  * `cluster_as_enabled` - Indicates whether to enable cluster node auto scaler.
   * `cluster_cidr` - A network address block of the cluster. Different from vpc cidr and cidr of other clusters within this vpc.
   * `cluster_deploy_type` - Deployment type of the cluster.
   * `cluster_desc` - Description of the cluster.
   * `cluster_external_endpoint` - External network address to access.
+  * `cluster_extra_args` - Customized parameters for master component.
+    * `kube_apiserver` - The customized parameters for kube-apiserver.
+    * `kube_controller_manager` - The customized parameters for kube-controller-manager.
+    * `kube_scheduler` - The customized parameters for kube-scheduler.
   * `cluster_ipvs` - Indicates whether ipvs is enabled.
   * `cluster_max_pod_num` - The maximum number of Pods per node in the cluster.
   * `cluster_max_service_num` - The maximum number of services in the cluster.
@@ -49,12 +55,19 @@ In addition to all arguments above, the following attributes are exported:
   * `cluster_os` - Operating system of the cluster.
   * `cluster_version` - Version of the cluster.
   * `container_runtime` - (**Deprecated**) It has been deprecated from version 1.18.1. Container runtime of the cluster.
+  * `deletion_protection` - Indicates whether cluster deletion protection is enabled.
   * `domain` - Domain name for access.
+  * `eni_subnet_ids` - Subnet Ids for cluster with VPC-CNI network mode.
   * `ignore_cluster_cidr_conflict` - Indicates whether to ignore the cluster cidr conflict error.
+  * `is_non_static_ip_mode` - Indicates whether static ip mode is enabled.
+  * `kube_proxy_mode` - Cluster kube-proxy mode.
+  * `network_type` - Cluster network type.
+  * `node_name_type` - Node name type of Cluster.
   * `password` - Password of account.
   * `pgw_endpoint` - The Intranet address used for access.
   * `project_id` - Project Id of the cluster.
   * `security_policy` - Access policy.
+  * `service_cidr` - The network address block of the cluster.
   * `tags` - Tags of the cluster.
   * `user_name` - User name of account.
   * `vpc_id` - Vpc Id of the cluster.


### PR DESCRIPTION
 Data Source: `tencentcloud_kubernetes_clusters`add new arguments `cluster_as_enabled`,`node_name_type`,`cluster_extra_args`,`network_type`,`is_non_static_ip_mode`,`kube_proxy_mode`,`service_cidr`,`eni_subnet_ids`,`claim_expired_seconds` and
`deletion_protection`.