### PR TITLE
fix: tke cluster endpoint can be created even if cluster only have serverless node

### DIFF
--- a/.changelog/1546.txt
+++ b/.changelog/1546.txt
@@ -1,3 +1,6 @@
 ```release-note:enhancement
 resource/tencentcloud_kubernetes_cluster_endpoint: support creating tke cluster endpoint even if cluster only have serverless node
 ```
+```release-note:enhancement
+resource/tencentcloud_kubernetes_cluster: support creating tke cluster endpoint even if cluster only have serverless node
+```

--- a/.changelog/1546.txt
+++ b/.changelog/1546.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_kubernetes_cluster_endpoint: support creating tke cluster endpoint even if cluster only have serverless node
+```


### PR DESCRIPTION
fix: tke cluster endpoint CheckOneOfClusterNodeReady include serverless nodes