### PR TITLE
resource tencentcloud_ssl_certificate fix bug when destroy a certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ ENHANCEMENTS:
 * Resource `tencentcloud_kubernetes_node_pool` add `unschedulable` to sets whether the joining node participates in the schedule.
 * Resource `tencentcloud_kubernetes_scale_worker` add `unschedulable` to sets whether the joining node participates in the schedule.
 
+BUG FIXES:
+
+* Resource `tencentcloud_ssl_certificate` fix bug when trying to destroy a certificate associated with multiple resources.
+
 ## 1.53.9 (March 19, 2021)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ FEATURES:
 * **New Data Source**: `tencentcloud_ssm_secrets` 
 * **New Data Source**: `tencentcloud_ssm_secret_versions` 
 
+ENHANCEMENTS:
+
+* Resource: `tencentcloud_ssl_certificate` refactor logic with api3.0 .
+* Data Source: `tencentcloud_ssl_certificates` refactor logic with api3.0 .
+
 ## 1.54.1 (March 24, 2021)
 
 ENHANCEMENTS:
@@ -28,10 +33,6 @@ ENHANCEMENTS:
 * Resource `tencentcloud_kubernetes_cluster` add `unschedulable` to sets whether the joining node participates in the schedule.
 * Resource `tencentcloud_kubernetes_node_pool` add `unschedulable` to sets whether the joining node participates in the schedule.
 * Resource `tencentcloud_kubernetes_scale_worker` add `unschedulable` to sets whether the joining node participates in the schedule.
-
-BUG FIXES:
-
-* Resource `tencentcloud_ssl_certificate` fix bug when trying to destroy a certificate associated with multiple resources.
 
 ## 1.53.9 (March 19, 2021)
 

--- a/tencentcloud/resource_tc_ssl_certificate.go
+++ b/tencentcloud/resource_tc_ssl_certificate.go
@@ -52,7 +52,7 @@ func resourceTencentCloudSslCertificate() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "Alia name of the SSL certificate.",
+				Description: "Name of the SSL certificate.",
 			},
 			"type": {
 				Type:         schema.TypeString,

--- a/tencentcloud/service_tencent_ssl_certificate.go
+++ b/tencentcloud/service_tencent_ssl_certificate.go
@@ -244,3 +244,25 @@ func (me *SSLService) DescribeCertificates(ctx context.Context, request *ssl.Des
 
 	return
 }
+
+func (me *SSLService) checkCertificateType(ctx context.Context, certId string, checkType string) (bool, error) {
+
+	//get certificate by id
+
+	request := ssl.NewDescribeCertificateDetailRequest()
+	request.CertificateId = helper.String(certId)
+	certificate, err := me.DescribeCertificateDetail(ctx, request)
+	if err != nil {
+		return false, err
+	}
+
+	if certificate != nil && certificate.Response != nil && *certificate.Response.CertificateType == checkType {
+		return true, nil
+	} else {
+		if certificate == nil || certificate.Response == nil || certificate.Response.CertificateId == nil {
+			return false, fmt.Errorf("certificate id %s is not found", certId)
+		}
+		return false, nil
+	}
+
+}

--- a/tencentcloud/service_tencentcloud_clb.go
+++ b/tencentcloud/service_tencentcloud_clb.go
@@ -946,7 +946,7 @@ func checkCertificateInputPara(ctx context.Context, d *schema.ResourceData, meta
 	certPara = &certificateInput
 
 	//check type valid
-	sslService := SslService{client: meta.(*TencentCloudClient).apiV3Conn}
+	sslService := SSLService{client: meta.(*TencentCloudClient).apiV3Conn}
 
 	if certificateInput.CertCaId != nil {
 		check, err := sslService.checkCertificateType(ctx, *certificateInput.CertCaId, SSL_CERT_TYPE_CA)

--- a/tencentcloud/service_tencentcloud_ssl.go
+++ b/tencentcloud/service_tencentcloud_ssl.go
@@ -212,7 +212,7 @@ func (me *SslService) DeleteCertificate(ctx context.Context, id string) error {
 	return nil
 }
 
-func (me *SslService) checkCertificateType(ctx context.Context, certId string, checkType string) (bool, error) {
+func (me *SslService) CheckCertificateType(ctx context.Context, certId string, checkType string) (bool, error) {
 
 	//get certificate by id
 

--- a/website/docs/r/ssl_certificate.html.markdown
+++ b/website/docs/r/ssl_certificate.html.markdown
@@ -29,8 +29,8 @@ The following arguments are supported:
 * `cert` - (Required, ForceNew) Content of the SSL certificate. Not allowed newline at the start and end.
 * `type` - (Required, ForceNew) Type of the SSL certificate. Valid values: `CA` and `SVR`.
 * `key` - (Optional, ForceNew) Key of the SSL certificate and required when certificate type is `SVR`. Not allowed newline at the start and end.
-* `name` - (Optional, ForceNew) Name of the SSL certificate.
-* `project_id` - (Optional, ForceNew) Project ID of the SSL certificate. Default is `0`.
+* `name` - (Optional) Alia name of the SSL certificate.
+* `project_id` - (Optional) Project ID of the SSL certificate. Default is `0`.
 
 ## Attributes Reference
 

--- a/website/docs/r/ssl_certificate.html.markdown
+++ b/website/docs/r/ssl_certificate.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 * `cert` - (Required, ForceNew) Content of the SSL certificate. Not allowed newline at the start and end.
 * `type` - (Required, ForceNew) Type of the SSL certificate. Valid values: `CA` and `SVR`.
 * `key` - (Optional, ForceNew) Key of the SSL certificate and required when certificate type is `SVR`. Not allowed newline at the start and end.
-* `name` - (Optional) Alia name of the SSL certificate.
+* `name` - (Optional) Name of the SSL certificate.
 * `project_id` - (Optional) Project ID of the SSL certificate. Default is `0`.
 
 ## Attributes Reference


### PR DESCRIPTION
## make testacc

##### 1. make testacc TESTARGS="-run=TestAccTencentCloudSslCertificate_basic"

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudSslCertificate_basic -timeout 120m
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/gendoc	0.042s [no tests to run]
=== RUN   TestAccTencentCloudSslCertificate_basic
--- PASS: TestAccTencentCloudSslCertificate_basic (2.66s)
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud	2.676s
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit	[no test files]
```

##### 2. make testacc TESTARGS="-run=TestAccTencentCloudSslCertificate_svr"

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudSslCertificate_svr -timeout 120m
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/gendoc	0.034s [no tests to run]
=== RUN   TestAccTencentCloudSslCertificate_svr
--- PASS: TestAccTencentCloudSslCertificate_svr (2.36s)
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud	2.381s
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit	[no test files]
```

##### 3. make testacc TESTARGS="-run=TestAccDataSourceTencentCloudSslCertificates_basic"

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceTencentCloudSslCertificates_basic -timeout 120m
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/gendoc	0.037s [no tests to run]
=== RUN   TestAccDataSourceTencentCloudSslCertificates_basic
--- PASS: TestAccDataSourceTencentCloudSslCertificates_basic (3.23s)
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud	3.255s
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit	[no test files]
```

##### 4. make testacc TESTARGS="-run=TestAccDataSourceTencentCloudSslCertificates_type"

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceTencentCloudSslCertificates_type -timeout 120m
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/gendoc	0.020s [no tests to run]
=== RUN   TestAccDataSourceTencentCloudSslCertificates_type
--- PASS: TestAccDataSourceTencentCloudSslCertificates_type (3.75s)
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud	3.771s
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit	[no test files]
```

##### 5. make testacc TESTARGS="-run=TestAccDataSourceTencentCloudSslCertificates_id"

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceTencentCloudSslCertificates_id -timeout 120m
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/gendoc	0.011s [no tests to run]
=== RUN   TestAccDataSourceTencentCloudSslCertificates_id
--- PASS: TestAccDataSourceTencentCloudSslCertificates_id (3.30s)
PASS
ok  	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud	3.314s
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper	[no test files]
?   	github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit	[no test files]
```

## terraform CLI

##### 1. old version create

```
terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.tencentcloud_ssl_certificates.ca will be read during apply
  # (config refers to values not yet known)
 <= data "tencentcloud_ssl_certificates" "ca"  {
      + certificates = (known after apply)
      + name         = "ssl-ca"
    }

  # data.tencentcloud_ssl_certificates.svr will be read during apply
  # (config refers to values not yet known)
 <= data "tencentcloud_ssl_certificates" "svr"  {
      + certificates = (known after apply)
      + id           = (known after apply)
      + name         = "ssl-svr"
      + type         = "SVR"
    }

  # tencentcloud_ssl_certificate.ca will be created
  + resource "tencentcloud_ssl_certificate" "ca" {
      + begin_time      = (known after apply)
      + cert            = <<-EOT
            -----BEGIN CERTIFICATE-----
            MIIEDjCCAnagAwIBAgIBATANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
            MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzA4MjBaFw0yOTA4
            MTAwMzA4MjBaMCgxDTALBgNVBAMTBHRlc3QxFzAVBgNVBAoTDnRlcnJhZm9ybSB0
            ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA0k2vqg/GHtFP5P7r
            dbzswfx1jSHeK9r4StV4mGOAoKyzvAJA5BvYbAHpSrL2ZAd6ShjHgRVU1qEroeFn
            8fwTrAVQttMltBFABx7G4iN4Zf6EUXzhhFN6vVVbWaqhYhrdMoPvZxgGSA/4hG4W
            GIr8MXZzXbKLoRoz4Bvq1Ymg5eO14KLJFSTahvIkG60egGN5pmi4czxWy2U7ycA5
            Q5TuQBnF0rKQJW5XKIV3kr5YrzDdJK7up9E6Od4T5jz+qY97KAjIpWD/pTAsc7+6
            fPBpY7NHT9Bw0fDmvsWO/PtswY4hW02n86b5eWA9sfKJGphhsBxgpuuhmxYHS6pA
            B+C7IkyxcADNT5u9tEo2JGOj+/veXKrEhZin7inKsQLD0WOobcg1Rh/3NSWD7geF
            TJBRnzgplaN7cK6c/utEAAnngS38q4DGBR/jHmkWjAeQPZj1eLLBk686HEEbKeU+
            9yAVcPRhA9tuL7wMeSX32VunWZunoA/f8iuGZYJlZsNBqyJbAgMBAAGjQzBBMA8G
            A1UdEwEB/wQFMAMBAf8wDwYDVR0PAQH/BAUDAweGADAdBgNVHQ4EFgQUKwfrmq79
            1mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAInM+aeaHoZdw9B9nAH2
            HscEoOulF+RxnysSXTTRLd2VQph4+ynlfRZT4evLBBj/ppmqjp8F7/OcRiiZwSXl
            namyP/UUINtHfgDM0kll/5Za0aYzMhrORNw+3ythIv2yPJX8t4LmsG1L4PMO8ZU8
            N0K9XyKRaL/tq6rw1gQM152OmNgTzfAQoKYxrvbftOZz4J0ZACctuBmwtp5upKvJ
            36aQ4wJLUzOt69mnW+AaL5EPA37mwtzdnzTTxd3SBfOYXjsflc3l2raljJznnqU2
            ySynjb6L3D3L/pObL1Uu7nQBy8CazJBsBsVFK/pr61vcllm8lG7vOhHOUSFUeezq
            FWukAolm9/cagmD6IhNishM3Uzng+UYyCC8uQq3Z7FGqJpXSI79wZYjudnCLPVCg
            OIfJHQeJFLryn6GxiSYmYs6dgUJiiTV+I/2Y5X7ZFdb5FC1J/WmvoCv6yO7NiirY
            BSgfV0lp5CuV8SfiSClpYfrM28NbNgxveUqET642BJOPLQ==
            -----END CERTIFICATE-----
        EOT
      + create_time     = (known after apply)
      + domain          = (known after apply)
      + end_time        = (known after apply)
      + id              = (known after apply)
      + name            = "ssl-ca"
      + product_zh_name = (known after apply)
      + project_id      = 0
      + status          = (known after apply)
      + subject_names   = (known after apply)
      + type            = "CA"
    }

  # tencentcloud_ssl_certificate.svr will be created
  + resource "tencentcloud_ssl_certificate" "svr" {
      + begin_time      = (known after apply)
      + cert            = <<-EOT
            -----BEGIN CERTIFICATE-----
            MIIERzCCAq+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
            MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzE5MzlaFw0yOTA4
            MTAwMzE5MzlaMC4xEzARBgNVBAMTCnNlcnZlciBzc2wxFzAVBgNVBAoTDnRlcnJh
            Zm9ybS10ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA1Ryp+DKK
            SNFKZsPtwfR+jzOnQ8YFieIKYgakV688d8YgpolenbmeEPrzT87tunFD7G9f6ALG
            ND8rj7npj0AowxhOL/h/v1D9u0UsIaj5i2GWJrqNAhGLaxWiEB/hy5WOiwxDrGei
            gQqJkFM52Ep7G1Yx7PHJmKFGwN9FhIsFi1cNZfVRopZuCe/RMPNusNVZaIi+qcEf
            fsE1cmfmuSlG3Ap0RKOIyR0ajDEzqZn9/0R7VwWCF97qy8TNYk94K/1tq3zyhVzR
            Z83xOSfrTqEfb3so3AU2jyKgYdwr/FZS72VCHS8IslgnqJW4izIXZqgIKmHaRZtM
            N4jUloi6l/6lktt6Lsgh9xECecxziSJtPMaog88aC8HnMqJJ3kScGCL36GYG+Kaw
            5PnDlWXBaeiDe8z/eWK9+Rr2M+rhTNxosAVGfDJyxAXyiX49LQ0v7f9qzwc/0JiD
            bvsUv1cm6OgpoEMP9SXqqBdwGqeKbD2/2jlP48xlYP6l1SoJG3GgZ8dbAgMBAAGj
            djB0MAwGA1UdEwEB/wQCMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0PAQH/
            BAUDAweAADAdBgNVHQ4EFgQULwWKBQNLL9s3cb3tTnyPVg+mpCMwHwYDVR0jBBgw
            FoAUKwfrmq791mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAMo5RglS
            AHdPgaicWJvmvjjexjF/42b7Rz4pPfMjYw6uYO8He/f4UZWv5CZLrbEe7MywaK3y
            0OsfH8AhyN29pv2x8g9wbmq7omZIOZ0oCAGduEXs/A/qY/hFaCohdkz/IN8qi6JW
            VXreGli3SrpcHFchSwHTyJEXgkutcGAsOvdsOuVSmplOyrkLHc8uUe8SG4j8kGyg
            EzaszFjHkR7g1dVyDVUedc588mjkQxYeAamJgfkgIhljWKMa2XzkVMcVfQHfNpM1
            n+bu8SmqRt9Wma2bMijKRG/Blm756LoI+skY+WRZmlDnq8zj95TT0vceGP0FUWh5
            hKyiocABmpQs9OK9HMi8vgSWISP+fYgkm/bKtKup2NbZBoO5/VL2vCEPInYzUhBO
            jCbLMjNjtM5KriCaR7wDARgHiG0gBEPOEW1PIjZ9UOH+LtIxbNZ4eEIIINLHnBHf
            L+doVeZtS/gJc4G4Adr5HYuaS9ZxJ0W2uy0eQlOHzjyxR6Mf/rpnilJlcQ==
            -----END CERTIFICATE-----
        EOT
      + create_time     = (known after apply)
      + domain          = (known after apply)
      + end_time        = (known after apply)
      + id              = (known after apply)
      + key             = (sensitive value)
      + name            = "ssl-svr"
      + product_zh_name = (known after apply)
      + project_id      = 0
      + status          = (known after apply)
      + subject_names   = (known after apply)
      + type            = "SVR"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_ssl_certificate.svr: Creating...
tencentcloud_ssl_certificate.ca: Creating...
tencentcloud_ssl_certificate.ca: Creation complete after 1s [id=lMuPPxPm]
data.tencentcloud_ssl_certificates.ca: Reading...
tencentcloud_ssl_certificate.svr: Creation complete after 1s [id=lMuPPygt]
data.tencentcloud_ssl_certificates.svr: Reading...
data.tencentcloud_ssl_certificates.ca: Read complete after 0s [id=867198670]
data.tencentcloud_ssl_certificates.svr: Read complete after 0s [id=824728486]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

##### 2. old version show

```
terraform show
# data.tencentcloud_ssl_certificates.ca:
data "tencentcloud_ssl_certificates" "ca" {
    certificates = [
        {
            begin_time      = "2019-08-13 11:08:20"
            cert            = <<-EOT
                -----BEGIN CERTIFICATE-----
                MIIEDjCCAnagAwIBAgIBATANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
                MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzA4MjBaFw0yOTA4
                MTAwMzA4MjBaMCgxDTALBgNVBAMTBHRlc3QxFzAVBgNVBAoTDnRlcnJhZm9ybSB0
                ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA0k2vqg/GHtFP5P7r
                dbzswfx1jSHeK9r4StV4mGOAoKyzvAJA5BvYbAHpSrL2ZAd6ShjHgRVU1qEroeFn
                8fwTrAVQttMltBFABx7G4iN4Zf6EUXzhhFN6vVVbWaqhYhrdMoPvZxgGSA/4hG4W
                GIr8MXZzXbKLoRoz4Bvq1Ymg5eO14KLJFSTahvIkG60egGN5pmi4czxWy2U7ycA5
                Q5TuQBnF0rKQJW5XKIV3kr5YrzDdJK7up9E6Od4T5jz+qY97KAjIpWD/pTAsc7+6
                fPBpY7NHT9Bw0fDmvsWO/PtswY4hW02n86b5eWA9sfKJGphhsBxgpuuhmxYHS6pA
                B+C7IkyxcADNT5u9tEo2JGOj+/veXKrEhZin7inKsQLD0WOobcg1Rh/3NSWD7geF
                TJBRnzgplaN7cK6c/utEAAnngS38q4DGBR/jHmkWjAeQPZj1eLLBk686HEEbKeU+
                9yAVcPRhA9tuL7wMeSX32VunWZunoA/f8iuGZYJlZsNBqyJbAgMBAAGjQzBBMA8G
                A1UdEwEB/wQFMAMBAf8wDwYDVR0PAQH/BAUDAweGADAdBgNVHQ4EFgQUKwfrmq79
                1mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAInM+aeaHoZdw9B9nAH2
                HscEoOulF+RxnysSXTTRLd2VQph4+ynlfRZT4evLBBj/ppmqjp8F7/OcRiiZwSXl
                namyP/UUINtHfgDM0kll/5Za0aYzMhrORNw+3ythIv2yPJX8t4LmsG1L4PMO8ZU8
                N0K9XyKRaL/tq6rw1gQM152OmNgTzfAQoKYxrvbftOZz4J0ZACctuBmwtp5upKvJ
                36aQ4wJLUzOt69mnW+AaL5EPA37mwtzdnzTTxd3SBfOYXjsflc3l2raljJznnqU2
                ySynjb6L3D3L/pObL1Uu7nQBy8CazJBsBsVFK/pr61vcllm8lG7vOhHOUSFUeezq
                FWukAolm9/cagmD6IhNishM3Uzng+UYyCC8uQq3Z7FGqJpXSI79wZYjudnCLPVCg
                OIfJHQeJFLryn6GxiSYmYs6dgUJiiTV+I/2Y5X7ZFdb5FC1J/WmvoCv6yO7NiirY
                BSgfV0lp5CuV8SfiSClpYfrM28NbNgxveUqET642BJOPLQ==
                -----END CERTIFICATE-----
            EOT
            create_time     = "2021-03-25 18:05:07"
            domain          = "test"
            end_time        = "2029-08-10 11:08:20"
            id              = "lMuPPxPm"
            name            = "ssl-ca"
            product_zh_name = "test"
            project_id      = 0
            status          = 1
            subject_names   = []
            type            = "CA"
        },
    ]
    id           = "867198670"
    name         = "ssl-ca"
}

# data.tencentcloud_ssl_certificates.svr:
data "tencentcloud_ssl_certificates" "svr" {
    certificates = [
        {
            begin_time      = "2019-08-13 11:19:39"
            cert            = <<-EOT
                -----BEGIN CERTIFICATE-----
                MIIERzCCAq+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
                MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzE5MzlaFw0yOTA4
                MTAwMzE5MzlaMC4xEzARBgNVBAMTCnNlcnZlciBzc2wxFzAVBgNVBAoTDnRlcnJh
                Zm9ybS10ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA1Ryp+DKK
                SNFKZsPtwfR+jzOnQ8YFieIKYgakV688d8YgpolenbmeEPrzT87tunFD7G9f6ALG
                ND8rj7npj0AowxhOL/h/v1D9u0UsIaj5i2GWJrqNAhGLaxWiEB/hy5WOiwxDrGei
                gQqJkFM52Ep7G1Yx7PHJmKFGwN9FhIsFi1cNZfVRopZuCe/RMPNusNVZaIi+qcEf
                fsE1cmfmuSlG3Ap0RKOIyR0ajDEzqZn9/0R7VwWCF97qy8TNYk94K/1tq3zyhVzR
                Z83xOSfrTqEfb3so3AU2jyKgYdwr/FZS72VCHS8IslgnqJW4izIXZqgIKmHaRZtM
                N4jUloi6l/6lktt6Lsgh9xECecxziSJtPMaog88aC8HnMqJJ3kScGCL36GYG+Kaw
                5PnDlWXBaeiDe8z/eWK9+Rr2M+rhTNxosAVGfDJyxAXyiX49LQ0v7f9qzwc/0JiD
                bvsUv1cm6OgpoEMP9SXqqBdwGqeKbD2/2jlP48xlYP6l1SoJG3GgZ8dbAgMBAAGj
                djB0MAwGA1UdEwEB/wQCMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0PAQH/
                BAUDAweAADAdBgNVHQ4EFgQULwWKBQNLL9s3cb3tTnyPVg+mpCMwHwYDVR0jBBgw
                FoAUKwfrmq791mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAMo5RglS
                AHdPgaicWJvmvjjexjF/42b7Rz4pPfMjYw6uYO8He/f4UZWv5CZLrbEe7MywaK3y
                0OsfH8AhyN29pv2x8g9wbmq7omZIOZ0oCAGduEXs/A/qY/hFaCohdkz/IN8qi6JW
                VXreGli3SrpcHFchSwHTyJEXgkutcGAsOvdsOuVSmplOyrkLHc8uUe8SG4j8kGyg
                EzaszFjHkR7g1dVyDVUedc588mjkQxYeAamJgfkgIhljWKMa2XzkVMcVfQHfNpM1
                n+bu8SmqRt9Wma2bMijKRG/Blm756LoI+skY+WRZmlDnq8zj95TT0vceGP0FUWh5
                hKyiocABmpQs9OK9HMi8vgSWISP+fYgkm/bKtKup2NbZBoO5/VL2vCEPInYzUhBO
                jCbLMjNjtM5KriCaR7wDARgHiG0gBEPOEW1PIjZ9UOH+LtIxbNZ4eEIIINLHnBHf
                L+doVeZtS/gJc4G4Adr5HYuaS9ZxJ0W2uy0eQlOHzjyxR6Mf/rpnilJlcQ==
                -----END CERTIFICATE-----
            EOT
            create_time     = "2021-03-25 18:05:07"
            domain          = "server ssl"
            end_time        = "2029-08-10 11:19:39"
            id              = "lMuPPygt"
            name            = "ssl-svr"
            product_zh_name = "test"
            project_id      = 0
            status          = 1
            subject_names   = []
            type            = "SVR"
        },
    ]
    id           = "824728486"
    name         = "ssl-svr"
    type         = "SVR"
}

# tencentcloud_ssl_certificate.ca:
resource "tencentcloud_ssl_certificate" "ca" {
    begin_time      = "2019-08-13 11:08:20"
    cert            = <<-EOT
        -----BEGIN CERTIFICATE-----
        MIIEDjCCAnagAwIBAgIBATANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
        MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzA4MjBaFw0yOTA4
        MTAwMzA4MjBaMCgxDTALBgNVBAMTBHRlc3QxFzAVBgNVBAoTDnRlcnJhZm9ybSB0
        ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA0k2vqg/GHtFP5P7r
        dbzswfx1jSHeK9r4StV4mGOAoKyzvAJA5BvYbAHpSrL2ZAd6ShjHgRVU1qEroeFn
        8fwTrAVQttMltBFABx7G4iN4Zf6EUXzhhFN6vVVbWaqhYhrdMoPvZxgGSA/4hG4W
        GIr8MXZzXbKLoRoz4Bvq1Ymg5eO14KLJFSTahvIkG60egGN5pmi4czxWy2U7ycA5
        Q5TuQBnF0rKQJW5XKIV3kr5YrzDdJK7up9E6Od4T5jz+qY97KAjIpWD/pTAsc7+6
        fPBpY7NHT9Bw0fDmvsWO/PtswY4hW02n86b5eWA9sfKJGphhsBxgpuuhmxYHS6pA
        B+C7IkyxcADNT5u9tEo2JGOj+/veXKrEhZin7inKsQLD0WOobcg1Rh/3NSWD7geF
        TJBRnzgplaN7cK6c/utEAAnngS38q4DGBR/jHmkWjAeQPZj1eLLBk686HEEbKeU+
        9yAVcPRhA9tuL7wMeSX32VunWZunoA/f8iuGZYJlZsNBqyJbAgMBAAGjQzBBMA8G
        A1UdEwEB/wQFMAMBAf8wDwYDVR0PAQH/BAUDAweGADAdBgNVHQ4EFgQUKwfrmq79
        1mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAInM+aeaHoZdw9B9nAH2
        HscEoOulF+RxnysSXTTRLd2VQph4+ynlfRZT4evLBBj/ppmqjp8F7/OcRiiZwSXl
        namyP/UUINtHfgDM0kll/5Za0aYzMhrORNw+3ythIv2yPJX8t4LmsG1L4PMO8ZU8
        N0K9XyKRaL/tq6rw1gQM152OmNgTzfAQoKYxrvbftOZz4J0ZACctuBmwtp5upKvJ
        36aQ4wJLUzOt69mnW+AaL5EPA37mwtzdnzTTxd3SBfOYXjsflc3l2raljJznnqU2
        ySynjb6L3D3L/pObL1Uu7nQBy8CazJBsBsVFK/pr61vcllm8lG7vOhHOUSFUeezq
        FWukAolm9/cagmD6IhNishM3Uzng+UYyCC8uQq3Z7FGqJpXSI79wZYjudnCLPVCg
        OIfJHQeJFLryn6GxiSYmYs6dgUJiiTV+I/2Y5X7ZFdb5FC1J/WmvoCv6yO7NiirY
        BSgfV0lp5CuV8SfiSClpYfrM28NbNgxveUqET642BJOPLQ==
        -----END CERTIFICATE-----
    EOT
    create_time     = "2021-03-25 18:05:07"
    domain          = "test"
    end_time        = "2029-08-10 11:08:20"
    id              = "lMuPPxPm"
    name            = "ssl-ca"
    product_zh_name = "test"
    project_id      = 0
    status          = 1
    subject_names   = []
    type            = "CA"
}

# tencentcloud_ssl_certificate.svr:
resource "tencentcloud_ssl_certificate" "svr" {
    begin_time      = "2019-08-13 11:19:39"
    cert            = <<-EOT
        -----BEGIN CERTIFICATE-----
        MIIERzCCAq+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
        MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzE5MzlaFw0yOTA4
        MTAwMzE5MzlaMC4xEzARBgNVBAMTCnNlcnZlciBzc2wxFzAVBgNVBAoTDnRlcnJh
        Zm9ybS10ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA1Ryp+DKK
        SNFKZsPtwfR+jzOnQ8YFieIKYgakV688d8YgpolenbmeEPrzT87tunFD7G9f6ALG
        ND8rj7npj0AowxhOL/h/v1D9u0UsIaj5i2GWJrqNAhGLaxWiEB/hy5WOiwxDrGei
        gQqJkFM52Ep7G1Yx7PHJmKFGwN9FhIsFi1cNZfVRopZuCe/RMPNusNVZaIi+qcEf
        fsE1cmfmuSlG3Ap0RKOIyR0ajDEzqZn9/0R7VwWCF97qy8TNYk94K/1tq3zyhVzR
        Z83xOSfrTqEfb3so3AU2jyKgYdwr/FZS72VCHS8IslgnqJW4izIXZqgIKmHaRZtM
        N4jUloi6l/6lktt6Lsgh9xECecxziSJtPMaog88aC8HnMqJJ3kScGCL36GYG+Kaw
        5PnDlWXBaeiDe8z/eWK9+Rr2M+rhTNxosAVGfDJyxAXyiX49LQ0v7f9qzwc/0JiD
        bvsUv1cm6OgpoEMP9SXqqBdwGqeKbD2/2jlP48xlYP6l1SoJG3GgZ8dbAgMBAAGj
        djB0MAwGA1UdEwEB/wQCMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0PAQH/
        BAUDAweAADAdBgNVHQ4EFgQULwWKBQNLL9s3cb3tTnyPVg+mpCMwHwYDVR0jBBgw
        FoAUKwfrmq791mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAMo5RglS
        AHdPgaicWJvmvjjexjF/42b7Rz4pPfMjYw6uYO8He/f4UZWv5CZLrbEe7MywaK3y
        0OsfH8AhyN29pv2x8g9wbmq7omZIOZ0oCAGduEXs/A/qY/hFaCohdkz/IN8qi6JW
        VXreGli3SrpcHFchSwHTyJEXgkutcGAsOvdsOuVSmplOyrkLHc8uUe8SG4j8kGyg
        EzaszFjHkR7g1dVyDVUedc588mjkQxYeAamJgfkgIhljWKMa2XzkVMcVfQHfNpM1
        n+bu8SmqRt9Wma2bMijKRG/Blm756LoI+skY+WRZmlDnq8zj95TT0vceGP0FUWh5
        hKyiocABmpQs9OK9HMi8vgSWISP+fYgkm/bKtKup2NbZBoO5/VL2vCEPInYzUhBO
        jCbLMjNjtM5KriCaR7wDARgHiG0gBEPOEW1PIjZ9UOH+LtIxbNZ4eEIIINLHnBHf
        L+doVeZtS/gJc4G4Adr5HYuaS9ZxJ0W2uy0eQlOHzjyxR6Mf/rpnilJlcQ==
        -----END CERTIFICATE-----
    EOT
    create_time     = "2021-03-25 18:05:07"
    domain          = "server ssl"
    end_time        = "2029-08-10 11:19:39"
    id              = "lMuPPygt"
    key             = (sensitive value)
    name            = "ssl-svr"
    product_zh_name = "test"
    project_id      = 0
    status          = 1
    subject_names   = []
    type            = "SVR"
}
```

##### 3. old version in new version

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

tencentcloud_ssl_certificate.ca: Refreshing state... [id=lMuPPxPm]
tencentcloud_ssl_certificate.svr: Refreshing state... [id=lMuPPygt]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

```
terraform show
# data.tencentcloud_ssl_certificates.ca:
data "tencentcloud_ssl_certificates" "ca" {
    certificates = [
        {
            begin_time      = "2019-08-13 11:08:20"
            cert            = <<-EOT
                -----BEGIN CERTIFICATE-----
                MIIEDjCCAnagAwIBAgIBATANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
                MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzA4MjBaFw0yOTA4
                MTAwMzA4MjBaMCgxDTALBgNVBAMTBHRlc3QxFzAVBgNVBAoTDnRlcnJhZm9ybSB0
                ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA0k2vqg/GHtFP5P7r
                dbzswfx1jSHeK9r4StV4mGOAoKyzvAJA5BvYbAHpSrL2ZAd6ShjHgRVU1qEroeFn
                8fwTrAVQttMltBFABx7G4iN4Zf6EUXzhhFN6vVVbWaqhYhrdMoPvZxgGSA/4hG4W
                GIr8MXZzXbKLoRoz4Bvq1Ymg5eO14KLJFSTahvIkG60egGN5pmi4czxWy2U7ycA5
                Q5TuQBnF0rKQJW5XKIV3kr5YrzDdJK7up9E6Od4T5jz+qY97KAjIpWD/pTAsc7+6
                fPBpY7NHT9Bw0fDmvsWO/PtswY4hW02n86b5eWA9sfKJGphhsBxgpuuhmxYHS6pA
                B+C7IkyxcADNT5u9tEo2JGOj+/veXKrEhZin7inKsQLD0WOobcg1Rh/3NSWD7geF
                TJBRnzgplaN7cK6c/utEAAnngS38q4DGBR/jHmkWjAeQPZj1eLLBk686HEEbKeU+
                9yAVcPRhA9tuL7wMeSX32VunWZunoA/f8iuGZYJlZsNBqyJbAgMBAAGjQzBBMA8G
                A1UdEwEB/wQFMAMBAf8wDwYDVR0PAQH/BAUDAweGADAdBgNVHQ4EFgQUKwfrmq79
                1mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAInM+aeaHoZdw9B9nAH2
                HscEoOulF+RxnysSXTTRLd2VQph4+ynlfRZT4evLBBj/ppmqjp8F7/OcRiiZwSXl
                namyP/UUINtHfgDM0kll/5Za0aYzMhrORNw+3ythIv2yPJX8t4LmsG1L4PMO8ZU8
                N0K9XyKRaL/tq6rw1gQM152OmNgTzfAQoKYxrvbftOZz4J0ZACctuBmwtp5upKvJ
                36aQ4wJLUzOt69mnW+AaL5EPA37mwtzdnzTTxd3SBfOYXjsflc3l2raljJznnqU2
                ySynjb6L3D3L/pObL1Uu7nQBy8CazJBsBsVFK/pr61vcllm8lG7vOhHOUSFUeezq
                FWukAolm9/cagmD6IhNishM3Uzng+UYyCC8uQq3Z7FGqJpXSI79wZYjudnCLPVCg
                OIfJHQeJFLryn6GxiSYmYs6dgUJiiTV+I/2Y5X7ZFdb5FC1J/WmvoCv6yO7NiirY
                BSgfV0lp5CuV8SfiSClpYfrM28NbNgxveUqET642BJOPLQ==
                -----END CERTIFICATE-----
            EOT
            create_time     = "2021-03-25 18:05:07"
            domain          = "test"
            end_time        = "2029-08-10 11:08:20"
            id              = "lMuPPxPm"
            name            = "ssl-ca"
            product_zh_name = "test"
            project_id      = 0
            status          = 1
            subject_names   = []
            type            = "CA"
        },
    ]
    id           = "867198670"
    name         = "ssl-ca"
}

# data.tencentcloud_ssl_certificates.svr:
data "tencentcloud_ssl_certificates" "svr" {
    certificates = [
        {
            begin_time      = "2019-08-13 11:19:39"
            cert            = <<-EOT
                -----BEGIN CERTIFICATE-----
                MIIERzCCAq+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
                MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzE5MzlaFw0yOTA4
                MTAwMzE5MzlaMC4xEzARBgNVBAMTCnNlcnZlciBzc2wxFzAVBgNVBAoTDnRlcnJh
                Zm9ybS10ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA1Ryp+DKK
                SNFKZsPtwfR+jzOnQ8YFieIKYgakV688d8YgpolenbmeEPrzT87tunFD7G9f6ALG
                ND8rj7npj0AowxhOL/h/v1D9u0UsIaj5i2GWJrqNAhGLaxWiEB/hy5WOiwxDrGei
                gQqJkFM52Ep7G1Yx7PHJmKFGwN9FhIsFi1cNZfVRopZuCe/RMPNusNVZaIi+qcEf
                fsE1cmfmuSlG3Ap0RKOIyR0ajDEzqZn9/0R7VwWCF97qy8TNYk94K/1tq3zyhVzR
                Z83xOSfrTqEfb3so3AU2jyKgYdwr/FZS72VCHS8IslgnqJW4izIXZqgIKmHaRZtM
                N4jUloi6l/6lktt6Lsgh9xECecxziSJtPMaog88aC8HnMqJJ3kScGCL36GYG+Kaw
                5PnDlWXBaeiDe8z/eWK9+Rr2M+rhTNxosAVGfDJyxAXyiX49LQ0v7f9qzwc/0JiD
                bvsUv1cm6OgpoEMP9SXqqBdwGqeKbD2/2jlP48xlYP6l1SoJG3GgZ8dbAgMBAAGj
                djB0MAwGA1UdEwEB/wQCMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0PAQH/
                BAUDAweAADAdBgNVHQ4EFgQULwWKBQNLL9s3cb3tTnyPVg+mpCMwHwYDVR0jBBgw
                FoAUKwfrmq791mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAMo5RglS
                AHdPgaicWJvmvjjexjF/42b7Rz4pPfMjYw6uYO8He/f4UZWv5CZLrbEe7MywaK3y
                0OsfH8AhyN29pv2x8g9wbmq7omZIOZ0oCAGduEXs/A/qY/hFaCohdkz/IN8qi6JW
                VXreGli3SrpcHFchSwHTyJEXgkutcGAsOvdsOuVSmplOyrkLHc8uUe8SG4j8kGyg
                EzaszFjHkR7g1dVyDVUedc588mjkQxYeAamJgfkgIhljWKMa2XzkVMcVfQHfNpM1
                n+bu8SmqRt9Wma2bMijKRG/Blm756LoI+skY+WRZmlDnq8zj95TT0vceGP0FUWh5
                hKyiocABmpQs9OK9HMi8vgSWISP+fYgkm/bKtKup2NbZBoO5/VL2vCEPInYzUhBO
                jCbLMjNjtM5KriCaR7wDARgHiG0gBEPOEW1PIjZ9UOH+LtIxbNZ4eEIIINLHnBHf
                L+doVeZtS/gJc4G4Adr5HYuaS9ZxJ0W2uy0eQlOHzjyxR6Mf/rpnilJlcQ==
                -----END CERTIFICATE-----
            EOT
            create_time     = "2021-03-25 18:05:07"
            domain          = "server ssl"
            end_time        = "2029-08-10 11:19:39"
            id              = "lMuPPygt"
            name            = "ssl-svr"
            product_zh_name = "test"
            project_id      = 0
            status          = 1
            subject_names   = []
            type            = "SVR"
        },
    ]
    id           = "824728486"
    name         = "ssl-svr"
    type         = "SVR"
}

# tencentcloud_ssl_certificate.ca:
resource "tencentcloud_ssl_certificate" "ca" {
    begin_time      = "2019-08-13 11:08:20"
    cert            = <<-EOT
        -----BEGIN CERTIFICATE-----
        MIIEDjCCAnagAwIBAgIBATANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
        MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzA4MjBaFw0yOTA4
        MTAwMzA4MjBaMCgxDTALBgNVBAMTBHRlc3QxFzAVBgNVBAoTDnRlcnJhZm9ybSB0
        ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA0k2vqg/GHtFP5P7r
        dbzswfx1jSHeK9r4StV4mGOAoKyzvAJA5BvYbAHpSrL2ZAd6ShjHgRVU1qEroeFn
        8fwTrAVQttMltBFABx7G4iN4Zf6EUXzhhFN6vVVbWaqhYhrdMoPvZxgGSA/4hG4W
        GIr8MXZzXbKLoRoz4Bvq1Ymg5eO14KLJFSTahvIkG60egGN5pmi4czxWy2U7ycA5
        Q5TuQBnF0rKQJW5XKIV3kr5YrzDdJK7up9E6Od4T5jz+qY97KAjIpWD/pTAsc7+6
        fPBpY7NHT9Bw0fDmvsWO/PtswY4hW02n86b5eWA9sfKJGphhsBxgpuuhmxYHS6pA
        B+C7IkyxcADNT5u9tEo2JGOj+/veXKrEhZin7inKsQLD0WOobcg1Rh/3NSWD7geF
        TJBRnzgplaN7cK6c/utEAAnngS38q4DGBR/jHmkWjAeQPZj1eLLBk686HEEbKeU+
        9yAVcPRhA9tuL7wMeSX32VunWZunoA/f8iuGZYJlZsNBqyJbAgMBAAGjQzBBMA8G
        A1UdEwEB/wQFMAMBAf8wDwYDVR0PAQH/BAUDAweGADAdBgNVHQ4EFgQUKwfrmq79
        1mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAInM+aeaHoZdw9B9nAH2
        HscEoOulF+RxnysSXTTRLd2VQph4+ynlfRZT4evLBBj/ppmqjp8F7/OcRiiZwSXl
        namyP/UUINtHfgDM0kll/5Za0aYzMhrORNw+3ythIv2yPJX8t4LmsG1L4PMO8ZU8
        N0K9XyKRaL/tq6rw1gQM152OmNgTzfAQoKYxrvbftOZz4J0ZACctuBmwtp5upKvJ
        36aQ4wJLUzOt69mnW+AaL5EPA37mwtzdnzTTxd3SBfOYXjsflc3l2raljJznnqU2
        ySynjb6L3D3L/pObL1Uu7nQBy8CazJBsBsVFK/pr61vcllm8lG7vOhHOUSFUeezq
        FWukAolm9/cagmD6IhNishM3Uzng+UYyCC8uQq3Z7FGqJpXSI79wZYjudnCLPVCg
        OIfJHQeJFLryn6GxiSYmYs6dgUJiiTV+I/2Y5X7ZFdb5FC1J/WmvoCv6yO7NiirY
        BSgfV0lp5CuV8SfiSClpYfrM28NbNgxveUqET642BJOPLQ==
        -----END CERTIFICATE-----
    EOT
    create_time     = "2021-03-25 18:05:07"
    domain          = "test"
    end_time        = "2029-08-10 11:08:20"
    id              = "lMuPPxPm"
    name            = "ssl-ca"
    product_zh_name = "test"
    project_id      = 0
    status          = 1
    subject_names   = []
    type            = "CA"
}

# tencentcloud_ssl_certificate.svr:
resource "tencentcloud_ssl_certificate" "svr" {
    begin_time      = "2019-08-13 11:19:39"
    cert            = <<-EOT
        -----BEGIN CERTIFICATE-----
        MIIERzCCAq+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
        MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzE5MzlaFw0yOTA4
        MTAwMzE5MzlaMC4xEzARBgNVBAMTCnNlcnZlciBzc2wxFzAVBgNVBAoTDnRlcnJh
        Zm9ybS10ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA1Ryp+DKK
        SNFKZsPtwfR+jzOnQ8YFieIKYgakV688d8YgpolenbmeEPrzT87tunFD7G9f6ALG
        ND8rj7npj0AowxhOL/h/v1D9u0UsIaj5i2GWJrqNAhGLaxWiEB/hy5WOiwxDrGei
        gQqJkFM52Ep7G1Yx7PHJmKFGwN9FhIsFi1cNZfVRopZuCe/RMPNusNVZaIi+qcEf
        fsE1cmfmuSlG3Ap0RKOIyR0ajDEzqZn9/0R7VwWCF97qy8TNYk94K/1tq3zyhVzR
        Z83xOSfrTqEfb3so3AU2jyKgYdwr/FZS72VCHS8IslgnqJW4izIXZqgIKmHaRZtM
        N4jUloi6l/6lktt6Lsgh9xECecxziSJtPMaog88aC8HnMqJJ3kScGCL36GYG+Kaw
        5PnDlWXBaeiDe8z/eWK9+Rr2M+rhTNxosAVGfDJyxAXyiX49LQ0v7f9qzwc/0JiD
        bvsUv1cm6OgpoEMP9SXqqBdwGqeKbD2/2jlP48xlYP6l1SoJG3GgZ8dbAgMBAAGj
        djB0MAwGA1UdEwEB/wQCMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0PAQH/
        BAUDAweAADAdBgNVHQ4EFgQULwWKBQNLL9s3cb3tTnyPVg+mpCMwHwYDVR0jBBgw
        FoAUKwfrmq791mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAMo5RglS
        AHdPgaicWJvmvjjexjF/42b7Rz4pPfMjYw6uYO8He/f4UZWv5CZLrbEe7MywaK3y
        0OsfH8AhyN29pv2x8g9wbmq7omZIOZ0oCAGduEXs/A/qY/hFaCohdkz/IN8qi6JW
        VXreGli3SrpcHFchSwHTyJEXgkutcGAsOvdsOuVSmplOyrkLHc8uUe8SG4j8kGyg
        EzaszFjHkR7g1dVyDVUedc588mjkQxYeAamJgfkgIhljWKMa2XzkVMcVfQHfNpM1
        n+bu8SmqRt9Wma2bMijKRG/Blm756LoI+skY+WRZmlDnq8zj95TT0vceGP0FUWh5
        hKyiocABmpQs9OK9HMi8vgSWISP+fYgkm/bKtKup2NbZBoO5/VL2vCEPInYzUhBO
        jCbLMjNjtM5KriCaR7wDARgHiG0gBEPOEW1PIjZ9UOH+LtIxbNZ4eEIIINLHnBHf
        L+doVeZtS/gJc4G4Adr5HYuaS9ZxJ0W2uy0eQlOHzjyxR6Mf/rpnilJlcQ==
        -----END CERTIFICATE-----
    EOT
    create_time     = "2021-03-25 18:05:07"
    domain          = "server ssl"
    end_time        = "2029-08-10 11:19:39"
    id              = "lMuPPygt"
    key             = (sensitive value)
    name            = "ssl-svr"
    product_zh_name = "test"
    project_id      = 0
    status          = 1
    subject_names   = []
    type            = "SVR"
}
```

##### 4. new version modify

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

tencentcloud_ssl_certificate.ca: Refreshing state... [id=lMuPPxPm]
tencentcloud_ssl_certificate.svr: Refreshing state... [id=lMuPPygt]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
 <= read (data resources)

Terraform will perform the following actions:

  # data.tencentcloud_ssl_certificates.ca will be read during apply
  # (config refers to values not yet known)
 <= data "tencentcloud_ssl_certificates" "ca"  {
      ~ certificates = [
          - {
              - begin_time      = "2019-08-13 11:08:20"
              - cert            = <<-EOT
                    -----BEGIN CERTIFICATE-----
                    MIIEDjCCAnagAwIBAgIBATANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
                    MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzA4MjBaFw0yOTA4
                    MTAwMzA4MjBaMCgxDTALBgNVBAMTBHRlc3QxFzAVBgNVBAoTDnRlcnJhZm9ybSB0
                    ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA0k2vqg/GHtFP5P7r
                    dbzswfx1jSHeK9r4StV4mGOAoKyzvAJA5BvYbAHpSrL2ZAd6ShjHgRVU1qEroeFn
                    8fwTrAVQttMltBFABx7G4iN4Zf6EUXzhhFN6vVVbWaqhYhrdMoPvZxgGSA/4hG4W
                    GIr8MXZzXbKLoRoz4Bvq1Ymg5eO14KLJFSTahvIkG60egGN5pmi4czxWy2U7ycA5
                    Q5TuQBnF0rKQJW5XKIV3kr5YrzDdJK7up9E6Od4T5jz+qY97KAjIpWD/pTAsc7+6
                    fPBpY7NHT9Bw0fDmvsWO/PtswY4hW02n86b5eWA9sfKJGphhsBxgpuuhmxYHS6pA
                    B+C7IkyxcADNT5u9tEo2JGOj+/veXKrEhZin7inKsQLD0WOobcg1Rh/3NSWD7geF
                    TJBRnzgplaN7cK6c/utEAAnngS38q4DGBR/jHmkWjAeQPZj1eLLBk686HEEbKeU+
                    9yAVcPRhA9tuL7wMeSX32VunWZunoA/f8iuGZYJlZsNBqyJbAgMBAAGjQzBBMA8G
                    A1UdEwEB/wQFMAMBAf8wDwYDVR0PAQH/BAUDAweGADAdBgNVHQ4EFgQUKwfrmq79
                    1mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAInM+aeaHoZdw9B9nAH2
                    HscEoOulF+RxnysSXTTRLd2VQph4+ynlfRZT4evLBBj/ppmqjp8F7/OcRiiZwSXl
                    namyP/UUINtHfgDM0kll/5Za0aYzMhrORNw+3ythIv2yPJX8t4LmsG1L4PMO8ZU8
                    N0K9XyKRaL/tq6rw1gQM152OmNgTzfAQoKYxrvbftOZz4J0ZACctuBmwtp5upKvJ
                    36aQ4wJLUzOt69mnW+AaL5EPA37mwtzdnzTTxd3SBfOYXjsflc3l2raljJznnqU2
                    ySynjb6L3D3L/pObL1Uu7nQBy8CazJBsBsVFK/pr61vcllm8lG7vOhHOUSFUeezq
                    FWukAolm9/cagmD6IhNishM3Uzng+UYyCC8uQq3Z7FGqJpXSI79wZYjudnCLPVCg
                    OIfJHQeJFLryn6GxiSYmYs6dgUJiiTV+I/2Y5X7ZFdb5FC1J/WmvoCv6yO7NiirY
                    BSgfV0lp5CuV8SfiSClpYfrM28NbNgxveUqET642BJOPLQ==
                    -----END CERTIFICATE-----
                EOT
              - create_time     = "2021-03-25 18:05:07"
              - domain          = "test"
              - end_time        = "2029-08-10 11:08:20"
              - id              = "lMuPPxPm"
              - name            = "ssl-ca"
              - product_zh_name = "test"
              - project_id      = 0
              - status          = 1
              - subject_names   = []
              - type            = "CA"
            },
        ] -> (known after apply)
      - id           = "867198670" -> null
      ~ name         = "ssl-ca" -> "ssl-ca-modify"
    }

  # data.tencentcloud_ssl_certificates.svr will be read during apply
  # (config refers to values not yet known)
 <= data "tencentcloud_ssl_certificates" "svr"  {
      ~ certificates = [
          - {
              - begin_time      = "2019-08-13 11:19:39"
              - cert            = <<-EOT
                    -----BEGIN CERTIFICATE-----
                    MIIERzCCAq+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
                    MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzE5MzlaFw0yOTA4
                    MTAwMzE5MzlaMC4xEzARBgNVBAMTCnNlcnZlciBzc2wxFzAVBgNVBAoTDnRlcnJh
                    Zm9ybS10ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA1Ryp+DKK
                    SNFKZsPtwfR+jzOnQ8YFieIKYgakV688d8YgpolenbmeEPrzT87tunFD7G9f6ALG
                    ND8rj7npj0AowxhOL/h/v1D9u0UsIaj5i2GWJrqNAhGLaxWiEB/hy5WOiwxDrGei
                    gQqJkFM52Ep7G1Yx7PHJmKFGwN9FhIsFi1cNZfVRopZuCe/RMPNusNVZaIi+qcEf
                    fsE1cmfmuSlG3Ap0RKOIyR0ajDEzqZn9/0R7VwWCF97qy8TNYk94K/1tq3zyhVzR
                    Z83xOSfrTqEfb3so3AU2jyKgYdwr/FZS72VCHS8IslgnqJW4izIXZqgIKmHaRZtM
                    N4jUloi6l/6lktt6Lsgh9xECecxziSJtPMaog88aC8HnMqJJ3kScGCL36GYG+Kaw
                    5PnDlWXBaeiDe8z/eWK9+Rr2M+rhTNxosAVGfDJyxAXyiX49LQ0v7f9qzwc/0JiD
                    bvsUv1cm6OgpoEMP9SXqqBdwGqeKbD2/2jlP48xlYP6l1SoJG3GgZ8dbAgMBAAGj
                    djB0MAwGA1UdEwEB/wQCMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0PAQH/
                    BAUDAweAADAdBgNVHQ4EFgQULwWKBQNLL9s3cb3tTnyPVg+mpCMwHwYDVR0jBBgw
                    FoAUKwfrmq791mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAMo5RglS
                    AHdPgaicWJvmvjjexjF/42b7Rz4pPfMjYw6uYO8He/f4UZWv5CZLrbEe7MywaK3y
                    0OsfH8AhyN29pv2x8g9wbmq7omZIOZ0oCAGduEXs/A/qY/hFaCohdkz/IN8qi6JW
                    VXreGli3SrpcHFchSwHTyJEXgkutcGAsOvdsOuVSmplOyrkLHc8uUe8SG4j8kGyg
                    EzaszFjHkR7g1dVyDVUedc588mjkQxYeAamJgfkgIhljWKMa2XzkVMcVfQHfNpM1
                    n+bu8SmqRt9Wma2bMijKRG/Blm756LoI+skY+WRZmlDnq8zj95TT0vceGP0FUWh5
                    hKyiocABmpQs9OK9HMi8vgSWISP+fYgkm/bKtKup2NbZBoO5/VL2vCEPInYzUhBO
                    jCbLMjNjtM5KriCaR7wDARgHiG0gBEPOEW1PIjZ9UOH+LtIxbNZ4eEIIINLHnBHf
                    L+doVeZtS/gJc4G4Adr5HYuaS9ZxJ0W2uy0eQlOHzjyxR6Mf/rpnilJlcQ==
                    -----END CERTIFICATE-----
                EOT
              - create_time     = "2021-03-25 18:05:07"
              - domain          = "server ssl"
              - end_time        = "2029-08-10 11:19:39"
              - id              = "lMuPPygt"
              - name            = "ssl-svr"
              - product_zh_name = "test"
              - project_id      = 0
              - status          = 1
              - subject_names   = []
              - type            = "SVR"
            },
        ] -> (known after apply)
      ~ id           = "824728486" -> "lMuPPygt"
        name         = "ssl-svr"
        # (1 unchanged attribute hidden)
    }

  # tencentcloud_ssl_certificate.ca will be updated in-place
  ~ resource "tencentcloud_ssl_certificate" "ca" {
        id              = "lMuPPxPm"
      ~ name            = "ssl-ca" -> "ssl-ca-modify"
        # (10 unchanged attributes hidden)
    }

  # tencentcloud_ssl_certificate.svr will be updated in-place
  ~ resource "tencentcloud_ssl_certificate" "svr" {
        id              = "lMuPPygt"
        name            = "ssl-svr"
      ~ project_id      = 0 -> 1154137
        # (10 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_ssl_certificate.ca: Modifying... [id=lMuPPxPm]
tencentcloud_ssl_certificate.svr: Modifying... [id=lMuPPygt]
tencentcloud_ssl_certificate.ca: Modifications complete after 1s [id=lMuPPxPm]
data.tencentcloud_ssl_certificates.ca: Reading... [id=867198670]
tencentcloud_ssl_certificate.svr: Modifications complete after 1s [id=lMuPPygt]
data.tencentcloud_ssl_certificates.svr: Reading... [id=824728486]
data.tencentcloud_ssl_certificates.ca: Read complete after 0s [id=867198670]
data.tencentcloud_ssl_certificates.svr: Read complete after 0s [id=824728486]

Apply complete! Resources: 0 added, 2 changed, 0 destroyed.
```

##### 5. new version destroy

```
terraform destroy

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # tencentcloud_ssl_certificate.ca will be destroyed
  - resource "tencentcloud_ssl_certificate" "ca" {
      - begin_time      = "2019-08-13 11:08:20" -> null
      - cert            = <<-EOT
            -----BEGIN CERTIFICATE-----
            MIIEDjCCAnagAwIBAgIBATANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
            MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzA4MjBaFw0yOTA4
            MTAwMzA4MjBaMCgxDTALBgNVBAMTBHRlc3QxFzAVBgNVBAoTDnRlcnJhZm9ybSB0
            ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA0k2vqg/GHtFP5P7r
            dbzswfx1jSHeK9r4StV4mGOAoKyzvAJA5BvYbAHpSrL2ZAd6ShjHgRVU1qEroeFn
            8fwTrAVQttMltBFABx7G4iN4Zf6EUXzhhFN6vVVbWaqhYhrdMoPvZxgGSA/4hG4W
            GIr8MXZzXbKLoRoz4Bvq1Ymg5eO14KLJFSTahvIkG60egGN5pmi4czxWy2U7ycA5
            Q5TuQBnF0rKQJW5XKIV3kr5YrzDdJK7up9E6Od4T5jz+qY97KAjIpWD/pTAsc7+6
            fPBpY7NHT9Bw0fDmvsWO/PtswY4hW02n86b5eWA9sfKJGphhsBxgpuuhmxYHS6pA
            B+C7IkyxcADNT5u9tEo2JGOj+/veXKrEhZin7inKsQLD0WOobcg1Rh/3NSWD7geF
            TJBRnzgplaN7cK6c/utEAAnngS38q4DGBR/jHmkWjAeQPZj1eLLBk686HEEbKeU+
            9yAVcPRhA9tuL7wMeSX32VunWZunoA/f8iuGZYJlZsNBqyJbAgMBAAGjQzBBMA8G
            A1UdEwEB/wQFMAMBAf8wDwYDVR0PAQH/BAUDAweGADAdBgNVHQ4EFgQUKwfrmq79
            1mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAInM+aeaHoZdw9B9nAH2
            HscEoOulF+RxnysSXTTRLd2VQph4+ynlfRZT4evLBBj/ppmqjp8F7/OcRiiZwSXl
            namyP/UUINtHfgDM0kll/5Za0aYzMhrORNw+3ythIv2yPJX8t4LmsG1L4PMO8ZU8
            N0K9XyKRaL/tq6rw1gQM152OmNgTzfAQoKYxrvbftOZz4J0ZACctuBmwtp5upKvJ
            36aQ4wJLUzOt69mnW+AaL5EPA37mwtzdnzTTxd3SBfOYXjsflc3l2raljJznnqU2
            ySynjb6L3D3L/pObL1Uu7nQBy8CazJBsBsVFK/pr61vcllm8lG7vOhHOUSFUeezq
            FWukAolm9/cagmD6IhNishM3Uzng+UYyCC8uQq3Z7FGqJpXSI79wZYjudnCLPVCg
            OIfJHQeJFLryn6GxiSYmYs6dgUJiiTV+I/2Y5X7ZFdb5FC1J/WmvoCv6yO7NiirY
            BSgfV0lp5CuV8SfiSClpYfrM28NbNgxveUqET642BJOPLQ==
            -----END CERTIFICATE-----
        EOT -> null
      - create_time     = "2021-03-25 18:05:07" -> null
      - domain          = "test" -> null
      - end_time        = "2029-08-10 11:08:20" -> null
      - id              = "lMuPPxPm" -> null
      - name            = "ssl-ca-modify" -> null
      - product_zh_name = "test" -> null
      - project_id      = 0 -> null
      - status          = 1 -> null
      - subject_names   = [] -> null
      - type            = "CA" -> null
    }

  # tencentcloud_ssl_certificate.svr will be destroyed
  - resource "tencentcloud_ssl_certificate" "svr" {
      - begin_time      = "2019-08-13 11:19:39" -> null
      - cert            = <<-EOT
            -----BEGIN CERTIFICATE-----
            MIIERzCCAq+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAoMQ0wCwYDVQQDEwR0ZXN0
            MRcwFQYDVQQKEw50ZXJyYWZvcm0gdGVzdDAeFw0xOTA4MTMwMzE5MzlaFw0yOTA4
            MTAwMzE5MzlaMC4xEzARBgNVBAMTCnNlcnZlciBzc2wxFzAVBgNVBAoTDnRlcnJh
            Zm9ybS10ZXN0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA1Ryp+DKK
            SNFKZsPtwfR+jzOnQ8YFieIKYgakV688d8YgpolenbmeEPrzT87tunFD7G9f6ALG
            ND8rj7npj0AowxhOL/h/v1D9u0UsIaj5i2GWJrqNAhGLaxWiEB/hy5WOiwxDrGei
            gQqJkFM52Ep7G1Yx7PHJmKFGwN9FhIsFi1cNZfVRopZuCe/RMPNusNVZaIi+qcEf
            fsE1cmfmuSlG3Ap0RKOIyR0ajDEzqZn9/0R7VwWCF97qy8TNYk94K/1tq3zyhVzR
            Z83xOSfrTqEfb3so3AU2jyKgYdwr/FZS72VCHS8IslgnqJW4izIXZqgIKmHaRZtM
            N4jUloi6l/6lktt6Lsgh9xECecxziSJtPMaog88aC8HnMqJJ3kScGCL36GYG+Kaw
            5PnDlWXBaeiDe8z/eWK9+Rr2M+rhTNxosAVGfDJyxAXyiX49LQ0v7f9qzwc/0JiD
            bvsUv1cm6OgpoEMP9SXqqBdwGqeKbD2/2jlP48xlYP6l1SoJG3GgZ8dbAgMBAAGj
            djB0MAwGA1UdEwEB/wQCMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0PAQH/
            BAUDAweAADAdBgNVHQ4EFgQULwWKBQNLL9s3cb3tTnyPVg+mpCMwHwYDVR0jBBgw
            FoAUKwfrmq791mY831S6UHARHtgYnlgwDQYJKoZIhvcNAQELBQADggGBAMo5RglS
            AHdPgaicWJvmvjjexjF/42b7Rz4pPfMjYw6uYO8He/f4UZWv5CZLrbEe7MywaK3y
            0OsfH8AhyN29pv2x8g9wbmq7omZIOZ0oCAGduEXs/A/qY/hFaCohdkz/IN8qi6JW
            VXreGli3SrpcHFchSwHTyJEXgkutcGAsOvdsOuVSmplOyrkLHc8uUe8SG4j8kGyg
            EzaszFjHkR7g1dVyDVUedc588mjkQxYeAamJgfkgIhljWKMa2XzkVMcVfQHfNpM1
            n+bu8SmqRt9Wma2bMijKRG/Blm756LoI+skY+WRZmlDnq8zj95TT0vceGP0FUWh5
            hKyiocABmpQs9OK9HMi8vgSWISP+fYgkm/bKtKup2NbZBoO5/VL2vCEPInYzUhBO
            jCbLMjNjtM5KriCaR7wDARgHiG0gBEPOEW1PIjZ9UOH+LtIxbNZ4eEIIINLHnBHf
            L+doVeZtS/gJc4G4Adr5HYuaS9ZxJ0W2uy0eQlOHzjyxR6Mf/rpnilJlcQ==
            -----END CERTIFICATE-----
        EOT -> null
      - create_time     = "2021-03-25 18:05:07" -> null
      - domain          = "server ssl" -> null
      - end_time        = "2029-08-10 11:19:39" -> null
      - id              = "lMuPPygt" -> null
      - key             = (sensitive value)
      - name            = "ssl-svr" -> null
      - product_zh_name = "test" -> null
      - project_id      = 1154137 -> null
      - status          = 1 -> null
      - subject_names   = [] -> null
      - type            = "SVR" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

tencentcloud_ssl_certificate.ca: Destroying... [id=lMuPPxPm]
tencentcloud_ssl_certificate.svr: Destroying... [id=lMuPPygt]
tencentcloud_ssl_certificate.ca: Destruction complete after 1s
tencentcloud_ssl_certificate.svr: Destruction complete after 1s

Destroy complete! Resources: 2 destroyed.
```

