### PR TITLE
fix(tke) scale worker support `data_disk.delete_with_instance`

### DIFF
--- a/.changelog/3387.txt
+++ b/.changelog/3387.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+resource/tencentcloud_kubernetes_scale_worker: support `data_disk.delete_with_instance` param
+```

--- a/tencentcloud/services/tke/resource_tc_kubernetes_scale_worker.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_scale_worker.go
@@ -80,6 +80,13 @@ func ResourceTencentCloudKubernetesScaleWorker() *schema.Resource {
 							Default:     "",
 							Description: "The name of the device or partition to mount.",
 						},
+						"delete_with_instance": {
+							Type: 		 schema.TypeBool,
+							Optional:	 true,
+							ForceNew:	 true,
+							Default:	 true,
+							Description: "Indicate whether to delete the disk when deleting the instance. Only supports disk paid by the hour",
+						},
 					},
 				},
 			},

--- a/website/docs/r/kubernetes_scale_worker.html.markdown
+++ b/website/docs/r/kubernetes_scale_worker.html.markdown
@@ -162,6 +162,7 @@ The `data_disk` object supports the following:
 * `disk_type` - (Optional, String, ForceNew) Types of disk, available values: `CLOUD_PREMIUM` and `CLOUD_SSD` and `CLOUD_HSSD` and `CLOUD_TSSD`.
 * `file_system` - (Optional, String, ForceNew) File system, e.g. `ext3/ext4/xfs`.
 * `mount_target` - (Optional, String, ForceNew) Mount target.
+* `delete_with_instance` - (Optional, Bool, ForceNew) Indicate whether to delete the disk when deleting the instance. Only supports disk paid by the hour. Default is `true`.
 
 The `gpu_args` object supports the following:
 


### PR DESCRIPTION
`resource/tencentcloud_kubernetes_scale_worker` support `data_disk.delete_with_instance`. 
Indicate whether to delete the disk when deleting the instance. Only supports disk paid by the hour