### PR TITLE
fix DiffSuppressFunc would ignore docker_graph_path defaults when computing diffs

### DIFF
--- a/.changelog/2090.txt
+++ b/.changelog/2090.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/tencentcloud_kubernetes_cluster: fix DiffSuppressFunc would ignore docker_graph_path defaults when computing diffs
+```

--- a/tencentcloud/resource_tc_kubernetes_cluster.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster.go
@@ -2522,6 +2522,8 @@ func resourceTencentCloudTkeClusterCreate(d *schema.ResourceData, meta interface
 	}
 	if temp, ok := d.GetOk("docker_graph_path"); ok {
 		iAdvanced.DockerGraphPath = temp.(string)
+	} else {
+		iAdvanced.DockerGraphPath = "/var/lib/docker"
 	}
 	if temp, ok := d.GetOk("mount_target"); ok {
 		iAdvanced.MountTarget = temp.(string)


### PR DESCRIPTION
1. Background: When using the default value of docker_graph_path, there is a situation where the parameter is not passed to the cloud API. The default value of the cloud API is /var/lib/contained, which causes the resource created by Terraform to not meet the requirements.
2. Bug: DiffSuppressFunc ignores the default value of docker_graph_path when calculating differences.
The modification should only affect incremental changes and not impact existing data.
3. The modification should only affect incremental changes and not impact existing data.
