### PR TITLE
fix: nat refresh

### DIFF
--- a/.changelog/2497.txt
+++ b/.changelog/2497.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/tencentcloud_clb_attachment: support cross-domain binding, `target` status writing
+```
+

--- a/tencentcloud/services/clb/extension_clb.go
+++ b/tencentcloud/services/clb/extension_clb.go
@@ -128,6 +128,7 @@ const (
 const (
 	CLB_BACKEND_TYPE_CVM = "CVM"
 	CLB_BACKEND_TYPE_ENI = "ENI"
+	CLB_BACKEND_TYPE_NAT = "NAT"
 )
 
 const (

--- a/tencentcloud/services/clb/resource_tc_clb_attachment.go
+++ b/tencentcloud/services/clb/resource_tc_clb_attachment.go
@@ -440,7 +440,7 @@ func resourceTencentCloudClbServerAttachmentRead(d *schema.ResourceData, meta in
 				"instance_id": *onlineTarget.InstanceId,
 			}
 			targets = append(targets, target)
-		} else if *onlineTarget.Type == CLB_BACKEND_TYPE_ENI {
+		} else if *onlineTarget.Type == CLB_BACKEND_TYPE_ENI || *onlineTarget.Type == CLB_BACKEND_TYPE_NAT {
 			target := map[string]interface{}{
 				"weight": int(*onlineTarget.Weight),
 				"port":   int(*onlineTarget.Port),


### PR DESCRIPTION
When clb is bound to the backend, cross-domain writing to the `target` is not supported.