### PR TITLE
fix create prepaid mysql error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.45.2 (Unreleased)
+
+BUG FIXES:
+* Resource: `tencentcloud_mysql_instance` fix creating prepaid instance error.
+
 ## 1.45.1 (October 16, 2020)
 
 ENHANCEMENTS:

--- a/tencentcloud/resource_tc_mysql_instance.go
+++ b/tencentcloud/resource_tc_mysql_instance.go
@@ -111,11 +111,8 @@ func TencentMsyqlBasicInfo() map[string]*schema.Schema {
 			Optional:      true,
 			Default:       1,
 			ConflictsWith: []string{"pay_type", "period"},
-			DiffSuppressFunc: func(k, olds, news string, d *schema.ResourceData) bool {
-				return true
-			},
-			ValidateFunc: validateAllowedIntValue(MYSQL_AVAILABLE_PERIOD),
-			Description:  "Period of instance. NOTES: Only supported prepaid instance.",
+			ValidateFunc:  validateAllowedIntValue(MYSQL_AVAILABLE_PERIOD),
+			Description:   "Period of instance. NOTES: Only supported prepaid instance.",
 		},
 		"auto_renew_flag": {
 			Type:         schema.TypeInt,


### PR DESCRIPTION
```
$ terraform apply
2020/10/16 19:10:41 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_mysql_instance.prepaid will be created
  + resource "tencentcloud_mysql_instance" "prepaid" {
      + auto_renew_flag   = 1
      + availability_zone = "ap-guangzhou-3"
      + charge_type       = "PREPAID"
      + engine_version    = "5.7"
      + first_slave_zone  = "ap-guangzhou-3"
      + force_delete      = false
      + gtid              = (known after apply)
      + id                = (known after apply)
      + instance_name     = "testAccMysqlPrepaid"
      + internet_host     = (known after apply)
      + internet_port     = (known after apply)
      + internet_service  = 0
      + intranet_ip       = (known after apply)
      + intranet_port     = 3360
      + locked            = (known after apply)
      + mem_size          = 1000
      + prepaid_period    = 2
      + project_id        = 0
      + root_password     = (sensitive value)
      + slave_deploy_mode = 0
      + slave_sync_mode   = 0
      + status            = (known after apply)
      + task_status       = (known after apply)
      + volume_size       = 50
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_mysql_instance.prepaid: Creating...
tencentcloud_mysql_instance.prepaid: Still creating... [10s elapsed]
tencentcloud_mysql_instance.prepaid: Still creating... [20s elapsed]
tencentcloud_mysql_instance.prepaid: Still creating... [30s elapsed]
tencentcloud_mysql_instance.prepaid: Still creating... [40s elapsed]
tencentcloud_mysql_instance.prepaid: Still creating... [50s elapsed]
tencentcloud_mysql_instance.prepaid: Still creating... [1m0s elapsed]
tencentcloud_mysql_instance.prepaid: Still creating... [1m10s elapsed]
tencentcloud_mysql_instance.prepaid: Still creating... [1m20s elapsed]
tencentcloud_mysql_instance.prepaid: Still creating... [1m30s elapsed]
tencentcloud_mysql_instance.prepaid: Creation complete after 1m32s [id=cdb-73xh0bl3]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```