### PR TITLE
get configuration from shared credentials on demand

### DIFF
--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -2199,24 +2199,27 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	needSecret := true
 	if v, ok := d.GetOk("secret_id"); ok {
 		secretId = v.(string)
+	} else {
+		secretId = getProviderConfig("secretId")
+
 	}
 
 	if v, ok := d.GetOk("secret_key"); ok {
 		secretKey = v.(string)
+	} else {
+		secretKey = getProviderConfig("secretKey")
 	}
 
 	if v, ok := d.GetOk("security_token"); ok {
 		securityToken = v.(string)
+	} else {
+		securityToken = getProviderConfig("token")
+
 	}
 
 	if v, ok := d.GetOk("region"); ok {
 		region = v.(string)
-	}
-
-	if secretId == "" && secretKey == "" && securityToken == "" && region == "" {
-		secretId = getProviderConfig("secretId")
-		secretKey = getProviderConfig("secretKey")
-		securityToken = getProviderConfig("token")
+	} else {
 		region = getProviderConfig("region")
 	}
 


### PR DESCRIPTION
consider this situation: 

a terraform project which manages multiple locations resources.

set credential with profile name "myorg1" by TCCLI, and set different regions in terraform providers.

```
provider "tencentcloud" {
  alias = "nanjing"
  profile  = "myorg1"
  region   = "ap-nanjing"
}


provider "tencentcloud" {
  alias = "shanghai"
  profile  = "myorg1"
  region   = "ap-shanghai"
}
```

latest version code would be exited with error:  "Please set your `secret_id` and `secret_key`." since region attribute was set.

the changes fix it.


