### PR TITLE
 fix bug that waiting 5 minutes when cloud disk sold out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.53.8 (Unreleased)
+
+BUG FIXES:
+
+* Resource `tencentcloud_instance` fix bug that waiting 5 minutes when cloud disk sold out.
+
 ## 1.53.7 (March 10, 2021)
 
 ENHANCEMENTS:

--- a/tencentcloud/extension_cvm.go
+++ b/tencentcloud/extension_cvm.go
@@ -48,7 +48,8 @@ const (
 	CVM_IMAGE_LOGIN     = "TRUE"
 	CVM_IMAGE_LOGIN_NOT = "FALSE"
 
-	CVM_ZONE_NOT_SUPPORT_ERROR = "InvalidParameterValue.ZoneNotSupported"
+	CVM_ZONE_NOT_SUPPORT_ERROR    = "InvalidParameterValue.ZoneNotSupported"
+	CVM_CLOUD_DISK_SOLD_OUT_ERROR = "ResourceInsufficient.CloudDiskSoldOut"
 )
 
 var CVM_CHARGE_TYPE = []string{

--- a/tencentcloud/resource_tc_instance.go
+++ b/tencentcloud/resource_tc_instance.go
@@ -87,6 +87,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit"
@@ -599,6 +600,10 @@ func resourceTencentCloudInstanceCreate(d *schema.ResourceData, meta interface{}
 		if err != nil {
 			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 				logId, request.GetAction(), request.ToJsonString(), err.Error())
+			e, ok := err.(*sdkErrors.TencentCloudSDKError)
+			if ok && e.Code == CVM_CLOUD_DISK_SOLD_OUT_ERROR {
+				return resource.NonRetryableError(e)
+			}
 			return retryError(err)
 		}
 		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",


### PR DESCRIPTION
##### 1.old version

```
terraform apply
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_instance.foo[0] will be created
  + resource "tencentcloud_instance" "foo" {
      + allocate_public_ip                      = false
      + availability_zone                       = "ap-shanghai-3"
      + create_time                             = (known after apply)
      + disable_monitor_service                 = true
      + disable_security_service                = false
      + expired_time                            = (known after apply)
      + force_delete                            = false
      + id                                      = (known after apply)
      + image_id                                = "img-25szkc8t"
      + instance_charge_type                    = "POSTPAID_BY_HOUR"
      + instance_charge_type_prepaid_renew_flag = (known after apply)
      + instance_name                           = "tf-cvm-test"
      + instance_status                         = (known after apply)
      + instance_type                           = "S5.SMALL2"
      + internet_charge_type                    = (known after apply)
      + internet_max_bandwidth_out              = (known after apply)
      + key_name                                = "skey-7fvz9f2p"
      + private_ip                              = (known after apply)
      + project_id                              = 0
      + public_ip                               = (known after apply)
      + running_flag                            = true
      + security_groups                         = (known after apply)
      + subnet_id                               = (known after apply)
      + system_disk_id                          = (known after apply)
      + system_disk_size                        = 50
      + system_disk_type                        = "CLOUD_PREMIUM"
      + vpc_id                                  = (known after apply)

      + data_disks {
          + data_disk_id           = (known after apply)
          + data_disk_size         = 50
          + data_disk_type         = "CLOUD_THROUGHPUT"
          + delete_with_instance   = true
          + encrypt                = false
          + throughput_performance = 0
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_instance.foo[0]: Creating...
tencentcloud_instance.foo[0]: Still creating... [10s elapsed]
tencentcloud_instance.foo[0]: Still creating... [20s elapsed]
tencentcloud_instance.foo[0]: Still creating... [30s elapsed]
tencentcloud_instance.foo[0]: Still creating... [40s elapsed]
tencentcloud_instance.foo[0]: Still creating... [50s elapsed]
tencentcloud_instance.foo[0]: Still creating... [1m0s elapsed]
tencentcloud_instance.foo[0]: Still creating... [1m10s elapsed]
tencentcloud_instance.foo[0]: Still creating... [1m20s elapsed]
tencentcloud_instance.foo[0]: Still creating... [1m30s elapsed]
tencentcloud_instance.foo[0]: Still creating... [1m40s elapsed]
tencentcloud_instance.foo[0]: Still creating... [1m50s elapsed]
tencentcloud_instance.foo[0]: Still creating... [2m0s elapsed]
tencentcloud_instance.foo[0]: Still creating... [2m10s elapsed]
tencentcloud_instance.foo[0]: Still creating... [2m20s elapsed]
tencentcloud_instance.foo[0]: Still creating... [2m30s elapsed]
tencentcloud_instance.foo[0]: Still creating... [2m40s elapsed]
tencentcloud_instance.foo[0]: Still creating... [2m50s elapsed]
tencentcloud_instance.foo[0]: Still creating... [3m0s elapsed]
tencentcloud_instance.foo[0]: Still creating... [3m10s elapsed]
tencentcloud_instance.foo[0]: Still creating... [3m20s elapsed]
tencentcloud_instance.foo[0]: Still creating... [3m30s elapsed]
tencentcloud_instance.foo[0]: Still creating... [3m40s elapsed]
tencentcloud_instance.foo[0]: Still creating... [3m50s elapsed]
tencentcloud_instance.foo[0]: Still creating... [4m0s elapsed]
tencentcloud_instance.foo[0]: Still creating... [4m10s elapsed]
tencentcloud_instance.foo[0]: Still creating... [4m20s elapsed]
tencentcloud_instance.foo[0]: Still creating... [4m30s elapsed]
tencentcloud_instance.foo[0]: Still creating... [4m40s elapsed]
tencentcloud_instance.foo[0]: Still creating... [4m50s elapsed]

Error: [TencentCloudSDKError] Code=ResourceInsufficient.CloudDiskSoldOut, Message=The specified cloud disk is sold out, RequestId=fe490336-ec9c-49c9-b00e-65f78c5e3b35

  on cvm.tf line 10, in resource "tencentcloud_instance" "foo":
  10: resource "tencentcloud_instance" "foo" {


```

##### 2.new version

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_instance.foo[0] will be created
  + resource "tencentcloud_instance" "foo" {
      + allocate_public_ip                      = false
      + availability_zone                       = "ap-shanghai-3"
      + create_time                             = (known after apply)
      + disable_monitor_service                 = true
      + disable_security_service                = false
      + expired_time                            = (known after apply)
      + force_delete                            = false
      + id                                      = (known after apply)
      + image_id                                = "img-25szkc8t"
      + instance_charge_type                    = "POSTPAID_BY_HOUR"
      + instance_charge_type_prepaid_renew_flag = (known after apply)
      + instance_name                           = "tf-cvm-test"
      + instance_status                         = (known after apply)
      + instance_type                           = "S5.SMALL2"
      + internet_charge_type                    = (known after apply)
      + internet_max_bandwidth_out              = (known after apply)
      + key_name                                = "skey-7fvz9f2p"
      + private_ip                              = (known after apply)
      + project_id                              = 0
      + public_ip                               = (known after apply)
      + running_flag                            = true
      + security_groups                         = (known after apply)
      + subnet_id                               = (known after apply)
      + system_disk_id                          = (known after apply)
      + system_disk_size                        = 50
      + system_disk_type                        = "CLOUD_PREMIUM"
      + vpc_id                                  = (known after apply)

      + data_disks {
          + data_disk_id           = (known after apply)
          + data_disk_size         = 50
          + data_disk_type         = "CLOUD_THROUGHPUT"
          + delete_with_instance   = true
          + encrypt                = false
          + throughput_performance = 0
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_instance.foo[0]: Creating...

Error: [TencentCloudSDKError] Code=ResourceInsufficient.CloudDiskSoldOut, Message=The specified cloud disk is sold out, RequestId=386e3aee-6963-43b3-b460-8e0f07a7cc79

  on cvm.tf line 10, in resource "tencentcloud_instance" "foo":
  10: resource "tencentcloud_instance" "foo" {
```

