### PR TITLE
[remove spec update validation]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ DEPRECATED:
 
 * Data Source: `tencentcloud_cdn_domains` optional argument `offset` is no longer supported.
 
+ENHANCEMENTS:
+
+* Resource: `tencentcloud_mongodb_instance`, `tencentcloud_mongodb_sharding_instance` and `tencentcloud_mongodb_standby_instance` remove spec update validation.
+
 ## 1.40.3 (August 11, 2020)
 
 ENHANCEMENTS:

--- a/tencentcloud/resource_tc_mongodb_instance.go
+++ b/tencentcloud/resource_tc_mongodb_instance.go
@@ -390,12 +390,6 @@ func resourceTencentCloudMongodbInstanceUpdate(d *schema.ResourceData, meta inte
 	d.Partial(true)
 
 	if d.HasChange("memory") || d.HasChange("volume") {
-		// precheck
-		oldMemory, newMemory := d.GetChange("memory")
-		oldVolume, newVolume := d.GetChange("volume")
-		if (newMemory.(int) >= oldMemory.(int) || newVolume.(int) >= oldVolume.(int)) && (newMemory.(int) <= oldMemory.(int) || newVolume.(int) <= oldVolume.(int)) {
-			return fmt.Errorf("[CRITAL] updating memory and volume of mongodb instance failed, memory and volume must upgrade/downgrade at same time")
-		}
 		memory := d.Get("memory").(int)
 		volume := d.Get("volume").(int)
 		err := mongodbService.UpgradeInstance(ctx, instanceId, memory, volume)

--- a/tencentcloud/resource_tc_mongodb_sharding_instance.go
+++ b/tencentcloud/resource_tc_mongodb_sharding_instance.go
@@ -385,12 +385,6 @@ func resourceMongodbShardingInstanceUpdate(d *schema.ResourceData, meta interfac
 	d.Partial(true)
 
 	if d.HasChange("memory") || d.HasChange("volume") {
-		// precheck
-		oldMemory, newMemory := d.GetChange("memory")
-		oldVolume, newVolume := d.GetChange("volume")
-		if (newMemory.(int) >= oldMemory.(int) || newVolume.(int) >= oldVolume.(int)) && (newMemory.(int) <= oldMemory.(int) || newVolume.(int) <= oldVolume.(int)) {
-			return fmt.Errorf("[CRITAL] updating memory and volume of mongodb instance failed, memory and volume must upgrade/downgrade at same time")
-		}
 		memory := d.Get("memory").(int)
 		volume := d.Get("volume").(int)
 		err := mongodbService.UpgradeInstance(ctx, instanceId, memory, volume)

--- a/tencentcloud/resource_tc_mongodb_standby_instance.go
+++ b/tencentcloud/resource_tc_mongodb_standby_instance.go
@@ -445,12 +445,6 @@ func resourceTencentCloudMongodbStandbyInstanceUpdate(d *schema.ResourceData, me
 	d.Partial(true)
 
 	if d.HasChange("memory") || d.HasChange("volume") {
-		// precheck
-		oldMemory, newMemory := d.GetChange("memory")
-		oldVolume, newVolume := d.GetChange("volume")
-		if (newMemory.(int) >= oldMemory.(int) || newVolume.(int) >= oldVolume.(int)) && (newMemory.(int) <= oldMemory.(int) || newVolume.(int) <= oldVolume.(int)) {
-			return fmt.Errorf("[CRITAL] updating memory and volume of mongodb instance failed, memory and volume must upgrade/downgrade at same time")
-		}
 		memory := d.Get("memory").(int)
 		volume := d.Get("volume").(int)
 		err := mongodbService.UpgradeInstance(ctx, instanceId, memory, volume)


### PR DESCRIPTION
1. remove spec update validation for mongodb instance in case SDK
changes its limitation without notifying us, so it's a protection.