### PR TITLE
remove zone string contains region name checks

### DIFF
--- a/tencentcloud/data_source_tc_redis_instances.go
+++ b/tencentcloud/data_source_tc_redis_instances.go
@@ -17,9 +17,7 @@ package tencentcloud
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
@@ -182,9 +180,6 @@ func dataSourceTencentRedisInstancesRead(d *schema.ResourceData, meta interface{
 		tempStr := temp.(string)
 		if tempStr != "" {
 			zone = tempStr
-			if !strings.Contains(zone, region) {
-				return fmt.Errorf("zone[%s] not in region[%s]", zone, region)
-			}
 		}
 	}
 	if temp, ok := d.GetOk("search_key"); ok {

--- a/tencentcloud/resource_tc_kubernetes_cluster.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster.go
@@ -741,12 +741,7 @@ func tkeGetCvmRunInstancesPara(dMap map[string]interface{}, meta interface{},
 
 	place.ProjectId = &projectId
 
-	configRegion := meta.(*TencentCloudClient).apiV3Conn.Region
 	if v, ok := dMap["availability_zone"]; ok {
-		if !strings.Contains(v.(string), configRegion) {
-			errRet = fmt.Errorf("availability_zone[%s] should in [%s]", v.(string), configRegion)
-			return
-		}
 		place.Zone = helper.String(v.(string))
 	}
 

--- a/tencentcloud/resource_tc_redis_instance.go
+++ b/tencentcloud/resource_tc_redis_instance.go
@@ -245,12 +245,6 @@ func resourceTencentCloudRedisInstanceCreate(d *schema.ResourceData, meta interf
 		}
 	}
 
-	if availabilityZone != "" {
-		if !strings.Contains(availabilityZone, region) {
-			return fmt.Errorf("zone[%s] not in region[%s]", availabilityZone, region)
-		}
-	}
-
 	if (typeId == 0 && redisType == "") || (typeId != 0 && redisType != "") {
 		return fmt.Errorf("`type_id` and `type` set one item and only one item")
 	}


### PR DESCRIPTION
for reasons:

- in some environments, the zone name doesn't respect this rule
- not all resources apply this rule, results a inconsistent codebase
- if region/zone not matched, the proper upstream server will panic