### PR TITLE
feat(cls): add Parquet content support for tencentcloud_cls_cos_shipper resource

### DIFF
--- a/tencentcloud/services/cls/resource_tc_cls_cos_shipper.go
+++ b/tencentcloud/services/cls/resource_tc_cls_cos_shipper.go
@@ -168,6 +168,41 @@ func ResourceTencentCloudClsCosShipper() *schema.Resource {
 							},
 							Description: "JSON format content description.Note: this field may return null, indicating that no valid values can be obtained.",
 						},
+						"parquet": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"parquet_key_info": {
+										Type:     schema.TypeList,
+										Required: true,
+										MinItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key_name": {
+													Type:        schema.TypeString,
+													Required:    true,
+													Description: "Key name (column name) written to Parquet header.",
+												},
+												"key_type": {
+													Type:        schema.TypeString,
+													Required:    true,
+													Description: "Supported: string, boolean, int32, int64, float, double.",
+												},
+												"key_non_existing_field": {
+													Type:        schema.TypeString,
+													Required:    true,
+													Description: "Default value when parsing fails / field missing.",
+												},
+											},
+										},
+										Description: "Parquet schema definition (list of keys/columns).",
+									},
+								},
+							},
+							Description: "Parquet format content description.",
+						},
 					},
 				},
 			},
@@ -308,6 +343,25 @@ func resourceTencentCloudClsCosShipperCreate(d *schema.ResourceData, meta interf
 					content.Json = &jsonInfo
 				}
 			}
+			if v, ok := dMap["parquet"]; ok {
+				if len(v.([]interface{})) == 1 {
+					parquet := v.([]interface{})[0].(map[string]interface{})
+
+					parquetInfo := cls.ParquetInfo{}
+					keyInfosRaw := parquet["parquet_key_info"].([]interface{})
+					for _, ki := range keyInfosRaw {
+						m := ki.(map[string]interface{})
+						kiObj := cls.ParquetKeyInfo{
+							KeyName:             helper.String(m["key_name"].(string)),
+							KeyType:             helper.String(m["key_type"].(string)),
+							KeyNonExistingField: helper.String(m["key_non_existing_field"].(string)),
+						}
+						parquetInfo.ParquetKeyInfo = append(parquetInfo.ParquetKeyInfo, &kiObj)
+					}
+
+					content.Parquet = &parquetInfo
+				}
+			}
 			contents = append(contents, &content)
 		}
 		request.Content = contents[0]
@@ -435,6 +489,20 @@ func resourceTencentCloudClsCosShipperRead(d *schema.ResourceData, meta interfac
 				"meta_fields": shipper.Content.Json.MetaFields,
 			}
 			content["json"] = []interface{}{json}
+		}
+		if shipper.Content.Parquet != nil {
+			pkis := make([]interface{}, 0, len(shipper.Content.Parquet.ParquetKeyInfo))
+			for _, pki := range shipper.Content.Parquet.ParquetKeyInfo {
+				pkis = append(pkis, map[string]interface{}{
+					"key_name":               pki.KeyName,
+					"key_type":               pki.KeyType,
+					"key_non_existing_field": pki.KeyNonExistingField,
+				})
+			}
+			parquet := map[string]interface{}{
+				"parquet_key_info": pkis,
+			}
+			content["parquet"] = []interface{}{parquet}
 		}
 		_ = d.Set("content", []interface{}{content})
 	}
@@ -585,6 +653,25 @@ func resourceTencentCloudClsCosShipperUpdate(d *schema.ResourceData, meta interf
 							jsonInfo.MetaFields = append(jsonInfo.MetaFields, helper.String(metaField.(string)))
 						}
 						content.Json = &jsonInfo
+					}
+				}
+				if v, ok := dMap["parquet"]; ok {
+					if len(v.([]interface{})) == 1 {
+						parquet := v.([]interface{})[0].(map[string]interface{})
+
+						parquetInfo := cls.ParquetInfo{}
+						keyInfosRaw := parquet["parquet_key_info"].([]interface{})
+						for _, ki := range keyInfosRaw {
+							m := ki.(map[string]interface{})
+							kiObj := cls.ParquetKeyInfo{
+								KeyName:             helper.String(m["key_name"].(string)),
+								KeyType:             helper.String(m["key_type"].(string)),
+								KeyNonExistingField: helper.String(m["key_non_existing_field"].(string)),
+							}
+							parquetInfo.ParquetKeyInfo = append(parquetInfo.ParquetKeyInfo, &kiObj)
+						}
+
+						content.Parquet = &parquetInfo
 					}
 				}
 				contents = append(contents, &content)

--- a/tencentcloud/services/cls/resource_tc_cls_cos_shipper_test.go
+++ b/tencentcloud/services/cls/resource_tc_cls_cos_shipper_test.go
@@ -97,15 +97,19 @@ resource "tencentcloud_cls_cos_shipper" "shipper" {
   }
 
   content {
-    format = "json"
+    format = "parquet"
 
-    json {
-      enable_tag  = true
-      meta_fields = [
-        "__FILENAME__",
-        "__SOURCE__",
-        "__TIMESTAMP__",
-      ]
+    parquet {
+      parquet_key_info {
+        key_name              = "level"
+        key_type              = "string"
+        key_non_existing_field = "NULL"
+      }
+      parquet_key_info {
+        key_name              = "status"
+        key_type              = "int32"
+        key_non_existing_field = "0"
+      }
     }
   }
 }

--- a/website/docs/r/cls_cos_shipper.html.markdown
+++ b/website/docs/r/cls_cos_shipper.html.markdown
@@ -98,9 +98,10 @@ The `compress` object supports the following:
 
 The `content` object supports the following:
 
-* `format` - (Required, String) Content format. Valid values: json, csv.
+* `format` - (Required, String) Content format. Valid values: json, csv, parquet.
 * `csv` - (Optional, List) CSV format content description.Note: this field may return null, indicating that no valid values can be obtained.
 * `json` - (Optional, List) JSON format content description.Note: this field may return null, indicating that no valid values can be obtained.
+* `parquet` - (Optional, List) Parquet format content description.Note: this field may return null, indicating that no valid values can be obtained.
 
 The `csv` object of `content` supports the following:
 
@@ -121,6 +122,16 @@ The `json` object of `content` supports the following:
 * `enable_tag` - (Required, Bool) Enablement flag.
 * `meta_fields` - (Required, Set) Metadata information list
 Note: this field may return null, indicating that no valid values can be obtained..
+
+The `parquet` object of `content` supports the following:
+
+* `parquet_key_info` - (Required, List) Definition of Parquet fields.
+
+The `parquet_key_info` object of `parquet` supports the following:
+
+* `key_name` - (Required, String) Name of the field (column name) written to the Parquet file.
+* `key_type` - (Required, String) Data type of the field. Supported values: string, boolean, int32, int64, float, double.
+* `key_non_existing_field` - (Required, String) Default value used when the field does not exist or parsing fails.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### What this PR does
Add Parquet content support for tencentcloud_cls_cos_shipper resource

### Why is this needed
Even though it is possible to create a Parquet shipping task through the console, the tencentcloud_cls_cos_shipper terraform resource only allow json or csv.

### Changes
- tencentcloud/services/cls/resource_tc_cls_cos_shipper.go: Add Parquet support in the Create/Update and Read methods
- tencentcloud/services/cls/resource_tc_cls_cos_shipper_test.go: Test values for Parquet
- website/docs/r/cls_cos_shipper.html.markdown: Add documentation for Parquet new option

### Usage example
See resource_tc_cls_cos_shipper_test.go

### Validation
- [x] go test PASS
- [x] create/update resource using builded provider