### PR TITLE
feat(emr): add cos_bucket parameter for StarRocks shared-data cluster

### DIFF
--- a/tencentcloud/services/emr/resource_tc_emr_cluster.go
+++ b/tencentcloud/services/emr/resource_tc_emr_cluster.go
@@ -250,6 +250,12 @@ func ResourceTencentCloudEmrCluster() *schema.Resource {
 				Computed:    true,
 				Description: "0 means turn off automatic renewal, 1 means turn on automatic renewal. Default is 0.",
 			},
+			"cos_bucket": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "COS bucket path, used when creating StarRocks shared-data cluster. Format: cosn://<bucket-name>-<appid>/<path>",
+			},
 			"pre_executed_file_settings": {
 				Type:        schema.TypeList,
 				Optional:    true,

--- a/tencentcloud/services/emr/service_tencentcloud_emr.go
+++ b/tencentcloud/services/emr/service_tencentcloud_emr.go
@@ -112,6 +112,10 @@ func (me *EMRService) CreateInstance(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
+	if v, ok := d.GetOk("cos_bucket"); ok {
+		request.CosBucket = helper.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("resource_spec"); ok {
 		tmpResourceSpec := v.([]interface{})
 		resourceSpec := tmpResourceSpec[0].(map[string]interface{})

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -127,6 +127,7 @@ The following arguments are supported:
 * `support_ha` - (Required, Int, ForceNew) The flag whether the instance support high availability.(0=>not support, 1=>support).
 * `vpc_settings` - (Required, Map, ForceNew) The private net config of EMR instance.
 * `auto_renew` - (Optional, Int) 0 means turn off automatic renewal, 1 means turn on automatic renewal. Default is 0.
+* `cos_bucket` - (Optional, String, ForceNew) COS bucket path for StarRocks shared-data cluster. Format: `cosn://<bucket-name>-<appid>/<path>`.
 * `display_strategy` - (Optional, String, **Deprecated**) It will be deprecated in later versions. Display strategy of EMR instance.
 * `extend_fs_field` - (Optional, String) Access the external file system.
 * `login_settings` - (Optional, Map) Instance login settings. There are two optional fields:- password: Instance login password: 8-16 characters, including uppercase letters, lowercase letters, numbers and special characters. Special symbols only support! @% ^ *. The first bit of the password cannot be a special character;- public_key_id: Public key id. After the key is associated, the instance can be accessed through the corresponding private key.


### PR DESCRIPTION
## What this PR does

Add `cos_bucket` parameter to `tencentcloud_emr_cluster` resource to support creating StarRocks shared-data (存算分离) clusters.

## Why is this needed

When creating StarRocks shared-data clusters via EMR API, the `CosBucket` parameter is required to specify the COS storage path. Without this parameter, users cannot create StarRocks shared-data clusters using Terraform.

**Error before this fix:**
```
Error: [TencentCloudSDKError] Code=InvalidParameter.InvalidCosBucket,
Message=CosBucket should be a valid value while creating a shared-data StarRocks cluster
```

## Changes

- `tencentcloud/services/emr/resource_tc_emr_cluster.go`: Add `cos_bucket` schema definition
- `tencentcloud/services/emr/service_tencentcloud_emr.go`: Add `cos_bucket` parameter handling in CreateInstance
- `website/docs/r/emr_cluster.html.markdown`: Add documentation for `cos_bucket` parameter

## Usage Example

```hcl
resource "tencentcloud_emr_cluster" "starrocks_shared_data" {
  product_id    = 70  # STARROCKS-V2.2.1
  scene_name    = "StarRocks-Shared-Data"
  instance_name = "starrocks-shared-data-cluster"

  cos_bucket = "cos-bucket-name"

  softwares    = ["starrocks-3.3.13", "knox-1.2.0"]
  support_ha   = 0

  vpc_settings = {
    vpc_id    = "vpc-xxxxx"
    subnet_id = "subnet-xxxxx"
  }

  resource_spec {
    master_resource_spec {
      mem_size     = 16384
      cpu          = 4
      disk_size    = 100
      disk_type    = "CLOUD_SSD"
      spec         = "CVM.S5.MEDIUM8"
      storage_type = 5
    }
    master_count = 1
    task_count   = 3
    task_resource_spec {
      mem_size     = 16384
      cpu          = 4
      disk_size    = 0
      disk_type    = "CLOUD_SSD"
      spec         = "CVM.S5.MEDIUM8"
      storage_type = 5
    }
  }
  # ... other config
}
```

## Testing

- [x] Tested creating StarRocks shared-data cluster with `cos_bucket` parameter
- [x] Verified API request includes `CosBucket` field

## References

- [EMR CreateInstance API](https://cloud.tencent.com/document/api/589/34261)
- [Tencentcloud EMR StarRocks shared data](https://cloud.tencent.com/document/product/589/109876)
