### PR TITLE
add tke node_pool_global_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.55.1 (Unreleased)
+
+ENHANCEMENTS:
+
+* Resource: `tencentcloud_kubernetes_cluster` add `node_pool_global_config` to support node pool global config setting.
+
 ## 1.55.0 (March 26, 2021)
 
 FEATURES:

--- a/tencentcloud/resource_tc_kubernetes_cluster.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster.go
@@ -207,6 +207,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
+	tke "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke/v20180525"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 )
 
@@ -471,6 +472,65 @@ func TkeCvmCreateInfo() map[string]*schema.Schema {
 	}
 }
 
+func TkeNodePoolGlobalConfig() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"is_scale_in_enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "Indicates whether to enable scale-in.",
+		},
+		"expander": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Indicates which scale-out method will be used when there are multiple scaling groups. Valid values: `random` - select a random scaling group, `most-pods` - select the scaling group that can schedule the most pods, `least-waste` - select the scaling group that can ensure the fewest remaining resources after Pod scheduling.",
+		},
+		"max_concurrent_scale_in": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "Max concurrent scale-in volume.",
+		},
+		"scale_in_delay": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "Number of minutes after cluster scale-out when the system starts judging whether to perform scale-in.",
+		},
+		"scale_in_unneeded_time": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "Number of consecutive minutes of idleness after which the node is subject to scale-in.",
+		},
+		"scale_in_utilization_threshold": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "Percentage of node resource usage below which the node is considered to be idle.",
+		},
+		"ignore_daemon_sets_utilization": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "Whether to ignore DaemonSet pods by default when calculating resource usage.",
+		},
+		"skip_nodes_with_local_storage": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "During scale-in, ignore nodes with local storage pods.",
+		},
+		"skip_nodes_with_system_pods": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "During scale-in, ignore nodes with pods in the kube-system namespace that are not managed by DaemonSet.",
+		},
+	}
+}
+
 func resourceTencentCloudTkeCluster() *schema.Resource {
 	schemaBody := map[string]*schema.Schema{
 		"cluster_name": {
@@ -535,6 +595,15 @@ func resourceTencentCloudTkeCluster() *schema.Resource {
 			Optional:    true,
 			Default:     false,
 			Description: "Indicates whether to enable cluster node auto scaler.",
+		},
+		"node_pool_global_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: TkeNodePoolGlobalConfig(),
+			},
+			Description: "Global config effective for all node pools.",
 		},
 		"cluster_extra_args": {
 			Type:     schema.TypeList,
@@ -1098,6 +1167,43 @@ func tkeGetCvmRunInstancesPara(dMap map[string]interface{}, meta interface{},
 	return
 }
 
+func tkeGetNodePoolGlobalConfig(d *schema.ResourceData) *tke.ModifyClusterAsGroupOptionAttributeRequest {
+	request := tke.NewModifyClusterAsGroupOptionAttributeRequest()
+	request.ClusterId = helper.String(d.Id())
+
+	clusterAsGroupOption := &tke.ClusterAsGroupOption{}
+	if v, ok := d.GetOk("node_pool_global_config.0.is_scale_in_enabled"); ok {
+		clusterAsGroupOption.IsScaleDownEnabled = helper.Bool(v.(bool))
+	}
+	if v, ok := d.GetOk("node_pool_global_config.0.expander"); ok {
+		clusterAsGroupOption.Expander = helper.String(v.(string))
+	}
+	if v, ok := d.GetOk("node_pool_global_config.0.max_concurrent_scale_in"); ok {
+		clusterAsGroupOption.MaxEmptyBulkDelete = helper.IntInt64(v.(int))
+	}
+	if v, ok := d.GetOk("node_pool_global_config.0.scale_in_delay"); ok {
+		clusterAsGroupOption.ScaleDownDelay = helper.IntInt64(v.(int))
+	}
+	if v, ok := d.GetOk("node_pool_global_config.0.scale_in_unneeded_time"); ok {
+		clusterAsGroupOption.ScaleDownUnneededTime = helper.IntInt64(v.(int))
+	}
+	if v, ok := d.GetOk("node_pool_global_config.0.scale_in_utilization_threshold"); ok {
+		clusterAsGroupOption.ScaleDownUtilizationThreshold = helper.IntInt64(v.(int))
+	}
+	if v, ok := d.GetOk("node_pool_global_config.0.ignore_daemon_sets_utilization"); ok {
+		clusterAsGroupOption.IgnoreDaemonSetsUtilization = helper.Bool(v.(bool))
+	}
+	if v, ok := d.GetOk("node_pool_global_config.0.skip_nodes_with_local_storage"); ok {
+		clusterAsGroupOption.SkipNodesWithLocalStorage = helper.Bool(v.(bool))
+	}
+	if v, ok := d.GetOk("node_pool_global_config.0.skip_nodes_with_system_pods"); ok {
+		clusterAsGroupOption.SkipNodesWithSystemPods = helper.Bool(v.(bool))
+	}
+
+	request.ClusterAsGroupOption = clusterAsGroupOption
+	return request
+}
+
 func resourceTencentCloudTkeClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	defer logElapsed("resource.tencentcloud_kubernetes_cluster.create")()
 
@@ -1436,6 +1542,21 @@ func resourceTencentCloudTkeClusterCreate(d *schema.ResourceData, meta interface
 		}
 	}
 
+	//Modify node pool global config
+	if _, ok := d.GetOk("node_pool_global_config"); ok {
+		request := tkeGetNodePoolGlobalConfig(d)
+		err = resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+			inErr := service.ModifyClusterNodePoolGlobalConfig(ctx, request)
+			if inErr != nil {
+				return retryError(inErr)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	if err = resourceTencentCloudTkeClusterRead(d, meta); err != nil {
 		log.Printf("[WARN]%s resource.kubernetes_cluster.read after create fail , %s", logId, err.Error())
 		return err
@@ -1588,6 +1709,37 @@ func resourceTencentCloudTkeClusterRead(d *schema.ResourceData, meta interface{}
 		_ = d.Set("cluster_intranet", true)
 	}
 
+	var globalConfig *tke.ClusterAsGroupOption
+	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
+		globalConfig, err = service.DescribeClusterNodePoolGlobalConfig(ctx, d.Id())
+		if e, ok := err.(*errors.TencentCloudSDKError); ok {
+			if e.GetCode() == "InternalError.ClusterNotFound" {
+				return nil
+			}
+		}
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if globalConfig != nil {
+		temp := make(map[string]interface{})
+		temp["is_scale_in_enabled"] = globalConfig.IsScaleDownEnabled
+		temp["expander"] = globalConfig.Expander
+		temp["max_concurrent_scale_in"] = globalConfig.MaxEmptyBulkDelete
+		temp["scale_in_delay"] = globalConfig.ScaleDownDelay
+		temp["scale_in_unneeded_time"] = globalConfig.ScaleDownUnneededTime
+		temp["scale_in_utilization_threshold"] = globalConfig.ScaleDownUtilizationThreshold
+		temp["ignore_daemon_sets_utilization"] = globalConfig.IgnoreDaemonSetsUtilization
+		temp["skip_nodes_with_local_storage"] = globalConfig.SkipNodesWithLocalStorage
+		temp["skip_nodes_with_system_pods"] = globalConfig.SkipNodesWithSystemPods
+
+		_ = d.Set("node_pool_global_config", []map[string]interface{}{temp})
+	}
 	return nil
 }
 
@@ -1906,6 +2058,22 @@ func resourceTencentCloudTkeClusterUpdate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return err
 		}
+	}
+
+	// update node pool global config
+	if d.HasChange("node_pool_global_config") {
+		request := tkeGetNodePoolGlobalConfig(d)
+		err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+			inErr := tkeService.ModifyClusterNodePoolGlobalConfig(ctx, request)
+			if inErr != nil {
+				return retryError(inErr)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		d.SetPartial("node_pool_global_config")
 	}
 
 	d.Partial(false)

--- a/tencentcloud/resource_tc_kubernetes_cluster.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster.go
@@ -1189,31 +1189,31 @@ func tkeGetNodePoolGlobalConfig(d *schema.ResourceData) *tke.ModifyClusterAsGrou
 	request.ClusterId = helper.String(d.Id())
 
 	clusterAsGroupOption := &tke.ClusterAsGroupOption{}
-	if v, ok := d.GetOk("node_pool_global_config.0.is_scale_in_enabled"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.is_scale_in_enabled"); ok {
 		clusterAsGroupOption.IsScaleDownEnabled = helper.Bool(v.(bool))
 	}
-	if v, ok := d.GetOk("node_pool_global_config.0.expander"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.expander"); ok {
 		clusterAsGroupOption.Expander = helper.String(v.(string))
 	}
-	if v, ok := d.GetOk("node_pool_global_config.0.max_concurrent_scale_in"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.max_concurrent_scale_in"); ok {
 		clusterAsGroupOption.MaxEmptyBulkDelete = helper.IntInt64(v.(int))
 	}
-	if v, ok := d.GetOk("node_pool_global_config.0.scale_in_delay"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.scale_in_delay"); ok {
 		clusterAsGroupOption.ScaleDownDelay = helper.IntInt64(v.(int))
 	}
-	if v, ok := d.GetOk("node_pool_global_config.0.scale_in_unneeded_time"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.scale_in_unneeded_time"); ok {
 		clusterAsGroupOption.ScaleDownUnneededTime = helper.IntInt64(v.(int))
 	}
-	if v, ok := d.GetOk("node_pool_global_config.0.scale_in_utilization_threshold"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.scale_in_utilization_threshold"); ok {
 		clusterAsGroupOption.ScaleDownUtilizationThreshold = helper.IntInt64(v.(int))
 	}
-	if v, ok := d.GetOk("node_pool_global_config.0.ignore_daemon_sets_utilization"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.ignore_daemon_sets_utilization"); ok {
 		clusterAsGroupOption.IgnoreDaemonSetsUtilization = helper.Bool(v.(bool))
 	}
-	if v, ok := d.GetOk("node_pool_global_config.0.skip_nodes_with_local_storage"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.skip_nodes_with_local_storage"); ok {
 		clusterAsGroupOption.SkipNodesWithLocalStorage = helper.Bool(v.(bool))
 	}
-	if v, ok := d.GetOk("node_pool_global_config.0.skip_nodes_with_system_pods"); ok {
+	if v, ok := d.GetOkExists("node_pool_global_config.0.skip_nodes_with_system_pods"); ok {
 		clusterAsGroupOption.SkipNodesWithSystemPods = helper.Bool(v.(bool))
 	}
 

--- a/tencentcloud/service_tencentcloud_tke.go
+++ b/tencentcloud/service_tencentcloud_tke.go
@@ -1113,21 +1113,13 @@ func (me *TkeService) DescribeNodePool(ctx context.Context, clusterId string, no
 }
 
 //node pool global config
-func (me *TkeService) ModifyClusterNodePoolGlobalConfig(ctx context.Context, clusterId string, isScaleDown bool, expanderStrategy string) (errRet error) {
-
+func (me *TkeService) ModifyClusterNodePoolGlobalConfig(ctx context.Context, request *tke.ModifyClusterAsGroupOptionAttributeRequest) (errRet error) {
 	logId := getLogId(ctx)
-	request := tke.NewModifyClusterAsGroupOptionAttributeRequest()
-
 	defer func() {
 		if errRet != nil {
 			log.Printf("[CRITAL]%s api[%s] fail, reason[%s]\n", logId, request.GetAction(), errRet.Error())
 		}
 	}()
-	request.ClusterId = &clusterId
-	request.ClusterAsGroupOption = &tke.ClusterAsGroupOption{
-		IsScaleDownEnabled: &isScaleDown,
-		Expander:           &expanderStrategy,
-	}
 
 	ratelimit.Check(request.GetAction())
 	_, err := me.client.UseTkeClient().ModifyClusterAsGroupOptionAttribute(request)

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -237,6 +237,7 @@ The following arguments are supported:
 * `mount_target` - (Optional, ForceNew) Mount target. Default is not mounting.
 * `network_type` - (Optional, ForceNew) Cluster network type, GR or VPC-CNI. Default is GR.
 * `node_name_type` - (Optional, ForceNew) Node name type of Cluster, the available values include: 'lan-ip' and 'hostname', Default is 'lan-ip'.
+* `node_pool_global_config` - (Optional) Global config effective for all node pools.
 * `project_id` - (Optional) Project ID, default value is 0.
 * `service_cidr` - (Optional, ForceNew) A network address block of the service. Different from vpc cidr and cidr of other clusters within this vpc. Must be in  10./192.168/172.[16-31] segments.
 * `tags` - (Optional) The tags of the cluster.
@@ -279,6 +280,18 @@ The `master_config` object supports the following:
 * `system_disk_size` - (Optional, ForceNew) Volume of system disk in GB. Default is `50`.
 * `system_disk_type` - (Optional, ForceNew) System disk type. For more information on limits of system disk types, see [Storage Overview](https://intl.cloud.tencent.com/document/product/213/4952). Valid values: `LOCAL_BASIC`: local disk, `LOCAL_SSD`: local SSD disk, `CLOUD_BASIC`: HDD cloud disk, `CLOUD_SSD`: SSD, `CLOUD_PREMIUM`: Premium Cloud Storage. NOTE: `LOCAL_BASIC` and `LOCAL_SSD` are deprecated.
 * `user_data` - (Optional, ForceNew) ase64-encoded User Data text, the length limit is 16KB.
+
+The `node_pool_global_config` object supports the following:
+
+* `expander` - (Optional) Indicates which scale-out method will be used when there are multiple scaling groups. Valid values: `random` - select a random scaling group, `most-pods` - select the scaling group that can schedule the most pods, `least-waste` - select the scaling group that can ensure the fewest remaining resources after Pod scheduling.
+* `ignore_daemon_sets_utilization` - (Optional) Whether to ignore DaemonSet pods by default when calculating resource usage.
+* `is_scale_in_enabled` - (Optional) Indicates whether to enable scale-in.
+* `max_concurrent_scale_in` - (Optional) Max concurrent scale-in volume.
+* `scale_in_delay` - (Optional) Number of minutes after cluster scale-out when the system starts judging whether to perform scale-in.
+* `scale_in_unneeded_time` - (Optional) Number of consecutive minutes of idleness after which the node is subject to scale-in.
+* `scale_in_utilization_threshold` - (Optional) Percentage of node resource usage below which the node is considered to be idle.
+* `skip_nodes_with_local_storage` - (Optional) During scale-in, ignore nodes with local storage pods.
+* `skip_nodes_with_system_pods` - (Optional) During scale-in, ignore nodes with pods in the kube-system namespace that are not managed by DaemonSet.
 
 The `worker_config` object supports the following:
 


### PR DESCRIPTION
##### 1. new version cluster create with node_pool_global_config

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be created
  + resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
      + certification_authority                    = (known after apply)
      + claim_expired_seconds                      = 300
      + cluster_as_enabled                         = false
      + cluster_cidr                               = "10.31.0.0/16"
      + cluster_deploy_type                        = "MANAGED_CLUSTER"
      + cluster_desc                               = "test cluster desc"
      + cluster_external_endpoint                  = (known after apply)
      + cluster_internet                           = true
      + cluster_intranet                           = false
      + cluster_ipvs                               = true
      + cluster_max_pod_num                        = 32
      + cluster_max_service_num                    = 32
      + cluster_name                               = "test"
      + cluster_node_num                           = (known after apply)
      + cluster_os                                 = "ubuntu16.04.1 LTSx86_64"
      + cluster_os_type                            = "GENERAL"
      + cluster_version                            = "1.10.5"
      + container_runtime                          = "docker"
      + deletion_protection                        = false
      + domain                                     = (known after apply)
      + id                                         = (known after apply)
      + ignore_cluster_cidr_conflict               = false
      + is_non_static_ip_mode                      = false
      + kube_config                                = (known after apply)
      + labels                                     = {
          + "test1" = "test1"
          + "test2" = "test2"
        }
      + managed_cluster_internet_security_policies = [
          + "3.3.3.3",
          + "1.1.1.1",
        ]
      + network_type                               = "GR"
      + node_name_type                             = "lan-ip"
      + password                                   = (known after apply)
      + pgw_endpoint                               = (known after apply)
      + security_policy                            = (known after apply)
      + unschedulable                              = 0
      + user_name                                  = (known after apply)
      + vpc_id                                     = "vpc-h70b6b49"
      + worker_instances_list                      = (known after apply)

      + node_pool_global_config {
          + expander                       = (known after apply)
          + ignore_daemon_sets_utilization = (known after apply)
          + is_scale_in_enabled            = true
          + max_concurrent_scale_in        = 12
          + scale_in_delay                 = 15
          + scale_in_unneeded_time         = 15
          + scale_in_utilization_threshold = 30
          + skip_nodes_with_local_storage  = false
          + skip_nodes_with_system_pods    = true
        }

      + worker_config {
          + availability_zone                       = "ap-guangzhou-3"
          + count                                   = 1
          + enhanced_monitor_service                = false
          + enhanced_security_service               = false
          + instance_charge_type                    = "POSTPAID_BY_HOUR"
          + instance_charge_type_prepaid_period     = 1
          + instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
          + instance_name                           = "sub machine of tke"
          + instance_type                           = "SA2.2XLARGE16"
          + internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out              = 100
          + password                                = (sensitive value)
          + public_ip_assigned                      = true
          + subnet_id                               = "subnet-1uwh63so"
          + system_disk_size                        = 60
          + system_disk_type                        = "CLOUD_SSD"
          + user_data                               = "dGVzdA=="

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }
      + worker_config {
          + availability_zone                       = "ap-guangzhou-4"
          + cam_role_name                           = "CVM_QcsRole"
          + count                                   = 1
          + enhanced_monitor_service                = false
          + enhanced_security_service               = false
          + instance_charge_type                    = "POSTPAID_BY_HOUR"
          + instance_charge_type_prepaid_period     = 1
          + instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
          + instance_name                           = "sub machine of tke"
          + instance_type                           = "SA2.2XLARGE16"
          + internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out              = 100
          + password                                = (sensitive value)
          + public_ip_assigned                      = true
          + subnet_id                               = "subnet-q6fhy1mi"
          + system_disk_size                        = 60
          + system_disk_type                        = "CLOUD_SSD"
          + user_data                               = "dGVzdA=="

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_kubernetes_cluster.managed_cluster: Creating...
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [5m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [5m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Creation complete after 5m19s [id=cls-mlrkoi8k]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

##### 2. terraform show

```
terraform show
# data.tencentcloud_vpc_subnets.vpc_first:
data "tencentcloud_vpc_subnets" "vpc_first" {
    availability_zone = "ap-guangzhou-3"
    id                = "515108a726ede70670174519bf2c8902"
    instance_list     = [
        {
            availability_zone  = "ap-guangzhou-3"
            available_ip_count = 4073
            cidr_block         = "172.16.0.0/20"
            create_time        = "2019-07-24 16:51:00"
            is_default         = true
            is_multicast       = false
            name               = "Default-Subnet-Terraform-Keep"
            route_table_id     = "rtb-4ux9eaoc"
            subnet_id          = "subnet-1uwh63so"
            tags               = {}
            vpc_id             = "vpc-h70b6b49"
        },
    ]
    is_default        = true
}

# data.tencentcloud_vpc_subnets.vpc_second:
data "tencentcloud_vpc_subnets" "vpc_second" {
    availability_zone = "ap-guangzhou-4"
    id                = "4bb54279b70dd614245512b3cf395f9e"
    instance_list     = [
        {
            availability_zone  = "ap-guangzhou-4"
            available_ip_count = 4090
            cidr_block         = "172.16.48.0/20"
            create_time        = "2019-08-08 16:23:05"
            is_default         = true
            is_multicast       = false
            name               = "Default-Subnet-Terraform-Keep"
            route_table_id     = "rtb-4ux9eaoc"
            subnet_id          = "subnet-q6fhy1mi"
            tags               = {}
            vpc_id             = "vpc-h70b6b49"
        },
    ]
    is_default        = true
}

# tencentcloud_kubernetes_cluster.managed_cluster:
resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
    certification_authority                    = <<-EOT
        -----BEGIN CERTIFICATE-----
        MIICyDCCAbCgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
        cm5ldGVzMB4XDTIxMDMyNjEwMzAwMloXDTMxMDMyNDEwMzAwMlowFTETMBEGA1UE
        AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALDE
        mik09Wdf+gBHEQI5d9V25GUvNcE2mx500/O37ktMMW6SpeDVVoJ/jH1ovmcjR77E
        fSOSDLorh4AFyCZMPGv56d81GmqmdES6+UxgyJzzQqXZ6EJYMZXM8FUhh7LUINGA
        CfyHLXD6EaR4Eek4tCPfTdkO0sVtptYUbiHUy0DxL3CN6g0s6BeTMFC7uXGm2Pc3
        kbGqTzrPbfUkmNAeWcjF+Lvdg80GiVMryiZKDTK+rTGu122whcAH+kQrK7VXWwuF
        Hywo48wveeP9s7TuO5FHzIG90zx8ToFlp++hKdipLVi9Ym+XTmGuIWMuhN622fJ4
        BYnZYMeqL6NB/s+fkE8CAwEAAaMjMCEwDgYDVR0PAQH/BAQDAgKUMA8GA1UdEwEB
        /wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBALCo6H19bwue1+MJS5llUl52HqkZ
        g583gExvR2yVDDSz+SEnN2kwNgEklSrx9Ud6VpbaToeRACMDrTJl7b1EM18bPXVd
        zJU2SP7IYTDyuL9L4k1iWKCGvONjlpZ3hByKJvOZxPRLK1SMkmVBrXloCbIelpuT
        /UzqsQCE4CCJjUss4XMe0XZs8GSxu6Z0gyutBWM1+OUt7kY3GL96JtR4T+Mec+He
        edbSXV2cUkN/mGMFY5O0wgxOKhIzDJmusMSw13jhzDMHvd1aWMJK7otdsvEFYkU0
        S1Ak4TYbkgVxrIusdd3PhCaEh4+5UIhFrO2K8UQyKiSzEgEdraIoI48bwqw=
        -----END CERTIFICATE-----
    EOT
    claim_expired_seconds                      = 300
    cluster_as_enabled                         = false
    cluster_cidr                               = "10.31.0.0/16"
    cluster_deploy_type                        = "MANAGED_CLUSTER"
    cluster_desc                               = "test cluster desc"
    cluster_external_endpoint                  = "https://cls-mlrkoi8k.ccs.tencent-cloud.com"
    cluster_internet                           = true
    cluster_intranet                           = false
    cluster_ipvs                               = true
    cluster_max_pod_num                        = 32
    cluster_max_service_num                    = 32
    cluster_name                               = "test"
    cluster_node_num                           = 2
    cluster_os                                 = "ubuntu16.04.1 LTSx86_64"
    cluster_os_type                            = "GENERAL"
    cluster_version                            = "1.10.5"
    container_runtime                          = "docker"
    deletion_protection                        = false
    domain                                     = "cls-mlrkoi8k.ccs.tencent-cloud.com"
    id                                         = "cls-mlrkoi8k"
    ignore_cluster_cidr_conflict               = false
    is_non_static_ip_mode                      = false
    kube_config                                = <<-EOT
        apiVersion: v1
        clusters:
        - cluster:
            certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ETXlOakV3TXpBd01sb1hEVE14TURNeU5ERXdNekF3TWxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTERFCm1pazA5V2RmK2dCSEVRSTVkOVYyNUdVdk5jRTJteDUwMC9PMzdrdE1NVzZTcGVEVlZvSi9qSDFvdm1jalI3N0UKZlNPU0RMb3JoNEFGeUNaTVBHdjU2ZDgxR21xbWRFUzYrVXhneUp6elFxWFo2RUpZTVpYTThGVWhoN0xVSU5HQQpDZnlITFhENkVhUjRFZWs0dENQZlRka08wc1Z0cHRZVWJpSFV5MER4TDNDTjZnMHM2QmVUTUZDN3VYR20yUGMzCmtiR3FUenJQYmZVa21OQWVXY2pGK0x2ZGc4MEdpVk1yeWlaS0RUSytyVEd1MTIyd2hjQUgra1FySzdWWFd3dUYKSHl3bzQ4d3ZlZVA5czdUdU81Rkh6SUc5MHp4OFRvRmxwKytoS2RpcExWaTlZbStYVG1HdUlXTXVoTjYyMmZKNApCWW5aWU1lcUw2TkIvcytma0U4Q0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0tVTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFMQ282SDE5Ynd1ZTErTUpTNWxsVWw1Mkhxa1oKZzU4M2dFeHZSMnlWRERTeitTRW5OMmt3TmdFa2xTcng5VWQ2VnBiYVRvZVJBQ01EclRKbDdiMUVNMThiUFhWZAp6SlUyU1A3SVlURHl1TDlMNGsxaVdLQ0d2T05qbHBaM2hCeUtKdk9aeFBSTEsxU01rbVZCclhsb0NiSWVscHVUCi9VenFzUUNFNENDSmpVc3M0WE1lMFhaczhHU3h1NlowZ3l1dEJXTTErT1V0N2tZM0dMOTZKdFI0VCtNZWMrSGUKZWRiU1hWMmNVa04vbUdNRlk1TzB3Z3hPS2hJekRKbXVzTVN3MTNqaHpETUh2ZDFhV01KSzdvdGRzdkVGWWtVMApTMUFrNFRZYmtnVnhySXVzZGQzUGhDYUVoNCs1VUloRnJPMks4VVF5S2lTekVnRWRyYUlvSTQ4Yndxdz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
            server: https://cls-mlrkoi8k.ccs.tencent-cloud.com
          name: cls-mlrkoi8k
        contexts:
        - context:
            cluster: cls-mlrkoi8k
            user: "100017870904"
          name: cls-mlrkoi8k-100017870904-context-default
        current-context: cls-mlrkoi8k-100017870904-context-default
        kind: Config
        preferences: {}
        users:
        - name: "100017870904"
          user:
            client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURERENDQWZTZ0F3SUJBZ0lJYTNSMjdmQzRBS3N3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TVRBek1qWXhNRE15TURoYUZ3MDBNVEF6TWpZeE1ETXlNRGhhTURZeApFakFRQmdOVkJBb1RDWFJyWlRwMWMyVnljekVnTUI0R0ExVUVBeE1YTVRBd01ERTNPRGN3T1RBMExURTJNVFkzCk5UUTNNamd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRRFNISXpKb2FjT09oWXYKZWZ4ejVWYTJndDVoL2dQMncrejJTQ0M1QWs2ZDJka0VBeTNleVRUWG5aL1NjVXg2TVFZcG9ZK3NCN3U1dVF6MwpmK3JERGtBQXY4Wm8zYVBzcC8wY21DQXZYb01uWVM1YVdJTVNIOHV4ZWl2eDhqQjJ3bTVmSnQ5L09KalMxMWFMCnlrWDJCeXJ5b0UrUHRhWGVhZkw1dlMveVhtRXlCdzJ0RXpyaHNnc3kxMDRWL3c4S21UcWhLT1RERFp0aTJNM0cKMGkveWtIUmRFVXlrNmhvMk1CV0luaEw5YitVRExjdzFrLzNQdWJhQjdNRkkwREc3Q3FGQ3JvTXlUeUtUdjRxWgpCcTA1N3ZONjVvVTZzQ1lRM1dUeUNzdUszSFFaM3Q3bXdzTGtKUEdTeDM0b0lNVmxZczUxWWdta2p2N29nTlh2Cm1pOXRya0I5QWdNQkFBR2pQekE5TUE0R0ExVWREd0VCL3dRRUF3SUNoREFkQmdOVkhTVUVGakFVQmdnckJnRUYKQlFjREFnWUlLd1lCQlFVSEF3RXdEQVlEVlIwVEFRSC9CQUl3QURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpsOWg0TnJrN3VHZ04wWGl6OUdmeHlSdHpvNnlqd2FOaDBhYzJUWklFNFFwT2dNNjdRNitRSVRIU2cxMWNXVGdnCkdqOTdxNkhCWjNSSTVLclRuUmJmN2VxaUFuV1pManhOQmsyRXZ6Y3k2czdzbHIraGJmZHR5aHVIdUJrZlh4WlkKQXpJVEQxS1dmVlpoL2t0OHhPZ3ZOQThUVCtwdGlJYlBmZTZWTGdJMkxkN0NXQS82TUhISk9XUy9vN095UllncwpNZXk3WmxVYXJYeTN6S1ZnZ0V1UCtTOVBBK0hjdVRERkVuaVNBaEJTT09SWWtVWjJQdWdUeVhvNHVOU1RRVjJFCk15OGc2bDJSOW1IYlM2bFdJMisyd1cvd2NzVi9zZjJVZ1N2V2lQTDNsOHlnaFNHemluRkYzT05HZFl4NTh3MnoKREVvZWVNbDhPd3AwaTJSTVp4MjRRdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
            client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBMGh5TXlhR25Eam9XTDNuOGMrVld0b0xlWWY0RDlzUHM5a2dndVFKT25kblpCQU10CjNzazAxNTJmMG5GTWVqRUdLYUdQckFlN3Via005My9xd3c1QUFML0dhTjJqN0tmOUhKZ2dMMTZESjJFdVdsaUQKRWgvTHNYb3I4Zkl3ZHNKdVh5YmZmemlZMHRkV2k4cEY5Z2NxOHFCUGo3V2wzbW55K2IwdjhsNWhNZ2NOclJNNgo0YklMTXRkT0ZmOFBDcGs2b1Nqa3d3MmJZdGpOeHRJdjhwQjBYUkZNcE9vYU5qQVZpSjRTL1cvbEF5M01OWlA5Cno3bTJnZXpCU05BeHV3cWhRcTZETWs4aWs3K0ttUWF0T2U3emV1YUZPckFtRU4xazhnckxpdHgwR2Q3ZTVzTEMKNUNUeGtzZCtLQ0RGWldMT2RXSUpwSTcrNklEVjc1b3ZiYTVBZlFJREFRQUJBb0lCQVFESG9tTE9qYTZKb1AxRgpYTlZXVlBpZjd4Wlc2eUJmRFdlUDFaWnAwdHhadFF3eWVNYlRvRDk2QW9WQlVXOUZ4bURCbTRWRUFoRUc5T0Z5CkkvTXVJOU1DSXpUa25Ick5PQXdSYUNWa2ZKdUhCaG9oczJuT0JiSG5UbHFFeHdYdlFPdlhzcnEyU1ZORE9XRTgKN3hLc0ljRlh5S1B2dXJyLzZaRDRZeDQwWGlKaGdZR3g1RklVd2dXRSs1bTB6SGJ1aVFjdFJtaUFOZElTU01QaApyem5JWFBsRm1DcjZ2a3VnL0x5MTVKTll1TXdCaDN4OW44aGRqOWh0czhTeERRSlBZU2ZpZWRUaGlBVVpPOHJLCkVVMUdtVXdPdGJQS3ZUYzNyd25VbHA5MGMrUmN3V3JUS2hpbk5FYUhRVDJFbTNtYlBkOHhSYmpZSDRVdE9zV1UKZnZ3eDFUWXRBb0dCQU5RNWdLSWJFQWdxQXZDY0RVckNwckVQVjd5dU41MnJwTTkzSFRGSklTbk9XWG5sd0tHcAphUXBldUJDSVQvRnYwQWdSdDBiajVCeENTazBiM0hkaGxGVk02aWY4RE9QSHBqd1VFNEgyUDN3WExNMWVyYkRTCnVCQjZ6U1oxTCs1WUJLU3FCTld5T1M4Q290NFRCVG9yalNxanVuZGJXT01YMTJncmpmWXNiSEtuQW9HQkFQMXoKZHpkaG9mbEZOK2twS0tHNDYwcGdDMk54eXZXbk5RVkEyVVVoSWhlOGxzWnI5bTNMT3FzSWVqYU1tM3hibmM5dQozcXJhZS9sekF1bkUweSt6c1ZRS1FBcEYrdnF3cm9iTVRhdmpQUkRJUmlGQWo2bElYWDJwVjVIam9ZclF3YVg4Ck5YTzZmODRrWWFIYy9GYkk0S0sxVmthenlkbjNsQ0FXZVpJRU1BdzdBb0dBSlo4MEFJalBwTUxkMW8yemhZZFEKU1o4d3JKQXQ1OU9mMmUrQnkxVHRmaDNJbXVWeDZyYS9ta2tFVkZuMTRoVXlTZHZxSTdVT29UdlhOQ2cyUXl1WApRaS9xYXNBeUFNZEozdWlvTktmVXhVak9kbkhNVk1abVB2V21IS1UxcEFrU2VhWnlTUGZaVDA0bVZUd0Y5elAxClNKUFI0SXJmRFJNUzZyS2Q3Z0FlRVkwQ2dZRUF3VjloYS8ydnFSSG9zSnBZaDlzZ21lUmhqQVA4Q0NVRXpQZEgKVGZrVG0reWxWTXAyZ0JwNHJwbVBOU05lVmlsSVpFV0EyZlpNZEd3Tm92SXE5dEF3MFovb2NHNG9LVEM0Vjl4MAp2bHBuOHUvNm9kQXlTOFFNb0oyZFZJL0tackVUcm1LWkhhMERhZkpVRXowWndkVU5udGFmOXQyaGVnM3RFL1pSCjF0Z2ZHSlVDZ1lFQXltMXpMNTlLMVd2SVh2dlliMEJHMEhnTFlMQVNScmNaS3NNNXQvdW9SajRnQk9VVjVrNXAKNUJWajZjakJ2UXZEKzMrUUtGQzJhSlFUOFhzK1dJL2dsbmttcFcvUVRmV3kvRUNQREM4L3dwOVZuQ0xrQ1VnSApRU1doTTR2cFRieHVnMXJ0NGFGempHWXhMTndRbWs4eFdCanJOWWg0VXlVMkZZUXgzdTFFdFFBPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
    EOT
    labels                                     = {
        "test1" = "test1"
        "test2" = "test2"
    }
    managed_cluster_internet_security_policies = [
        "3.3.3.3",
        "1.1.1.1",
    ]
    network_type                               = "GR"
    node_name_type                             = "lan-ip"
    password                                   = "ERM0IUxU4yBlM0Q0qVfREYEZJQ98rYWN"
    project_id                                 = 0
    security_policy                            = [
        "3.3.3.3",
        "1.1.1.1",
    ]
    unschedulable                              = 0
    user_name                                  = "admin"
    vpc_id                                     = "vpc-h70b6b49"
    worker_instances_list                      = [
        {
            failed_reason  = ""
            instance_id    = "ins-65s89p48"
            instance_role  = "WORKER"
            instance_state = "initializing"
            lan_ip         = "172.16.1.223"
        },
        {
            failed_reason  = ""
            instance_id    = "ins-3yv0g886"
            instance_role  = "WORKER"
            instance_state = "initializing"
            lan_ip         = "172.16.48.121"
        },
    ]

    node_pool_global_config {
        expander                       = "random"
        ignore_daemon_sets_utilization = false
        is_scale_in_enabled            = true
        max_concurrent_scale_in        = 12
        scale_in_delay                 = 15
        scale_in_unneeded_time         = 15
        scale_in_utilization_threshold = 30
        skip_nodes_with_local_storage  = true
        skip_nodes_with_system_pods    = true
    }

    worker_config {
        availability_zone                       = "ap-guangzhou-3"
        count                                   = 1
        enhanced_monitor_service                = false
        enhanced_security_service               = false
        instance_charge_type                    = "POSTPAID_BY_HOUR"
        instance_charge_type_prepaid_period     = 1
        instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
        instance_name                           = "sub machine of tke"
        instance_type                           = "SA2.2XLARGE16"
        internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
        internet_max_bandwidth_out              = 100
        password                                = (sensitive value)
        public_ip_assigned                      = true
        subnet_id                               = "subnet-1uwh63so"
        system_disk_size                        = 60
        system_disk_type                        = "CLOUD_SSD"
        user_data                               = "dGVzdA=="

        data_disk {
            disk_size = 50
            disk_type = "CLOUD_PREMIUM"
        }
    }
    worker_config {
        availability_zone                       = "ap-guangzhou-4"
        cam_role_name                           = "CVM_QcsRole"
        count                                   = 1
        enhanced_monitor_service                = false
        enhanced_security_service               = false
        instance_charge_type                    = "POSTPAID_BY_HOUR"
        instance_charge_type_prepaid_period     = 1
        instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
        instance_name                           = "sub machine of tke"
        instance_type                           = "SA2.2XLARGE16"
        internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
        internet_max_bandwidth_out              = 100
        password                                = (sensitive value)
        public_ip_assigned                      = true
        subnet_id                               = "subnet-q6fhy1mi"
        system_disk_size                        = 60
        system_disk_type                        = "CLOUD_SSD"
        user_data                               = "dGVzdA=="

        data_disk {
            disk_size = 50
            disk_type = "CLOUD_PREMIUM"
        }
    }
}
```

##### 3. new version modify

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

tencentcloud_kubernetes_cluster.managed_cluster: Refreshing state... [id=cls-mlrkoi8k]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be updated in-place
  ~ resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
        id                                         = "cls-mlrkoi8k"
        tags                                       = {}
        # (34 unchanged attributes hidden)

      ~ node_pool_global_config {
          ~ expander                       = "random" -> "most-pods"
          ~ ignore_daemon_sets_utilization = false -> true
          ~ max_concurrent_scale_in        = 12 -> 11
          ~ scale_in_delay                 = 15 -> 11
          ~ scale_in_unneeded_time         = 15 -> 11
          ~ scale_in_utilization_threshold = 30 -> 50
          ~ skip_nodes_with_system_pods    = true -> false
            # (2 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_kubernetes_cluster.managed_cluster: Modifying... [id=cls-mlrkoi8k]
tencentcloud_kubernetes_cluster.managed_cluster: Modifications complete after 2s [id=cls-mlrkoi8k]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

```
terraform show
# data.tencentcloud_vpc_subnets.vpc_first:
data "tencentcloud_vpc_subnets" "vpc_first" {
    availability_zone = "ap-guangzhou-3"
    id                = "515108a726ede70670174519bf2c8902"
    instance_list     = [
        {
            availability_zone  = "ap-guangzhou-3"
            available_ip_count = 4071
            cidr_block         = "172.16.0.0/20"
            create_time        = "2019-07-24 16:51:00"
            is_default         = true
            is_multicast       = false
            name               = "Default-Subnet-Terraform-Keep"
            route_table_id     = "rtb-4ux9eaoc"
            subnet_id          = "subnet-1uwh63so"
            tags               = {}
            vpc_id             = "vpc-h70b6b49"
        },
    ]
    is_default        = true
}

# data.tencentcloud_vpc_subnets.vpc_second:
data "tencentcloud_vpc_subnets" "vpc_second" {
    availability_zone = "ap-guangzhou-4"
    id                = "4bb54279b70dd614245512b3cf395f9e"
    instance_list     = [
        {
            availability_zone  = "ap-guangzhou-4"
            available_ip_count = 4088
            cidr_block         = "172.16.48.0/20"
            create_time        = "2019-08-08 16:23:05"
            is_default         = true
            is_multicast       = false
            name               = "Default-Subnet-Terraform-Keep"
            route_table_id     = "rtb-4ux9eaoc"
            subnet_id          = "subnet-q6fhy1mi"
            tags               = {}
            vpc_id             = "vpc-h70b6b49"
        },
    ]
    is_default        = true
}

# tencentcloud_kubernetes_cluster.managed_cluster:
resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
    certification_authority                    = <<-EOT
        -----BEGIN CERTIFICATE-----
        MIICyDCCAbCgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
        cm5ldGVzMB4XDTIxMDMyNjEwMzAwMloXDTMxMDMyNDEwMzAwMlowFTETMBEGA1UE
        AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALDE
        mik09Wdf+gBHEQI5d9V25GUvNcE2mx500/O37ktMMW6SpeDVVoJ/jH1ovmcjR77E
        fSOSDLorh4AFyCZMPGv56d81GmqmdES6+UxgyJzzQqXZ6EJYMZXM8FUhh7LUINGA
        CfyHLXD6EaR4Eek4tCPfTdkO0sVtptYUbiHUy0DxL3CN6g0s6BeTMFC7uXGm2Pc3
        kbGqTzrPbfUkmNAeWcjF+Lvdg80GiVMryiZKDTK+rTGu122whcAH+kQrK7VXWwuF
        Hywo48wveeP9s7TuO5FHzIG90zx8ToFlp++hKdipLVi9Ym+XTmGuIWMuhN622fJ4
        BYnZYMeqL6NB/s+fkE8CAwEAAaMjMCEwDgYDVR0PAQH/BAQDAgKUMA8GA1UdEwEB
        /wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBALCo6H19bwue1+MJS5llUl52HqkZ
        g583gExvR2yVDDSz+SEnN2kwNgEklSrx9Ud6VpbaToeRACMDrTJl7b1EM18bPXVd
        zJU2SP7IYTDyuL9L4k1iWKCGvONjlpZ3hByKJvOZxPRLK1SMkmVBrXloCbIelpuT
        /UzqsQCE4CCJjUss4XMe0XZs8GSxu6Z0gyutBWM1+OUt7kY3GL96JtR4T+Mec+He
        edbSXV2cUkN/mGMFY5O0wgxOKhIzDJmusMSw13jhzDMHvd1aWMJK7otdsvEFYkU0
        S1Ak4TYbkgVxrIusdd3PhCaEh4+5UIhFrO2K8UQyKiSzEgEdraIoI48bwqw=
        -----END CERTIFICATE-----
    EOT
    claim_expired_seconds                      = 300
    cluster_as_enabled                         = false
    cluster_cidr                               = "10.31.0.0/16"
    cluster_deploy_type                        = "MANAGED_CLUSTER"
    cluster_desc                               = "test cluster desc"
    cluster_external_endpoint                  = "https://cls-mlrkoi8k.ccs.tencent-cloud.com"
    cluster_internet                           = true
    cluster_intranet                           = false
    cluster_ipvs                               = true
    cluster_max_pod_num                        = 32
    cluster_max_service_num                    = 32
    cluster_name                               = "test"
    cluster_node_num                           = 2
    cluster_os                                 = "ubuntu16.04.1 LTSx86_64"
    cluster_os_type                            = "GENERAL"
    cluster_version                            = "1.10.5"
    container_runtime                          = "docker"
    deletion_protection                        = false
    domain                                     = "cls-mlrkoi8k.ccs.tencent-cloud.com"
    id                                         = "cls-mlrkoi8k"
    ignore_cluster_cidr_conflict               = false
    is_non_static_ip_mode                      = false
    kube_config                                = <<-EOT
        apiVersion: v1
        clusters:
        - cluster:
            certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ETXlOakV3TXpBd01sb1hEVE14TURNeU5ERXdNekF3TWxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTERFCm1pazA5V2RmK2dCSEVRSTVkOVYyNUdVdk5jRTJteDUwMC9PMzdrdE1NVzZTcGVEVlZvSi9qSDFvdm1jalI3N0UKZlNPU0RMb3JoNEFGeUNaTVBHdjU2ZDgxR21xbWRFUzYrVXhneUp6elFxWFo2RUpZTVpYTThGVWhoN0xVSU5HQQpDZnlITFhENkVhUjRFZWs0dENQZlRka08wc1Z0cHRZVWJpSFV5MER4TDNDTjZnMHM2QmVUTUZDN3VYR20yUGMzCmtiR3FUenJQYmZVa21OQWVXY2pGK0x2ZGc4MEdpVk1yeWlaS0RUSytyVEd1MTIyd2hjQUgra1FySzdWWFd3dUYKSHl3bzQ4d3ZlZVA5czdUdU81Rkh6SUc5MHp4OFRvRmxwKytoS2RpcExWaTlZbStYVG1HdUlXTXVoTjYyMmZKNApCWW5aWU1lcUw2TkIvcytma0U4Q0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0tVTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFMQ282SDE5Ynd1ZTErTUpTNWxsVWw1Mkhxa1oKZzU4M2dFeHZSMnlWRERTeitTRW5OMmt3TmdFa2xTcng5VWQ2VnBiYVRvZVJBQ01EclRKbDdiMUVNMThiUFhWZAp6SlUyU1A3SVlURHl1TDlMNGsxaVdLQ0d2T05qbHBaM2hCeUtKdk9aeFBSTEsxU01rbVZCclhsb0NiSWVscHVUCi9VenFzUUNFNENDSmpVc3M0WE1lMFhaczhHU3h1NlowZ3l1dEJXTTErT1V0N2tZM0dMOTZKdFI0VCtNZWMrSGUKZWRiU1hWMmNVa04vbUdNRlk1TzB3Z3hPS2hJekRKbXVzTVN3MTNqaHpETUh2ZDFhV01KSzdvdGRzdkVGWWtVMApTMUFrNFRZYmtnVnhySXVzZGQzUGhDYUVoNCs1VUloRnJPMks4VVF5S2lTekVnRWRyYUlvSTQ4Yndxdz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
            server: https://cls-mlrkoi8k.ccs.tencent-cloud.com
          name: cls-mlrkoi8k
        contexts:
        - context:
            cluster: cls-mlrkoi8k
            user: "100017870904"
          name: cls-mlrkoi8k-100017870904-context-default
        current-context: cls-mlrkoi8k-100017870904-context-default
        kind: Config
        preferences: {}
        users:
        - name: "100017870904"
          user:
            client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURERENDQWZTZ0F3SUJBZ0lJYTNSMjdmQzRBS3N3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TVRBek1qWXhNRE15TURoYUZ3MDBNVEF6TWpZeE1ETXlNRGhhTURZeApFakFRQmdOVkJBb1RDWFJyWlRwMWMyVnljekVnTUI0R0ExVUVBeE1YTVRBd01ERTNPRGN3T1RBMExURTJNVFkzCk5UUTNNamd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRRFNISXpKb2FjT09oWXYKZWZ4ejVWYTJndDVoL2dQMncrejJTQ0M1QWs2ZDJka0VBeTNleVRUWG5aL1NjVXg2TVFZcG9ZK3NCN3U1dVF6MwpmK3JERGtBQXY4Wm8zYVBzcC8wY21DQXZYb01uWVM1YVdJTVNIOHV4ZWl2eDhqQjJ3bTVmSnQ5L09KalMxMWFMCnlrWDJCeXJ5b0UrUHRhWGVhZkw1dlMveVhtRXlCdzJ0RXpyaHNnc3kxMDRWL3c4S21UcWhLT1RERFp0aTJNM0cKMGkveWtIUmRFVXlrNmhvMk1CV0luaEw5YitVRExjdzFrLzNQdWJhQjdNRkkwREc3Q3FGQ3JvTXlUeUtUdjRxWgpCcTA1N3ZONjVvVTZzQ1lRM1dUeUNzdUszSFFaM3Q3bXdzTGtKUEdTeDM0b0lNVmxZczUxWWdta2p2N29nTlh2Cm1pOXRya0I5QWdNQkFBR2pQekE5TUE0R0ExVWREd0VCL3dRRUF3SUNoREFkQmdOVkhTVUVGakFVQmdnckJnRUYKQlFjREFnWUlLd1lCQlFVSEF3RXdEQVlEVlIwVEFRSC9CQUl3QURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpsOWg0TnJrN3VHZ04wWGl6OUdmeHlSdHpvNnlqd2FOaDBhYzJUWklFNFFwT2dNNjdRNitRSVRIU2cxMWNXVGdnCkdqOTdxNkhCWjNSSTVLclRuUmJmN2VxaUFuV1pManhOQmsyRXZ6Y3k2czdzbHIraGJmZHR5aHVIdUJrZlh4WlkKQXpJVEQxS1dmVlpoL2t0OHhPZ3ZOQThUVCtwdGlJYlBmZTZWTGdJMkxkN0NXQS82TUhISk9XUy9vN095UllncwpNZXk3WmxVYXJYeTN6S1ZnZ0V1UCtTOVBBK0hjdVRERkVuaVNBaEJTT09SWWtVWjJQdWdUeVhvNHVOU1RRVjJFCk15OGc2bDJSOW1IYlM2bFdJMisyd1cvd2NzVi9zZjJVZ1N2V2lQTDNsOHlnaFNHemluRkYzT05HZFl4NTh3MnoKREVvZWVNbDhPd3AwaTJSTVp4MjRRdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
            client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBMGh5TXlhR25Eam9XTDNuOGMrVld0b0xlWWY0RDlzUHM5a2dndVFKT25kblpCQU10CjNzazAxNTJmMG5GTWVqRUdLYUdQckFlN3Via005My9xd3c1QUFML0dhTjJqN0tmOUhKZ2dMMTZESjJFdVdsaUQKRWgvTHNYb3I4Zkl3ZHNKdVh5YmZmemlZMHRkV2k4cEY5Z2NxOHFCUGo3V2wzbW55K2IwdjhsNWhNZ2NOclJNNgo0YklMTXRkT0ZmOFBDcGs2b1Nqa3d3MmJZdGpOeHRJdjhwQjBYUkZNcE9vYU5qQVZpSjRTL1cvbEF5M01OWlA5Cno3bTJnZXpCU05BeHV3cWhRcTZETWs4aWs3K0ttUWF0T2U3emV1YUZPckFtRU4xazhnckxpdHgwR2Q3ZTVzTEMKNUNUeGtzZCtLQ0RGWldMT2RXSUpwSTcrNklEVjc1b3ZiYTVBZlFJREFRQUJBb0lCQVFESG9tTE9qYTZKb1AxRgpYTlZXVlBpZjd4Wlc2eUJmRFdlUDFaWnAwdHhadFF3eWVNYlRvRDk2QW9WQlVXOUZ4bURCbTRWRUFoRUc5T0Z5CkkvTXVJOU1DSXpUa25Ick5PQXdSYUNWa2ZKdUhCaG9oczJuT0JiSG5UbHFFeHdYdlFPdlhzcnEyU1ZORE9XRTgKN3hLc0ljRlh5S1B2dXJyLzZaRDRZeDQwWGlKaGdZR3g1RklVd2dXRSs1bTB6SGJ1aVFjdFJtaUFOZElTU01QaApyem5JWFBsRm1DcjZ2a3VnL0x5MTVKTll1TXdCaDN4OW44aGRqOWh0czhTeERRSlBZU2ZpZWRUaGlBVVpPOHJLCkVVMUdtVXdPdGJQS3ZUYzNyd25VbHA5MGMrUmN3V3JUS2hpbk5FYUhRVDJFbTNtYlBkOHhSYmpZSDRVdE9zV1UKZnZ3eDFUWXRBb0dCQU5RNWdLSWJFQWdxQXZDY0RVckNwckVQVjd5dU41MnJwTTkzSFRGSklTbk9XWG5sd0tHcAphUXBldUJDSVQvRnYwQWdSdDBiajVCeENTazBiM0hkaGxGVk02aWY4RE9QSHBqd1VFNEgyUDN3WExNMWVyYkRTCnVCQjZ6U1oxTCs1WUJLU3FCTld5T1M4Q290NFRCVG9yalNxanVuZGJXT01YMTJncmpmWXNiSEtuQW9HQkFQMXoKZHpkaG9mbEZOK2twS0tHNDYwcGdDMk54eXZXbk5RVkEyVVVoSWhlOGxzWnI5bTNMT3FzSWVqYU1tM3hibmM5dQozcXJhZS9sekF1bkUweSt6c1ZRS1FBcEYrdnF3cm9iTVRhdmpQUkRJUmlGQWo2bElYWDJwVjVIam9ZclF3YVg4Ck5YTzZmODRrWWFIYy9GYkk0S0sxVmthenlkbjNsQ0FXZVpJRU1BdzdBb0dBSlo4MEFJalBwTUxkMW8yemhZZFEKU1o4d3JKQXQ1OU9mMmUrQnkxVHRmaDNJbXVWeDZyYS9ta2tFVkZuMTRoVXlTZHZxSTdVT29UdlhOQ2cyUXl1WApRaS9xYXNBeUFNZEozdWlvTktmVXhVak9kbkhNVk1abVB2V21IS1UxcEFrU2VhWnlTUGZaVDA0bVZUd0Y5elAxClNKUFI0SXJmRFJNUzZyS2Q3Z0FlRVkwQ2dZRUF3VjloYS8ydnFSSG9zSnBZaDlzZ21lUmhqQVA4Q0NVRXpQZEgKVGZrVG0reWxWTXAyZ0JwNHJwbVBOU05lVmlsSVpFV0EyZlpNZEd3Tm92SXE5dEF3MFovb2NHNG9LVEM0Vjl4MAp2bHBuOHUvNm9kQXlTOFFNb0oyZFZJL0tackVUcm1LWkhhMERhZkpVRXowWndkVU5udGFmOXQyaGVnM3RFL1pSCjF0Z2ZHSlVDZ1lFQXltMXpMNTlLMVd2SVh2dlliMEJHMEhnTFlMQVNScmNaS3NNNXQvdW9SajRnQk9VVjVrNXAKNUJWajZjakJ2UXZEKzMrUUtGQzJhSlFUOFhzK1dJL2dsbmttcFcvUVRmV3kvRUNQREM4L3dwOVZuQ0xrQ1VnSApRU1doTTR2cFRieHVnMXJ0NGFGempHWXhMTndRbWs4eFdCanJOWWg0VXlVMkZZUXgzdTFFdFFBPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
    EOT
    labels                                     = {
        "test1" = "test1"
        "test2" = "test2"
    }
    managed_cluster_internet_security_policies = [
        "3.3.3.3",
        "1.1.1.1",
    ]
    network_type                               = "GR"
    node_name_type                             = "lan-ip"
    password                                   = "ERM0IUxU4yBlM0Q0qVfREYEZJQ98rYWN"
    project_id                                 = 0
    security_policy                            = [
        "3.3.3.3",
        "1.1.1.1",
    ]
    tags                                       = {}
    unschedulable                              = 0
    user_name                                  = "admin"
    vpc_id                                     = "vpc-h70b6b49"
    worker_instances_list                      = [
        {
            failed_reason  = "=Ready:True"
            instance_id    = "ins-65s89p48"
            instance_role  = "WORKER"
            instance_state = "running"
            lan_ip         = "172.16.1.223"
        },
        {
            failed_reason  = "=Ready:True"
            instance_id    = "ins-3yv0g886"
            instance_role  = "WORKER"
            instance_state = "running"
            lan_ip         = "172.16.48.121"
        },
    ]

    node_pool_global_config {
        expander                       = "most-pods"
        ignore_daemon_sets_utilization = true
        is_scale_in_enabled            = true
        max_concurrent_scale_in        = 11
        scale_in_delay                 = 11
        scale_in_unneeded_time         = 11
        scale_in_utilization_threshold = 50
        skip_nodes_with_local_storage  = true
        skip_nodes_with_system_pods    = true
    }

    worker_config {
        availability_zone                       = "ap-guangzhou-3"
        count                                   = 1
        enhanced_monitor_service                = false
        enhanced_security_service               = false
        instance_charge_type                    = "POSTPAID_BY_HOUR"
        instance_charge_type_prepaid_period     = 1
        instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
        instance_name                           = "sub machine of tke"
        instance_type                           = "SA2.2XLARGE16"
        internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
        internet_max_bandwidth_out              = 100
        key_ids                                 = []
        password                                = (sensitive value)
        public_ip_assigned                      = true
        security_group_ids                      = []
        subnet_id                               = "subnet-1uwh63so"
        system_disk_size                        = 60
        system_disk_type                        = "CLOUD_SSD"
        user_data                               = "dGVzdA=="

        data_disk {
            disk_size = 50
            disk_type = "CLOUD_PREMIUM"
        }
    }
    worker_config {
        availability_zone                       = "ap-guangzhou-4"
        cam_role_name                           = "CVM_QcsRole"
        count                                   = 1
        enhanced_monitor_service                = false
        enhanced_security_service               = false
        instance_charge_type                    = "POSTPAID_BY_HOUR"
        instance_charge_type_prepaid_period     = 1
        instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
        instance_name                           = "sub machine of tke"
        instance_type                           = "SA2.2XLARGE16"
        internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
        internet_max_bandwidth_out              = 100
        key_ids                                 = []
        password                                = (sensitive value)
        public_ip_assigned                      = true
        security_group_ids                      = []
        subnet_id                               = "subnet-q6fhy1mi"
        system_disk_size                        = 60
        system_disk_type                        = "CLOUD_SSD"
        user_data                               = "dGVzdA=="

        data_disk {
            disk_size = 50
            disk_type = "CLOUD_PREMIUM"
        }
    }
}
```

##### 4. new version cluster destroy

```
terraform destroy

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be destroyed
  - resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
      - certification_authority                    = <<-EOT
            -----BEGIN CERTIFICATE-----
            MIICyDCCAbCgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
            cm5ldGVzMB4XDTIxMDMyNjEwMzAwMloXDTMxMDMyNDEwMzAwMlowFTETMBEGA1UE
            AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALDE
            mik09Wdf+gBHEQI5d9V25GUvNcE2mx500/O37ktMMW6SpeDVVoJ/jH1ovmcjR77E
            fSOSDLorh4AFyCZMPGv56d81GmqmdES6+UxgyJzzQqXZ6EJYMZXM8FUhh7LUINGA
            CfyHLXD6EaR4Eek4tCPfTdkO0sVtptYUbiHUy0DxL3CN6g0s6BeTMFC7uXGm2Pc3
            kbGqTzrPbfUkmNAeWcjF+Lvdg80GiVMryiZKDTK+rTGu122whcAH+kQrK7VXWwuF
            Hywo48wveeP9s7TuO5FHzIG90zx8ToFlp++hKdipLVi9Ym+XTmGuIWMuhN622fJ4
            BYnZYMeqL6NB/s+fkE8CAwEAAaMjMCEwDgYDVR0PAQH/BAQDAgKUMA8GA1UdEwEB
            /wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBALCo6H19bwue1+MJS5llUl52HqkZ
            g583gExvR2yVDDSz+SEnN2kwNgEklSrx9Ud6VpbaToeRACMDrTJl7b1EM18bPXVd
            zJU2SP7IYTDyuL9L4k1iWKCGvONjlpZ3hByKJvOZxPRLK1SMkmVBrXloCbIelpuT
            /UzqsQCE4CCJjUss4XMe0XZs8GSxu6Z0gyutBWM1+OUt7kY3GL96JtR4T+Mec+He
            edbSXV2cUkN/mGMFY5O0wgxOKhIzDJmusMSw13jhzDMHvd1aWMJK7otdsvEFYkU0
            S1Ak4TYbkgVxrIusdd3PhCaEh4+5UIhFrO2K8UQyKiSzEgEdraIoI48bwqw=
            -----END CERTIFICATE-----
        EOT -> null
      - claim_expired_seconds                      = 300 -> null
      - cluster_as_enabled                         = false -> null
      - cluster_cidr                               = "10.31.0.0/16" -> null
      - cluster_deploy_type                        = "MANAGED_CLUSTER" -> null
      - cluster_desc                               = "test cluster desc" -> null
      - cluster_external_endpoint                  = "https://cls-mlrkoi8k.ccs.tencent-cloud.com" -> null
      - cluster_internet                           = true -> null
      - cluster_intranet                           = false -> null
      - cluster_ipvs                               = true -> null
      - cluster_max_pod_num                        = 32 -> null
      - cluster_max_service_num                    = 32 -> null
      - cluster_name                               = "test" -> null
      - cluster_node_num                           = 2 -> null
      - cluster_os                                 = "ubuntu16.04.1 LTSx86_64" -> null
      - cluster_os_type                            = "GENERAL" -> null
      - cluster_version                            = "1.10.5" -> null
      - container_runtime                          = "docker" -> null
      - deletion_protection                        = false -> null
      - domain                                     = "cls-mlrkoi8k.ccs.tencent-cloud.com" -> null
      - id                                         = "cls-mlrkoi8k" -> null
      - ignore_cluster_cidr_conflict               = false -> null
      - is_non_static_ip_mode                      = false -> null
      - kube_config                                = <<-EOT
            apiVersion: v1
            clusters:
            - cluster:
                certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ETXlOakV3TXpBd01sb1hEVE14TURNeU5ERXdNekF3TWxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTERFCm1pazA5V2RmK2dCSEVRSTVkOVYyNUdVdk5jRTJteDUwMC9PMzdrdE1NVzZTcGVEVlZvSi9qSDFvdm1jalI3N0UKZlNPU0RMb3JoNEFGeUNaTVBHdjU2ZDgxR21xbWRFUzYrVXhneUp6elFxWFo2RUpZTVpYTThGVWhoN0xVSU5HQQpDZnlITFhENkVhUjRFZWs0dENQZlRka08wc1Z0cHRZVWJpSFV5MER4TDNDTjZnMHM2QmVUTUZDN3VYR20yUGMzCmtiR3FUenJQYmZVa21OQWVXY2pGK0x2ZGc4MEdpVk1yeWlaS0RUSytyVEd1MTIyd2hjQUgra1FySzdWWFd3dUYKSHl3bzQ4d3ZlZVA5czdUdU81Rkh6SUc5MHp4OFRvRmxwKytoS2RpcExWaTlZbStYVG1HdUlXTXVoTjYyMmZKNApCWW5aWU1lcUw2TkIvcytma0U4Q0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0tVTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFMQ282SDE5Ynd1ZTErTUpTNWxsVWw1Mkhxa1oKZzU4M2dFeHZSMnlWRERTeitTRW5OMmt3TmdFa2xTcng5VWQ2VnBiYVRvZVJBQ01EclRKbDdiMUVNMThiUFhWZAp6SlUyU1A3SVlURHl1TDlMNGsxaVdLQ0d2T05qbHBaM2hCeUtKdk9aeFBSTEsxU01rbVZCclhsb0NiSWVscHVUCi9VenFzUUNFNENDSmpVc3M0WE1lMFhaczhHU3h1NlowZ3l1dEJXTTErT1V0N2tZM0dMOTZKdFI0VCtNZWMrSGUKZWRiU1hWMmNVa04vbUdNRlk1TzB3Z3hPS2hJekRKbXVzTVN3MTNqaHpETUh2ZDFhV01KSzdvdGRzdkVGWWtVMApTMUFrNFRZYmtnVnhySXVzZGQzUGhDYUVoNCs1VUloRnJPMks4VVF5S2lTekVnRWRyYUlvSTQ4Yndxdz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
                server: https://cls-mlrkoi8k.ccs.tencent-cloud.com
              name: cls-mlrkoi8k
            contexts:
            - context:
                cluster: cls-mlrkoi8k
                user: "100017870904"
              name: cls-mlrkoi8k-100017870904-context-default
            current-context: cls-mlrkoi8k-100017870904-context-default
            kind: Config
            preferences: {}
            users:
            - name: "100017870904"
              user:
                client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURERENDQWZTZ0F3SUJBZ0lJYTNSMjdmQzRBS3N3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TVRBek1qWXhNRE15TURoYUZ3MDBNVEF6TWpZeE1ETXlNRGhhTURZeApFakFRQmdOVkJBb1RDWFJyWlRwMWMyVnljekVnTUI0R0ExVUVBeE1YTVRBd01ERTNPRGN3T1RBMExURTJNVFkzCk5UUTNNamd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRRFNISXpKb2FjT09oWXYKZWZ4ejVWYTJndDVoL2dQMncrejJTQ0M1QWs2ZDJka0VBeTNleVRUWG5aL1NjVXg2TVFZcG9ZK3NCN3U1dVF6MwpmK3JERGtBQXY4Wm8zYVBzcC8wY21DQXZYb01uWVM1YVdJTVNIOHV4ZWl2eDhqQjJ3bTVmSnQ5L09KalMxMWFMCnlrWDJCeXJ5b0UrUHRhWGVhZkw1dlMveVhtRXlCdzJ0RXpyaHNnc3kxMDRWL3c4S21UcWhLT1RERFp0aTJNM0cKMGkveWtIUmRFVXlrNmhvMk1CV0luaEw5YitVRExjdzFrLzNQdWJhQjdNRkkwREc3Q3FGQ3JvTXlUeUtUdjRxWgpCcTA1N3ZONjVvVTZzQ1lRM1dUeUNzdUszSFFaM3Q3bXdzTGtKUEdTeDM0b0lNVmxZczUxWWdta2p2N29nTlh2Cm1pOXRya0I5QWdNQkFBR2pQekE5TUE0R0ExVWREd0VCL3dRRUF3SUNoREFkQmdOVkhTVUVGakFVQmdnckJnRUYKQlFjREFnWUlLd1lCQlFVSEF3RXdEQVlEVlIwVEFRSC9CQUl3QURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpsOWg0TnJrN3VHZ04wWGl6OUdmeHlSdHpvNnlqd2FOaDBhYzJUWklFNFFwT2dNNjdRNitRSVRIU2cxMWNXVGdnCkdqOTdxNkhCWjNSSTVLclRuUmJmN2VxaUFuV1pManhOQmsyRXZ6Y3k2czdzbHIraGJmZHR5aHVIdUJrZlh4WlkKQXpJVEQxS1dmVlpoL2t0OHhPZ3ZOQThUVCtwdGlJYlBmZTZWTGdJMkxkN0NXQS82TUhISk9XUy9vN095UllncwpNZXk3WmxVYXJYeTN6S1ZnZ0V1UCtTOVBBK0hjdVRERkVuaVNBaEJTT09SWWtVWjJQdWdUeVhvNHVOU1RRVjJFCk15OGc2bDJSOW1IYlM2bFdJMisyd1cvd2NzVi9zZjJVZ1N2V2lQTDNsOHlnaFNHemluRkYzT05HZFl4NTh3MnoKREVvZWVNbDhPd3AwaTJSTVp4MjRRdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
                client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBMGh5TXlhR25Eam9XTDNuOGMrVld0b0xlWWY0RDlzUHM5a2dndVFKT25kblpCQU10CjNzazAxNTJmMG5GTWVqRUdLYUdQckFlN3Via005My9xd3c1QUFML0dhTjJqN0tmOUhKZ2dMMTZESjJFdVdsaUQKRWgvTHNYb3I4Zkl3ZHNKdVh5YmZmemlZMHRkV2k4cEY5Z2NxOHFCUGo3V2wzbW55K2IwdjhsNWhNZ2NOclJNNgo0YklMTXRkT0ZmOFBDcGs2b1Nqa3d3MmJZdGpOeHRJdjhwQjBYUkZNcE9vYU5qQVZpSjRTL1cvbEF5M01OWlA5Cno3bTJnZXpCU05BeHV3cWhRcTZETWs4aWs3K0ttUWF0T2U3emV1YUZPckFtRU4xazhnckxpdHgwR2Q3ZTVzTEMKNUNUeGtzZCtLQ0RGWldMT2RXSUpwSTcrNklEVjc1b3ZiYTVBZlFJREFRQUJBb0lCQVFESG9tTE9qYTZKb1AxRgpYTlZXVlBpZjd4Wlc2eUJmRFdlUDFaWnAwdHhadFF3eWVNYlRvRDk2QW9WQlVXOUZ4bURCbTRWRUFoRUc5T0Z5CkkvTXVJOU1DSXpUa25Ick5PQXdSYUNWa2ZKdUhCaG9oczJuT0JiSG5UbHFFeHdYdlFPdlhzcnEyU1ZORE9XRTgKN3hLc0ljRlh5S1B2dXJyLzZaRDRZeDQwWGlKaGdZR3g1RklVd2dXRSs1bTB6SGJ1aVFjdFJtaUFOZElTU01QaApyem5JWFBsRm1DcjZ2a3VnL0x5MTVKTll1TXdCaDN4OW44aGRqOWh0czhTeERRSlBZU2ZpZWRUaGlBVVpPOHJLCkVVMUdtVXdPdGJQS3ZUYzNyd25VbHA5MGMrUmN3V3JUS2hpbk5FYUhRVDJFbTNtYlBkOHhSYmpZSDRVdE9zV1UKZnZ3eDFUWXRBb0dCQU5RNWdLSWJFQWdxQXZDY0RVckNwckVQVjd5dU41MnJwTTkzSFRGSklTbk9XWG5sd0tHcAphUXBldUJDSVQvRnYwQWdSdDBiajVCeENTazBiM0hkaGxGVk02aWY4RE9QSHBqd1VFNEgyUDN3WExNMWVyYkRTCnVCQjZ6U1oxTCs1WUJLU3FCTld5T1M4Q290NFRCVG9yalNxanVuZGJXT01YMTJncmpmWXNiSEtuQW9HQkFQMXoKZHpkaG9mbEZOK2twS0tHNDYwcGdDMk54eXZXbk5RVkEyVVVoSWhlOGxzWnI5bTNMT3FzSWVqYU1tM3hibmM5dQozcXJhZS9sekF1bkUweSt6c1ZRS1FBcEYrdnF3cm9iTVRhdmpQUkRJUmlGQWo2bElYWDJwVjVIam9ZclF3YVg4Ck5YTzZmODRrWWFIYy9GYkk0S0sxVmthenlkbjNsQ0FXZVpJRU1BdzdBb0dBSlo4MEFJalBwTUxkMW8yemhZZFEKU1o4d3JKQXQ1OU9mMmUrQnkxVHRmaDNJbXVWeDZyYS9ta2tFVkZuMTRoVXlTZHZxSTdVT29UdlhOQ2cyUXl1WApRaS9xYXNBeUFNZEozdWlvTktmVXhVak9kbkhNVk1abVB2V21IS1UxcEFrU2VhWnlTUGZaVDA0bVZUd0Y5elAxClNKUFI0SXJmRFJNUzZyS2Q3Z0FlRVkwQ2dZRUF3VjloYS8ydnFSSG9zSnBZaDlzZ21lUmhqQVA4Q0NVRXpQZEgKVGZrVG0reWxWTXAyZ0JwNHJwbVBOU05lVmlsSVpFV0EyZlpNZEd3Tm92SXE5dEF3MFovb2NHNG9LVEM0Vjl4MAp2bHBuOHUvNm9kQXlTOFFNb0oyZFZJL0tackVUcm1LWkhhMERhZkpVRXowWndkVU5udGFmOXQyaGVnM3RFL1pSCjF0Z2ZHSlVDZ1lFQXltMXpMNTlLMVd2SVh2dlliMEJHMEhnTFlMQVNScmNaS3NNNXQvdW9SajRnQk9VVjVrNXAKNUJWajZjakJ2UXZEKzMrUUtGQzJhSlFUOFhzK1dJL2dsbmttcFcvUVRmV3kvRUNQREM4L3dwOVZuQ0xrQ1VnSApRU1doTTR2cFRieHVnMXJ0NGFGempHWXhMTndRbWs4eFdCanJOWWg0VXlVMkZZUXgzdTFFdFFBPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
        EOT -> null
      - labels                                     = {
          - "test1" = "test1"
          - "test2" = "test2"
        } -> null
      - managed_cluster_internet_security_policies = [
          - "3.3.3.3",
          - "1.1.1.1",
        ] -> null
      - network_type                               = "GR" -> null
      - node_name_type                             = "lan-ip" -> null
      - password                                   = "ERM0IUxU4yBlM0Q0qVfREYEZJQ98rYWN" -> null
      - project_id                                 = 0 -> null
      - security_policy                            = [
          - "3.3.3.3",
          - "1.1.1.1",
        ] -> null
      - tags                                       = {} -> null
      - unschedulable                              = 0 -> null
      - user_name                                  = "admin" -> null
      - vpc_id                                     = "vpc-h70b6b49" -> null
      - worker_instances_list                      = [
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-65s89p48"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.1.223"
            },
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-3yv0g886"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.48.121"
            },
        ] -> null

      - node_pool_global_config {
          - expander                       = "most-pods" -> null
          - ignore_daemon_sets_utilization = true -> null
          - is_scale_in_enabled            = true -> null
          - max_concurrent_scale_in        = 11 -> null
          - scale_in_delay                 = 11 -> null
          - scale_in_unneeded_time         = 11 -> null
          - scale_in_utilization_threshold = 50 -> null
          - skip_nodes_with_local_storage  = true -> null
          - skip_nodes_with_system_pods    = true -> null
        }

      - worker_config {
          - availability_zone                       = "ap-guangzhou-3" -> null
          - count                                   = 1 -> null
          - enhanced_monitor_service                = false -> null
          - enhanced_security_service               = false -> null
          - instance_charge_type                    = "POSTPAID_BY_HOUR" -> null
          - instance_charge_type_prepaid_period     = 1 -> null
          - instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW" -> null
          - instance_name                           = "sub machine of tke" -> null
          - instance_type                           = "SA2.2XLARGE16" -> null
          - internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR" -> null
          - internet_max_bandwidth_out              = 100 -> null
          - key_ids                                 = [] -> null
          - password                                = (sensitive value)
          - public_ip_assigned                      = true -> null
          - security_group_ids                      = [] -> null
          - subnet_id                               = "subnet-1uwh63so" -> null
          - system_disk_size                        = 60 -> null
          - system_disk_type                        = "CLOUD_SSD" -> null
          - user_data                               = "dGVzdA==" -> null

          - data_disk {
              - disk_size = 50 -> null
              - disk_type = "CLOUD_PREMIUM" -> null
            }
        }
      - worker_config {
          - availability_zone                       = "ap-guangzhou-4" -> null
          - cam_role_name                           = "CVM_QcsRole" -> null
          - count                                   = 1 -> null
          - enhanced_monitor_service                = false -> null
          - enhanced_security_service               = false -> null
          - instance_charge_type                    = "POSTPAID_BY_HOUR" -> null
          - instance_charge_type_prepaid_period     = 1 -> null
          - instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW" -> null
          - instance_name                           = "sub machine of tke" -> null
          - instance_type                           = "SA2.2XLARGE16" -> null
          - internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR" -> null
          - internet_max_bandwidth_out              = 100 -> null
          - key_ids                                 = [] -> null
          - password                                = (sensitive value)
          - public_ip_assigned                      = true -> null
          - security_group_ids                      = [] -> null
          - subnet_id                               = "subnet-q6fhy1mi" -> null
          - system_disk_size                        = 60 -> null
          - system_disk_type                        = "CLOUD_SSD" -> null
          - user_data                               = "dGVzdA==" -> null

          - data_disk {
              - disk_size = 50 -> null
              - disk_type = "CLOUD_PREMIUM" -> null
            }
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

tencentcloud_kubernetes_cluster.managed_cluster: Destroying... [id=cls-mlrkoi8k]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-mlrkoi8k, 10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-mlrkoi8k, 20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-mlrkoi8k, 30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-mlrkoi8k, 40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-mlrkoi8k, 50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-mlrkoi8k, 1m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-mlrkoi8k, 1m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-mlrkoi8k, 1m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Destruction complete after 1m27s

Destroy complete! Resources: 1 destroyed.
```

##### 5. new version create with no node_pool_global_config

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be created
  + resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
      + certification_authority                    = (known after apply)
      + claim_expired_seconds                      = 300
      + cluster_as_enabled                         = false
      + cluster_cidr                               = "10.32.0.0/16"
      + cluster_deploy_type                        = "MANAGED_CLUSTER"
      + cluster_desc                               = "test cluster desc"
      + cluster_external_endpoint                  = (known after apply)
      + cluster_internet                           = true
      + cluster_intranet                           = false
      + cluster_ipvs                               = true
      + cluster_max_pod_num                        = 32
      + cluster_max_service_num                    = 32
      + cluster_name                               = "old-version-test"
      + cluster_node_num                           = (known after apply)
      + cluster_os                                 = "ubuntu16.04.1 LTSx86_64"
      + cluster_os_type                            = "GENERAL"
      + cluster_version                            = "1.10.5"
      + container_runtime                          = "docker"
      + deletion_protection                        = false
      + domain                                     = (known after apply)
      + id                                         = (known after apply)
      + ignore_cluster_cidr_conflict               = false
      + is_non_static_ip_mode                      = false
      + kube_config                                = (known after apply)
      + labels                                     = {
          + "test1" = "test1"
          + "test2" = "test2"
        }
      + managed_cluster_internet_security_policies = [
          + "3.3.3.3",
          + "1.1.1.1",
        ]
      + network_type                               = "GR"
      + node_name_type                             = "lan-ip"
      + password                                   = (known after apply)
      + pgw_endpoint                               = (known after apply)
      + security_policy                            = (known after apply)
      + unschedulable                              = 0
      + user_name                                  = (known after apply)
      + vpc_id                                     = "vpc-h70b6b49"
      + worker_instances_list                      = (known after apply)

      + node_pool_global_config {
          + expander                       = (known after apply)
          + ignore_daemon_sets_utilization = (known after apply)
          + is_scale_in_enabled            = (known after apply)
          + max_concurrent_scale_in        = (known after apply)
          + scale_in_delay                 = (known after apply)
          + scale_in_unneeded_time         = (known after apply)
          + scale_in_utilization_threshold = (known after apply)
          + skip_nodes_with_local_storage  = (known after apply)
          + skip_nodes_with_system_pods    = (known after apply)
        }

      + worker_config {
          + availability_zone                       = "ap-guangzhou-3"
          + count                                   = 1
          + enhanced_monitor_service                = false
          + enhanced_security_service               = false
          + instance_charge_type                    = "POSTPAID_BY_HOUR"
          + instance_charge_type_prepaid_period     = 1
          + instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
          + instance_name                           = "sub machine of tke"
          + instance_type                           = "SA2.2XLARGE16"
          + internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out              = 100
          + password                                = (sensitive value)
          + public_ip_assigned                      = true
          + subnet_id                               = "subnet-1uwh63so"
          + system_disk_size                        = 60
          + system_disk_type                        = "CLOUD_SSD"
          + user_data                               = "dGVzdA=="

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }
      + worker_config {
          + availability_zone                       = "ap-guangzhou-4"
          + cam_role_name                           = "CVM_QcsRole"
          + count                                   = 1
          + enhanced_monitor_service                = false
          + enhanced_security_service               = false
          + instance_charge_type                    = "POSTPAID_BY_HOUR"
          + instance_charge_type_prepaid_period     = 1
          + instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
          + instance_name                           = "sub machine of tke"
          + instance_type                           = "SA2.2XLARGE16"
          + internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out              = 100
          + password                                = (sensitive value)
          + public_ip_assigned                      = true
          + subnet_id                               = "subnet-q6fhy1mi"
          + system_disk_size                        = 60
          + system_disk_type                        = "CLOUD_SSD"
          + user_data                               = "dGVzdA=="

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_kubernetes_cluster.managed_cluster: Creating...
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Creation complete after 2m9s [id=cls-cdxaw58y]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

```
terraform show
# data.tencentcloud_vpc_subnets.vpc_first:
data "tencentcloud_vpc_subnets" "vpc_first" {
    availability_zone = "ap-guangzhou-3"
    id                = "515108a726ede70670174519bf2c8902"
    instance_list     = [
        {
            availability_zone  = "ap-guangzhou-3"
            available_ip_count = 4072
            cidr_block         = "172.16.0.0/20"
            create_time        = "2019-07-24 16:51:00"
            is_default         = true
            is_multicast       = false
            name               = "Default-Subnet-Terraform-Keep"
            route_table_id     = "rtb-4ux9eaoc"
            subnet_id          = "subnet-1uwh63so"
            tags               = {}
            vpc_id             = "vpc-h70b6b49"
        },
    ]
    is_default        = true
}

# data.tencentcloud_vpc_subnets.vpc_second:
data "tencentcloud_vpc_subnets" "vpc_second" {
    availability_zone = "ap-guangzhou-4"
    id                = "4bb54279b70dd614245512b3cf395f9e"
    instance_list     = [
        {
            availability_zone  = "ap-guangzhou-4"
            available_ip_count = 4089
            cidr_block         = "172.16.48.0/20"
            create_time        = "2019-08-08 16:23:05"
            is_default         = true
            is_multicast       = false
            name               = "Default-Subnet-Terraform-Keep"
            route_table_id     = "rtb-4ux9eaoc"
            subnet_id          = "subnet-q6fhy1mi"
            tags               = {}
            vpc_id             = "vpc-h70b6b49"
        },
    ]
    is_default        = true
}

# tencentcloud_kubernetes_cluster.managed_cluster:
resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
    certification_authority                    = <<-EOT
        -----BEGIN CERTIFICATE-----
        MIICyDCCAbCgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
        cm5ldGVzMB4XDTIxMDMyNjEwMzA1MloXDTMxMDMyNDEwMzA1MlowFTETMBEGA1UE
        AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKNR
        AMDVgFWIftaBQXkNPVE+OyotV76ZKgAfoXlM1JZ9DDTf6/Iy2KjFaEFapjCxMCBM
        glrVtxhOQpEojKyBMN7xSqGM5ESdVa/vAEzcnNcwBUTH3hVEJ3V34W3M2mvsukZC
        htLIOTCE24id0tsGGvkC0nGS2kboMDsDhPMt2HsYWfY1UmZE08pbMzdfzuPGKMTP
        cC7zaVSStIsqtcBB52H/eV4IkSaEsLSP3tyHXulRejcv9L/QvZMYB2bwWmArxIZz
        cLe6quXoDZ62gEMNMUsqazpOMbZOJHHSsRb8+r8mOp0EBh5xN8MeDC56s4Xg5xf0
        D8dAH03CoSr5/9b35y8CAwEAAaMjMCEwDgYDVR0PAQH/BAQDAgKUMA8GA1UdEwEB
        /wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHc891wFTMVCd4irQbwlapHVLDbX
        Tnc6qcdrhMHUL8DBXTQI+UJECaLVp1Fwd2TvB1ZGXp+AcsvhjnMuYEUMWsDD9V4v
        DgrWi1QqpwoW02Mn+X5mjlWCZQzluCjAuzM8+m/PwsW1UjiafealjImWzXsFZo1u
        HYgAXhdLNkAd+iwtmY0nSZZYLU3mSgl4xor31AzYAEfI9kvlRLGzYYurNQQSXC91
        7MpQg0AltH9BLlbUzVbgcx9BX/s077o0WPeGkGZYBZdWgch9kF4lpMoc03tqVctJ
        v31Tne7SofyeJYgpe1FFghMjwh5KSFtc2q7Uw2AMAccc10fufO8v5jj6ogw=
        -----END CERTIFICATE-----
    EOT
    claim_expired_seconds                      = 300
    cluster_as_enabled                         = false
    cluster_cidr                               = "10.32.0.0/16"
    cluster_deploy_type                        = "MANAGED_CLUSTER"
    cluster_desc                               = "test cluster desc"
    cluster_external_endpoint                  = "https://cls-cdxaw58y.ccs.tencent-cloud.com"
    cluster_internet                           = true
    cluster_intranet                           = false
    cluster_ipvs                               = true
    cluster_max_pod_num                        = 32
    cluster_max_service_num                    = 32
    cluster_name                               = "old-version-test"
    cluster_node_num                           = 2
    cluster_os                                 = "ubuntu16.04.1 LTSx86_64"
    cluster_os_type                            = "GENERAL"
    cluster_version                            = "1.10.5"
    container_runtime                          = "docker"
    deletion_protection                        = false
    domain                                     = "cls-cdxaw58y.ccs.tencent-cloud.com"
    id                                         = "cls-cdxaw58y"
    ignore_cluster_cidr_conflict               = false
    is_non_static_ip_mode                      = false
    kube_config                                = <<-EOT
        apiVersion: v1
        clusters:
        - cluster:
            certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ETXlOakV3TXpBMU1sb1hEVE14TURNeU5ERXdNekExTWxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBS05SCkFNRFZnRldJZnRhQlFYa05QVkUrT3lvdFY3NlpLZ0Fmb1hsTTFKWjlERFRmNi9JeTJLakZhRUZhcGpDeE1DQk0KZ2xyVnR4aE9RcEVvakt5Qk1ON3hTcUdNNUVTZFZhL3ZBRXpjbk5jd0JVVEgzaFZFSjNWMzRXM00ybXZzdWtaQwpodExJT1RDRTI0aWQwdHNHR3ZrQzBuR1Mya2JvTURzRGhQTXQySHNZV2ZZMVVtWkUwOHBiTXpkZnp1UEdLTVRQCmNDN3phVlNTdElzcXRjQkI1MkgvZVY0SWtTYUVzTFNQM3R5SFh1bFJlamN2OUwvUXZaTVlCMmJ3V21BcnhJWnoKY0xlNnF1WG9EWjYyZ0VNTk1Vc3FhenBPTWJaT0pISFNzUmI4K3I4bU9wMEVCaDV4TjhNZURDNTZzNFhnNXhmMApEOGRBSDAzQ29TcjUvOWIzNXk4Q0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0tVTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFIYzg5MXdGVE1WQ2Q0aXJRYndsYXBIVkxEYlgKVG5jNnFjZHJoTUhVTDhEQlhUUUkrVUpFQ2FMVnAxRndkMlR2QjFaR1hwK0Fjc3Zoam5NdVlFVU1Xc0REOVY0dgpEZ3JXaTFRcXB3b1cwMk1uK1g1bWpsV0NaUXpsdUNqQXV6TTgrbS9Qd3NXMVVqaWFmZWFsakltV3pYc0ZabzF1CkhZZ0FYaGRMTmtBZCtpd3RtWTBuU1paWUxVM21TZ2w0eG9yMzFBellBRWZJOWt2bFJMR3pZWXVyTlFRU1hDOTEKN01wUWcwQWx0SDlCTGxiVXpWYmdjeDlCWC9zMDc3bzBXUGVHa0daWUJaZFdnY2g5a0Y0bHBNb2MwM3RxVmN0Sgp2MzFUbmU3U29meWVKWWdwZTFGRmdoTWp3aDVLU0Z0YzJxN1V3MkFNQWNjYzEwZnVmTzh2NWpqNm9ndz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
            server: https://cls-cdxaw58y.ccs.tencent-cloud.com
          name: cls-cdxaw58y
        contexts:
        - context:
            cluster: cls-cdxaw58y
            user: "100017870904"
          name: cls-cdxaw58y-100017870904-context-default
        current-context: cls-cdxaw58y-100017870904-context-default
        kind: Config
        preferences: {}
        users:
        - name: "100017870904"
          user:
            client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURERENDQWZTZ0F3SUJBZ0lJR3ZsM2Rkck1xcjR3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TVRBek1qWXhNRE15TkRaYUZ3MDBNVEF6TWpZeE1ETXlORFZhTURZeApFakFRQmdOVkJBb1RDWFJyWlRwMWMyVnljekVnTUI0R0ExVUVBeE1YTVRBd01ERTNPRGN3T1RBMExURTJNVFkzCk5UUTNOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRRHNFMStjcVV2T3NiTmUKenIwVDMvMWNyU1pZZkJUT2Q0MmpCMXlneEZzWTlCOGx1ZkRzWGhHOU5GMklzK0pVNVVnZmlyd3dkNDFHcjQ1VQp2M2xxSCtRMjFBeEJvYU9GcXFlVTBWWktIK1VhVzllMCtSK0RNVGVhOTNNd3pIcGVGMTJ5WTZFdWRtMURQVEl2CkcvRzZtVk1vQ2N0dzV1N1crby9tSVY5WVZqTWI4ZEhWNVM0RDBkUTNKZHpDbFpUSWkxdG44ZXI2QjQrMXZtcjkKYVVqMVVENmc4VXZYTDc0UDZMQ2tEN2VTUUMwQWZJTCsyOGMzckZ1WTJ5VzRvZFRUY3JhdFB0M2hkZCtTVklmMwpVbWc4QUhpb0crY1ZwdVA0WGN1UDhvOTloUlJGK0RxaDh3MG13dmJRQXN5dDZjajhWTVVvczl2bzkzUlg3QTRCClBJYzRYR3RmQWdNQkFBR2pQekE5TUE0R0ExVWREd0VCL3dRRUF3SUNoREFkQmdOVkhTVUVGakFVQmdnckJnRUYKQlFjREFnWUlLd1lCQlFVSEF3RXdEQVlEVlIwVEFRSC9CQUl3QURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpGem5CU05Xa3hCL1dPSlk2WFk4a2FWTmo0QlBRLzJnd1c2UUt3Yks1cDRxQ2FlM3hRTzVQa3g0NWJaZ3YxVTZpCk1zZHpDRTBOWEFWd1lFcHY4bnVZZGxlbFFkOVo3RUx1aWtnbjBTWG14NmhZVmFod205T3c3d29aS1dDUldmcGEKWVFCZ3ZJZ0ZzMjJIeEhkcVRjRm4rN3ZuZjRxV3VSVk1RcjN5ZW51SUpqanJqZTZLenhPOEQyWjlMSCtjTXl4KwoycG5uaVdqK0I4OVcvTm5nN2E0bVdzK1k1Nm1KbWsyNWRrbGFxcldhcVB6cVFMcCttYU1PUnEySy80cS8xWTdyCjNaTVN0SlA1VEFYQkxkMHZFRUpCaW45dTVaSHl3OVV4SUQrb1RPS1lOMGVOKy9pVG9KWlRudkpXd1ZZZ004WUYKUFlyZjRmS0h1QkpGa3FFaG5Gb1B3QT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
            client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBN0JOZm5LbEx6ckd6WHM2OUU5LzlYSzBtV0h3VXpuZU5vd2Rjb01SYkdQUWZKYm53CjdGNFJ2VFJkaUxQaVZPVklINHE4TUhlTlJxK09WTDk1YWgva050UU1RYUdqaGFxbmxORldTaC9sR2x2WHRQa2YKZ3pFM212ZHpNTXg2WGhkZHNtT2hMblp0UXoweUx4dnh1cGxUS0FuTGNPYnUxdnFQNWlGZldGWXpHL0hSMWVVdQpBOUhVTnlYY3dwV1V5SXRiWi9IcStnZVB0YjVxL1dsSTlWQStvUEZMMXkrK0QraXdwQSsza2tBdEFIeUMvdHZICk42eGJtTnNsdUtIVTAzSzJyVDdkNFhYZmtsU0g5MUpvUEFCNHFCdm5GYWJqK0YzTGovS1BmWVVVUmZnNm9mTU4KSnNMMjBBTE1yZW5JL0ZURktMUGI2UGQwVit3T0FUeUhPRnhyWHdJREFRQUJBb0lCQVFDUGx3RVMwczV2UEJxegowZCtqbFJ3UUlLa3dMTmlpOUlqTDNwQnlvTHdnSTJ4R2tDQ0FSSDlacTk0d1plbUdaYWRHdUNYYS9QeUxRQUM4CmYzSWtJSjI0MDZWWXppNGVBVHpKQWNNUWR2SHM1R3dCZ1gydldHSlArYTZ3d2M2MEtGWXZTUFlpd3BtV3lrUVoKNzA5S2hqUFVLSkQ3YlJ0YzJ5NW5kV2orMi85ZVFMNlkzSHJTT2Y0U2R3MkZONFdIWEpldzRtdlh0WmR0OXJoMgp2bGp3L296ci9IVWs1ekh0Y24rMXFoMFB6WEFGcGdLdFRYREpBSndwbUNUbUVtTTBjbTd5Tlh4UlMzRTNXVzVFCk16ZFNPRDRqRmJoVmJlT0w3UFdqdE1EWUNjOFJ2OXBuM1k3Vi9xK0l4TWpjNXBoQVI2Q2crbngyWG44Qzg5UDAKOEovaFpsZWhBb0dCQVBEMlN4dm5sOStyY0l6cW85Y3JlZHpXSTBUZmI2aHFWOWxPc0hsck5KbUZJWWxzK0ZHZwoyc1dNNm5VRWJCaU5UeDdpVUlXZFN6SWUwcmpLcFBEdnJZMkNLVTFSU0FEcXN4WCtmeDlkNGZyVit5SXJnSDhpCmJnUlI2bnVxSitKNUdLNElwaTF4YWl5RWhnNlZaM01HMDRtSTRaK1FyUkNNcGdDOHJyWGlKTmxwQW9HQkFQclAKQTA1bG5SS3BwMm9ZZDZuZHZSbTdjcUNrNnR1TGV0K0pDMW1yNUV5aU1WZmdITDJYeCt3WFdpazV2eEZWcVM2MQprZ01GMERHUk9rOUZUdDREdDE2ekEwaXJKMTREa09yREk3RnYwK3BGQ0wzQXc2Q3cvajVvVnBRTzVLdFN1eElECnR6VVpxZnR0aVJhYm9KbzRqWXQxN2NQQnlhRXE3c1RWY21wZ2FmMkhBb0dBUmhmZkVXYjFEdU5ZQWlYZk15QTYKZXJydjE0RUhnZjR0UDlGY0ZIWFMvelZ5NC84RzNQZmxxOEdxRWhBUFFiVVpadXArY2Qrbm1CVFBSMkhyU1FydgplVko3b1RvYnIraVYzN2dBVXFlRXJPckIrdGFjc2w3WmtmZ2lOWWJ4d3pkbXJubGxuYUo0T0NyMHRCbFIxbXdOCjdOd2NoY1lZRWRCWUdhN0pRNjljK01FQ2dZQVo5bFBoU2FONHl4Y0paSDcrbG5WOHRHcXBObWtaVU5iblRNaGYKLytzaUE2Z1g4SnNKQlMwc3d6NFNCbWhBNHgwZ09LdGtwTFZvYkNBZEZJK1ZhODBQZ0hoV2pXRUYybGlsOUkwOQpVTlllNmdaOW5mYWlLN0FseGFjd3JGbi9ZaEQ3VEdjcWwvMkFpVlluZ1BTZkFqdWt0QkJvc3lhc0NFV3ZHbWs5Cm1iMWZBUUtCZ0FjL0tPVlJwcWFTazR0Tmd1WTduWWFsNEJlUWZjbm5uVUV1akJSeU9yOVlOd1VUQTN4MTFQblQKZnRXYXgyb3FKcEpWWExGTzJjL3BJWVowc3dpaEJqcGIvS0JUb21wZEpXYUtrMExlWnVGVlpFUEY5ZG00STBjUApPZmtYQnV0SXVPb0NMeGNsWm1PL0NEWlNYcm5yUDMxOXg2eXNWNzgwd3RxNVozQVdJY3lRCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
    EOT
    labels                                     = {
        "test1" = "test1"
        "test2" = "test2"
    }
    managed_cluster_internet_security_policies = [
        "3.3.3.3",
        "1.1.1.1",
    ]
    network_type                               = "GR"
    node_name_type                             = "lan-ip"
    password                                   = "axcBshoJ6hylUNOYBrJc6p3H6XFnQztk"
    project_id                                 = 0
    security_policy                            = [
        "3.3.3.3",
        "1.1.1.1",
    ]
    unschedulable                              = 0
    user_name                                  = "admin"
    vpc_id                                     = "vpc-h70b6b49"
    worker_instances_list                      = [
        {
            failed_reason  = ""
            instance_id    = "ins-kautpwsq"
            instance_role  = "WORKER"
            instance_state = "initializing"
            lan_ip         = "172.16.1.19"
        },
        {
            failed_reason  = ""
            instance_id    = "ins-r6ro9igy"
            instance_role  = "WORKER"
            instance_state = "initializing"
            lan_ip         = "172.16.48.25"
        },
    ]

    node_pool_global_config {
        expander                       = "random"
        ignore_daemon_sets_utilization = false
        is_scale_in_enabled            = false
        max_concurrent_scale_in        = 10
        scale_in_delay                 = 10
        scale_in_unneeded_time         = 10
        scale_in_utilization_threshold = 50
        skip_nodes_with_local_storage  = true
        skip_nodes_with_system_pods    = true
    }

    worker_config {
        availability_zone                       = "ap-guangzhou-3"
        count                                   = 1
        enhanced_monitor_service                = false
        enhanced_security_service               = false
        instance_charge_type                    = "POSTPAID_BY_HOUR"
        instance_charge_type_prepaid_period     = 1
        instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
        instance_name                           = "sub machine of tke"
        instance_type                           = "SA2.2XLARGE16"
        internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
        internet_max_bandwidth_out              = 100
        password                                = (sensitive value)
        public_ip_assigned                      = true
        subnet_id                               = "subnet-1uwh63so"
        system_disk_size                        = 60
        system_disk_type                        = "CLOUD_SSD"
        user_data                               = "dGVzdA=="

        data_disk {
            disk_size = 50
            disk_type = "CLOUD_PREMIUM"
        }
    }
    worker_config {
        availability_zone                       = "ap-guangzhou-4"
        cam_role_name                           = "CVM_QcsRole"
        count                                   = 1
        enhanced_monitor_service                = false
        enhanced_security_service               = false
        instance_charge_type                    = "POSTPAID_BY_HOUR"
        instance_charge_type_prepaid_period     = 1
        instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
        instance_name                           = "sub machine of tke"
        instance_type                           = "SA2.2XLARGE16"
        internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
        internet_max_bandwidth_out              = 100
        password                                = (sensitive value)
        public_ip_assigned                      = true
        subnet_id                               = "subnet-q6fhy1mi"
        system_disk_size                        = 60
        system_disk_type                        = "CLOUD_SSD"
        user_data                               = "dGVzdA=="

        data_disk {
            disk_size = 50
            disk_type = "CLOUD_PREMIUM"
        }
    }
}
```

##### 6. old version in new version

```
terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be created
  + resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
      + certification_authority                    = (known after apply)
      + claim_expired_seconds                      = 300
      + cluster_as_enabled                         = false
      + cluster_cidr                               = "10.31.0.0/16"
      + cluster_deploy_type                        = "MANAGED_CLUSTER"
      + cluster_desc                               = "test cluster desc"
      + cluster_external_endpoint                  = (known after apply)
      + cluster_internet                           = true
      + cluster_intranet                           = false
      + cluster_ipvs                               = true
      + cluster_max_pod_num                        = 32
      + cluster_max_service_num                    = 32
      + cluster_name                               = "test"
      + cluster_node_num                           = (known after apply)
      + cluster_os                                 = "ubuntu16.04.1 LTSx86_64"
      + cluster_os_type                            = "GENERAL"
      + cluster_version                            = "1.10.5"
      + container_runtime                          = "docker"
      + deletion_protection                        = false
      + domain                                     = (known after apply)
      + id                                         = (known after apply)
      + ignore_cluster_cidr_conflict               = false
      + is_non_static_ip_mode                      = false
      + kube_config                                = (known after apply)
      + labels                                     = {
          + "test1" = "test1"
          + "test2" = "test2"
        }
      + managed_cluster_internet_security_policies = [
          + "3.3.3.3",
          + "1.1.1.1",
        ]
      + network_type                               = "GR"
      + node_name_type                             = "lan-ip"
      + password                                   = (known after apply)
      + pgw_endpoint                               = (known after apply)
      + security_policy                            = (known after apply)
      + unschedulable                              = 0
      + user_name                                  = (known after apply)
      + vpc_id                                     = "vpc-h70b6b49"
      + worker_instances_list                      = (known after apply)

      + worker_config {
          + availability_zone                       = "ap-guangzhou-3"
          + count                                   = 1
          + enhanced_monitor_service                = false
          + enhanced_security_service               = false
          + instance_charge_type                    = "POSTPAID_BY_HOUR"
          + instance_charge_type_prepaid_period     = 1
          + instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
          + instance_name                           = "sub machine of tke"
          + instance_type                           = "SA2.2XLARGE16"
          + internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out              = 100
          + password                                = (sensitive value)
          + public_ip_assigned                      = true
          + subnet_id                               = "subnet-1uwh63so"
          + system_disk_size                        = 60
          + system_disk_type                        = "CLOUD_SSD"
          + user_data                               = "dGVzdA=="

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }
      + worker_config {
          + availability_zone                       = "ap-guangzhou-4"
          + cam_role_name                           = "CVM_QcsRole"
          + count                                   = 1
          + enhanced_monitor_service                = false
          + enhanced_security_service               = false
          + instance_charge_type                    = "POSTPAID_BY_HOUR"
          + instance_charge_type_prepaid_period     = 1
          + instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
          + instance_name                           = "sub machine of tke"
          + instance_type                           = "SA2.2XLARGE16"
          + internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out              = 100
          + password                                = (sensitive value)
          + public_ip_assigned                      = true
          + subnet_id                               = "subnet-q6fhy1mi"
          + system_disk_size                        = 60
          + system_disk_type                        = "CLOUD_SSD"
          + user_data                               = "dGVzdA=="

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }
    }

  # tencentcloud_kubernetes_node_pool.mynodepool will be created
  + resource "tencentcloud_kubernetes_node_pool" "mynodepool" {
      + auto_scaling_group_id = (known after apply)
      + cluster_id            = (known after apply)
      + delete_keep_instance  = true
      + desired_capacity      = 4
      + enable_auto_scale     = true
      + id                    = (known after apply)
      + labels                = {
          + "test1" = "test1"
          + "test2" = "test2"
        }
      + launch_config_id      = (known after apply)
      + max_size              = 6
      + min_size              = 1
      + name                  = "mynodepool"
      + node_count            = (known after apply)
      + node_os               = "tlinux2.4x86_64"
      + node_os_type          = "GENERAL"
      + retry_policy          = "INCREMENTAL_INTERVALS"
      + status                = (known after apply)
      + subnet_ids            = [
          + "subnet-1uwh63so",
        ]
      + unschedulable         = 0
      + vpc_id                = "vpc-h70b6b49"

      + auto_scaling_config {
          + enhanced_monitor_service   = false
          + enhanced_security_service  = false
          + instance_type              = "SA2.2XLARGE16"
          + internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out = 10
          + password                   = (sensitive value)
          + public_ip_assigned         = true
          + security_group_ids         = [
              + "sg-71y8m1m5",
            ]
          + system_disk_size           = 50
          + system_disk_type           = "CLOUD_PREMIUM"

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }

      + taints {
          + effect = "PreferNoSchedule"
          + key    = "test_taint"
          + value  = "taint_value"
        }
      + taints {
          + effect = "PreferNoSchedule"
          + key    = "test_taint2"
          + value  = "taint_value2"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_kubernetes_cluster.managed_cluster: Creating...
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Creation complete after 2m18s [id=cls-qofsazle]
tencentcloud_kubernetes_node_pool.mynodepool: Creating...
tencentcloud_kubernetes_node_pool.mynodepool: Creation complete after 4s [id=cls-qofsazle#np-149gcxju]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

tencentcloud_kubernetes_cluster.managed_cluster: Refreshing state... [id=cls-qofsazle]
tencentcloud_kubernetes_node_pool.mynodepool: Refreshing state... [id=cls-qofsazle#np-149gcxju]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

tencentcloud_kubernetes_cluster.managed_cluster: Refreshing state... [id=cls-qofsazle]
tencentcloud_kubernetes_node_pool.mynodepool: Refreshing state... [id=cls-qofsazle#np-149gcxju]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be updated in-place
  ~ resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
        id                                         = "cls-qofsazle"
        tags                                       = {}
        # (34 unchanged attributes hidden)

      ~ node_pool_global_config {
          ~ ignore_daemon_sets_utilization = false -> true
          ~ is_scale_in_enabled            = false -> true
          ~ max_concurrent_scale_in        = 10 -> 5
          ~ scale_in_delay                 = 10 -> 15
          ~ scale_in_unneeded_time         = 10 -> 15
          ~ scale_in_utilization_threshold = 50 -> 30
          ~ skip_nodes_with_local_storage  = true -> false
            # (2 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_kubernetes_cluster.managed_cluster: Modifying... [id=cls-qofsazle]
tencentcloud_kubernetes_cluster.managed_cluster: Modifications complete after 1s [id=cls-qofsazle]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

```
terraform destroy

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be destroyed
  - resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
      - certification_authority                    = <<-EOT
            -----BEGIN CERTIFICATE-----
            MIICyDCCAbCgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
            cm5ldGVzMB4XDTIxMDMyOTAzMTUzMloXDTMxMDMyNzAzMTUzMlowFTETMBEGA1UE
            AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvf
            hNFiB/qdPx0veLgv0/XGshL2DZcv8X6bhYkqIFpHmrb2a9WAHevCILbLUy/54GjV
            3Cr5jGdMPoSG81sYg92lWfCWYdKXXifyKa7UElVd6M3ILGfhJJBAVhBGVf4LyLAe
            WtYfujhKI8s7b1pZgGD5OWcsQt/TyJGNhyPCJBVXeKvGdfVa4jHsWHezVXViyq9K
            B61hUKmyTojoo0fmwQLjZb95QHIPQNPJ9z7eFmvoo/hLOBr2xHoY8QJqt1y0qRqg
            oFkUA2bGlaVIFEqWXbl8Q5B1ktdPYi+GHXSkkMqv1AVUopiH8GECYvIxYufSxpms
            B95zgBX0X4aKH5olyrkCAwEAAaMjMCEwDgYDVR0PAQH/BAQDAgKUMA8GA1UdEwEB
            /wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAIVDABez7Lg7oA8xQEBdU+mWnVRZ
            yd1tw9Nf4g4s4Yu/BkIpvvC8l5XDHa9Nkx/7mcwLGw/262I0pGGMldfPGbzkDNht
            V1aPrKPJdS+hxVnnnTFUhKLdGLuNlVjUoXQb4YeiHn3QRrAwlE/V2tFZNKek3vCh
            Ee+ZO3HRrpoZEhqhwMJaBonvEXwE+6xqLmaHxBEpPybP/p+HNCcnOBpfbAB47jhI
            de0YL2NYFRqx1Lu5E15QlDsWic2VLxrD4YlmR/tKW3MilxjBVu91m0HynWabQBE1
            qsRzzjxGyNvAepKqwSlt+8Xir2cWX+WQaYts4Gf8AGIn5Uy3XIHmruYH514=
            -----END CERTIFICATE-----
        EOT -> null
      - claim_expired_seconds                      = 300 -> null
      - cluster_as_enabled                         = false -> null
      - cluster_cidr                               = "10.31.0.0/16" -> null
      - cluster_deploy_type                        = "MANAGED_CLUSTER" -> null
      - cluster_desc                               = "test cluster desc" -> null
      - cluster_external_endpoint                  = "https://cls-qofsazle.ccs.tencent-cloud.com" -> null
      - cluster_internet                           = true -> null
      - cluster_intranet                           = false -> null
      - cluster_ipvs                               = true -> null
      - cluster_max_pod_num                        = 32 -> null
      - cluster_max_service_num                    = 32 -> null
      - cluster_name                               = "test" -> null
      - cluster_node_num                           = 6 -> null
      - cluster_os                                 = "ubuntu16.04.1 LTSx86_64" -> null
      - cluster_os_type                            = "GENERAL" -> null
      - cluster_version                            = "1.10.5" -> null
      - container_runtime                          = "docker" -> null
      - deletion_protection                        = false -> null
      - domain                                     = "cls-qofsazle.ccs.tencent-cloud.com" -> null
      - id                                         = "cls-qofsazle" -> null
      - ignore_cluster_cidr_conflict               = false -> null
      - is_non_static_ip_mode                      = false -> null
      - kube_config                                = <<-EOT
            apiVersion: v1
            clusters:
            - cluster:
                certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ETXlPVEF6TVRVek1sb1hEVE14TURNeU56QXpNVFV6TWxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHZmCmhORmlCL3FkUHgwdmVMZ3YwL1hHc2hMMkRaY3Y4WDZiaFlrcUlGcEhtcmIyYTlXQUhldkNJTGJMVXkvNTRHalYKM0NyNWpHZE1Qb1NHODFzWWc5MmxXZkNXWWRLWFhpZnlLYTdVRWxWZDZNM0lMR2ZoSkpCQVZoQkdWZjRMeUxBZQpXdFlmdWpoS0k4czdiMXBaZ0dENU9XY3NRdC9UeUpHTmh5UENKQlZYZUt2R2RmVmE0akhzV0hlelZYVml5cTlLCkI2MWhVS215VG9qb28wZm13UUxqWmI5NVFISVBRTlBKOXo3ZUZtdm9vL2hMT0JyMnhIb1k4UUpxdDF5MHFScWcKb0ZrVUEyYkdsYVZJRkVxV1hibDhRNUIxa3RkUFlpK0dIWFNra01xdjFBVlVvcGlIOEdFQ1l2SXhZdWZTeHBtcwpCOTV6Z0JYMFg0YUtINW9seXJrQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0tVTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFJVkRBQmV6N0xnN29BOHhRRUJkVSttV25WUloKeWQxdHc5TmY0ZzRzNFl1L0JrSXB2dkM4bDVYREhhOU5reC83bWN3TEd3LzI2MkkwcEdHTWxkZlBHYnprRE5odApWMWFQcktQSmRTK2h4Vm5ublRGVWhLTGRHTHVObFZqVW9YUWI0WWVpSG4zUVJyQXdsRS9WMnRGWk5LZWszdkNoCkVlK1pPM0hScnBvWkVocWh3TUphQm9udkVYd0UrNnhxTG1hSHhCRXBQeWJQL3ArSE5DY25PQnBmYkFCNDdqaEkKZGUwWUwyTllGUnF4MUx1NUUxNVFsRHNXaWMyVkx4ckQ0WWxtUi90S1czTWlseGpCVnU5MW0wSHluV2FiUUJFMQpxc1J6emp4R3lOdkFlcEtxd1NsdCs4WGlyMmNXWCtXUWFZdHM0R2Y4QUdJbjVVeTNYSUhtcnVZSDUxND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
                server: https://cls-qofsazle.ccs.tencent-cloud.com
              name: cls-qofsazle
            contexts:
            - context:
                cluster: cls-qofsazle
                user: "100017870904"
              name: cls-qofsazle-100017870904-context-default
            current-context: cls-qofsazle-100017870904-context-default
            kind: Config
            preferences: {}
            users:
            - name: "100017870904"
              user:
                client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURERENDQWZTZ0F3SUJBZ0lJSVJKVVJmTXc5aWN3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TVRBek1qa3dNekUzTXpSYUZ3MDBNVEF6TWprd016RTNNelJhTURZeApFakFRQmdOVkJBb1RDWFJyWlRwMWMyVnljekVnTUI0R0ExVUVBeE1YTVRBd01ERTNPRGN3T1RBMExURTJNVFk1Ck9EYzROVFF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRRGdjbU03RFhmQ3NNREwKU0prTnNsaDI0YUxCSW8xbUQzZytwdEdjUjhkc3h5L1l6ZHl0OTFIM2JyNUY1RkJwcm92cDlhTjR6UUwzZjNmcQphckhCWnpZWXNkdEFmdjd3MTRFZVBHdnhEUWQrb2tERUNCdnJmNm9NWnA4VTNBOEFSNThKb0g0UGVFVEtQaXBGCmJDMUtNYUYzT0NjYkhLREt0RHNMeXJmOUMyYXpNQi9Ja2VVQ0ZMRldHZWdRTXoyYUNUUHRpQWxVQlkrbk1sVVcKNnBEYTNqNGF3U3FvTk9STDR3ZS9SYlM2NUJPRTY0VCtkK0VDdnFOTUZHT0psL2RjQWdkZ1Y2VXZ4ak9TV3NCTgppdlJsT1d5OUlweHlYV1BZS1Fxcm1hN1RBSjR3clR3T0t3NXdab2E1cEZVWWI0VlpNbG9nWitrdm9TQ2x2dnViCjZaY3djdk5EQWdNQkFBR2pQekE5TUE0R0ExVWREd0VCL3dRRUF3SUNoREFkQmdOVkhTVUVGakFVQmdnckJnRUYKQlFjREFnWUlLd1lCQlFVSEF3RXdEQVlEVlIwVEFRSC9CQUl3QURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpLOHhPbit5RGRtU0lyR1RSeWZiTk1jY0ZrZTIvbzQ2YTl5bE1NcUVVYkRESmVYdE5XNU1YREg0OTJXZm1lUUJKClFPd3h6c0VKOEZBWFpzeHlpSFFrcjhsTzBBMGhNUTVSNFZUZGdudkFVc09JNEdCM09Hd2ZFYkRZNDBRUHJOMHYKRUVOTW9jZHVTUE5ZTjhiK2ZTK3NOWlRTQjRtZ0Z6VXRNVzZSVjlLOXU3MkRTQStvU2tGS3dtTkJZaE9ocjN0cApCeW5PcllMTm85bHlkaGJGc01yNHlJa1dxQXV2NWtnYm9rSyt4TGtWa25lY0wxTkttTTBuRWJ3Qm9iWW1pREIyCkpqbkVwUjZpdFpSWk9iQ0o4T3RrSkJ6K21JVnhtN1hPWm5FMDM3S2ZWNFVSVnRzbTRHSmJYS1phWDUrSHFuZS8KT3dZNHdic1JIeG1IVmxIQ1V4SHpQUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
                client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBNEhKak93MTN3ckRBeTBpWkRiSllkdUdpd1NLTlpnOTRQcWJSbkVmSGJNY3YyTTNjCnJmZFI5MjYrUmVSUWFhNkw2ZldqZU0wQzkzOTM2bXF4d1djMkdMSGJRSDcrOE5lQkhqeHI4UTBIZnFKQXhBZ2IKNjMrcURHYWZGTndQQUVlZkNhQitEM2hFeWo0cVJXd3RTakdoZHpnbkd4eWd5clE3QzhxMy9RdG1zekFmeUpIbApBaFN4Vmhub0VETTltZ2t6N1lnSlZBV1BwekpWRnVxUTJ0NCtHc0VxcURUa1MrTUh2MFcwdXVRVGhPdUUvbmZoCkFyNmpUQlJqaVpmM1hBSUhZRmVsTDhZemtsckFUWXIwWlRsc3ZTS2NjbDFqMkNrS3E1bXUwd0NlTUswOERpc08KY0dhR3VhUlZHRytGV1RKYUlHZnBMNkVncGI3N20rbVhNSEx6UXdJREFRQUJBb0lCQURkbTVPbWh0R3NoV0NXVgpvUG9KaU42bmFaWkU0aVJNTTBFN3lrZktUQWFrMEVHeTV3TW1KbHh1UUpkZCtSOXREMnBMMFBNem44VForUTZyCkVYK002NFNDK256Y0hDLzA4aEUxbHV0a2JQSXNPTkpxc2dHYWZLNGM4cTJpZUMxNGdHQk85bTc1SC9uUUNIMGsKYTdXQnRMcUo2TlUvWnMxQ1djVGFZRG9kQTFlOVZmS0RuRWFZMDNuUUtSUWIzcGRwRFhrbnV5VDFhS3BuOG1sbAovV3N2RjRFdDlIMmRoeU41ZDQyTWNqbE15MjZXbmVvZHFhNWE2emlWbzczemh1K3Y5c2lZWWFpQm4xYkgrZXlYCnZaQmJoUVYvbGlCQkpyU2NkZFRyanNJbWtoSnZCamdwaW03c2lzbHlmcHArcjZXS1VlVW5HL2hjdSthOEFDdGsKSi94U0g1RUNnWUVBN1BLdUtnZU9zU1ozMGlnNWU3bEZzUzZGbVV4WW42dG9HOGorZjhoVC9kQU1Fanp0cmZYcwp2aThWdDlsTmZ3NWo3RlZvTWI1dnJKNVFTYWVISlNxcGkwbDRhMzhRditaTnIwTFUydy8ycnlLdGJSSjF6K21SCmhuM2taNG5DNEQ2R3hJbEgxWnE2emMzeGt1MmwrS0JFMlhUbXdXTUpwbjZCbUh3d0lKb3JQNmtDZ1lFQThuNWkKZWNMQk4ydTU1MkJuZWZMLzZwWUpHRjFmNkZmUmJWVFF3WGhobWcvNVNrNVprclMyVXBFL2E3VU9lVkV5cCt0OApOeHVZNDNta0VQYmEvSVZrdWN3NUgzQS8xK2FkT0hmMHgyLzgyZ3Bjc2FueDhaNlFBaCtKNUQ0UVJmNG83TnVvCjFacmRuM2x3RWtYc0tCYUlZK1NKbXFJZlRHVmV1MXVKbmxUcjN3c0NnWUVBdkhNcWw1elpIUVdtU0l2YlpBNXYKWWtMSTJLcUMxY0xDazA2aE1zb0dHeGlMY1RucUl2QXpzUExMeUNQWTRkTjFIM0t4NHRZK0JVRUlRL3dzblIrNApKbUp4bHJWQmdnNU4vTFVmaTNhLzBIeTVCOFdsMDQxRlEzeisybVlUaXJ2UC9hSGRjd0tUemJrY2g2bmcxY1BKCjNsVitiWkl5QzZ3VHNFNGRET0R3d3JrQ2dZRUF2OEVSUGhlemtvK3RRam9KbVhWK3laSTdQdmtYampOamVJRkoKVXJSTytmVUh2S3FZU2xwOGttNHBLSkxVRHpzV1E1TURkdEJyNWZXYXQ0OTlPNUtBUkN3cVA2SVQyamFTdk1TZQoyOWJDcStqbHc5Z1BhbkZvajBWQlZTdCswdHBZb25SUTNoaklpQU1QakdPZWkxVEdKYmZpMkZTN1N6NGQyeXBYCmVNek9lR0VDZ1lCUDlxTVBlTFh5Z0dzZGFqNFI1UUR2MUVKQlJCUllsOTBYUGMzYTNCMHhuVGx0TUY0MUp4TW8KdGlaMVZ2K2tHTUhMaklhUUJtc1J4UHZKdS83K294RG5pTWVyUzRLRFk0QURITk1CcVIzY01vNGJiRmZKdnozYwp1OHpVTm8wd25xdUFiSkxXbmJhRjZ0RmtTWkZVbllKc3M2bVc4SWlIQ1pTUXF3anMycHFnL0E9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
        EOT -> null
      - labels                                     = {
          - "test1" = "test1"
          - "test2" = "test2"
        } -> null
      - managed_cluster_internet_security_policies = [
          - "3.3.3.3",
          - "1.1.1.1",
        ] -> null
      - network_type                               = "GR" -> null
      - node_name_type                             = "lan-ip" -> null
      - password                                   = "5fExWoFArI7SO8VY63yn9ueIJGr5SaJA" -> null
      - project_id                                 = 0 -> null
      - security_policy                            = [
          - "3.3.3.3",
          - "1.1.1.1",
        ] -> null
      - tags                                       = {} -> null
      - unschedulable                              = 0 -> null
      - user_name                                  = "admin" -> null
      - vpc_id                                     = "vpc-h70b6b49" -> null
      - worker_instances_list                      = [
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-ol0hvykm"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.48.6"
            },
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-g0e9l3t4"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.0.137"
            },
          - {
              - failed_reason  = ""
              - instance_id    = "ins-9p2b3qi4"
              - instance_role  = "WORKER"
              - instance_state = "initializing"
              - lan_ip         = "172.16.0.166"
            },
          - {
              - failed_reason  = ""
              - instance_id    = "ins-2ccymya6"
              - instance_role  = "WORKER"
              - instance_state = "initializing"
              - lan_ip         = "172.16.3.235"
            },
          - {
              - failed_reason  = ""
              - instance_id    = "ins-p014rdxq"
              - instance_role  = "WORKER"
              - instance_state = "initializing"
              - lan_ip         = "172.16.0.239"
            },
          - {
              - failed_reason  = ""
              - instance_id    = "ins-f5n64d3g"
              - instance_role  = "WORKER"
              - instance_state = "initializing"
              - lan_ip         = "172.16.3.217"
            },
        ] -> null

      - node_pool_global_config {
          - expander                       = "random" -> null
          - ignore_daemon_sets_utilization = true -> null
          - is_scale_in_enabled            = true -> null
          - max_concurrent_scale_in        = 5 -> null
          - scale_in_delay                 = 15 -> null
          - scale_in_unneeded_time         = 15 -> null
          - scale_in_utilization_threshold = 30 -> null
          - skip_nodes_with_local_storage  = false -> null
          - skip_nodes_with_system_pods    = true -> null
        }

      - worker_config {
          - availability_zone                       = "ap-guangzhou-3" -> null
          - count                                   = 1 -> null
          - disaster_recover_group_ids              = [] -> null
          - enhanced_monitor_service                = false -> null
          - enhanced_security_service               = false -> null
          - instance_charge_type                    = "POSTPAID_BY_HOUR" -> null
          - instance_charge_type_prepaid_period     = 1 -> null
          - instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW" -> null
          - instance_name                           = "sub machine of tke" -> null
          - instance_type                           = "SA2.2XLARGE16" -> null
          - internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR" -> null
          - internet_max_bandwidth_out              = 100 -> null
          - key_ids                                 = [] -> null
          - password                                = (sensitive value)
          - public_ip_assigned                      = true -> null
          - security_group_ids                      = [] -> null
          - subnet_id                               = "subnet-1uwh63so" -> null
          - system_disk_size                        = 60 -> null
          - system_disk_type                        = "CLOUD_SSD" -> null
          - user_data                               = "dGVzdA==" -> null

          - data_disk {
              - disk_size = 50 -> null
              - disk_type = "CLOUD_PREMIUM" -> null
            }
        }
      - worker_config {
          - availability_zone                       = "ap-guangzhou-4" -> null
          - cam_role_name                           = "CVM_QcsRole" -> null
          - count                                   = 1 -> null
          - disaster_recover_group_ids              = [] -> null
          - enhanced_monitor_service                = false -> null
          - enhanced_security_service               = false -> null
          - instance_charge_type                    = "POSTPAID_BY_HOUR" -> null
          - instance_charge_type_prepaid_period     = 1 -> null
          - instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW" -> null
          - instance_name                           = "sub machine of tke" -> null
          - instance_type                           = "SA2.2XLARGE16" -> null
          - internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR" -> null
          - internet_max_bandwidth_out              = 100 -> null
          - key_ids                                 = [] -> null
          - password                                = (sensitive value)
          - public_ip_assigned                      = true -> null
          - security_group_ids                      = [] -> null
          - subnet_id                               = "subnet-q6fhy1mi" -> null
          - system_disk_size                        = 60 -> null
          - system_disk_type                        = "CLOUD_SSD" -> null
          - user_data                               = "dGVzdA==" -> null

          - data_disk {
              - disk_size = 50 -> null
              - disk_type = "CLOUD_PREMIUM" -> null
            }
        }
    }

  # tencentcloud_kubernetes_node_pool.mynodepool will be destroyed
  - resource "tencentcloud_kubernetes_node_pool" "mynodepool" {
      - auto_scaling_group_id = "asg-cpi5m5ow" -> null
      - cluster_id            = "cls-qofsazle" -> null
      - delete_keep_instance  = true -> null
      - desired_capacity      = 4 -> null
      - enable_auto_scale     = true -> null
      - id                    = "cls-qofsazle#np-149gcxju" -> null
      - labels                = {
          - "test1" = "test1"
          - "test2" = "test2"
        } -> null
      - launch_config_id      = "asc-0744vtm6" -> null
      - max_size              = 6 -> null
      - min_size              = 1 -> null
      - name                  = "mynodepool" -> null
      - node_os               = "tlinux2.4x86_64" -> null
      - node_os_type          = "GENERAL" -> null
      - retry_policy          = "INCREMENTAL_INTERVALS" -> null
      - status                = "normal" -> null
      - subnet_ids            = [
          - "subnet-1uwh63so",
        ] -> null
      - unschedulable         = 0 -> null
      - vpc_id                = "vpc-h70b6b49" -> null

      - auto_scaling_config {
          - enhanced_monitor_service   = false -> null
          - enhanced_security_service  = false -> null
          - instance_type              = "SA2.2XLARGE16" -> null
          - internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR" -> null
          - internet_max_bandwidth_out = 10 -> null
          - key_ids                    = [] -> null
          - password                   = (sensitive value)
          - public_ip_assigned         = true -> null
          - security_group_ids         = [
              - "sg-71y8m1m5",
            ] -> null
          - system_disk_size           = 50 -> null
          - system_disk_type           = "CLOUD_PREMIUM" -> null

          - data_disk {
              - disk_size = 50 -> null
              - disk_type = "CLOUD_PREMIUM" -> null
            }
        }

      - taints {
          - effect = "PreferNoSchedule" -> null
          - key    = "test_taint" -> null
          - value  = "taint_value" -> null
        }
      - taints {
          - effect = "PreferNoSchedule" -> null
          - key    = "test_taint2" -> null
          - value  = "taint_value2" -> null
        }
    }

Plan: 0 to add, 0 to change, 2 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

tencentcloud_kubernetes_node_pool.mynodepool: Destroying... [id=cls-qofsazle#np-149gcxju]
tencentcloud_kubernetes_node_pool.mynodepool: Destruction complete after 1s
tencentcloud_kubernetes_cluster.managed_cluster: Destroying... [id=cls-qofsazle]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-qofsazle, 10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-qofsazle, 20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-qofsazle, 30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-qofsazle, 40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Destruction complete after 45s

Destroy complete! Resources: 2 destroyed.
```

##### 7. new version create with resource node pool

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be created
  + resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
      + certification_authority                    = (known after apply)
      + claim_expired_seconds                      = 300
      + cluster_as_enabled                         = false
      + cluster_cidr                               = "10.31.0.0/16"
      + cluster_deploy_type                        = "MANAGED_CLUSTER"
      + cluster_desc                               = "test cluster desc"
      + cluster_external_endpoint                  = (known after apply)
      + cluster_internet                           = true
      + cluster_intranet                           = false
      + cluster_ipvs                               = true
      + cluster_max_pod_num                        = 32
      + cluster_max_service_num                    = 32
      + cluster_name                               = "test"
      + cluster_node_num                           = (known after apply)
      + cluster_os                                 = "ubuntu16.04.1 LTSx86_64"
      + cluster_os_type                            = "GENERAL"
      + cluster_version                            = "1.10.5"
      + container_runtime                          = "docker"
      + deletion_protection                        = false
      + domain                                     = (known after apply)
      + id                                         = (known after apply)
      + ignore_cluster_cidr_conflict               = false
      + is_non_static_ip_mode                      = false
      + kube_config                                = (known after apply)
      + labels                                     = {
          + "test1" = "test1"
          + "test2" = "test2"
        }
      + managed_cluster_internet_security_policies = [
          + "3.3.3.3",
          + "1.1.1.1",
        ]
      + network_type                               = "GR"
      + node_name_type                             = "lan-ip"
      + password                                   = (known after apply)
      + pgw_endpoint                               = (known after apply)
      + security_policy                            = (known after apply)
      + unschedulable                              = 0
      + user_name                                  = (known after apply)
      + vpc_id                                     = "vpc-h70b6b49"
      + worker_instances_list                      = (known after apply)

      + node_pool_global_config {
          + expander                       = "most-pods"
          + ignore_daemon_sets_utilization = (known after apply)
          + is_scale_in_enabled            = true
          + max_concurrent_scale_in        = 15
          + scale_in_delay                 = (known after apply)
          + scale_in_unneeded_time         = (known after apply)
          + scale_in_utilization_threshold = (known after apply)
          + skip_nodes_with_local_storage  = true
          + skip_nodes_with_system_pods    = false
        }

      + worker_config {
          + availability_zone                       = "ap-guangzhou-3"
          + count                                   = 1
          + enhanced_monitor_service                = false
          + enhanced_security_service               = false
          + instance_charge_type                    = "POSTPAID_BY_HOUR"
          + instance_charge_type_prepaid_period     = 1
          + instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
          + instance_name                           = "sub machine of tke"
          + instance_type                           = "SA2.2XLARGE16"
          + internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out              = 100
          + password                                = (sensitive value)
          + public_ip_assigned                      = true
          + subnet_id                               = "subnet-1uwh63so"
          + system_disk_size                        = 60
          + system_disk_type                        = "CLOUD_SSD"
          + user_data                               = "dGVzdA=="

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }
      + worker_config {
          + availability_zone                       = "ap-guangzhou-4"
          + cam_role_name                           = "CVM_QcsRole"
          + count                                   = 1
          + enhanced_monitor_service                = false
          + enhanced_security_service               = false
          + instance_charge_type                    = "POSTPAID_BY_HOUR"
          + instance_charge_type_prepaid_period     = 1
          + instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW"
          + instance_name                           = "sub machine of tke"
          + instance_type                           = "SA2.2XLARGE16"
          + internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out              = 100
          + password                                = (sensitive value)
          + public_ip_assigned                      = true
          + subnet_id                               = "subnet-q6fhy1mi"
          + system_disk_size                        = 60
          + system_disk_type                        = "CLOUD_SSD"
          + user_data                               = "dGVzdA=="

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }
    }

  # tencentcloud_kubernetes_node_pool.mynodepool will be created
  + resource "tencentcloud_kubernetes_node_pool" "mynodepool" {
      + auto_scaling_group_id = (known after apply)
      + cluster_id            = (known after apply)
      + delete_keep_instance  = true
      + desired_capacity      = 4
      + enable_auto_scale     = true
      + id                    = (known after apply)
      + labels                = {
          + "test1" = "test1"
          + "test2" = "test2"
        }
      + launch_config_id      = (known after apply)
      + max_size              = 6
      + min_size              = 1
      + name                  = "mynodepool"
      + node_count            = (known after apply)
      + node_os               = "tlinux2.4x86_64"
      + node_os_type          = "GENERAL"
      + retry_policy          = "INCREMENTAL_INTERVALS"
      + status                = (known after apply)
      + subnet_ids            = [
          + "subnet-1uwh63so",
        ]
      + unschedulable         = 0
      + vpc_id                = "vpc-h70b6b49"

      + auto_scaling_config {
          + enhanced_monitor_service   = false
          + enhanced_security_service  = false
          + instance_type              = "SA2.2XLARGE16"
          + internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR"
          + internet_max_bandwidth_out = 10
          + password                   = (sensitive value)
          + public_ip_assigned         = true
          + security_group_ids         = [
              + "sg-71y8m1m5",
            ]
          + system_disk_size           = 50
          + system_disk_type           = "CLOUD_PREMIUM"

          + data_disk {
              + disk_size = 50
              + disk_type = "CLOUD_PREMIUM"
            }
        }

      + taints {
          + effect = "PreferNoSchedule"
          + key    = "test_taint"
          + value  = "taint_value"
        }
      + taints {
          + effect = "PreferNoSchedule"
          + key    = "test_taint2"
          + value  = "taint_value2"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_kubernetes_cluster.managed_cluster: Creating...
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [1m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [2m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [3m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [4m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [5m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [5m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [5m20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [5m30s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [5m40s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [5m50s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [6m0s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still creating... [6m10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Creation complete after 6m11s [id=cls-0de11l94]
tencentcloud_kubernetes_node_pool.mynodepool: Creating...
tencentcloud_kubernetes_node_pool.mynodepool: Creation complete after 5s [id=cls-0de11l94#np-7d063g4y]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

```
terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

tencentcloud_kubernetes_cluster.managed_cluster: Refreshing state... [id=cls-0de11l94]
tencentcloud_kubernetes_node_pool.mynodepool: Refreshing state... [id=cls-0de11l94#np-7d063g4y]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be updated in-place
  ~ resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
        id                                         = "cls-0de11l94"
        tags                                       = {}
        # (34 unchanged attributes hidden)

      ~ node_pool_global_config {
          ~ expander                       = "most-pods" -> "random"
          ~ ignore_daemon_sets_utilization = false -> true
          ~ max_concurrent_scale_in        = 15 -> 5
          ~ scale_in_delay                 = 10 -> 15
          ~ scale_in_unneeded_time         = 10 -> 15
          ~ scale_in_utilization_threshold = 50 -> 30
          ~ skip_nodes_with_local_storage  = true -> false
          ~ skip_nodes_with_system_pods    = false -> true
            # (1 unchanged attribute hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_kubernetes_cluster.managed_cluster: Modifying... [id=cls-0de11l94]
tencentcloud_kubernetes_cluster.managed_cluster: Modifications complete after 2s [id=cls-0de11l94]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

```
terraform destroy

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud
 - tencentcloudstack/tencentcloud in /home/hxt/projects/terraform-provider-tencentcloud

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # tencentcloud_kubernetes_cluster.managed_cluster will be destroyed
  - resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
      - certification_authority                    = <<-EOT
            -----BEGIN CERTIFICATE-----
            MIICyDCCAbCgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
            cm5ldGVzMB4XDTIxMDMyOTAyNTY1NVoXDTMxMDMyNzAyNTY1NVowFTETMBEGA1UE
            AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANCX
            Sr1UUs1Bit1dTmBzFKu63tBso7gA19nagNKyLxiUgHdQaPBXXQiHsqvfNauNI7Jo
            ak3if2NoRTHPPvGeDlJflbFNkIuxiKAUlNDOSUIyEDxjuy1enmhucAZ7qSe6plle
            aBS1UIhuQi9Xr2vTl4LG0RE2yQEOh4tOMOa9d/qOS+2PC9XOar7j+sUy+ns6qmzz
            /IDIRqP51l4+WyqPKWGqkMuapxx9JDEF0vhFXxPCEUiXPJj2uSDmIWpc1nXyrOCx
            7FsNXMtsQZqAuIvqeZGCp5/iMrc9PdffIzcUyIfDRKlhoUKt+Gac+pZN4jPQtaxi
            hqa+/kLtLeNUth5LjMMCAwEAAaMjMCEwDgYDVR0PAQH/BAQDAgKUMA8GA1UdEwEB
            /wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAD1vNvks5nK2GHZxITOZi8UDD8rA
            34kRL3MXzZ+xf7FRagOvHq9pRqtgAwNWZb4pZ060PUUYHJqwab9Hz1d83lOJSzz2
            OlzyVqfFf8PnMf3Za2XW1wXWQ+1w2AJwyn/4OFhmReAswzFWvl/kIu2myE4V5tD/
            K4hRrjePsKwM5HcGpK27Kgx1ek0KADFpXw02vG9OEN1kov6bFkufyxK1jyD+9hSO
            MJm9LR8ohb8qzZDgVIAc5ax+JDwDotWZxyuhJiuqmFKlRb9K18tG/OvVnzui0hrh
            ewM3o+jG2YUGJw4gOXZXyxxbbHZ197J68s2On6aURwDBTsw3CXXabYJ9tL4=
            -----END CERTIFICATE-----
        EOT -> null
      - claim_expired_seconds                      = 300 -> null
      - cluster_as_enabled                         = false -> null
      - cluster_cidr                               = "10.31.0.0/16" -> null
      - cluster_deploy_type                        = "MANAGED_CLUSTER" -> null
      - cluster_desc                               = "test cluster desc" -> null
      - cluster_external_endpoint                  = "https://cls-0de11l94.ccs.tencent-cloud.com" -> null
      - cluster_internet                           = true -> null
      - cluster_intranet                           = false -> null
      - cluster_ipvs                               = true -> null
      - cluster_max_pod_num                        = 32 -> null
      - cluster_max_service_num                    = 32 -> null
      - cluster_name                               = "test" -> null
      - cluster_node_num                           = 6 -> null
      - cluster_os                                 = "ubuntu16.04.1 LTSx86_64" -> null
      - cluster_os_type                            = "GENERAL" -> null
      - cluster_version                            = "1.10.5" -> null
      - container_runtime                          = "docker" -> null
      - deletion_protection                        = false -> null
      - domain                                     = "cls-0de11l94.ccs.tencent-cloud.com" -> null
      - id                                         = "cls-0de11l94" -> null
      - ignore_cluster_cidr_conflict               = false -> null
      - is_non_static_ip_mode                      = false -> null
      - kube_config                                = <<-EOT
            apiVersion: v1
            clusters:
            - cluster:
                certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ETXlPVEF5TlRZMU5Wb1hEVE14TURNeU56QXlOVFkxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTkNYClNyMVVVczFCaXQxZFRtQnpGS3U2M3RCc283Z0ExOW5hZ05LeUx4aVVnSGRRYVBCWFhRaUhzcXZmTmF1Tkk3Sm8KYWszaWYyTm9SVEhQUHZHZURsSmZsYkZOa0l1eGlLQVVsTkRPU1VJeUVEeGp1eTFlbm1odWNBWjdxU2U2cGxsZQphQlMxVUlodVFpOVhyMnZUbDRMRzBSRTJ5UUVPaDR0T01PYTlkL3FPUysyUEM5WE9hcjdqK3NVeStuczZxbXp6Ci9JRElScVA1MWw0K1d5cVBLV0dxa011YXB4eDlKREVGMHZoRlh4UENFVWlYUEpqMnVTRG1JV3BjMW5YeXJPQ3gKN0ZzTlhNdHNRWnFBdUl2cWVaR0NwNS9pTXJjOVBkZmZJemNVeUlmRFJLbGhvVUt0K0dhYytwWk40alBRdGF4aQpocWErL2tMdExlTlV0aDVMak1NQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0tVTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFEMXZOdmtzNW5LMkdIWnhJVE9aaThVREQ4ckEKMzRrUkwzTVh6Wit4ZjdGUmFnT3ZIcTlwUnF0Z0F3TldaYjRwWjA2MFBVVVlISnF3YWI5SHoxZDgzbE9KU3p6MgpPbHp5VnFmRmY4UG5NZjNaYTJYVzF3WFdRKzF3MkFKd3luLzRPRmhtUmVBc3d6Rld2bC9rSXUybXlFNFY1dEQvCks0aFJyamVQc0t3TTVIY0dwSzI3S2d4MWVrMEtBREZwWHcwMnZHOU9FTjFrb3Y2YkZrdWZ5eEsxanlEKzloU08KTUptOUxSOG9oYjhxelpEZ1ZJQWM1YXgrSkR3RG90V1p4eXVoSml1cW1GS2xSYjlLMTh0Ry9PdlZuenVpMGhyaApld00zbytqRzJZVUdKdzRnT1haWHl4eGJiSFoxOTdKNjhzMk9uNmFVUndEQlRzdzNDWFhhYllKOXRMND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
                server: https://cls-0de11l94.ccs.tencent-cloud.com
              name: cls-0de11l94
            contexts:
            - context:
                cluster: cls-0de11l94
                user: "100017870904"
              name: cls-0de11l94-100017870904-context-default
            current-context: cls-0de11l94-100017870904-context-default
            kind: Config
            preferences: {}
            users:
            - name: "100017870904"
              user:
                client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURERENDQWZTZ0F3SUJBZ0lJRnV4NE5ETHp1Sjh3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TVRBek1qa3dNekF5TlRGYUZ3MDBNVEF6TWprd016QXlOVEZhTURZeApFakFRQmdOVkJBb1RDWFJyWlRwMWMyVnljekVnTUI0R0ExVUVBeE1YTVRBd01ERTNPRGN3T1RBMExURTJNVFk1Ck9EWTVOekV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRRFlNWGZVcENyWSsvUUgKVDl3VTg3SFdHNHFtd2ZxMk4yTkR2bDM3RzNkeHVUTy9UeSt6SjdjT3ZwMXlzVDU1QjN0SVE3b0svaFhacE9UbApXRHlTaU1NU1RJRmprbUFKRHBFVndBNXBBRnE1M1NEQTlkZldrYzdKMGMwVGh4SGpQQUdpdjIzZ0FtY3oyOGJWCjAvOTZiOFlLTlhLKzAxM2Jlelh3WkxHNjFIVituUHoyWWM1Um1DNDh6NlM3Zld4RHRTY2pobW5tWk5paVNKTUYKRzdLVnlJOXR4UjRpVVppSTNaL0ROb1VibWdUZUtXeE9HbmROdktYZklvbGY0Q0ZJdHZtcU5sVzJNaU9WL01YdApSTWJhbk1nWHRrR2llMkRmbE8rUEtHbVliYTZLakpORS9FUk40bTVXSEJURkxmT3BXZDVLN2lLU0ZXTTJET0k5CldmZThrcU5qQWdNQkFBR2pQekE5TUE0R0ExVWREd0VCL3dRRUF3SUNoREFkQmdOVkhTVUVGakFVQmdnckJnRUYKQlFjREFnWUlLd1lCQlFVSEF3RXdEQVlEVlIwVEFRSC9CQUl3QURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpmbmc1OGt6TXM1VmdJZk56Vk82TGJjSUM3R2FoSS80cDZQL0Z2R2p1U3Q0b3d4TkFLZTBudHhJNzYxSjI0WGFXCnhRaWRvU1FIMklrdFp2RjF0bGlIWUhnVWZ3Mkp5M0JYN1hkUjJoUGh6RWJFNVZIbm9peUZRbWhVcXNGVXBjbVkKMGEyRE5XVSsrZXFUeE1IalJOTFIyWm0vQlBUK2VITzlpWVFLdUtWZXg3Rzk2aGVuWTZxSmcxUVpaTFBVdlRmegpGTHVWQ3h6blMyY3JEaWhMTXpReWg3Nm91a0xtYlhZK0JWRFBhYVZIMy9MelN5VzNvYkl5TkJncDB1alU1OGRsCm1KWXB2T04zWFdxME9KYkJMYm45ZjBjWTA2NmhEeTBRUTAvdmxIU1FrTVV4Ulhtb09HQ2pmR1lIeXZkZEw2NlIKMWt4Smk2Z09iOFJzTTRkampnbVN5Zz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
                client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBMkRGMzFLUXEyUHYwQjAvY0ZQT3gxaHVLcHNINnRqZGpRNzVkK3h0M2Nia3p2MDh2CnN5ZTNEcjZkY3JFK2VRZDdTRU82Q3Y0VjJhVGs1Vmc4a29qREVreUJZNUpnQ1E2UkZjQU9hUUJhdWQwZ3dQWFgKMXBIT3lkSE5FNGNSNHp3Qm9yOXQ0QUpuTTl2RzFkUC9lbS9HQ2pWeXZ0TmQyM3MxOEdTeHV0UjFmcHo4OW1ITwpVWmd1UE0ra3UzMXNRN1VuSTRacDVtVFlva2lUQlJ1eWxjaVBiY1VlSWxHWWlOMmZ3emFGRzVvRTNpbHNUaHAzClRieWwzeUtKWCtBaFNMYjVxalpWdGpJamxmekY3VVRHMnB6SUY3WkJvbnRnMzVUdmp5aHBtRzJ1aW95VFJQeEUKVGVKdVZod1V4UzN6cVZuZVN1NGlraFZqTmd6aVBWbjN2SktqWXdJREFRQUJBb0lCQUNRUTFKSEh0Vkl2YmYxTwpTRVBDaDdkVkx1TTAxeE5RMkNGei80K2xmRjZmYTgrTmNVS3M3Ry9zUXEzZ2ZiQ0pHL3JwT1g4ZDloMHgwZkdrCnI2NHVYSVNQK01IWXFHYTZaRi9CZzJYbTVqdTlkUHBieU44RndmNlBIbXdVaTFwaUowKzBLYXRHRzF0ZVhhUk0KVW9GbFpoOUwzVkdTUjBVWEg5OXpuT2F6RE1yTExSUjlFdFZ5ZG15bDMxMjlTcVpKeEN1eCtwemVhVVRvOVFBUApLYlpnOXhWM1EvaUc2YXZBU0I2WEVuQ0l3U1hnb1A1RjEvSmJ1c1hGcEEwTGlTTkd2YmROVVBmbDFTUjdLSUdpCnYzbkZvcHlHdWJhQzkveWcrU1Z0T3ZNUXBWTDNzY3BXRklTM0FTRXBGaU5zYzZMdnZNY0NoOFpDbmZTU3hONGoKQi9VR1d6RUNnWUVBM2hLaEd5MFg5NldpdkNsd2xXS2pRQTA4UEtYVk9RM0NwTE85bkwrdmxrb3lzUnArUTRhNwo2WVh3VDliT0pEYVFYYXhzbTM5eVgyQ3FqdzZHUzlPa3pHUkxtcE9sdXF6RXNOYUEwYU54Q3BIajF6Z1FudVhjCjR2WGhPRFBwNkEwTUdEbC9BQWhqMUdMMGptMERDRnJiRWxueDZ5ZElESmZUVU4zbmpMaGl1dHNDZ1lFQStUamoKS056ZHlMTWdXNGFKcms5cXJ0VWxEbVR5cXNQakdrcWV2WXc2ekN2Z1VZdTZGZTlzaHVXQ1VJaU9UWGx6a254Vgo0Y3VnM0wwU1ZmOElRQjVkNXZxdXdnbVhwZktPQkZvT0lwVVFWZHYxaUhtMjlvZG4rVmVLMnIrNkhQN2ZDWmpICjB4WWk3eFdMNWozaHZxcjZKOGhDTzhFQ0hJc2wxNEVHNUg1dWJCa0NnWUJzRDBDWnlyMkk0ZTVvQlBvbGx0TzkKVFROc2gzMVR2K0JnNkoxeGNzenNJcnE3OXhwTm5YZyt6OC81NlpweGdLT0xFV1hmM0lvNDR2N2JrY1BEamY3NAovaXpUME5pcUYzdTJXUXBoK0ZmL1BySlJmWlNJM1cwNGUxRFdXbHlOY0J2Y2hjM0lwRXgvZ285aDVxVzlJUWpNCnl6dXVvM1NwdkE4MW9HVVYwbnNvVlFLQmdRRHN5WUx5b1I3TGdIMSsyRTNaNHJTdTFlNTJSYTFXVi9WZlZvU0oKL1VFa0dZL3dpbnhNT1FYNUNQaU9nYUFLdGhqN2xjeVhVcnhNM2dzY3o4bkwrYzRvRmdlU2JrQzZOOEY5R3Y4UgpGbVhGM2Mza1ZCaGxGUFBSc0w1SjVoM3pUS2ttMmhVSlZwL3NYcUZrS1dsaG1kdEJqd0IyKzRPQkVTZnNJRGduClFvU3hpUUtCZ1FDenV6aTRvcWd4TjkvOXVEaW9QaGFKNUVHSlNCa2Jzc2xJcmUyRDlmOHdSb284eXpSTnEvMkkKTWw5Mk82QXpPMG1tQjZOL3pQc3U3SDdlUFNncC9UdjE5eEdkUUF1SG1XL0prMGQ2RTNjV0hnb1FDTUVQTUJZRQpIdTRabTJWbVh3WUYwVVlpb1Q0bzN5UmFnNmdLMFFXa1AxUXZPekV0T3NpZFFUVW5oQVYvVUE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
        EOT -> null
      - labels                                     = {
          - "test1" = "test1"
          - "test2" = "test2"
        } -> null
      - managed_cluster_internet_security_policies = [
          - "3.3.3.3",
          - "1.1.1.1",
        ] -> null
      - network_type                               = "GR" -> null
      - node_name_type                             = "lan-ip" -> null
      - password                                   = "cCc39w6HbcnjmPo0YIWW5iWFQ76EbmSd" -> null
      - project_id                                 = 0 -> null
      - security_policy                            = [
          - "3.3.3.3",
          - "1.1.1.1",
        ] -> null
      - tags                                       = {} -> null
      - unschedulable                              = 0 -> null
      - user_name                                  = "admin" -> null
      - vpc_id                                     = "vpc-h70b6b49" -> null
      - worker_instances_list                      = [
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-ealjmcco"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.48.94"
            },
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-o9mfmeha"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.3.92"
            },
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-8w8g1x2k"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.4.11"
            },
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-p8nx202w"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.2.161"
            },
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-ddqdmc22"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.1.158"
            },
          - {
              - failed_reason  = "=Ready:True"
              - instance_id    = "ins-igghvrb8"
              - instance_role  = "WORKER"
              - instance_state = "running"
              - lan_ip         = "172.16.0.14"
            },
        ] -> null

      - node_pool_global_config {
          - expander                       = "random" -> null
          - ignore_daemon_sets_utilization = true -> null
          - is_scale_in_enabled            = false -> null
          - max_concurrent_scale_in        = 5 -> null
          - scale_in_delay                 = 15 -> null
          - scale_in_unneeded_time         = 15 -> null
          - scale_in_utilization_threshold = 30 -> null
          - skip_nodes_with_local_storage  = false -> null
          - skip_nodes_with_system_pods    = true -> null
        }

      - worker_config {
          - availability_zone                       = "ap-guangzhou-3" -> null
          - count                                   = 1 -> null
          - disaster_recover_group_ids              = [] -> null
          - enhanced_monitor_service                = false -> null
          - enhanced_security_service               = false -> null
          - instance_charge_type                    = "POSTPAID_BY_HOUR" -> null
          - instance_charge_type_prepaid_period     = 1 -> null
          - instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW" -> null
          - instance_name                           = "sub machine of tke" -> null
          - instance_type                           = "SA2.2XLARGE16" -> null
          - internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR" -> null
          - internet_max_bandwidth_out              = 100 -> null
          - key_ids                                 = [] -> null
          - password                                = (sensitive value)
          - public_ip_assigned                      = true -> null
          - security_group_ids                      = [] -> null
          - subnet_id                               = "subnet-1uwh63so" -> null
          - system_disk_size                        = 60 -> null
          - system_disk_type                        = "CLOUD_SSD" -> null
          - user_data                               = "dGVzdA==" -> null

          - data_disk {
              - disk_size = 50 -> null
              - disk_type = "CLOUD_PREMIUM" -> null
            }
        }
      - worker_config {
          - availability_zone                       = "ap-guangzhou-4" -> null
          - cam_role_name                           = "CVM_QcsRole" -> null
          - count                                   = 1 -> null
          - disaster_recover_group_ids              = [] -> null
          - enhanced_monitor_service                = false -> null
          - enhanced_security_service               = false -> null
          - instance_charge_type                    = "POSTPAID_BY_HOUR" -> null
          - instance_charge_type_prepaid_period     = 1 -> null
          - instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_MANUAL_RENEW" -> null
          - instance_name                           = "sub machine of tke" -> null
          - instance_type                           = "SA2.2XLARGE16" -> null
          - internet_charge_type                    = "TRAFFIC_POSTPAID_BY_HOUR" -> null
          - internet_max_bandwidth_out              = 100 -> null
          - key_ids                                 = [] -> null
          - password                                = (sensitive value)
          - public_ip_assigned                      = true -> null
          - security_group_ids                      = [] -> null
          - subnet_id                               = "subnet-q6fhy1mi" -> null
          - system_disk_size                        = 60 -> null
          - system_disk_type                        = "CLOUD_SSD" -> null
          - user_data                               = "dGVzdA==" -> null

          - data_disk {
              - disk_size = 50 -> null
              - disk_type = "CLOUD_PREMIUM" -> null
            }
        }
    }

  # tencentcloud_kubernetes_node_pool.mynodepool will be destroyed
  - resource "tencentcloud_kubernetes_node_pool" "mynodepool" {
      - auto_scaling_group_id = "asg-o3l17cv0" -> null
      - cluster_id            = "cls-0de11l94" -> null
      - delete_keep_instance  = true -> null
      - desired_capacity      = 4 -> null
      - enable_auto_scale     = true -> null
      - id                    = "cls-0de11l94#np-7d063g4y" -> null
      - labels                = {
          - "test1" = "test1"
          - "test2" = "test2"
        } -> null
      - launch_config_id      = "asc-5gkcq8f6" -> null
      - max_size              = 6 -> null
      - min_size              = 1 -> null
      - name                  = "mynodepool" -> null
      - node_os               = "tlinux2.4x86_64" -> null
      - node_os_type          = "GENERAL" -> null
      - retry_policy          = "INCREMENTAL_INTERVALS" -> null
      - status                = "normal" -> null
      - subnet_ids            = [
          - "subnet-1uwh63so",
        ] -> null
      - unschedulable         = 0 -> null
      - vpc_id                = "vpc-h70b6b49" -> null

      - auto_scaling_config {
          - enhanced_monitor_service   = false -> null
          - enhanced_security_service  = false -> null
          - instance_type              = "SA2.2XLARGE16" -> null
          - internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR" -> null
          - internet_max_bandwidth_out = 10 -> null
          - key_ids                    = [] -> null
          - password                   = (sensitive value)
          - public_ip_assigned         = true -> null
          - security_group_ids         = [
              - "sg-71y8m1m5",
            ] -> null
          - system_disk_size           = 50 -> null
          - system_disk_type           = "CLOUD_PREMIUM" -> null

          - data_disk {
              - disk_size = 50 -> null
              - disk_type = "CLOUD_PREMIUM" -> null
            }
        }

      - taints {
          - effect = "PreferNoSchedule" -> null
          - key    = "test_taint" -> null
          - value  = "taint_value" -> null
        }
      - taints {
          - effect = "PreferNoSchedule" -> null
          - key    = "test_taint2" -> null
          - value  = "taint_value2" -> null
        }
    }

Plan: 0 to add, 0 to change, 2 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

tencentcloud_kubernetes_node_pool.mynodepool: Destroying... [id=cls-0de11l94#np-7d063g4y]
tencentcloud_kubernetes_node_pool.mynodepool: Destruction complete after 0s
tencentcloud_kubernetes_cluster.managed_cluster: Destroying... [id=cls-0de11l94]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-0de11l94, 10s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Still destroying... [id=cls-0de11l94, 20s elapsed]
tencentcloud_kubernetes_cluster.managed_cluster: Destruction complete after 26s

Destroy complete! Resources: 2 destroyed.
```

