### PR TITLE
fix update issue in resource `tencentcloud_vpn_connection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.41.2 (Unreleased)
+
+BUG FIXES:
+* Resource: `tencentcloud_vpn_connection` fix `security_group_policy` update issue when apply repeatedly.
+
 ## 1.41.1 (August 27, 2020)
 
 BUG FIXES:

--- a/tencentcloud/resource_tc_vpn_connection.go
+++ b/tencentcloud/resource_tc_vpn_connection.go
@@ -110,7 +110,7 @@ func resourceTencentCloudVpnConnection() *schema.Resource {
 				Description: "Pre-shared key of the VPN connection.",
 			},
 			"security_group_policy": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "Security group policy of the VPN connection.",
 				Elem: &schema.Resource{
@@ -320,7 +320,7 @@ func resourceTencentCloudVpnConnectionCreate(d *schema.ResourceData, meta interf
 
 	//set up  SecurityPolicyDatabases
 
-	sgps := d.Get("security_group_policy").([]interface{})
+	sgps := d.Get("security_group_policy").(*schema.Set).List()
 	if len(sgps) < 1 {
 		return fmt.Errorf("Para `security_group_policy` should be set at least one.")
 	}
@@ -639,13 +639,13 @@ func resourceTencentCloudVpnConnectionUpdate(d *schema.ResourceData, meta interf
 
 	//set up  SecurityPolicyDatabases
 	if d.HasChange("security_group_policy") {
-		sgps := d.Get("security_group_policy").([]interface{})
+		sgps := d.Get("security_group_policy").(*schema.Set).List()
 		if len(sgps) < 1 {
 			return fmt.Errorf("Para `security_group_policy` should be set at least one.")
 		}
+		request.SecurityPolicyDatabases = make([]*vpc.SecurityPolicyDatabase, 0, len(sgps))
 		for _, v := range sgps {
 			m := v.(map[string]interface{})
-			request.SecurityPolicyDatabases = make([]*vpc.SecurityPolicyDatabase, 0, len(sgps))
 			var sgp vpc.SecurityPolicyDatabase
 			local := m["local_cidr_block"].(string)
 			sgp.LocalCidrBlock = &local


### PR DESCRIPTION
The SDK will return this parameter reordered and cause an updating issue. And this parameter should not be set with type List.


terraform apply
```
 terraform apply
2020/08/27 19:45:55 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
data.tencentcloud_vpc_instances.foo: Refreshing state...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_vpn_connection.connection will be created
  + resource "tencentcloud_vpn_connection" "connection" {
      + create_time                = (known after apply)
      + customer_gateway_id        = (known after apply)
      + encrypt_proto              = (known after apply)
      + id                         = (known after apply)
      + ike_dh_group_name          = "GROUP1"
      + ike_exchange_mode          = "MAIN"
      + ike_local_address          = (known after apply)
      + ike_local_identity         = "ADDRESS"
      + ike_proto_authen_algorithm = "MD5"
      + ike_proto_encry_algorithm  = "3DES-CBC"
      + ike_remote_address         = "3.3.3.3"
      + ike_remote_identity        = "ADDRESS"
      + ike_sa_lifetime_seconds    = 86400
      + ike_version                = "IKEV1"
      + ipsec_encrypt_algorithm    = "3DES-CBC"
      + ipsec_integrity_algorithm  = "MD5"
      + ipsec_pfs_dh_group         = "DH-GROUP1"
      + ipsec_sa_lifetime_seconds  = 3600
      + ipsec_sa_lifetime_traffic  = 2560
      + is_ccn_type                = (known after apply)
      + name                       = "vpn_connection_test"
      + net_status                 = (known after apply)
      + pre_share_key              = "test"
      + route_type                 = (known after apply)
      + state                      = (known after apply)
      + tags                       = {
          + "test" = "test"
        }
      + vpc_id                     = "vpc-h70b6b49"
      + vpn_gateway_id             = (known after apply)
      + vpn_proto                  = (known after apply)

      + security_group_policy {
          + local_cidr_block  = "10.31.64.0/24"
          + remote_cidr_block = [
              + "3.3.3.0/32",
            ]
        }
      + security_group_policy {
          + local_cidr_block  = "172.16.0.0/16"
          + remote_cidr_block = [
              + "3.3.3.0/32",
            ]
        }
    }

  # tencentcloud_vpn_customer_gateway.cgw will be created
  + resource "tencentcloud_vpn_customer_gateway" "cgw" {
      + create_time       = (known after apply)
      + id                = (known after apply)
      + name              = "terraform_test"
      + public_ip_address = "3.3.3.3"
    }

  # tencentcloud_vpn_gateway.vpn will be created
  + resource "tencentcloud_vpn_gateway" "vpn" {
      + bandwidth          = 5
      + charge_type        = "POSTPAID_BY_HOUR"
      + create_time        = (known after apply)
      + expired_time       = (known after apply)
      + id                 = (known after apply)
      + is_address_blocked = (known after apply)
      + name               = "terraform_update"
      + new_purchase_plan  = (known after apply)
      + prepaid_period     = 1
      + prepaid_renew_flag = "NOTIFY_AND_AUTO_RENEW"
      + public_ip_address  = (known after apply)
      + restrict_state     = (known after apply)
      + state              = (known after apply)
      + tags               = {
          + "test" = "test"
        }
      + type               = (known after apply)
      + vpc_id             = "vpc-h70b6b49"
      + zone               = "ap-guangzhou-3"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_vpn_customer_gateway.cgw: Creating...
tencentcloud_vpn_gateway.vpn: Creating...
tencentcloud_vpn_customer_gateway.cgw: Creation complete after 1s [id=cgw-bhjj0mk1]
tencentcloud_vpn_gateway.vpn: Still creating... [10s elapsed]
tencentcloud_vpn_gateway.vpn: Still creating... [20s elapsed]
tencentcloud_vpn_gateway.vpn: Still creating... [30s elapsed]
tencentcloud_vpn_gateway.vpn: Still creating... [40s elapsed]
tencentcloud_vpn_gateway.vpn: Still creating... [50s elapsed]
tencentcloud_vpn_gateway.vpn: Still creating... [1m0s elapsed]
tencentcloud_vpn_gateway.vpn: Still creating... [1m10s elapsed]
tencentcloud_vpn_gateway.vpn: Still creating... [1m20s elapsed]
tencentcloud_vpn_gateway.vpn: Creation complete after 1m22s [id=vpngw-9vupm6k7]
tencentcloud_vpn_connection.connection: Creating...
tencentcloud_vpn_connection.connection: Creation complete after 6s [id=vpnx-lba8zd40]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

```


double apply

```
 terraform apply
2020/08/27 19:48:34 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
data.tencentcloud_vpc_instances.foo: Refreshing state...
tencentcloud_vpn_customer_gateway.cgw: Refreshing state... [id=cgw-bhjj0mk1]
tencentcloud_vpn_gateway.vpn: Refreshing state... [id=vpngw-9vupm6k7]
tencentcloud_vpn_connection.connection: Refreshing state... [id=vpnx-lba8zd40]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

terraform destroy

```
 terraform destroy
2020/08/27 19:49:06 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
data.tencentcloud_vpc_instances.foo: Refreshing state...
tencentcloud_vpn_customer_gateway.cgw: Refreshing state... [id=cgw-bhjj0mk1]
tencentcloud_vpn_gateway.vpn: Refreshing state... [id=vpngw-9vupm6k7]
tencentcloud_vpn_connection.connection: Refreshing state... [id=vpnx-lba8zd40]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # tencentcloud_vpn_connection.connection will be destroyed
  - resource "tencentcloud_vpn_connection" "connection" {
      - create_time                = "2020-08-27 19:48:26" -> null
      - customer_gateway_id        = "cgw-bhjj0mk1" -> null
      - encrypt_proto              = "IKE" -> null
      - id                         = "vpnx-lba8zd40" -> null
      - ike_dh_group_name          = "GROUP1" -> null
      - ike_exchange_mode          = "MAIN" -> null
      - ike_local_address          = "203.195.165.109" -> null
      - ike_local_identity         = "ADDRESS" -> null
      - ike_proto_authen_algorithm = "MD5" -> null
      - ike_proto_encry_algorithm  = "3DES-CBC" -> null
      - ike_remote_address         = "3.3.3.3" -> null
      - ike_remote_identity        = "ADDRESS" -> null
      - ike_sa_lifetime_seconds    = 86400 -> null
      - ike_version                = "IKEV1" -> null
      - ipsec_encrypt_algorithm    = "3DES-CBC" -> null
      - ipsec_integrity_algorithm  = "MD5" -> null
      - ipsec_pfs_dh_group         = "DH-GROUP1" -> null
      - ipsec_sa_lifetime_seconds  = 3600 -> null
      - ipsec_sa_lifetime_traffic  = 2560 -> null
      - is_ccn_type                = false -> null
      - name                       = "vpn_connection_test" -> null
      - net_status                 = "UNAVAILABLE" -> null
      - pre_share_key              = "test" -> null
      - route_type                 = "STATIC" -> null
      - state                      = "AVAILABLE" -> null
      - tags                       = {
          - "test" = "test"
        } -> null
      - vpc_id                     = "vpc-h70b6b49" -> null
      - vpn_gateway_id             = "vpngw-9vupm6k7" -> null
      - vpn_proto                  = "IPSEC" -> null

      - security_group_policy {
          - local_cidr_block  = "10.31.64.0/24" -> null
          - remote_cidr_block = [
              - "3.3.3.0/32",
            ] -> null
        }
      - security_group_policy {
          - local_cidr_block  = "172.16.0.0/16" -> null
          - remote_cidr_block = [
              - "3.3.3.0/32",
            ] -> null
        }
    }

  # tencentcloud_vpn_customer_gateway.cgw will be destroyed
  - resource "tencentcloud_vpn_customer_gateway" "cgw" {
      - create_time       = "2020-08-27 19:47:04" -> null
      - id                = "cgw-bhjj0mk1" -> null
      - name              = "terraform_test" -> null
      - public_ip_address = "3.3.3.3" -> null
      - tags              = {} -> null
    }

  # tencentcloud_vpn_gateway.vpn will be destroyed
  - resource "tencentcloud_vpn_gateway" "vpn" {
      - bandwidth          = 5 -> null
      - charge_type        = "POSTPAID_BY_HOUR" -> null
      - create_time        = "2020-08-27 19:47:05" -> null
      - expired_time       = "2020-08-27 19:48:23" -> null
      - id                 = "vpngw-9vupm6k7" -> null
      - is_address_blocked = false -> null
      - name               = "terraform_update" -> null
      - prepaid_period     = 1 -> null
      - prepaid_renew_flag = "NOTIFY_AND_AUTO_RENEW" -> null
      - public_ip_address  = "203.195.165.109" -> null
      - restrict_state     = "NORMAL" -> null
      - state              = "AVAILABLE" -> null
      - tags               = {
          - "test" = "test"
        } -> null
      - type               = "IPSEC" -> null
      - vpc_id             = "vpc-h70b6b49" -> null
      - zone               = "ap-guangzhou-3" -> null
    }

Plan: 0 to add, 0 to change, 3 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

tencentcloud_vpn_connection.connection: Destroying... [id=vpnx-lba8zd40]
tencentcloud_vpn_connection.connection: Destruction complete after 5s
tencentcloud_vpn_gateway.vpn: Destroying... [id=vpngw-9vupm6k7]
tencentcloud_vpn_customer_gateway.cgw: Destroying... [id=cgw-bhjj0mk1]
tencentcloud_vpn_customer_gateway.cgw: Destruction complete after 0s
tencentcloud_vpn_gateway.vpn: Still destroying... [id=vpngw-9vupm6k7, 10s elapsed]
tencentcloud_vpn_gateway.vpn: Still destroying... [id=vpngw-9vupm6k7, 20s elapsed]
tencentcloud_vpn_gateway.vpn: Destruction complete after 28s

Destroy complete! Resources: 3 destroyed.
```