### PR TITLE
CLB support import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 * Resource: `tencentcloud_clb_listener` support import.
-* Resource: `tencentcloud_clb_listener` add computed argument `listener_id`, when refer to listener ID, please use this argument instead of the origin id of resource `tencentcloud_clb_listener`.
+* Resource: `tencentcloud_clb_listener` add computed argument `listener_id`.
 * Resource: `tencentcloud_clb_listener_rule` support import.
 * Resource: `tencentcloud_cdn_domain` add example that use COS bucket url as origin.
 * Data Source: `tencentcloud_instance_types` add argument `exclude_sold_out` to support filtering sold out instance types. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 1.46.5 (Unreleased)
+## 1.47.0 (Unreleased)
+
+ENHANCEMENTS:
+* Resource: `tencentcloud_clb_listener` support import.
+* Resource: `tencentcloud_clb_listener` add computed argument `listener_id`, when refer to listener ID, please use this argument instead of the origin id of resource `tencentcloud_clb_listener`.
+* Resource: `tencentcloud_clb_listener_rule` support import.
+* Resource: `tencentcloud_cdn_domain` add example that use COS bucket url as origin.
+* Data Source: `tencentcloud_instance_types` add argument `exclude_sold_out` to support filtering sold out instance types. 
 
 BUG FIXES:
 * Resource: `tencentcloud_redis_instance` fix incorrect number when updating `mem_size`.

--- a/examples/tencentcloud-clb/main.tf
+++ b/examples/tencentcloud-clb/main.tf
@@ -52,7 +52,7 @@ resource "tencentcloud_clb_listener" "listener_tcp" {
 
 resource "tencentcloud_clb_attachment" "attachment_tcp" {
   clb_id      = tencentcloud_clb_instance.example.id
-  listener_id = tencentcloud_clb_listener.listener_tcp.id
+  listener_id = tencentcloud_clb_listener.listener_tcp.listener_id
 
   targets {
     instance_id = tencentcloud_instance.foo.id
@@ -72,7 +72,7 @@ resource "tencentcloud_clb_listener" "listener_https" {
 
 resource "tencentcloud_clb_listener_rule" "rule_https" {
   clb_id              = tencentcloud_clb_instance.example.id
-  listener_id         = tencentcloud_clb_listener.listener_https.id
+  listener_id         = tencentcloud_clb_listener.listener_https.listener_id
   domain              = "abc.com"
   url                 = "/"
   session_expire_time = 30
@@ -81,8 +81,8 @@ resource "tencentcloud_clb_listener_rule" "rule_https" {
 
 resource "tencentcloud_clb_attachment" "attachment_https" {
   clb_id      = tencentcloud_clb_instance.example.id
-  listener_id = tencentcloud_clb_listener.listener_https.id
-  rule_id     = tencentcloud_clb_listener_rule.rule_https.id
+  listener_id = tencentcloud_clb_listener.listener_https.listener_id
+  rule_id     = tencentcloud_clb_listener_rule.rule_https.rule_id
 
   targets {
     instance_id = tencentcloud_instance.foo.id
@@ -100,7 +100,7 @@ resource "tencentcloud_clb_listener" "listener_http_src" {
 
 resource "tencentcloud_clb_listener_rule" "rule_http_src" {
   clb_id              = tencentcloud_clb_instance.example.id
-  listener_id         = tencentcloud_clb_listener.listener_http_src.id
+  listener_id         = tencentcloud_clb_listener.listener_http_src.listener_id
   domain              = "abc.com"
   url                 = "/"
   session_expire_time = 30
@@ -116,7 +116,7 @@ resource "tencentcloud_clb_listener" "listener_http_dst" {
 
 resource "tencentcloud_clb_listener_rule" "rule_http_dst" {
   clb_id              = tencentcloud_clb_instance.example.id
-  listener_id         = tencentcloud_clb_listener.listener_http_dst.id
+  listener_id         = tencentcloud_clb_listener.listener_http_dst.listener_id
   domain              = "abcd.com"
   url                 = "/"
   session_expire_time = 30
@@ -125,10 +125,10 @@ resource "tencentcloud_clb_listener_rule" "rule_http_dst" {
 
 resource "tencentcloud_clb_redirection" "redirection_http" {
   clb_id             = tencentcloud_clb_instance.example.id
-  source_listener_id = tencentcloud_clb_listener.listener_http_src.id
-  target_listener_id = tencentcloud_clb_listener.listener_http_dst.id
-  source_rule_id     = tencentcloud_clb_listener_rule.rule_http_src.id
-  target_rule_id     = tencentcloud_clb_listener_rule.rule_http_dst.id
+  source_listener_id = tencentcloud_clb_listener.listener_http_src.listener_id
+  target_listener_id = tencentcloud_clb_listener.listener_http_dst.listener_id
+  source_rule_id     = tencentcloud_clb_listener_rule.rule_http_src.listener_id
+  target_rule_id     = tencentcloud_clb_listener_rule.rule_http_dst.listener_id
 }
 
 resource "tencentcloud_clb_instance" "clb_basic" {
@@ -145,7 +145,7 @@ resource "tencentcloud_clb_listener" "listener_basic" {
 
 resource "tencentcloud_clb_listener_rule" "rule_basic" {
   clb_id              = tencentcloud_clb_instance.clb_basic.id
-  listener_id         = tencentcloud_clb_listener.listener_basic.id
+  listener_id         = tencentcloud_clb_listener.listener_basic.listener_id
   domain              = "abc.com"
   url                 = "/"
   session_expire_time = 30
@@ -166,8 +166,8 @@ resource "tencentcloud_clb_target_group_instance_attachment" "test"{
 
 resource "tencentcloud_clb_target_group_attachment" "group" {
     clb_id          = tencentcloud_clb_instance.clb_basic.id
-    listener_id     = tencentcloud_clb_listener.listener_basic.id
-	rule_id         = tencentcloud_clb_listener_rule.rule_basic.id
+    listener_id     = tencentcloud_clb_listener.listener_basic.listener_id
+	rule_id         = tencentcloud_clb_listener_rule.rule_basic.rule_id
     targrt_group_id = tencentcloud_clb_target_group.test.id
 }
 
@@ -181,20 +181,20 @@ data "tencentcloud_clb_instances" "instances" {
 
 data "tencentcloud_clb_listeners" "listeners" {
   clb_id      = tencentcloud_clb_instance.example.id
-  listener_id = tencentcloud_clb_listener.listener_tcp.id
+  listener_id = tencentcloud_clb_listener.listener_tcp.listener_id
 }
 
 data "tencentcloud_clb_listener_rules" "rules" {
   clb_id      = tencentcloud_clb_instance.example.id
-  listener_id = tencentcloud_clb_listener.listener_https.id
+  listener_id = tencentcloud_clb_listener.listener_https.listener_id
   domain      = tencentcloud_clb_listener_rule.rule_https.domain
   url         = tencentcloud_clb_listener_rule.rule_https.url
 }
 
 data "tencentcloud_clb_attachments" "attachments" {
   clb_id      = tencentcloud_clb_instance.example.id
-  listener_id = tencentcloud_clb_listener.listener_https.id
-  rule_id     = tencentcloud_clb_attachment.attachment_https.id
+  listener_id = tencentcloud_clb_listener.listener_https.listener_id
+  rule_id     = tencentcloud_clb_attachment.attachment_https.rule_id
 }
 
 data "tencentcloud_clb_redirections" "redirections" {

--- a/tencentcloud/basic_test.go
+++ b/tencentcloud/basic_test.go
@@ -23,8 +23,8 @@ const (
 	defaultInsName       = "tf-ci-test"
 	defaultInsNameUpdate = "tf-ci-test-update"
 
-	defaultSshCertificate  = "VjANRdz8"
-	defaultSshCertificateB = "VfqO4zkB"
+	defaultSshCertificate  = "f8kGFR2T"
+	defaultSshCertificateB = "fbW9Spiy"
 
 	defaultDayuBgp    = "bgp-000006mq"
 	defaultDayuBgpMul = "bgp-0000008o"

--- a/tencentcloud/data_source_tc_availability_regions.go
+++ b/tencentcloud/data_source_tc_availability_regions.go
@@ -29,7 +29,7 @@ func dataSourceTencentCloudAvailabilityRegions() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "When specified, only the region with the exactly name match will be returned. `default` value means it consistent with the TIC resource stack region.",
+				Description: "When specified, only the region with the exactly name match will be returned. `default` value means it consistent with the provider region.",
 			},
 			"include_unavailable": {
 				Type:        schema.TypeBool,

--- a/tencentcloud/data_source_tc_availability_regions.go
+++ b/tencentcloud/data_source_tc_availability_regions.go
@@ -29,7 +29,7 @@ func dataSourceTencentCloudAvailabilityRegions() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "When specified, only the region with the exactly name match will be returned.",
+				Description: "When specified, only the region with the exactly name match will be returned. `default` value means it consistent with the TIC resource stack region.",
 			},
 			"include_unavailable": {
 				Type:        schema.TypeBool,

--- a/tencentcloud/data_source_tc_clb_attachments.go
+++ b/tencentcloud/data_source_tc_clb_attachments.go
@@ -114,9 +114,17 @@ func dataSourceTencentCloudClbServerAttachmentsRead(d *schema.ResourceData, meta
 	params := make(map[string]string)
 	clbId := d.Get("clb_id").(string)
 	listenerId := d.Get("listener_id").(string)
+	checkErr := ListenerIdCheck(listenerId)
+	if checkErr != nil {
+		return checkErr
+	}
 	locationId := ""
 	if v, ok := d.GetOk("rule_id"); ok {
 		locationId = v.(string)
+		checkErr := RuleIdCheck(locationId)
+		if checkErr != nil {
+			return checkErr
+		}
 		params["rule_id"] = locationId
 	}
 	params["clb_id"] = clbId

--- a/tencentcloud/data_source_tc_clb_listener_rules.go
+++ b/tencentcloud/data_source_tc_clb_listener_rules.go
@@ -178,6 +178,10 @@ func dataSourceTencentCloudClbListenerRulesRead(d *schema.ResourceData, meta int
 	ctx := context.WithValue(context.TODO(), logIdKey, logId)
 
 	listenerId := d.Get("listener_id").(string)
+	checkErr := ListenerIdCheck(listenerId)
+	if checkErr != nil {
+		return checkErr
+	}
 	clbId := d.Get("clb_id").(string)
 	params := make(map[string]string)
 	params["clb_id"] = clbId
@@ -190,6 +194,10 @@ func dataSourceTencentCloudClbListenerRulesRead(d *schema.ResourceData, meta int
 	}
 	if v, ok := d.GetOk("rule_id"); ok {
 		params["rule_id"] = v.(string)
+		checkErr := RuleIdCheck(params["rule_id"])
+		if checkErr != nil {
+			return checkErr
+		}
 	}
 	if v, ok := d.GetOk("domain"); ok {
 		params["domain"] = v.(string)

--- a/tencentcloud/data_source_tc_clb_listener_rules_test.go
+++ b/tencentcloud/data_source_tc_clb_listener_rules_test.go
@@ -45,7 +45,7 @@ resource "tencentcloud_clb_listener" "listener" {
 
 resource "tencentcloud_clb_listener_rule" "rule" {
   clb_id              = tencentcloud_clb_instance.clb.id
-  listener_id         = tencentcloud_clb_listener.listener.id
+  listener_id         = tencentcloud_clb_listener.listener.listener_id
   domain              = "abcde.com"
   url                 = "/"
   session_expire_time = 30
@@ -54,7 +54,7 @@ resource "tencentcloud_clb_listener_rule" "rule" {
 
 data "tencentcloud_clb_listener_rules" "rules" {
   clb_id      = tencentcloud_clb_instance.clb.id
-  listener_id = tencentcloud_clb_listener.listener.id
+  listener_id = tencentcloud_clb_listener.listener.listener_id
   domain      = tencentcloud_clb_listener_rule.rule.domain
   url         = tencentcloud_clb_listener_rule.rule.url
 }

--- a/tencentcloud/data_source_tc_clb_listeners.go
+++ b/tencentcloud/data_source_tc_clb_listeners.go
@@ -160,7 +160,12 @@ func dataSourceTencentCloudClbListenersRead(d *schema.ResourceData, meta interfa
 	params := make(map[string]interface{})
 	params["clb_id"] = clbId
 	if v, ok := d.GetOk("listener_id"); ok {
-		params["listener_id"] = v.(string)
+		listenerId := v.(string)
+		params["listener_id"] = listenerId
+		checkErr := ListenerIdCheck(listenerId)
+		if checkErr != nil {
+			return checkErr
+		}
 	}
 	if v, ok := d.GetOk("port"); ok {
 		params["port"] = v.(int)

--- a/tencentcloud/data_source_tc_clb_listeners_test.go
+++ b/tencentcloud/data_source_tc_clb_listeners_test.go
@@ -49,6 +49,6 @@ resource "tencentcloud_clb_listener" "listener" {
 
 data "tencentcloud_clb_listeners" "listeners" {
   clb_id      = tencentcloud_clb_instance.clb.id
-  listener_id = tencentcloud_clb_listener.listener.id
+  listener_id = tencentcloud_clb_listener.listener.listener_id
 }
 `

--- a/tencentcloud/data_source_tc_clb_redirections.go
+++ b/tencentcloud/data_source_tc_clb_redirections.go
@@ -107,12 +107,28 @@ func dataSourceTencentCloudClbRedirectionsRead(d *schema.ResourceData, meta inte
 	params := make(map[string]string)
 	params["clb_id"] = d.Get("clb_id").(string)
 	params["source_listener_id"] = d.Get("source_listener_id").(string)
+	checkErr := ListenerIdCheck(params["source_listener_id"])
+	if checkErr != nil {
+		return checkErr
+	}
 	params["source_rule_id"] = d.Get("source_rule_id").(string)
+	checkErr = RuleIdCheck(params["source_rule_id"])
+	if checkErr != nil {
+		return checkErr
+	}
 	if v, ok := d.GetOk("target_listener_id"); ok {
 		params["target_listener_id"] = v.(string)
+		checkErr := ListenerIdCheck(params["target_listener_id"])
+		if checkErr != nil {
+			return checkErr
+		}
 	}
 	if v, ok := d.GetOk("target_rule_id"); ok {
 		params["target_rule_id"] = v.(string)
+		checkErr = RuleIdCheck(params["target_rule_id"])
+		if checkErr != nil {
+			return checkErr
+		}
 	}
 
 	clbService := ClbService{

--- a/tencentcloud/data_source_tc_instance_types_test.go
+++ b/tencentcloud/data_source_tc_instance_types_test.go
@@ -23,10 +23,46 @@ func TestAccTencentCloudInstanceTypesDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccTencentCloudInstanceTypesDataSource_sell(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTencentCloudInstanceTypesDataSourceConfigSell,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.tencentcloud_instance_types.t4c8g", "instance_types.0.cpu_core_count", "1"),
+					resource.TestCheckResourceAttr("data.tencentcloud_instance_types.t4c8g", "instance_types.0.memory_size", "1"),
+					resource.TestCheckResourceAttr("data.tencentcloud_instance_types.t4c8g", "instance_types.0.availability_zone", "ap-guangzhou-3"),
+					resource.TestCheckResourceAttr("data.tencentcloud_instance_types.t4c8g", "instance_types.0.family", "SA2"),
+				),
+			},
+		},
+	})
+}
+
 const testAccTencentCloudInstanceTypesDataSourceConfigBasic = `
 data "tencentcloud_instance_types" "t4c8g" {
   availability_zone = "ap-guangzhou-3"
   cpu_core_count = 4
   memory_size    = 8
+}
+`
+
+const testAccTencentCloudInstanceTypesDataSourceConfigSell = `
+data "tencentcloud_instance_types" "t4c8g" {
+  cpu_core_count = 1
+  memory_size    = 1
+  exclude_sold_out = true
+
+  filter{
+	name = "instance-family"
+    values = ["SA2"]
+  }
+
+  filter{
+	name = "zone"
+    values = ["ap-guangzhou-3"]
+  }
 }
 `

--- a/tencentcloud/extension_cvm.go
+++ b/tencentcloud/extension_cvm.go
@@ -47,6 +47,8 @@ const (
 
 	CVM_IMAGE_LOGIN     = "TRUE"
 	CVM_IMAGE_LOGIN_NOT = "FALSE"
+
+	CVM_ZONE_NOT_SUPPORT_ERROR = "InvalidParameterValue.ZoneNotSupported"
 )
 
 var CVM_CHARGE_TYPE = []string{

--- a/tencentcloud/resource_tc_cdn_domain.go
+++ b/tencentcloud/resource_tc_cdn_domain.go
@@ -35,7 +35,7 @@ Example Usage of COS bucket url as origin
 ```hcl
 resource "tencentcloud_cos_bucket" "bucket" {
   # Bucket format should be [custom name]-[appid].
-  bucket = "ajaxhe-demo-bucket-1251234567"
+  bucket = "demo-bucket-1251234567"
   acl    = "private"
 }
 

--- a/tencentcloud/resource_tc_cdn_domain.go
+++ b/tencentcloud/resource_tc_cdn_domain.go
@@ -30,6 +30,40 @@ resource "tencentcloud_cdn_domain" "foo" {
 }
 ```
 
+Example Usage of COS bucket url as origin
+
+```hcl
+resource "tencentcloud_cos_bucket" "bucket" {
+  # Bucket format should be [custom name]-[appid].
+  bucket = "ajaxhe-demo-bucket-1251234567"
+  acl    = "private"
+}
+
+# Create cdn domain
+resource "tencentcloud_cdn_domain" "cdn" {
+  domain         = "abc.com"
+  service_type   = "web"
+  area           = "mainland"
+  full_url_cache = false
+
+  origin {
+    origin_type          = "cos"
+    origin_list          = [tencentcloud_cos_bucket.bucket.cos_bucket_url]
+    server_name          = tencentcloud_cos_bucket.bucket.cos_bucket_url
+    origin_pull_protocol = "follow"
+    cos_private_access   = "on"
+  }
+
+  https_config {
+    https_switch         = "off"
+    http2_switch         = "off"
+    ocsp_stapling_switch = "off"
+    spdy_switch          = "off"
+    verify_client        = "off"
+  }
+}
+```
+
 Import
 
 CDN domain can be imported using the id, e.g.

--- a/tencentcloud/resource_tc_clb_attachment.go
+++ b/tencentcloud/resource_tc_clb_attachment.go
@@ -114,6 +114,10 @@ func resourceTencentCloudClbServerAttachmentCreate(d *schema.ResourceData, meta 
 
 	logId := getLogId(contextNil)
 	listenerId := d.Get("listener_id").(string)
+	checkErr := ListenerIdCheck(listenerId)
+	if checkErr != nil {
+		return checkErr
+	}
 	clbId := d.Get("clb_id").(string)
 	locationId := ""
 	request := clb.NewRegisterTargetsRequest()
@@ -121,6 +125,10 @@ func resourceTencentCloudClbServerAttachmentCreate(d *schema.ResourceData, meta 
 	request.ListenerId = helper.String(listenerId)
 	if v, ok := d.GetOk("rule_id"); ok {
 		locationId = v.(string)
+		checkErr := RuleIdCheck(locationId)
+		if checkErr != nil {
+			return checkErr
+		}
 		if locationId != "" {
 			request.LocationId = helper.String(locationId)
 		}

--- a/tencentcloud/resource_tc_clb_listener_rule_test.go
+++ b/tencentcloud/resource_tc_clb_listener_rule_test.go
@@ -3,6 +3,7 @@ package tencentcloud
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -43,6 +44,11 @@ func TestAccTencentCloudClbListenerRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("tencentcloud_clb_listener_rule.rule_basic", "scheduler", "WRR"),
 					resource.TestCheckResourceAttr("tencentcloud_clb_listener_rule.rule_basic", "forward_type", "HTTP"),
 				),
+			},
+			{
+				ResourceName:      "tencentcloud_clb_listener_rule.rule_basic",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -99,6 +105,11 @@ func TestAccTencentCloudClbListenerRule_full(t *testing.T) {
 					resource.TestCheckResourceAttr("tencentcloud_clb_listener_rule.rule_full", "certificate_id", defaultSshCertificateB),
 				),
 			},
+			{
+				ResourceName:      "tencentcloud_clb_listener_rule.rule_full",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -114,7 +125,10 @@ func testAccCheckClbListenerRuleDestroy(s *terraform.State) error {
 		if rs.Type != "tencentcloud_clb_listener_rule" {
 			continue
 		}
-		locationId := rs.Primary.ID
+		resourceId := rs.Primary.ID
+		items := strings.Split(resourceId, FILED_SP)
+		itemLength := len(items)
+		locationId := items[itemLength-1]
 		listenerId := rs.Primary.Attributes["listener_id"]
 		clbId := rs.Primary.Attributes["clb_id"]
 		//this function is not supported by api, need to be travelled
@@ -142,7 +156,10 @@ func testAccCheckClbListenerRuleExists(n string) resource.TestCheckFunc {
 		clbService := ClbService{
 			client: testAccProvider.Meta().(*TencentCloudClient).apiV3Conn,
 		}
-		locationId := rs.Primary.ID
+		resourceId := rs.Primary.ID
+		items := strings.Split(resourceId, FILED_SP)
+		itemLength := len(items)
+		locationId := items[itemLength-1]
 		listenerId := rs.Primary.Attributes["listener_id"]
 		clbId := rs.Primary.Attributes["clb_id"]
 		filter := map[string]string{"rule_id": locationId, "listener_id": listenerId, "clb_id": clbId}
@@ -172,7 +189,7 @@ resource "tencentcloud_clb_listener" "listener_basic" {
 
 resource "tencentcloud_clb_listener_rule" "rule_basic" {
   clb_id              = tencentcloud_clb_instance.clb_basic.id
-  listener_id         = tencentcloud_clb_listener.listener_basic.id
+  listener_id         = tencentcloud_clb_listener.listener_basic.listener_id
   domain              = "abc.com"
   url                 = "/"
   session_expire_time = 30
@@ -197,7 +214,7 @@ resource "tencentcloud_clb_listener" "listener_basic" {
 
 resource "tencentcloud_clb_listener_rule" "rule_basic" {
   clb_id              = tencentcloud_clb_instance.clb_basic.id
-  listener_id         = tencentcloud_clb_listener.listener_basic.id
+  listener_id         = tencentcloud_clb_listener.listener_basic.listener_id
   domain              = "abc.com"
   url                 = "/"
   session_expire_time = 30
@@ -219,11 +236,12 @@ resource "tencentcloud_clb_listener" "listener_basic" {
   protocol             = "HTTPS"
   certificate_ssl_mode = "UNIDIRECTIONAL"
   certificate_id       = "%s"
+  sni_switch = true
 }
 
 resource "tencentcloud_clb_listener_rule" "rule_full" {
   clb_id                     = tencentcloud_clb_instance.clb_basic.id
-  listener_id                = tencentcloud_clb_listener.listener_basic.id
+  listener_id                = tencentcloud_clb_listener.listener_basic.listener_id
   domain                     = "abc.com"
   url                        = "/"
   session_expire_time        = 30
@@ -254,11 +272,12 @@ resource "tencentcloud_clb_listener" "listener_basic" {
   protocol             = "HTTPS"
   certificate_ssl_mode = "UNIDIRECTIONAL"
   certificate_id       = "%s"
+  sni_switch = true
 }
 
 resource "tencentcloud_clb_listener_rule" "rule_full" {
   clb_id                     = tencentcloud_clb_instance.clb_basic.id
-  listener_id                = tencentcloud_clb_listener.listener_basic.id
+  listener_id                = tencentcloud_clb_listener.listener_basic.listener_id
   domain                     = "abcdr.com"
   url                        = "/"
   session_expire_time        = 60

--- a/tencentcloud/resource_tc_clb_redirection.go
+++ b/tencentcloud/resource_tc_clb_redirection.go
@@ -120,14 +120,30 @@ func resourceTencentCloudClbRedirectionCreate(d *schema.ResourceData, meta inter
 
 	clbId := d.Get("clb_id").(string)
 	targetListenerId := d.Get("target_listener_id").(string)
+	checkErr := ListenerIdCheck(targetListenerId)
+	if checkErr != nil {
+		return checkErr
+	}
 	targetLocId := d.Get("target_rule_id").(string)
+	checkErr = RuleIdCheck(targetLocId)
+	if checkErr != nil {
+		return checkErr
+	}
 	sourceListenerId := ""
 	sourceLocId := ""
 	if v, ok := d.GetOk("source_listener_id"); ok {
 		sourceListenerId = v.(string)
+		checkErr := ListenerIdCheck(sourceListenerId)
+		if checkErr != nil {
+			return checkErr
+		}
 	}
 	if v, ok := d.GetOk("source_rule_id"); ok {
 		sourceLocId = v.(string)
+		checkErr = RuleIdCheck(sourceLocId)
+		if checkErr != nil {
+			return checkErr
+		}
 	}
 
 	//check is auto forwarding or not

--- a/tencentcloud/resource_tc_clb_target_group_attachment.go
+++ b/tencentcloud/resource_tc_clb_target_group_attachment.go
@@ -115,6 +115,16 @@ func resourceTencentCloudClbTargetGroupAttachmentCreate(d *schema.ResourceData, 
 		err              error
 	)
 
+	//check listenerId
+	checkErr := ListenerIdCheck(listenerId)
+	if checkErr != nil {
+		return checkErr
+	}
+	//check ruleId
+	checkErr = RuleIdCheck(locationId)
+	if checkErr != nil {
+		return checkErr
+	}
 	//check rule
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
 		listener, err = clbService.DescribeListenerById(ctx, listenerId, clbId)

--- a/tencentcloud/service_tencentcloud_clb.go
+++ b/tencentcloud/service_tencentcloud_clb.go
@@ -20,6 +20,26 @@ type ClbService struct {
 	client *connectivity.TencentCloudClient
 }
 
+func RuleIdCheck(ruleId string) error {
+	//check clb listener rule id first
+	//old example file cause wrong usage of listener.id
+	items := strings.Split(ruleId, FILED_SP)
+	if len(items) > 1 {
+		return fmt.Errorf("Unsupported references of rule_id since version 1.47.0, please check your tf content and use `tencentcloud_clb_listener_rule.xxx.rule_id` instead of `tencentcloud_clb_listener_rule.xxx.id`")
+	}
+	return nil
+}
+
+func ListenerIdCheck(listenerId string) error {
+	//check clb listener listener id first
+	//old example file cause wrong usage of listener.id
+	items := strings.Split(listenerId, FILED_SP)
+	if len(items) > 1 {
+		return fmt.Errorf("Unsupported references of listener_id since version 1.47.0, please check your tf content and use `tencentcloud_clb_listener.xxx.listener_id` instead of `tencentcloud_clb_listener.xxx.id`")
+	}
+	return nil
+}
+
 func (me *ClbService) DescribeLoadBalancerById(ctx context.Context, clbId string) (clbInstance *clb.LoadBalancer, errRet error) {
 	logId := getLogId(ctx)
 	request := clb.NewDescribeLoadBalancersRequest()
@@ -90,7 +110,6 @@ func (me *ClbService) DescribeLoadBalancerByFilter(ctx context.Context, params m
 }
 
 func (me *ClbService) DeleteLoadBalancerById(ctx context.Context, clbId string) error {
-
 	logId := getLogId(ctx)
 	request := clb.NewDeleteLoadBalancerRequest()
 	request.LoadBalancerIds = []*string{&clbId}
@@ -117,7 +136,6 @@ func (me *ClbService) DeleteLoadBalancerById(ctx context.Context, clbId string) 
 func (me *ClbService) DescribeListenerById(ctx context.Context, listenerId string, clbId string) (clbListener *clb.Listener, errRet error) {
 	logId := getLogId(ctx)
 	request := clb.NewDescribeListenersRequest()
-
 	request.ListenerIds = []*string{&listenerId}
 	request.LoadBalancerId = &clbId
 	ratelimit.Check(request.GetAction())

--- a/website/docs/d/availability_regions.html.markdown
+++ b/website/docs/d/availability_regions.html.markdown
@@ -24,7 +24,7 @@ data "tencentcloud_availability_regions" "my_favourite_region" {
 The following arguments are supported:
 
 * `include_unavailable` - (Optional) A bool variable indicates that the query will include `UNAVAILABLE` regions.
-* `name` - (Optional) When specified, only the region with the exactly name match will be returned.
+* `name` - (Optional) When specified, only the region with the exactly name match will be returned. `default` value means it consistent with the TIC resource stack region.
 * `result_output_file` - (Optional) Used to save results.
 
 ## Attributes Reference

--- a/website/docs/d/availability_regions.html.markdown
+++ b/website/docs/d/availability_regions.html.markdown
@@ -24,7 +24,7 @@ data "tencentcloud_availability_regions" "my_favourite_region" {
 The following arguments are supported:
 
 * `include_unavailable` - (Optional) A bool variable indicates that the query will include `UNAVAILABLE` regions.
-* `name` - (Optional) When specified, only the region with the exactly name match will be returned. `default` value means it consistent with the TIC resource stack region.
+* `name` - (Optional) When specified, only the region with the exactly name match will be returned. `default` value means it consistent with the provider region.
 * `result_output_file` - (Optional) Used to save results.
 
 ## Attributes Reference

--- a/website/docs/d/instance_types.html.markdown
+++ b/website/docs/d/instance_types.html.markdown
@@ -27,6 +27,7 @@ The following arguments are supported:
 
 * `availability_zone` - (Optional) The available zone that the CVM instance locates at. This field is conflict with `filter`.
 * `cpu_core_count` - (Optional) The number of CPU cores of the instance.
+* `exclude_sold_out` - (Optional) Indicate to filter instances types that is sold out or not, default is false.
 * `filter` - (Optional) One or more name/value pairs to filter. This field is conflict with `availability_zone`.
 * `gpu_core_count` - (Optional) The number of GPU cores of the instance.
 * `memory_size` - (Optional) Instance memory capacity, unit in GB.

--- a/website/docs/r/cdn_domain.html.markdown
+++ b/website/docs/r/cdn_domain.html.markdown
@@ -45,7 +45,7 @@ Example Usage of COS bucket url as origin
 ```hcl
 resource "tencentcloud_cos_bucket" "bucket" {
   # Bucket format should be [custom name]-[appid].
-  bucket = "ajaxhe-demo-bucket-1251234567"
+  bucket = "demo-bucket-1251234567"
   acl    = "private"
 }
 

--- a/website/docs/r/cdn_domain.html.markdown
+++ b/website/docs/r/cdn_domain.html.markdown
@@ -40,6 +40,40 @@ resource "tencentcloud_cdn_domain" "foo" {
 }
 ```
 
+Example Usage of COS bucket url as origin
+
+```hcl
+resource "tencentcloud_cos_bucket" "bucket" {
+  # Bucket format should be [custom name]-[appid].
+  bucket = "ajaxhe-demo-bucket-1251234567"
+  acl    = "private"
+}
+
+# Create cdn domain
+resource "tencentcloud_cdn_domain" "cdn" {
+  domain         = "abc.com"
+  service_type   = "web"
+  area           = "mainland"
+  full_url_cache = false
+
+  origin {
+    origin_type          = "cos"
+    origin_list          = [tencentcloud_cos_bucket.bucket.cos_bucket_url]
+    server_name          = tencentcloud_cos_bucket.bucket.cos_bucket_url
+    origin_pull_protocol = "follow"
+    cos_private_access   = "on"
+  }
+
+  https_config {
+    https_switch         = "off"
+    http2_switch         = "off"
+    ocsp_stapling_switch = "off"
+    spdy_switch          = "off"
+    verify_client        = "off"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/clb_listener.html.markdown
+++ b/website/docs/r/clb_listener.html.markdown
@@ -102,6 +102,14 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
+* `listener_id` - Id of this CLB listener.
 
 
+## Import
+
+CLB listener can be imported using the id (version >= 1.47.0), e.g.
+
+```
+$ terraform import tencentcloud_clb_listener.foo lb-7a0t6zqb#lbl-hh141sn9
+```
 

--- a/website/docs/r/clb_listener_rule.html.markdown
+++ b/website/docs/r/clb_listener_rule.html.markdown
@@ -66,6 +66,14 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
+* `rule_id` - Id of this CLB listener rule.
 
 
+## Import
+
+CLB listener rule can be imported using the id (version >= 1.47.0), e.g.
+
+```
+$ terraform import tencentcloud_clb_listener_rule.foo lb-7a0t6zqb#lbl-hh141sn9#loc-agg236ys
+```
 


### PR DESCRIPTION
CLB 
```
$ make testacc TESTARGS=" -run=TestAccTencentCloudClbListener"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudClbListener -timeout 120m
?       github.com/tencentcloudstack/terraform-provider-tencentcloud    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/tencentcloudstack/terraform-provider-tencentcloud/gendoc     (cached) [no tests to run]
=== RUN   TestAccTencentCloudClbListenerRulesDataSource
=== PAUSE TestAccTencentCloudClbListenerRulesDataSource
=== RUN   TestAccTencentCloudClbListenersDataSource
=== PAUSE TestAccTencentCloudClbListenersDataSource
=== RUN   TestAccTencentCloudClbListenerRule_basic
=== PAUSE TestAccTencentCloudClbListenerRule_basic
=== RUN   TestAccTencentCloudClbListenerRule_full
=== PAUSE TestAccTencentCloudClbListenerRule_full
=== RUN   TestAccTencentCloudClbListener_basic
=== PAUSE TestAccTencentCloudClbListener_basic
=== RUN   TestAccTencentCloudClbListener_tcp
=== PAUSE TestAccTencentCloudClbListener_tcp
=== RUN   TestAccTencentCloudClbListener_https
=== PAUSE TestAccTencentCloudClbListener_https
=== RUN   TestAccTencentCloudClbListener_tcpssl
=== PAUSE TestAccTencentCloudClbListener_tcpssl
=== CONT  TestAccTencentCloudClbListenerRulesDataSource
=== CONT  TestAccTencentCloudClbListener_tcp
=== CONT  TestAccTencentCloudClbListener_tcpssl
=== CONT  TestAccTencentCloudClbListener_https
=== CONT  TestAccTencentCloudClbListenerRule_full
=== CONT  TestAccTencentCloudClbListener_basic
=== CONT  TestAccTencentCloudClbListenerRule_basic
=== CONT  TestAccTencentCloudClbListenersDataSource
--- PASS: TestAccTencentCloudClbListener_basic (132.07s)
--- PASS: TestAccTencentCloudClbListenersDataSource (140.47s)
--- PASS: TestAccTencentCloudClbListener_tcp (169.15s)
--- PASS: TestAccTencentCloudClbListener_tcpssl (173.28s)
--- PASS: TestAccTencentCloudClbListener_https (194.93s)
--- PASS: TestAccTencentCloudClbListenerRulesDataSource (198.49s)
--- PASS: TestAccTencentCloudClbListenerRule_full (204.76s)
--- PASS: TestAccTencentCloudClbListenerRule_basic (206.93s)
PASS
ok      github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud       208.326s
?       github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity  [no test files]
?       github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper       [no test files]
?       github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit     [no test files]
```


SOLD OUT CVM DATA FILTER
```
$ make testacc TESTARGS=" -run=TestAccTencentCloudInstanceTypesDataSource_sell"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudInstanceTypesDataSource_sell -timeout 120m
?       github.com/tencentcloudstack/terraform-provider-tencentcloud    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/tencentcloudstack/terraform-provider-tencentcloud/gendoc     (cached) [no tests to run]
=== RUN   TestAccTencentCloudInstanceTypesDataSource_sell
--- PASS: TestAccTencentCloudInstanceTypesDataSource_sell (7.07s)
PASS
ok      github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud       8.461s
?       github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity  [no test files]
?       github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper       [no test files]
?       github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit     [no test files]

```



CLB old state read on new version
```
terraform apply
2020/11/12 15:51:35 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
tencentcloud_clb_listener.HTTPS_listener: Refreshing state... [id=lbl-hnuxzjwo]
tencentcloud_clb_listener_rule.rule_full: Refreshing state... [id=loc-4r61x83y]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.



```

old state update on new version

```
terraform apply
2020/11/12 15:53:45 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
tencentcloud_clb_listener.HTTPS_listener: Refreshing state... [id=lbl-hnuxzjwo]
tencentcloud_clb_listener_rule.rule_full: Refreshing state... [id=loc-4r61x83y]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # tencentcloud_clb_listener.HTTPS_listener will be updated in-place
  ~ resource "tencentcloud_clb_listener" "HTTPS_listener" {
        certificate_id       = "f8kGFR2T"
        certificate_ssl_mode = "UNIDIRECTIONAL"
        clb_id               = "lb-cn4x4i80"
        id                   = "lbl-hnuxzjwo"
        listener_id          = "lbl-hnuxzjwo"
      ~ listener_name        = "test_listener" -> "test_listenere"
        port                 = 80
        protocol             = "HTTPS"
        scheduler            = "WRR"
        session_expire_time  = 0
        sni_switch           = true
    }

  # tencentcloud_clb_listener_rule.rule_full will be updated in-place
  ~ resource "tencentcloud_clb_listener_rule" "rule_full" {
        certificate_id             = "f8kGFR2T"
        certificate_ssl_mode       = "UNIDIRECTIONAL"
        clb_id                     = "lb-cn4x4i80"
        domain                     = "abc.com"
        forward_type               = "HTTP"
        health_check_health_num    = 3
        health_check_http_code     = 31
        health_check_http_domain   = "abc.com"
        health_check_http_method   = "GET"
        health_check_http_path     = "/"
        health_check_interval_time = 200
        health_check_switch        = true
      ~ health_check_unhealth_num  = 3 -> 6
        id                         = "loc-4r61x83y"
        listener_id                = "lbl-hnuxzjwo"
        rule_id                    = "loc-4r61x83y"
        scheduler                  = "WRR"
        session_expire_time        = 30
        target_type                = "NODE"
        url                        = "/"
    }

Plan: 0 to add, 2 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_clb_listener.HTTPS_listener: Modifying... [id=lbl-hnuxzjwo]
tencentcloud_clb_listener.HTTPS_listener: Modifications complete after 3s [id=lbl-hnuxzjwo]
tencentcloud_clb_listener_rule.rule_full: Modifying... [id=loc-4r61x83y]
tencentcloud_clb_listener_rule.rule_full: Modifications complete after 5s [id=loc-4r61x83y]

Apply complete! Resources: 0 added, 2 changed, 0 destroyed.

```

old state destroy on new version
```
 terraform destroy
2020/11/12 15:54:25 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
tencentcloud_clb_listener.HTTPS_listener: Refreshing state... [id=lbl-hnuxzjwo]
tencentcloud_clb_listener_rule.rule_full: Refreshing state... [id=loc-4r61x83y]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # tencentcloud_clb_listener.HTTPS_listener will be destroyed
  - resource "tencentcloud_clb_listener" "HTTPS_listener" {
      - certificate_id       = "f8kGFR2T" -> null
      - certificate_ssl_mode = "UNIDIRECTIONAL" -> null
      - clb_id               = "lb-cn4x4i80" -> null
      - id                   = "lbl-hnuxzjwo" -> null
      - listener_id          = "lbl-hnuxzjwo" -> null
      - listener_name        = "test_listenere" -> null
      - port                 = 80 -> null
      - protocol             = "HTTPS" -> null
      - scheduler            = "WRR" -> null
      - session_expire_time  = 0 -> null
      - sni_switch           = true -> null
    }

  # tencentcloud_clb_listener_rule.rule_full will be destroyed
  - resource "tencentcloud_clb_listener_rule" "rule_full" {
      - certificate_id             = "f8kGFR2T" -> null
      - certificate_ssl_mode       = "UNIDIRECTIONAL" -> null
      - clb_id                     = "lb-cn4x4i80" -> null
      - domain                     = "abc.com" -> null
      - forward_type               = "HTTP" -> null
      - health_check_health_num    = 3 -> null
      - health_check_http_code     = 31 -> null
      - health_check_http_domain   = "abc.com" -> null
      - health_check_http_method   = "GET" -> null
      - health_check_http_path     = "/" -> null
      - health_check_interval_time = 200 -> null
      - health_check_switch        = true -> null
      - health_check_unhealth_num  = 6 -> null
      - id                         = "loc-4r61x83y" -> null
      - listener_id                = "lbl-hnuxzjwo" -> null
      - rule_id                    = "loc-4r61x83y" -> null
      - scheduler                  = "WRR" -> null
      - session_expire_time        = 30 -> null
      - target_type                = "NODE" -> null
      - url                        = "/" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

tencentcloud_clb_listener_rule.rule_full: Destroying... [id=loc-4r61x83y]
tencentcloud_clb_listener_rule.rule_full: Destruction complete after 5s
tencentcloud_clb_listener.HTTPS_listener: Destroying... [id=lbl-hnuxzjwo]
tencentcloud_clb_listener.HTTPS_listener: Destruction complete after 2s

Destroy complete! Resources: 2 destroyed.
```

old state use `listener_id` instead of `id` (tf change )on new version
```
terraform apply
2020/11/12 16:36:05 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
tencentcloud_clb_listener.HTTPS_listener: Refreshing state... [id=lbl-2fbcl48w]
tencentcloud_clb_listener_rule.rule_full: Refreshing state... [id=loc-rn8p4fzi]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```