### PR TITLE
Make the `description` parameter of the TEM Application required

### DIFF
--- a/.changelog/1527.txt
+++ b/.changelog/1527.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/tencentcloud_tem_application: Make the `description` parameter of the TEM Application required
+```

--- a/tencentcloud/resource_tc_tem_application.go
+++ b/tencentcloud/resource_tc_tem_application.go
@@ -49,7 +49,7 @@ func resourceTencentCloudTemApplication() *schema.Resource {
 
 			"description": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Description: "application description.",
 			},
 

--- a/website/docs/r/tem_application.html.markdown
+++ b/website/docs/r/tem_application.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `application_name` - (Required, String) application name.
 * `coding_language` - (Required, String) program language, like JAVA.
-* `description` - (Optional, String) application description.
+* `description` - (Required, String) application description.
 * `instance_id` - (Optional, String) tcr instance id.
 * `repo_name` - (Optional, String) repository name.
 * `repo_server` - (Optional, String) registry address.


### PR DESCRIPTION
The `description` parameter is required even on the `CreateApplication` API spec: https://www.tencentcloud.com/document/product/1094/42036
And in fact trying to apply without that causes an error.