### PR TITLE
Fix typo in supported TLS version strings

### DIFF
--- a/tencentcloud/services/cdn/resource_tc_cdn_domain.go
+++ b/tencentcloud/services/cdn/resource_tc_cdn_domain.go
@@ -302,7 +302,7 @@ func ResourceTencentCloudCdnDomain() *schema.Resource {
 							Optional:    true,
 							Computed:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
-							Description: "Tls version settings, only support some Advanced domain names, support settings TLSv1, TLSV1.1, TLSV1.2, TLSv1.3, when modifying must open consecutive versions.",
+							Description: "Tls version settings, only support some Advanced domain names, support settings TLSv1, TLSv1.1, TLSv1.2, TLSv1.3, when modifying must open consecutive versions.",
 						},
 					},
 				},

--- a/website/docs/r/cdn_domain.html.markdown
+++ b/website/docs/r/cdn_domain.html.markdown
@@ -300,7 +300,7 @@ The `https_config` object supports the following:
 * `ocsp_stapling_switch` - (Optional, String) OCSP configuration switch. Valid values are `on` and `off`. and default value is `off`.
 * `server_certificate_config` - (Optional, List) Server certificate configuration information.
 * `spdy_switch` - (Optional, String) Spdy configuration switch. Valid values are `on` and `off`. and default value is `off`. This parameter is for white-list customer.
-* `tls_versions` - (Optional, List) Tls version settings, only support some Advanced domain names, support settings TLSv1, TLSV1.1, TLSV1.2, TLSv1.3, when modifying must open consecutive versions.
+* `tls_versions` - (Optional, List) Tls version settings, only support some Advanced domain names, support settings TLSv1, TLSv1.1, TLSv1.2, TLSv1.3, when modifying must open consecutive versions.
 * `verify_client` - (Optional, String) Client certificate authentication feature. Valid values are `on` and `off`. and default value is `off`.
 
 The `hw_private_access` object supports the following:


### PR DESCRIPTION
The 'V' in the TLS version strings needs to be lowercase since the strings are case sensitive:

```
Error: [TencentCloudSDKError] Code=FailedOperation.CdnConfigError, Message=invalid https tls version, RequestId=08fc10a1-7c33-4924-8832-2a13021d5e59
```