### PR TITLE
Remove unused "tags" field from "tencentcloud_cvm_launch_template"

### DIFF
--- a/tencentcloud/services/cvm/resource_tc_cvm_launch_template.go
+++ b/tencentcloud/services/cvm/resource_tc_cvm_launch_template.go
@@ -593,13 +593,6 @@ func ResourceTencentCloudCvmLaunchTemplate() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Instance destruction protection flag.",
 			},
-
-			"tags": {
-				Type:        schema.TypeMap,
-				ForceNew:    true,
-				Optional:    true,
-				Description: "Tag description list.",
-			},
 		},
 	}
 }

--- a/website/docs/r/cvm_launch_template.html.markdown
+++ b/website/docs/r/cvm_launch_template.html.markdown
@@ -58,7 +58,6 @@ The following arguments are supported:
 * `security_group_ids` - (Optional, Set: [`String`], ForceNew) The security group ID of instance. If this parameter is not specified, the default security group is bound.
 * `system_disk` - (Optional, List, ForceNew) System disk configuration information of the instance. If this parameter is not specified, it is assigned according to the system default.
 * `tag_specification` - (Optional, List, ForceNew) Tag description list.
-* `tags` - (Optional, Map, ForceNew) Tag description list.
 * `user_data` - (Optional, String, ForceNew) The data of users.
 * `virtual_private_cloud` - (Optional, List, ForceNew) The configuration information of VPC. If this parameter is not specified, the basic network is used by default.
 


### PR DESCRIPTION
The only parameter that has any effect is `tag_specification` which is used to specify tags that launched instances should have. The launch template itself cannot be tagged according to https://www.tencentcloud.com/document/api/213/45362.