### PR TITLE
add tcr vpc dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.54.1 (Unreleased)
+
+ENHANCEMENTS:
+
+* Resource `tencentcloud_tcr_vpc_attachment` add `enable_public_domain_dns`, `enable_vpc_domain_dns` to set whether to enable dns.
+* Data Source `tencentcloud_tcr_vpc_attachments` add `enable_public_domain_dns`, `enable_vpc_domain_dns`.
+
 ## 1.54.0 (March 22, 2021)
 
 FEATURES:

--- a/tencentcloud/data_source_tc_tcr_vpc_attachments.go
+++ b/tencentcloud/data_source_tc_tcr_vpc_attachments.go
@@ -72,6 +72,16 @@ func dataSourceTencentCloudTCRVPCAttachments() *schema.Resource {
 							Computed:    true,
 							Description: "IP address of this VPC access.",
 						},
+						"enable_public_domain_dns": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether to enable public domain dns.",
+						},
+						"enable_vpc_domain_dns": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether to enable vpc domain dns.",
+						},
 					},
 				},
 			},
@@ -119,6 +129,19 @@ func dataSourceTencentCloudTCRVPCAttachmentsRead(d *schema.ResourceData, meta in
 			"subnet_id": vpcAccess.SubnetId,
 			"status":    vpcAccess.Status,
 			"access_ip": vpcAccess.AccessIp,
+		}
+		if *vpcAccess.AccessIp != "" {
+			publicDomainDnsStatus, err := GetDnsStatus(ctx, tcrService, instanceId, *vpcAccess.VpcId, *vpcAccess.AccessIp, true)
+			if err != nil {
+				return err
+			}
+			mapping["enable_public_domain_dns"] = *publicDomainDnsStatus.Status == TCR_VPC_DNS_STATUS_ENABLED
+
+			vpcDomainDnsStatus, err := GetDnsStatus(ctx, tcrService, instanceId, *vpcAccess.VpcId, *vpcAccess.AccessIp, false)
+			if err != nil {
+				return err
+			}
+			mapping["enable_vpc_domain_dns"] = *vpcDomainDnsStatus.Status == TCR_VPC_DNS_STATUS_ENABLED
 		}
 
 		vpcAccessList = append(vpcAccessList, mapping)

--- a/tencentcloud/extension_tcr.go
+++ b/tencentcloud/extension_tcr.go
@@ -1,0 +1,6 @@
+package tencentcloud
+
+const (
+	TCR_VPC_DNS_STATUS_ENABLED  = "ENABLED"
+	TCR_VPC_DNS_STATUS_DISABLED = "DISABLED"
+)

--- a/tencentcloud/resource_tc_tcr_vpc_attachment.go
+++ b/tencentcloud/resource_tc_tcr_vpc_attachment.go
@@ -28,12 +28,14 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	tcr "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcr/v20190924"
 )
 
 func resourceTencentCloudTcrVpcAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTencentCloudTcrVpcAttachmentCreate,
 		Read:   resourceTencentCloudTcrVpcAttachmentRead,
+		Update: resourceTencentCloudTcrVpcAttachmentUpdate,
 		Delete: resourceTencentCLoudTcrVpcAttachmentDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -57,6 +59,18 @@ func resourceTencentCloudTcrVpcAttachment() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: "ID of subnet.",
+			},
+			"enable_public_domain_dns": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to enable public domain dns. Default value is `false`.",
+			},
+			"enable_vpc_domain_dns": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to enable vpc domain dns. Default value is `false`.",
 			},
 			//computed
 			"status": {
@@ -120,6 +134,19 @@ func resourceTencentCloudTcrVpcAttachmentCreate(d *schema.ResourceData, meta int
 		return outErr
 	}
 
+	if enablePublicDomainDns := d.Get("enable_public_domain_dns").(bool); enablePublicDomainDns {
+		err := EnableTcrVpcDns(ctx, tcrService, instanceId, vpcId, subnetId, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	if enableVpcDomainDns := d.Get("enable_vpc_domain_dns").(bool); enableVpcDomainDns {
+		err := EnableTcrVpcDns(ctx, tcrService, instanceId, vpcId, subnetId, false)
+		if err != nil {
+			return err
+		}
+	}
 	return resourceTencentCloudTcrVpcAttachmentRead(d, meta)
 }
 
@@ -165,7 +192,70 @@ func resourceTencentCloudTcrVpcAttachmentRead(d *schema.ResourceData, meta inter
 	_ = d.Set("vpc_id", vpcId)
 	_ = d.Set("subnet_id", subnetId)
 
+	if *vpcAccess.AccessIp != "" {
+		publicDomainDnsStatus, err := GetDnsStatus(ctx, tcrService, instanceId, vpcId, *vpcAccess.AccessIp, true)
+		if err != nil {
+			return err
+		}
+		_ = d.Set("enable_public_domain_dns", *publicDomainDnsStatus.Status == TCR_VPC_DNS_STATUS_ENABLED)
+
+		vpcDomainDnsStatus, err := GetDnsStatus(ctx, tcrService, instanceId, vpcId, *vpcAccess.AccessIp, false)
+		if err != nil {
+			return err
+		}
+		_ = d.Set("enable_vpc_domain_dns", *vpcDomainDnsStatus.Status == TCR_VPC_DNS_STATUS_ENABLED)
+	}
+
 	return nil
+}
+
+func resourceTencentCloudTcrVpcAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer logElapsed("resource.tencentcloud_tcr_vpc_attachment.update")()
+
+	logId := getLogId(contextNil)
+	ctx := context.WithValue(context.TODO(), logIdKey, logId)
+
+	tcrService := TCRService{client: meta.(*TencentCloudClient).apiV3Conn}
+
+	var (
+		instanceId = d.Get("instance_id").(string)
+		vpcId      = d.Get("vpc_id").(string)
+		subnetId   = d.Get("subnet_id").(string)
+	)
+
+	d.Partial(true)
+	if d.HasChange("enable_public_domain_dns") {
+		if isEnabled := d.Get("enable_public_domain_dns").(bool); isEnabled {
+			err := EnableTcrVpcDns(ctx, tcrService, instanceId, vpcId, subnetId, true)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := DisableTcrVpcDns(ctx, tcrService, instanceId, vpcId, subnetId, true)
+			if err != nil {
+				return err
+			}
+		}
+		d.SetPartial("enable_public_domain_dns")
+	}
+
+	if d.HasChange("enable_vpc_domain_dns") {
+		if isEnabled := d.Get("enable_vpc_domain_dns").(bool); isEnabled {
+			err := EnableTcrVpcDns(ctx, tcrService, instanceId, vpcId, subnetId, false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := DisableTcrVpcDns(ctx, tcrService, instanceId, vpcId, subnetId, false)
+			if err != nil {
+				return err
+			}
+		}
+		d.SetPartial("enable_vpc_domain_dns")
+	}
+	d.Partial(false)
+
+	return resourceTencentCloudTcrVpcAttachmentRead(d, meta)
 }
 
 func resourceTencentCLoudTcrVpcAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
@@ -221,4 +311,89 @@ func resourceTencentCLoudTcrVpcAttachmentDelete(d *schema.ResourceData, meta int
 	}
 
 	return nil
+}
+
+func EnableTcrVpcDns(ctx context.Context, tcrService TCRService, instanceId string, vpcId string, subnetId string, usePublicDomain bool) error {
+	var vpcAccess *tcr.AccessVpc
+	outErr := resource.Retry(readRetryTimeout, func() *resource.RetryError {
+		result, has, inErr := tcrService.DescribeTCRVPCAttachmentById(ctx, instanceId, vpcId, subnetId)
+		if inErr != nil {
+			return retryError(inErr)
+		}
+		if !has {
+			inErr = fmt.Errorf("%s create tcr vpcAccess %s fail, vpcAccess is not exists from SDK DescribeTcrVpcAttachmentById", instanceId, vpcId)
+			return resource.RetryableError(inErr)
+		}
+
+		if *result.AccessIp == "" {
+			inErr = fmt.Errorf("%s get tcr accessIp fail, accessIp is not exists from SDK DescribeTcrVpcAttachmentById", vpcId)
+			return resource.RetryableError(inErr)
+		}
+		vpcAccess = result
+		return nil
+	})
+	if outErr != nil {
+		return outErr
+	}
+
+	outErr = resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+		inErr := tcrService.CreateTcrVpcDns(ctx, instanceId, vpcId, *vpcAccess.AccessIp, usePublicDomain)
+		if inErr != nil {
+			return retryError(inErr)
+		}
+		return nil
+	})
+
+	return outErr
+}
+
+func DisableTcrVpcDns(ctx context.Context, tcrService TCRService, instanceId string, vpcId string, subnetId string, usePublicDomain bool) error {
+	var vpcAccess *tcr.AccessVpc
+	outErr := resource.Retry(readRetryTimeout, func() *resource.RetryError {
+		result, has, inErr := tcrService.DescribeTCRVPCAttachmentById(ctx, instanceId, vpcId, subnetId)
+		if inErr != nil {
+			return retryError(inErr)
+		}
+		if !has {
+			inErr = fmt.Errorf("%s create tcr vpcAccess %s fail, vpcAccess is not exists from SDK DescribeTcrVpcAttachmentById", instanceId, vpcId)
+			return resource.RetryableError(inErr)
+		}
+
+		if *result.AccessIp == "" {
+			inErr = fmt.Errorf("%s get tcr accessIp fail, accessIp is not exists from SDK DescribeTcrVpcAttachmentById", vpcId)
+			return resource.RetryableError(inErr)
+		}
+		vpcAccess = result
+		return nil
+	})
+	if outErr != nil {
+		return outErr
+	}
+
+	outErr = resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+		inErr := tcrService.DeleteTcrVpcDns(ctx, instanceId, vpcId, *vpcAccess.AccessIp, usePublicDomain)
+		if inErr != nil {
+			return retryError(inErr)
+		}
+		return nil
+	})
+
+	return outErr
+}
+
+func GetDnsStatus(ctx context.Context, tcrService TCRService, instanceId string, vpcId string, accessIp string, usePublicDomain bool) (status *tcr.VpcPrivateDomainStatus, err error) {
+	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
+		result, has, inErr := tcrService.DescribeTcrVpcDnsById(ctx, instanceId, vpcId, accessIp, usePublicDomain)
+		if inErr != nil {
+			return retryError(inErr)
+		}
+		if !has {
+			inErr = fmt.Errorf("%s get tcr vpc dns status fail, vpc dns is not exists from SDK DescribeTcrVpcDnsById", instanceId)
+			return resource.RetryableError(inErr)
+		}
+		status = result
+		return nil
+	})
+
+	return
 }

--- a/website/docs/d/tcr_vpc_attachments.html.markdown
+++ b/website/docs/d/tcr_vpc_attachments.html.markdown
@@ -34,6 +34,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `vpc_attachment_list` - Information list of the dedicated TCR namespaces.
   * `access_ip` - IP address of this VPC access.
+  * `enable_public_domain_dns` - Whether to enable public domain dns.
+  * `enable_vpc_domain_dns` - Whether to enable vpc domain dns.
   * `status` - Status of this VPC access.
   * `subnet_id` - ID of subnet.
   * `vpc_id` - ID of VPC.

--- a/website/docs/r/tcr_vpc_attachment.html.markdown
+++ b/website/docs/r/tcr_vpc_attachment.html.markdown
@@ -28,6 +28,8 @@ The following arguments are supported:
 * `instance_id` - (Required, ForceNew) ID of the TCR instance.
 * `subnet_id` - (Required, ForceNew) ID of subnet.
 * `vpc_id` - (Required, ForceNew) ID of VPC.
+* `enable_public_domain_dns` - (Optional) Whether to enable public domain dns. Default value is `false`.
+* `enable_vpc_domain_dns` - (Optional) Whether to enable vpc domain dns. Default value is `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
##### 1. new verson apply

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.tencentcloud_tcr_vpc_attachments.example will be read during apply
  # (config refers to values not yet known)
 <= data "tencentcloud_tcr_vpc_attachments" "example"  {
      + id                  = (known after apply)
      + instance_id         = (known after apply)
      + vpc_attachment_list = (known after apply)
    }

  # tencentcloud_subnet.example will be created
  + resource "tencentcloud_subnet" "example" {
      + availability_zone  = "ap-guangzhou-3"
      + available_ip_count = (known after apply)
      + cidr_block         = "10.0.20.0/28"
      + create_time        = (known after apply)
      + id                 = (known after apply)
      + is_default         = (known after apply)
      + is_multicast       = false
      + name               = "example"
      + route_table_id     = (known after apply)
      + vpc_id             = (known after apply)
    }

  # tencentcloud_tcr_instance.example will be created
  + resource "tencentcloud_tcr_instance" "example" {
      + delete_bucket         = true
      + id                    = (known after apply)
      + instance_type         = "standard"
      + internal_end_point    = (known after apply)
      + name                  = "tf-test"
      + open_public_operation = false
      + public_domain         = (known after apply)
      + public_status         = (known after apply)
      + status                = (known after apply)
      + tags                  = {
          + "test1" = "test1"
        }
    }

  # tencentcloud_tcr_vpc_attachment.example will be created
  + resource "tencentcloud_tcr_vpc_attachment" "example" {
      + access_ip                = (known after apply)
      + enable_public_domain_dns = true
      + enable_vpc_domain_dns    = false
      + id                       = (known after apply)
      + instance_id              = (known after apply)
      + status                   = (known after apply)
      + subnet_id                = (known after apply)
      + vpc_id                   = (known after apply)
    }

  # tencentcloud_vpc.example will be created
  + resource "tencentcloud_vpc" "example" {
      + cidr_block   = "10.0.0.0/16"
      + create_time  = (known after apply)
      + dns_servers  = (known after apply)
      + id           = (known after apply)
      + is_default   = (known after apply)
      + is_multicast = true
      + name         = "example"
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_tcr_instance.example: Creating...
tencentcloud_vpc.example: Creating...
tencentcloud_vpc.example: Creation complete after 2s [id=vpc-e7hdgmtn]
tencentcloud_subnet.example: Creating...
tencentcloud_subnet.example: Creation complete after 2s [id=subnet-rorg0wpc]
tencentcloud_tcr_instance.example: Still creating... [10s elapsed]
tencentcloud_tcr_instance.example: Still creating... [20s elapsed]
tencentcloud_tcr_instance.example: Still creating... [30s elapsed]
tencentcloud_tcr_instance.example: Creation complete after 38s [id=tcr-cgueo1ww]
tencentcloud_tcr_vpc_attachment.example: Creating...
tencentcloud_tcr_vpc_attachment.example: Still creating... [10s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [20s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [30s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [40s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [50s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [1m0s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [1m10s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [1m20s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [1m30s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [1m40s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [1m50s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [2m0s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [2m10s elapsed]
tencentcloud_tcr_vpc_attachment.example: Still creating... [2m20s elapsed]
tencentcloud_tcr_vpc_attachment.example: Creation complete after 2m20s [id=tcr-cgueo1ww#vpc-e7hdgmtn#subnet-rorg0wpc]
data.tencentcloud_tcr_vpc_attachments.example: Reading...
data.tencentcloud_tcr_vpc_attachments.example: Read complete after 2s [id=2658420493]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

##### 2. new version modify

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

tencentcloud_vpc.example: Refreshing state... [id=vpc-e7hdgmtn]
tencentcloud_tcr_instance.example: Refreshing state... [id=tcr-cgueo1ww]
tencentcloud_subnet.example: Refreshing state... [id=subnet-rorg0wpc]
tencentcloud_tcr_vpc_attachment.example: Refreshing state... [id=tcr-cgueo1ww#vpc-e7hdgmtn#subnet-rorg0wpc]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
 <= read (data resources)

Terraform will perform the following actions:

  # data.tencentcloud_tcr_vpc_attachments.example will be read during apply
  # (config refers to values not yet known)
 <= data "tencentcloud_tcr_vpc_attachments" "example"  {
      ~ id                  = "2658420493" -> (known after apply)
      ~ vpc_attachment_list = [
          - {
              - access_ip                = "10.0.20.4"
              - enable_public_domain_dns = true
              - enable_vpc_domain_dns    = false
              - status                   = "Running"
              - subnet_id                = "subnet-rorg0wpc"
              - vpc_id                   = "vpc-e7hdgmtn"
            },
        ] -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # tencentcloud_tcr_vpc_attachment.example will be updated in-place
  ~ resource "tencentcloud_tcr_vpc_attachment" "example" {
      ~ enable_public_domain_dns = true -> false
      ~ enable_vpc_domain_dns    = false -> true
        id                       = "tcr-cgueo1ww#vpc-e7hdgmtn#subnet-rorg0wpc"
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_tcr_vpc_attachment.example: Modifying... [id=tcr-cgueo1ww#vpc-e7hdgmtn#subnet-rorg0wpc]
tencentcloud_tcr_vpc_attachment.example: Modifications complete after 5s [id=tcr-cgueo1ww#vpc-e7hdgmtn#subnet-rorg0wpc]
data.tencentcloud_tcr_vpc_attachments.example: Reading... [id=2658420493]
data.tencentcloud_tcr_vpc_attachments.example: Read complete after 1s [id=2658420493]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

##### 3. new version show

```
# data.tencentcloud_tcr_vpc_attachments.example:
data "tencentcloud_tcr_vpc_attachments" "example" {
    id                  = "2658420493"
    instance_id         = "tcr-cgueo1ww"
    vpc_attachment_list = [
        {
            access_ip                = "10.0.20.4"
            enable_public_domain_dns = false
            enable_vpc_domain_dns    = true
            status                   = "Running"
            subnet_id                = "subnet-rorg0wpc"
            vpc_id                   = "vpc-e7hdgmtn"
        },
    ]
}

# tencentcloud_subnet.example:
resource "tencentcloud_subnet" "example" {
    availability_zone  = "ap-guangzhou-3"
    available_ip_count = 12
    cidr_block         = "10.0.20.0/28"
    create_time        = "2021-03-23 17:34:51"
    id                 = "subnet-rorg0wpc"
    is_default         = false
    is_multicast       = false
    name               = "example"
    route_table_id     = "rtb-5yx9de9s"
    tags               = {}
    vpc_id             = "vpc-e7hdgmtn"
}

# tencentcloud_tcr_instance.example:
resource "tencentcloud_tcr_instance" "example" {
    delete_bucket         = true
    id                    = "tcr-cgueo1ww"
    instance_type         = "standard"
    internal_end_point    = "10.1.67.225"
    name                  = "tf-test"
    open_public_operation = false
    public_domain         = "tf-test.tencentcloudcr.com"
    public_status         = "Closed"
    status                = "Running"
    tags                  = {
        "test1" = "test1"
    }
}

# tencentcloud_tcr_vpc_attachment.example:
resource "tencentcloud_tcr_vpc_attachment" "example" {
    access_ip                = "10.0.20.4"
    enable_public_domain_dns = false
    enable_vpc_domain_dns    = true
    id                       = "tcr-cgueo1ww#vpc-e7hdgmtn#subnet-rorg0wpc"
    instance_id              = "tcr-cgueo1ww"
    status                   = "Running"
    subnet_id                = "subnet-rorg0wpc"
    vpc_id                   = "vpc-e7hdgmtn"
}

# tencentcloud_vpc.example:
resource "tencentcloud_vpc" "example" {
    cidr_block   = "10.0.0.0/16"
    create_time  = "2021-03-23 17:34:49"
    dns_servers  = [
        "183.60.82.98",
        "183.60.83.19",
    ]
    id           = "vpc-e7hdgmtn"
    is_default   = false
    is_multicast = true
    name         = "example"
    tags         = {}
}
```

##### 4. new version destroy

```
terraform destroy

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # tencentcloud_subnet.example will be destroyed
  - resource "tencentcloud_subnet" "example" {
      - availability_zone  = "ap-guangzhou-3" -> null
      - available_ip_count = 12 -> null
      - cidr_block         = "10.0.20.0/28" -> null
      - create_time        = "2021-03-23 17:34:51" -> null
      - id                 = "subnet-rorg0wpc" -> null
      - is_default         = false -> null
      - is_multicast       = false -> null
      - name               = "example" -> null
      - route_table_id     = "rtb-5yx9de9s" -> null
      - tags               = {} -> null
      - vpc_id             = "vpc-e7hdgmtn" -> null
    }

  # tencentcloud_tcr_instance.example will be destroyed
  - resource "tencentcloud_tcr_instance" "example" {
      - delete_bucket         = true -> null
      - id                    = "tcr-cgueo1ww" -> null
      - instance_type         = "standard" -> null
      - internal_end_point    = "10.1.67.225" -> null
      - name                  = "tf-test" -> null
      - open_public_operation = false -> null
      - public_domain         = "tf-test.tencentcloudcr.com" -> null
      - public_status         = "Closed" -> null
      - status                = "Running" -> null
      - tags                  = {
          - "test1" = "test1"
        } -> null
    }

  # tencentcloud_tcr_vpc_attachment.example will be destroyed
  - resource "tencentcloud_tcr_vpc_attachment" "example" {
      - access_ip                = "10.0.20.4" -> null
      - enable_public_domain_dns = false -> null
      - enable_vpc_domain_dns    = true -> null
      - id                       = "tcr-cgueo1ww#vpc-e7hdgmtn#subnet-rorg0wpc" -> null
      - instance_id              = "tcr-cgueo1ww" -> null
      - status                   = "Running" -> null
      - subnet_id                = "subnet-rorg0wpc" -> null
      - vpc_id                   = "vpc-e7hdgmtn" -> null
    }

  # tencentcloud_vpc.example will be destroyed
  - resource "tencentcloud_vpc" "example" {
      - cidr_block   = "10.0.0.0/16" -> null
      - create_time  = "2021-03-23 17:34:49" -> null
      - dns_servers  = [
          - "183.60.82.98",
          - "183.60.83.19",
        ] -> null
      - id           = "vpc-e7hdgmtn" -> null
      - is_default   = false -> null
      - is_multicast = true -> null
      - name         = "example" -> null
      - tags         = {} -> null
    }

Plan: 0 to add, 0 to change, 4 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

tencentcloud_tcr_vpc_attachment.example: Destroying... [id=tcr-cgueo1ww#vpc-e7hdgmtn#subnet-rorg0wpc]
tencentcloud_tcr_vpc_attachment.example: Destruction complete after 1s
tencentcloud_tcr_instance.example: Destroying... [id=tcr-cgueo1ww]
tencentcloud_subnet.example: Destroying... [id=subnet-rorg0wpc]
tencentcloud_tcr_instance.example: Destruction complete after 2s
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 10s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 20s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 30s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 40s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 50s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 1m0s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 1m10s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 1m20s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 1m30s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 1m40s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 1m50s elapsed]
tencentcloud_subnet.example: Still destroying... [id=subnet-rorg0wpc, 2m0s elapsed]
tencentcloud_subnet.example: Destruction complete after 2m2s
tencentcloud_vpc.example: Destroying... [id=vpc-e7hdgmtn]
tencentcloud_vpc.example: Destruction complete after 4s

Destroy complete! Resources: 4 destroyed.
```

##### 5. old version in new version

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

tencentcloud_vpc.example: Refreshing state... [id=vpc-hhu3s4dj]
tencentcloud_tcr_instance.example: Refreshing state... [id=tcr-4zzuya3g]
tencentcloud_subnet.example: Refreshing state... [id=subnet-obwwpzdq]
tencentcloud_tcr_vpc_attachment.example: Refreshing state... [id=tcr-4zzuya3g#vpc-hhu3s4dj#subnet-obwwpzdq]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

