### PR TITLE
fix(cos): [129797408] Continue process multiple grantees

### DIFF
--- a/tencentcloud/services/cos/service_tencentcloud_cos.go
+++ b/tencentcloud/services/cos/service_tencentcloud_cos.go
@@ -1861,7 +1861,6 @@ func (me *CosService) transACLBodyOrderly(ctx context.Context, rawAclBody string
 				if granteeEle != nil {
 					if granteeEle.SelectAttrValue("type", "unknown") == typeSeq {
 						orderedACL.AddChild(grantEle)
-						break
 					}
 				}
 			}


### PR DESCRIPTION
when user requires multiple grantees on one type, the break will only process first element and leave the other grantee requests unprocessed.

```
2026-01-05T17:17:14.454+0800 [INFO]  provider.terraform-provider-tencentcloud_v1.82.12: 2026/01/05 17:17:14 [DEBUG]1767604633788-1 transACLBodyOrderly success, before:[
<AccessControlPolicy>
  <Owner>
    <ID>qcs::cam::uin/xxxxxxx:uin/xxxxxxx</ID>
    <DisplayName>qcs::cam::uin/xxxxxxx:uin/xxxxxxx</DisplayName>
  </Owner>
  <AccessControlList>
    <Grant>
      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
        <ID>qcs::cam::uin/xxxxxxx:uin/xxxxxxx1</ID>
        <DisplayName>qcs::cam::uin/xxxxxxx:uin/xxxxxxx1</DisplayName>
      </Grantee>
      <Permission>READ</Permission>
    </Grant>
    <Grant>
      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
        <ID>qcs::cam::uin/xxxxxxx:uin/xxxxxxx2</ID>
        <DisplayName>qcs::cam::uin/xxxxxxx:uin/xxxxxxx2</DisplayName>
      </Grantee>
      <Permission>READ</Permission>
    </Grant>
    <Grant>
      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
        <ID>qcs::cam::uin/xxxxxxx:uin/xxxxxxx1</ID>
        <DisplayName>qcs::cam::uin/xxxxxxx:uin/xxxxxxx1</DisplayName>
      </Grantee>
      <Permission>WRITE</Permission>
    </Grant>
    <Grant>
      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
        <ID>qcs::cam::uin/xxxxxxx:uin/xxxxxxx2</ID>
        <DisplayName>qcs::cam::uin/xxxxxxx:uin/xxxxxxx2</DisplayName>
      </Grantee>
      <Permission>WRITE</Permission>
    </Grant>
  </AccessControlList>
</AccessControlPolicy>

], after:[
<AccessControlPolicy>
  <Owner>
    <ID>qcs::cam::uin/xxxxxxx:uin/xxxxxxx</ID>
    <DisplayName>qcs::cam::uin/xxxxxxx:uin/xxxxxxx</DisplayName>
  </Owner>
  <AccessControlList>
    <Grant>
      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
        <ID>qcs::cam::uin/xxxxxxx:uin/xxxxxxx1</ID>
        <DisplayName>qcs::cam::uin/xxxxxxx:uin/xxxxxxx1</DisplayName>
      </Grantee>
      <Permission>READ</Permission>
    </Grant>
    <Grant>
      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
        <ID>qcs::cam::uin/xxxxxxx:uin/xxxxxxx1</ID>
        <DisplayName>qcs::cam::uin/xxxxxxx:uin/xxxxxxx1</DisplayName>
      </Grantee>
      <Permission>WRITE</Permission>
    </Grant>
  </AccessControlList>
</AccessControlPolicy>

]: timestamp="2026-01-05T17:17:14.454+0800"
```