### PR TITLE
fix: postgresql - DescribeAccounts DBInstanceId

### DIFF
--- a/tencentcloud/data_source_tc_postgresql_instances.go
+++ b/tencentcloud/data_source_tc_postgresql_instances.go
@@ -216,7 +216,7 @@ func dataSourceTencentCloudPostgresqlInstanceRead(d *schema.ResourceData, meta i
 		listItem["public_access_host"] = ""
 
 		// rootUser
-		accounts, outErr := service.DescribeRootUser(ctx, d.Id())
+		accounts, outErr := service.DescribeRootUser(ctx, *v.DBInstanceId)
 		if outErr != nil {
 			return outErr
 		}


### PR DESCRIPTION
fix sdk InvalidParameterValue.InvalidParameterValueError: DBInstanceId is empty

```
│ Error: [TencentCloudSDKError] Code=InvalidParameterValue.InvalidParameterValueError, Message=The DBInstanceId parameter value is invalid and should meet the rule: (0,INF), RequestId=71aac352-f4b4-4142-b761-58d974ea1096
│
│   with data.tencentcloud_postgresql_instances.pgsql,
│   on resource.tf line 1, in data "tencentcloud_postgresql_instances" "pgsql":
│    1: data "tencentcloud_postgresql_instances" "pgsql" {
```