### PR TITLE
acl attachment perfect example field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 
-* Resource: `tencentcloud_vpc_acl_attachment` perfect example field `subnet_ids` to `subnet_id`.
+* Resource: `tencentcloud_vpc_acl_attachment` perfect example field `subnet_ids` to `subnet_id`([#505](https://github.com/tencentcloudstack/terraform-provider-tencentcloud/issues/505)).
 
 ## 1.41.2 (August 28, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.41.3 (Unreleased)
+
+ENHANCEMENTS:
+
+* Resource: `tencentcloud_vpc_acl_attachment` perfect example field `subnet_ids` to `subnet_id`.
+
 ## 1.41.2 (August 28, 2020)
 
 BUG FIXES:

--- a/examples/tencentcloud-vpc/main.tf
+++ b/examples/tencentcloud-vpc/main.tf
@@ -22,8 +22,8 @@ resource "tencentcloud_vpc_acl" "default" {
 }
 
 resource "tencentcloud_vpc_acl_attachment" "example" {
-  acl_id     = tencentcloud_vpc_acl.default.id
-  subnet_ids = data.tencentcloud_vpc_instances.default.instance_list[0].subnet_ids
+  acl_id    = tencentcloud_vpc_acl.default.id
+  subnet_id = data.tencentcloud_vpc_instances.default.instance_list[0].subnet_ids[0]
 }
 
 data "tencentcloud_vpc_acls" "default" {

--- a/tencentcloud/resource_tc_vpc_acl_attachment.go
+++ b/tencentcloud/resource_tc_vpc_acl_attachment.go
@@ -21,8 +21,9 @@ resource "tencentcloud_vpc_acl" "foo" {
 
 resource "tencentcloud_vpc_acl_attachment" "attachment"{
 		acl_id = tencentcloud_vpc_acl.foo.id
-		subnet_ids = data.tencentcloud_vpc_instances.id_instances.instance_list[0].subnet_ids
+		subnet_id = data.tencentcloud_vpc_instances.id_instances.instance_list[0].subnet_ids[0]
 }
+```
 */
 package tencentcloud
 

--- a/tencentcloud/resource_tc_vpc_acl_attachment_test.go
+++ b/tencentcloud/resource_tc_vpc_acl_attachment_test.go
@@ -74,7 +74,7 @@ func testVpcAclAttachmentExists(n string) resource.TestCheckFunc {
 
 const testAclAttachment_basic = `
 data "tencentcloud_vpc_instances" "id_instances" {
-	name = "acl_test"
+	name = "pulse-line-dev"
 }
 resource "tencentcloud_vpc_acl" "foo" {  
     vpc_id  = data.tencentcloud_vpc_instances.id_instances.instance_list.0.vpc_id

--- a/website/docs/r/vpc_acl_attachment.html.markdown
+++ b/website/docs/r/vpc_acl_attachment.html.markdown
@@ -12,7 +12,27 @@ Provide a resource to attach an existing subnet to Network ACL.
 
 ## Example Usage
 
+```hcl
+data "tencentcloud_vpc_instances" "id_instances" {
+}
+resource "tencentcloud_vpc_acl" "foo" {
+  vpc_id = data.tencentcloud_vpc_instances.id_instances.instance_list.0.vpc_id
+  name   = "test_acl"
+  ingress = [
+    "ACCEPT#192.168.1.0/24#800#TCP",
+    "ACCEPT#192.168.1.0/24#800-900#TCP",
+  ]
+  egress = [
+    "ACCEPT#192.168.1.0/24#800#TCP",
+    "ACCEPT#192.168.1.0/24#800-900#TCP",
+  ]
+}
 
+resource "tencentcloud_vpc_acl_attachment" "attachment" {
+  acl_id    = tencentcloud_vpc_acl.foo.id
+  subnet_id = data.tencentcloud_vpc_instances.id_instances.instance_list[0].subnet_ids[0]
+}
+```
 
 ## Argument Reference
 


### PR DESCRIPTION
change field `subnet_ids` to `subnet_id`.
***

± make testacc TESTARGS=" -run=TestAccTencentCloudVpcAclAttachment_basic"                                                                                                                                                                 ⏎
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudVpcAclAttachment_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc   0.016s [no tests to run]
=== RUN   TestAccTencentCloudVpcAclAttachment_basic
--- PASS: TestAccTencentCloudVpcAclAttachment_basic (8.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud     8.377s
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity        [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper     [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit   [no test files]