### PR TITLE
tke支持cluster_version升级时携带历史cluster_extra_args记录

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/tencentcloudstack/tencentcloud" {
+  version = "1.56.1"
+  hashes = [
+    "h1:yJCl2QobJnmj1idiOzw0tZvg+iPS0t6NYrMb+dmtZ7w=",
+    "zh:2df5c8e2372fb1a582b5cce09cef551fc9714095bee579ef1d9e01263d998e7e",
+    "zh:39d1a9820d893c1ba492bc83ae506f79ce0f46152ff012a7fc49f7ea67b6b5d7",
+    "zh:3e3c28c4223b3f6b37fe7416e6c73809e23eceb0a681d37d219f305f98c39a50",
+    "zh:66e2575cd5f67abc201d80a31f384bd6ca1b5d81fb47aaa1ec6d5db45597af46",
+    "zh:67de6601dd791efa2debf2d333a198f29221c0e1215292dbc9c2c91c26153543",
+    "zh:6aace7f16374e62e591eac6e5fd925403e705017acd16f1ba46884f45bab00ed",
+    "zh:74470161bf8f731922c83d45e638be6780a9771d8e0f36b0532a2b1f1271dd4e",
+    "zh:7bfb780ff36953a1bc0c5b0ced67aa721e40107a2a0a0f14b5a41e8db0ecfee6",
+    "zh:87c162a8ade55363554bc9e75d0a12bfd2ca90bbb288294cbf941764e0d87314",
+    "zh:a21b53417455564f472d1ad7113e2d2d839977b80ecf9d468d56a7d35613ee25",
+    "zh:fe52c6b0ea3450b81cd7ff161b83e39be5dfc17f5fb7fe5d86b150b6d4e151e7",
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## 1.56.2 (Unreleased)
+## 1.56.3 (Unreleased)
+## 1.56.2 (April 19, 2021)
+BUG FIXES:
+
+* Remove `ResourceInsufficient` from `retryableErrorCode`.
+
+ENHANCEMENTS:
+
+* Resource: `tencentcloud_kubernetes_cluster` upgrade `cluster_version` will send old `cluster_extra_args` to tke.
+
 ## 1.56.1 (April 6，2021)
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
-	github.com/tencentcloud/tencentcloud-sdk-go v1.0.123
+	github.com/tencentcloud/tencentcloud-sdk-go v1.0.137
 	github.com/yangwenmai/ratelimit v0.0.0-20180104140304-44221c2292e1
 	github.com/zclconf/go-cty v1.4.2 // indirect
 	golang.org/x/sys v0.0.0-20200523222454-059865788121 // indirect

--- a/go.sum
+++ b/go.sum
@@ -443,6 +443,8 @@ github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2 h1:Xr9gkxfOP0K
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tencentcloud/tencentcloud-sdk-go v1.0.123 h1:6yOMrmTuKtW1Y8VtWgN5Jt3jUcWnWtRX0gZfD1LxRcc=
 github.com/tencentcloud/tencentcloud-sdk-go v1.0.123/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
+github.com/tencentcloud/tencentcloud-sdk-go v1.0.137 h1:NEV2Dp7NofwDsyT0OpY5W0fEqsgsbKETD5gWI7/Nn/s=
+github.com/tencentcloud/tencentcloud-sdk-go v1.0.137/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
 github.com/tetafro/godot v0.3.7 h1:+mecr7RKrUKB5UQ1gwqEMn13sDKTyDR8KNIquB9mm+8=
 github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e h1:RumXZ56IrCj4CL+g1b9OL/oH0QnsF976bC8xQFYUD5Q=

--- a/k8s.tf
+++ b/k8s.tf
@@ -1,0 +1,98 @@
+variable "availability_zone_first" {
+  default = "ap-guangzhou-4"
+}
+
+variable "availability_zone_second" {
+  default = "ap-guangzhou-4"
+}
+
+variable "cluster_cidr" {
+  default = "10.31.0.0/20"
+}
+
+variable "default_instance_type" {
+  default = "S2.MEDIUM2"
+  #default = "SA2.2XLARGE16"
+}
+
+data "tencentcloud_vpc_subnets" "vpc_first" {
+  is_default        = true
+  availability_zone = var.availability_zone_first
+}
+
+data "tencentcloud_vpc_subnets" "vpc_second" {
+  is_default        = true
+  availability_zone = var.availability_zone_second
+}
+
+resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
+  vpc_id                                     = data.tencentcloud_vpc_subnets.vpc_first.instance_list.0.vpc_id
+  cluster_cidr                               = var.cluster_cidr
+  cluster_max_pod_num                        = 32
+  cluster_name                               = "rosta-test"
+  cluster_desc                               = "test cluster desc"
+  cluster_max_service_num                    = 32
+  cluster_internet                           = true
+  managed_cluster_internet_security_policies = ["3.3.3.3", "1.1.1.1"]
+  cluster_deploy_type                        = "MANAGED_CLUSTER"
+  cluster_version                            = "1.16.3"
+  #cluster_version                            = "1.18.4"
+
+  cluster_extra_args {
+    kube_apiserver = [
+      "service-account-issuer=kubernetes.default.svc", 
+      "service-account-signing-key-file=/etc/kubernetes/files/apiserver/service-account.key",
+      "api-audiences=kubernetes.default.svc"
+    ]
+  }
+
+  worker_config {
+    count                      = 1
+    availability_zone          = var.availability_zone_first
+    instance_type              = var.default_instance_type
+    system_disk_type           = "CLOUD_SSD"
+    system_disk_size           = 60
+    internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR"
+    internet_max_bandwidth_out = 100
+    public_ip_assigned         = true
+    subnet_id                  = data.tencentcloud_vpc_subnets.vpc_first.instance_list.0.subnet_id
+
+    data_disk {
+      disk_type = "CLOUD_PREMIUM"
+      disk_size = 50
+    }
+
+    enhanced_security_service = false
+    enhanced_monitor_service  = false
+    user_data                 = "dGVzdA=="
+    password                  = "ZZXXccvv1212"
+  }
+
+  worker_config {
+    count                      = 1
+    availability_zone          = var.availability_zone_second
+    instance_type              = var.default_instance_type
+    system_disk_type           = "CLOUD_SSD"
+    system_disk_size           = 60
+    internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR"
+    internet_max_bandwidth_out = 100
+    public_ip_assigned         = true
+    subnet_id                  = data.tencentcloud_vpc_subnets.vpc_second.instance_list.0.subnet_id
+
+    data_disk {
+      disk_type = "CLOUD_PREMIUM"
+      disk_size = 50
+    }
+
+    enhanced_security_service = false
+    enhanced_monitor_service  = false
+    user_data                 = "dGVzdA=="
+    password                  = "ZZXXccvv1212"
+  cam_role_name       = "CVM_QcsRole"
+  }
+
+  labels = {
+    "test1" = "test1",
+    "test2" = "test2",
+  }
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    tencentcloud = {
+      source = "tencentcloudstack/tencentcloud"
+#      version = "1.53.0"
+    }
+  }
+}
+
+provider "tencentcloud" {
+  region = "ap-guangzhou"
+}
+

--- a/tencentcloud/common.go
+++ b/tencentcloud/common.go
@@ -50,7 +50,7 @@ var retryableErrorCode = []string{
 	"TradeUnknownError",
 	"RequestLimitExceeded",
 	"ResourceInUse",
-	"ResourceInsufficient",
+	//"ResourceInsufficient",
 	"ResourceUnavailable",
 	// cbs
 	"ResourceBusy",

--- a/tencentcloud/resource_tc_kubernetes_cluster.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster.go
@@ -2124,9 +2124,12 @@ func resourceTencentCloudTkeClusterUpdate(d *schema.ResourceData, meta interface
 		if !isOk {
 			return fmt.Errorf("version %s is unsupported", newVersion)
 		}
-
+		extraArgs, ok := d.GetOk("cluster_extra_args")
+		if !ok {
+			extraArgs = nil
+		}
 		err = resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-			inErr := tkeService.ModifyClusterVersion(ctx, id, newVersion)
+			inErr := tkeService.ModifyClusterVersion(ctx, id, newVersion, extraArgs)
 			if inErr != nil {
 				return retryError(inErr)
 			}


### PR DESCRIPTION
1.  Remove `ResourceInsufficient` from `retryableErrorCode` ；
2. Resource: `tencentcloud_kubernetes_cluster` upgrade `cluster_version` will send old `cluster_extra_args` to tke.