### PR TITLE
feat(teo): add teo alias domain resource

### DIFF
--- a/.changelog/4010.txt
+++ b/.changelog/4010.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_teo_alias_domain
+```

--- a/openspec/changes/add-teo-alias-domain-resource/.openspec.yaml
+++ b/openspec/changes/add-teo-alias-domain-resource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/add-teo-alias-domain-resource/design.md
+++ b/openspec/changes/add-teo-alias-domain-resource/design.md
@@ -1,0 +1,97 @@
+## Context
+
+Terraform Provider for TencentCloud 目前缺少对 Teo 产品的别称域名（Alias Domain）资源支持。Teo 是腾讯云的边缘安全加速产品，别称域名功能允许用户为站点配置别名域名。当前用户需要通过云 API 或控制台手动管理别称域名，无法通过 Terraform 进行声明式管理。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 实现 Teo 别称域名的完整 CRUD 操作
+- 支持通过 Terraform 声明式管理别称域名的生命周期
+- 确保异步操作的可靠性，通过轮询机制确认操作生效
+- 提供完整的测试覆盖和文档
+
+**Non-Goals:**
+- 不支持批量创建或删除别称域名（云 API 只支持单个操作）
+- 不支持别称域名的其他高级配置（如自定义规则等，仅支持基本配置）
+- 不涉及 Teo 其他资源的修改或新增
+
+## Decisions
+
+### 1. 异步操作的轮询机制
+**决策**: 对所有标记为异步的云 API（CreateAliasDomain、ModifyAliasDomain、ModifyAliasDomainStatus、DeleteAliasDomain），在调用后立即调用 DescribeAliasDomains 接口轮询，直到资源状态与预期一致或达到超时。
+
+**理由**:
+- Teo 云 API 的创建、修改、删除、状态修改都是异步操作，立即返回可能表示操作已受理但未实际生效
+- Terraform 期望资源状态在 apply 完成后是最终一致的状态，轮询机制可以保证这一点
+- 使用 `helper.Retry()` 函数实现轮询，与 provider 现有模式保持一致
+
+**备选方案**:
+- 使用 state refreshers: 功能类似，但 helper.Retry() 更简单直接
+- 直接返回不轮询: 会导致 Terraform state 与实际状态不一致，不符合最佳实践
+
+### 2. 资源 ID 格式
+**决策**: 使用复合 ID 格式 `zone_id#alias_name`，其中 `zone_id` 是站点 ID，`alias_name` 是别称域名名称。
+
+**理由**:
+- 别称域名由 `zone_id` 和 `alias_name` 唯一标识
+- 使用 `#` 分隔符与 provider 现有模式一致（如 `instanceId#userId`）
+- 在 Read 操作中可以从 ID 解析出这两个关键字段
+
+### 3. 状态暂停/启用机制
+**决策**: 通过 `paused` 参数控制别称域名的暂停/启用状态，true 表示暂停，false 表示启用。在 Update 函数中检测 `paused` 参数的变化，如果变化则调用 ModifyAliasDomainStatus API。
+
+**理由**:
+- 云 API 的 ModifyAliasDomainStatus 接口专门用于修改状态
+- 将状态修改集成到 Update 函数中，用户可以通过修改配置文件来切换状态
+- 需要与其他参数的修改（通过 ModifyAliasDomain）分开处理
+
+### 4. Timeout 配置
+**决策**: 在 Schema 中声明 Timeouts 块，提供 Create、Update、Delete 的自定义超时配置。
+
+**理由**:
+- 异步操作可能需要较长时间才能生效，默认超时可能不够
+- 允许用户根据实际情况调整超时时间，提高配置的灵活性
+- 符合 Terraform provider 的最佳实践
+
+## Risks / Trade-offs
+
+### 1. 轮询超时导致的状态不一致
+**风险**: 如果云 API 操作失败或网络问题导致轮询超时，Terraform state 可能与实际状态不一致。
+
+**缓解措施**:
+- 使用合理的默认超时时间（建议 10 分钟）
+- 在轮询失败时返回明确的错误信息
+- 提供文档说明，指导用户在超时后使用 `terraform refresh` 同步状态
+
+### 2. 云 API 行为变化
+**风险**: 云 API 的行为或参数可能在未来版本中变化，导致 provider 代码需要更新。
+
+**缓解措施**:
+- 使用 vendor 模式管理依赖，锁定具体版本
+- 在测试中覆盖主要场景，尽早发现 API 变化
+- 添加适当的错误处理和日志记录
+
+### 3. 并发操作冲突
+**风险**: 同一个别称域名被多个 Terraform 配置并发操作，可能导致状态不一致。
+
+**缓解措施**:
+- 云 API 本身应该有并发控制，依赖其实现
+- 提示用户避免对同一资源进行并发操作
+- 在文档中说明最佳实践
+
+## Migration Plan
+
+由于这是一个全新的资源，不涉及现有资源的迁移或数据迁移。
+
+**部署步骤**:
+1. 代码审查和测试
+2. 发布新版本 provider
+3. 用户更新 provider 版本后即可使用新资源
+
+**回滚策略**:
+- 如果新资源有严重问题，可以发布新版本移除该资源
+- 不会影响现有资源和配置的向后兼容性
+
+## Open Questions
+
+目前没有未决的问题。所有技术决策都已经明确。

--- a/openspec/changes/add-teo-alias-domain-resource/proposal.md
+++ b/openspec/changes/add-teo-alias-domain-resource/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+当前 Terraform Provider for TencentCloud 缺少对 Teo（边缘安全加速）产品中别称域名（Alias Domain）资源的支持，用户无法通过 Terraform 来管理 Teo 的别称域名。新增此资源将帮助用户实现基础设施即代码，简化别称域名的创建、更新、删除等操作。
+
+## What Changes
+
+- 新增 Terraform Resource `resource_tc_teo_alias_domain`，用于管理 Teo 别称域名
+- 支持别称域名的 CRUD 操作（Create、Read、Update、Delete）
+- 支持修改别称域名的暂停/启用状态
+- 实现异步操作的轮询机制，确保操作生效后再返回
+
+## Capabilities
+
+### New Capabilities
+- `teo-alias-domain`: Teo 别称域名管理，支持创建、查询、更新、删除别称域名，以及修改别称域名的暂停/启用状态
+
+### Modified Capabilities
+None
+
+## Impact
+
+- 新增文件：
+  - `tencentcloud/services/teo/resource_tc_teo_alias_domain.go`
+  - `tencentcloud/services/teo/resource_tc_teo_alias_domain_test.go`
+  - `tencentcloud/services/teo/resource_tc_teo_alias_domain.md`
+- 依赖云 API 包：`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`
+- 不影响现有资源和数据源的向后兼容性

--- a/openspec/changes/add-teo-alias-domain-resource/specs/teo-alias-domain/spec.md
+++ b/openspec/changes/add-teo-alias-domain-resource/specs/teo-alias-domain/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+### Requirement: 创建别称域名
+系统 SHALL 允许用户创建 Teo 别称域名，指定站点 ID、别称域名名称和目标域名。
+
+#### Scenario: 成功创建别称域名
+- **WHEN** 用户提供 zone_id、alias_name 和 target_name 参数
+- **THEN** 系统调用 CreateAliasDomain 云 API 创建别称域名
+- **AND** 系统轮询 DescribeAliasDomains API 直到别称域名创建成功
+- **AND** 系统返回资源 ID（格式：zone_id#alias_name）
+- **AND** 系统记录资源的 zone_id、alias_name、target_name 和 paused 状态到 Terraform state
+
+#### Scenario: 创建时缺少必需参数
+- **WHEN** 用户未提供 zone_id 或 alias_name 或 target_name 参数
+- **THEN** 系统返回参数验证错误
+- **AND** 资源创建失败
+
+### Requirement: 查询别称域名
+系统 SHALL 允许用户查询现有的 Teo 别称域名信息。
+
+#### Scenario: 成功查询别称域名
+- **WHEN** 用户通过资源 ID（zone_id#alias_name）查询别称域名
+- **THEN** 系统解析 ID 获取 zone_id 和 alias_name
+- **AND** 系统调用 DescribeAliasDomains 云 API 查询别称域名信息
+- **AND** 系统返回别称域名的 zone_id、alias_name、target_name 和 paused 状态
+
+#### Scenario: 查询不存在的别称域名
+- **WHEN** 用户查询的别称域名不存在
+- **THEN** 系统返回资源不存在的错误
+- **AND** 资源标记为已删除状态
+
+### Requirement: 更新别称域名
+系统 SHALL 允许用户更新 Teo 别称域名，包括修改目标域名和暂停/启用状态。
+
+#### Scenario: 成功更新目标域名
+- **WHEN** 用户修改 target_name 参数
+- **THEN** 系统调用 ModifyAliasDomain 云 API 更新目标域名
+- **AND** 系统轮询 DescribeAliasDomains API 直到更新生效
+- **AND** 系统更新 Terraform state 中的 target_name
+
+#### Scenario: 成功切换暂停/启用状态
+- **WHEN** 用户修改 paused 参数
+- **THEN** 系统调用 ModifyAliasDomainStatus 云 API 更新状态
+- **AND** 系统轮询 DescribeAliasDomains API 直到状态更新生效
+- **AND** 系统更新 Terraform state 中的 paused 状态
+
+#### Scenario: 同时更新多个参数
+- **WHEN** 用户同时修改 target_name 和 paused 参数
+- **THEN** 系统先调用 ModifyAliasDomain 更新 target_name
+- **AND** 系统轮询确认 target_name 更新生效
+- **AND** 系统再调用 ModifyAliasDomainStatus 更新 paused 状态
+- **AND** 系统轮询确认 paused 状态更新生效
+- **AND** 系统更新 Terraform state 中的所有变更
+
+#### Scenario: 未修改任何参数
+- **WHEN** 用户未修改任何参数
+- **THEN** 系统不调用任何云 API
+- **AND** 资源保持不变
+
+### Requirement: 删除别称域名
+系统 SHALL 允许用户删除现有的 Teo 别称域名。
+
+#### Scenario: 成功删除别称域名
+- **WHEN** 用户请求删除别称域名
+- **THEN** 系统调用 DeleteAliasDomain 云 API 删除别称域名
+- **AND** 系统轮询 DescribeAliasDomains API 直到别称域名不再存在
+- **AND** 系统从 Terraform state 中移除该资源
+
+#### Scenario: 删除已不存在的别称域名
+- **WHEN** 用户删除的别称域名已经不存在
+- **THEN** 系统返回成功
+- **AND** 不执行任何云 API 调用
+- **AND** 系统从 Terraform state 中移除该资源
+
+### Requirement: 异步操作轮询
+系统 SHALL 对所有异步操作执行轮询，确保操作完全生效后再返回。
+
+#### Scenario: 创建操作轮询成功
+- **WHEN** 系统调用 CreateAliasDomain API
+- **AND** API 返回成功
+- **THEN** 系统开始轮询 DescribeAliasDomains API
+- **AND** 系统每 5 秒轮询一次
+- **AND** 系统在轮询中检测到别称域名创建成功
+- **AND** 系统返回成功
+
+#### Scenario: 更新操作轮询超时
+- **WHEN** 系统调用 ModifyAliasDomain API
+- **AND** API 返回成功
+- **THEN** 系统开始轮询 DescribeAliasDomains API
+- **AND** 系统轮询达到默认超时时间（10 分钟）
+- **AND** 别称域名仍未更新到预期状态
+- **THEN** 系统返回超时错误
+- **AND** 提示用户手动检查资源状态
+
+#### Scenario: 删除操作轮询成功
+- **WHEN** 系统调用 DeleteAliasDomain API
+- **AND** API 返回成功
+- **THEN** 系统开始轮询 DescribeAliasDomains API
+- **AND** 系统在轮询中检测到别称域名已不存在
+- **AND** 系统返回成功
+
+### Requirement: 资源 ID 解析
+系统 SHALL 支持从复合资源 ID 中解析出 zone_id 和 alias_name。
+
+#### Scenario: 解析有效的资源 ID
+- **WHEN** 系统收到资源 ID "zone-123#example.com"
+- **THEN** 系统解析出 zone_id 为 "zone-123"
+- **AND** 系统解析出 alias_name 为 "example.com"
+
+#### Scenario: 解析无效的资源 ID
+- **WHEN** 系统收到格式错误的资源 ID
+- **THEN** 系统返回资源 ID 格式错误的提示
+
+### Requirement: Timeout 配置
+系统 SHALL 允许用户自定义异步操作的超时时间。
+
+#### Scenario: 使用默认超时配置
+- **WHEN** 用户未配置 Timeouts
+- **THEN** 系统使用默认超时时间（Create: 10分钟, Update: 10分钟, Delete: 10分钟）
+
+#### Scenario: 使用自定义超时配置
+- **WHEN** 用户配置了 Timeouts.create 为 20 分钟
+- **THEN** 系统在创建操作中使用 20 分钟超时时间
+- **AND** 其他操作使用默认超时时间
+
+### Requirement: 导入现有资源
+系统 SHALL 支持导入已存在的别称域名到 Terraform 管理。
+
+#### Scenario: 成功导入别称域名
+- **WHEN** 用户使用 terraform import 命令导入资源
+- **AND** 导入 ID 格式为 "zone_id#alias_name"
+- **THEN** 系统调用 DescribeAliasDomains API 查询资源信息
+- **AND** 系统将资源信息写入 Terraform state
+- **AND** 资源成功导入到 Terraform 管理
+
+#### Scenario: 导入不存在的资源
+- **WHEN** 用户尝试导入不存在的别称域名
+- **THEN** 系统返回资源不存在的错误
+- **AND** 导入失败

--- a/openspec/changes/add-teo-alias-domain-resource/tasks.md
+++ b/openspec/changes/add-teo-alias-domain-resource/tasks.md
@@ -1,0 +1,44 @@
+## 1. 资源代码实现
+
+- [x] 1.1 创建 resource_tc_teo_alias_domain.go 文件
+- [x] 1.2 定义资源 Schema，包括 zone_id（Required）、alias_name（Required）、target_name（Required）、paused（Optional）参数
+- [x] 1.3 在 Schema 中定义 Timeouts 块，支持 Create、Update、Delete 的自定义超时配置
+- [x] 1.4 实现 resourceTencentcloudTeoAliasDomainCreate 函数，调用 CreateAliasDomain 云 API
+- [x] 1.5 在 Create 函数中添加轮询逻辑，使用 helper.Retry() 调用 DescribeAliasDomains API 直到创建成功
+- [x] 1.6 实现 resourceTencentcloudTeoAliasDomainRead 函数，调用 DescribeAliasDomains 云 API 查询资源信息
+- [x] 1.7 在 Read 函数中实现资源 ID 解析，从 zone_id#alias_name 格式中解析出 zone_id 和 alias_name
+- [x] 1.8 实现 resourceTencentcloudTeoAliasDomainUpdate 函数，处理 target_name 和 paused 参数的更新
+- [x] 1.9 在 Update 函数中实现 target_name 更新逻辑，调用 ModifyAliasDomain 云 API 并轮询
+- [x] 1.10 在 Update 函数中实现 paused 状态更新逻辑，调用 ModifyAliasDomainStatus 云 API 并轮询
+- [x] 1.11 实现 resourceTencentcloudTeoAliasDomainDelete 函数，调用 DeleteAliasDomain 云 API
+- [x] 1.12 在 Delete 函数中添加轮询逻辑，使用 helper.Retry() 调用 DescribeAliasDomains API 直到资源被删除
+- [x] 1.13 实现 resourceTencentcloudTeoAliasDomainImporter 函数，支持使用 terraform import 导入资源
+- [x] 1.14 添加错误处理和日志记录，使用 defer tccommon.LogElapsed() 和 defer tccommon.InconsistentCheck()
+- [x] 1.15 注册资源到 teo 服务的资源列表中
+
+## 2. 测试代码实现
+
+- [x] 2.1 创建 resource_tc_teo_alias_domain_test.go 文件
+- [x] 2.2 实现 TestAccTencentcloudTeoAliasDomain_basic 测试用例，测试基本 CRUD 操作
+- [x] 2.3 在测试用例中覆盖创建资源场景，验证 zone_id、alias_name、target_name 参数
+- [x] 2.4 在测试用例中覆盖更新资源场景，验证 target_name 更新
+- [x] 2.5 在测试用例中覆盖暂停/启用状态更新场景，验证 paused 参数
+- [x] 2.6 在测试 case 中覆盖删除资源场景，验证资源被正确删除
+- [x] 2.7 实现 TestAccTencentcloudTeoAliasDomain_import 测试用例，测试资源导入功能
+- [ ] 2.8 添加 mock 测试或使用真实的云 API 进行验收测试（需要 TF_ACC=1 环境变量）
+
+## 3. 文档更新
+
+- [x] 3.1 创建 resource_tc_teo_alias_domain.md 示例文件
+- [x] 3.2 在示例文件中添加资源使用示例，包括完整的 Terraform 配置
+- [x] 3.3 在示例文件中说明资源 ID 格式（zone_id#alias_name）
+- [x] 3.4 在示例文件中说明 Timeouts 配置方法
+- [x] 3.5 在示例文件中说明导入资源的方法
+- [ ] 3.6 运行 make doc 命令生成 website/docs/ 下的文档
+
+## 4. 代码验证
+
+- [x] 4.1 使用 gofmt 格式化新增的 Go 代码
+- [ ] 4.2 运行单元测试验证代码逻辑
+- [ ] 4.3 运行验收测试（TF_ACC=1）验证资源功能（如果环境支持）
+- [ ] 4.4 检查代码是否符合 provider 编码规范和最佳实践

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -2061,6 +2061,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_teo_ownership_verify":                                                     teo.ResourceTencentCloudTeoOwnershipVerify(),
 			"tencentcloud_teo_certificate_config":                                                   teo.ResourceTencentCloudTeoCertificateConfig(),
 			"tencentcloud_teo_acceleration_domain":                                                  teo.ResourceTencentCloudTeoAccelerationDomain(),
+			"tencentcloud_teo_alias_domain":                                                         teo.ResourceTencentCloudTeoAliasDomain(),
 			"tencentcloud_teo_application_proxy":                                                    teo.ResourceTencentCloudTeoApplicationProxy(),
 			"tencentcloud_teo_application_proxy_rule":                                               teo.ResourceTencentCloudTeoApplicationProxyRule(),
 			"tencentcloud_teo_realtime_log_delivery":                                                teo.ResourceTencentCloudTeoRealtimeLogDelivery(),

--- a/tencentcloud/services/teo/resource_tc_teo_alias_domain.go
+++ b/tencentcloud/services/teo/resource_tc_teo_alias_domain.go
@@ -1,0 +1,408 @@
+package teo
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	teo "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudTeoAliasDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudTeoAliasDomainCreate,
+		Read:   resourceTencentCloudTeoAliasDomainRead,
+		Update: resourceTencentCloudTeoAliasDomainUpdate,
+		Delete: resourceTencentCloudTeoAliasDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(3 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ID of the site.",
+			},
+
+			"alias_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Alias domain name.",
+			},
+
+			"target_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Target domain name.",
+			},
+
+			"paused": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether the alias domain is paused. true: paused, false: active.",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudTeoAliasDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_alias_domain.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request   = teo.NewCreateAliasDomainRequest()
+		zoneId    string
+		aliasName string
+	)
+
+	if v, ok := d.GetOk("zone_id"); ok {
+		request.ZoneId = helper.String(v.(string))
+		zoneId = v.(string)
+	}
+
+	if v, ok := d.GetOk("alias_name"); ok {
+		request.AliasName = helper.String(v.(string))
+		aliasName = v.(string)
+	}
+
+	if v, ok := d.GetOk("target_name"); ok {
+		request.TargetName = helper.String(v.(string))
+	}
+
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoClient().CreateAliasDomainWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s create teo alias domain failed, reason:%+v", logId, err)
+		return err
+	}
+
+	// wait for creation to complete
+	if err := resourceTencentCloudTeoAliasDomainCreatePostHandle(ctx, zoneId, aliasName, meta, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return err
+	}
+
+	d.SetId(strings.Join([]string{zoneId, aliasName}, tccommon.FILED_SP))
+
+	// set paused status if specified
+	if v, ok := d.GetOkExists("paused"); ok && v.(bool) {
+		request := teo.NewModifyAliasDomainStatusRequest()
+		request.ZoneId = helper.String(zoneId)
+		request.AliasNames = []*string{helper.String(aliasName)}
+		request.Paused = helper.Bool(v.(bool))
+
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoClient().ModifyAliasDomainStatusWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s update teo alias domain paused status failed, reason:%+v", logId, err)
+			return err
+		}
+
+		// wait for status update to complete
+		if err := resourceTencentCloudTeoAliasDomainUpdatePostHandle(ctx, zoneId, aliasName, v.(bool), meta, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return err
+		}
+	}
+
+	return resourceTencentCloudTeoAliasDomainRead(d, meta)
+}
+
+func resourceTencentCloudTeoAliasDomainRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_alias_domain.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service = TeoService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	zoneId := idSplit[0]
+	aliasName := idSplit[1]
+
+	_ = d.Set("zone_id", zoneId)
+	_ = d.Set("alias_name", aliasName)
+
+	respData, err := service.DescribeTeoAliasDomainById(ctx, zoneId, aliasName)
+	if err != nil {
+		return err
+	}
+
+	if respData == nil {
+		log.Printf("[WARN]%s resource `teo_alias_domain` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if respData.ZoneId != nil {
+		_ = d.Set("zone_id", respData.ZoneId)
+	}
+
+	if respData.AliasName != nil {
+		_ = d.Set("alias_name", respData.AliasName)
+	}
+
+	if respData.TargetName != nil {
+		_ = d.Set("target_name", respData.TargetName)
+	}
+
+	if respData.Status != nil {
+		// paused is true if status is "stop", false otherwise
+		paused := *respData.Status == "stop"
+		_ = d.Set("paused", paused)
+	}
+
+	return nil
+}
+
+func resourceTencentCloudTeoAliasDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_alias_domain.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	zoneId := idSplit[0]
+	aliasName := idSplit[1]
+
+	// update target_name
+	if d.HasChange("target_name") {
+		request := teo.NewModifyAliasDomainRequest()
+		request.ZoneId = helper.String(zoneId)
+		request.AliasName = helper.String(aliasName)
+
+		if v, ok := d.GetOk("target_name"); ok {
+			request.TargetName = helper.String(v.(string))
+		}
+
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoClient().ModifyAliasDomainWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s update teo alias domain failed, reason:%+v", logId, err)
+			return err
+		}
+
+		// wait for target_name update to complete
+		if err := resourceTencentCloudTeoAliasDomainUpdatePostHandle(ctx, zoneId, aliasName, d.Get("paused").(bool), meta, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return err
+		}
+	}
+
+	// update paused status
+	if d.HasChange("paused") {
+		request := teo.NewModifyAliasDomainStatusRequest()
+		request.ZoneId = helper.String(zoneId)
+		request.AliasNames = []*string{helper.String(aliasName)}
+
+		if v, ok := d.GetOkExists("paused"); ok {
+			request.Paused = helper.Bool(v.(bool))
+		}
+
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoClient().ModifyAliasDomainStatusWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s update teo alias domain paused status failed, reason:%+v", logId, err)
+			return err
+		}
+
+		// wait for status update to complete
+		paused := d.Get("paused").(bool)
+		if err := resourceTencentCloudTeoAliasDomainUpdatePostHandle(ctx, zoneId, aliasName, paused, meta, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return err
+		}
+	}
+
+	return resourceTencentCloudTeoAliasDomainRead(d, meta)
+}
+
+func resourceTencentCloudTeoAliasDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_alias_domain.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = teo.NewDeleteAliasDomainRequest()
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	zoneId := idSplit[0]
+	aliasName := idSplit[1]
+
+	request.ZoneId = helper.String(zoneId)
+	request.AliasNames = []*string{helper.String(aliasName)}
+
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoClient().DeleteAliasDomainWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s delete teo alias domain failed, reason:%+v", logId, err)
+		return err
+	}
+
+	// wait for deletion to complete
+	if err := resourceTencentCloudTeoAliasDomainDeletePostHandle(ctx, zoneId, aliasName, meta, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceTencentCloudTeoAliasDomainCreatePostHandle(ctx context.Context, zoneId, aliasName string, meta interface{}, timeout time.Duration) error {
+	service := TeoService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+
+	err := resource.Retry(timeout, func() *resource.RetryError {
+		respData, e := service.DescribeTeoAliasDomainById(ctx, zoneId, aliasName)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if respData == nil {
+			return resource.NonRetryableError(fmt.Errorf("alias domain %s not found", aliasName))
+		}
+
+		if respData.Status != nil && (*respData.Status == "active" || *respData.Status == "stop") {
+			return nil
+		}
+
+		return resource.RetryableError(fmt.Errorf("alias domain status is %s, waiting for it to be active or stop", *respData.Status))
+	})
+
+	if err != nil {
+		return fmt.Errorf("wait for alias domain creation to complete failed: %v", err)
+	}
+
+	return nil
+}
+
+func resourceTencentCloudTeoAliasDomainUpdatePostHandle(ctx context.Context, zoneId, aliasName string, paused bool, meta interface{}, timeout time.Duration) error {
+	service := TeoService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+
+	expectedStatus := "stop"
+	if !paused {
+		expectedStatus = "active"
+	}
+
+	err := resource.Retry(timeout, func() *resource.RetryError {
+		respData, e := service.DescribeTeoAliasDomainById(ctx, zoneId, aliasName)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if respData == nil {
+			return resource.NonRetryableError(fmt.Errorf("alias domain %s not found", aliasName))
+		}
+
+		if respData.Status != nil && *respData.Status == expectedStatus {
+			return nil
+		}
+
+		return resource.RetryableError(fmt.Errorf("alias domain status is %s, waiting for it to be %s", *respData.Status, expectedStatus))
+	})
+
+	if err != nil {
+		return fmt.Errorf("wait for alias domain update to complete failed: %v", err)
+	}
+
+	return nil
+}
+
+func resourceTencentCloudTeoAliasDomainDeletePostHandle(ctx context.Context, zoneId, aliasName string, meta interface{}, timeout time.Duration) error {
+	service := TeoService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+
+	err := resource.Retry(timeout, func() *resource.RetryError {
+		respData, e := service.DescribeTeoAliasDomainById(ctx, zoneId, aliasName)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if respData == nil {
+			return nil
+		}
+
+		return resource.RetryableError(fmt.Errorf("alias domain %s still exists", aliasName))
+	})
+
+	if err != nil {
+		return fmt.Errorf("wait for alias domain deletion to complete failed: %v", err)
+	}
+
+	return nil
+}

--- a/tencentcloud/services/teo/resource_tc_teo_alias_domain.md
+++ b/tencentcloud/services/teo/resource_tc_teo_alias_domain.md
@@ -1,0 +1,48 @@
+Provides a resource to create a TEO alias domain
+
+Example Usage
+
+```hcl
+resource "tencentcloud_teo_alias_domain" "example" {
+  zone_id     = "zone-39quuimqg8r6"
+  alias_name  = "alias.example.com"
+  target_name = "www.example.com"
+}
+```
+
+Example with paused status
+
+```hcl
+resource "tencentcloud_teo_alias_domain" "example" {
+  zone_id     = "zone-39quuimqg8r6"
+  alias_name  = "alias.example.com"
+  target_name = "www.example.com"
+  paused      = true
+}
+```
+
+Example with timeouts configuration
+
+```hcl
+resource "tencentcloud_teo_alias_domain" "example" {
+  zone_id     = "zone-39quuimqg8r6"
+  alias_name  = "alias.example.com"
+  target_name = "www.example.com"
+
+  timeouts {
+    create = "15m"
+    update = "15m"
+    delete = "15m"
+  }
+}
+```
+
+Import
+
+TEO alias domain can be imported using the id, e.g.
+
+```
+terraform import tencentcloud_teo_alias_domain.example zone-39quuimqg8r6#alias.example.com
+```
+
+Note: The resource ID format is `zone_id#alias_name`.

--- a/tencentcloud/services/teo/resource_tc_teo_alias_domain_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_alias_domain_test.go
@@ -1,0 +1,128 @@
+package teo_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	svcteo "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccTencentCloudTeoAliasDomainResource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { tcacctest.AccPreCheckCommon(t, tcacctest.ACCOUNT_TYPE_PRIVATE) },
+		Providers:    tcacctest.AccProviders,
+		CheckDestroy: testAccCheckTeoAliasDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeoAliasDomain,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTeoAliasDomainExists("tencentcloud_teo_alias_domain.alias_domain"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_alias_domain.alias_domain", "id"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_alias_domain.alias_domain", "zone_id"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_alias_domain.alias_domain", "alias_name"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_alias_domain.alias_domain", "target_name"),
+					resource.TestCheckResourceAttr("tencentcloud_teo_alias_domain.alias_domain", "paused", "false"),
+				),
+			},
+			{
+				ResourceName:      "tencentcloud_teo_alias_domain.alias_domain",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTeoAliasDomainUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTeoAliasDomainExists("tencentcloud_teo_alias_domain.alias_domain"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_alias_domain.alias_domain", "id"),
+					resource.TestCheckResourceAttr("tencentcloud_teo_alias_domain.alias_domain", "target_name", "updated.tf-teo.xyz"),
+					resource.TestCheckResourceAttr("tencentcloud_teo_alias_domain.alias_domain", "paused", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTeoAliasDomainDestroy(s *terraform.State) error {
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+	service := svcteo.NewTeoService(tcacctest.AccProvider.Meta().(tccommon.ProviderMeta).GetAPIV3Conn())
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tencentcloud_teo_alias_domain" {
+			continue
+		}
+
+		idSplit := strings.Split(rs.Primary.ID, tccommon.FILED_SP)
+		if len(idSplit) != 2 {
+			return fmt.Errorf("id is broken,%s", rs.Primary.ID)
+		}
+		zoneId := idSplit[0]
+		aliasName := idSplit[1]
+
+		aliasDomain, err := service.DescribeTeoAliasDomainById(ctx, zoneId, aliasName)
+		if aliasDomain != nil {
+			return fmt.Errorf("AliasDomain %s still exists", rs.Primary.ID)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckTeoAliasDomainExists(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		logId := tccommon.GetLogId(tccommon.ContextNil)
+		ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmt.Errorf("resource %s is not found", r)
+		}
+
+		idSplit := strings.Split(rs.Primary.ID, tccommon.FILED_SP)
+		if len(idSplit) != 2 {
+			return fmt.Errorf("id is broken,%s", rs.Primary.ID)
+		}
+		zoneId := idSplit[0]
+		aliasName := idSplit[1]
+
+		service := svcteo.NewTeoService(tcacctest.AccProvider.Meta().(tccommon.ProviderMeta).GetAPIV3Conn())
+		aliasDomain, err := service.DescribeTeoAliasDomainById(ctx, zoneId, aliasName)
+		if aliasDomain == nil {
+			return fmt.Errorf("AliasDomain %s is not found", rs.Primary.ID)
+		}
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+const testAccTeoAliasDomain = testAccTeoZone + `
+
+resource "tencentcloud_teo_alias_domain" "alias_domain" {
+    zone_id     = tencentcloud_teo_zone.basic.id
+    alias_name  = "alias.test.tf-teo.xyz"
+    target_name = "test.tf-teo.xyz"
+}
+
+`
+
+const testAccTeoAliasDomainUpdate = testAccTeoZone + `
+
+resource "tencentcloud_teo_alias_domain" "alias_domain" {
+    zone_id     = tencentcloud_teo_zone.basic.id
+    alias_name  = "alias.test.tf-teo.xyz"
+    target_name = "updated.tf-teo.xyz"
+    paused      = true
+}
+
+`

--- a/tencentcloud/services/teo/service_tencentcloud_teo.go
+++ b/tencentcloud/services/teo/service_tencentcloud_teo.go
@@ -2508,3 +2508,70 @@ func (me *TeoService) DescribeTeoConfigGroupVersionById(ctx context.Context, zon
 	ret = response.Response
 	return
 }
+
+func (me *TeoService) DescribeTeoAliasDomainById(ctx context.Context,
+	zoneId, aliasName string) (aliasDomain *teo.AliasDomain, errRet error) {
+	var (
+		logId   = tccommon.GetLogId(ctx)
+		request = teo.NewDescribeAliasDomainsRequest()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, "query object", request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	request.ZoneId = &zoneId
+	request.Filters = append(
+		request.Filters,
+		&teo.AdvancedFilter{
+			Name:   helper.String("alias-name"),
+			Values: []*string{&aliasName},
+		},
+	)
+
+	var offset int64 = 0
+	var pageSize int64 = 100
+	aliasDomains := make([]*teo.AliasDomain, 0)
+
+	for {
+		request.Offset = &offset
+		request.Limit = &pageSize
+		ratelimit.Check(request.GetAction())
+		response := teo.NewDescribeAliasDomainsResponse()
+		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			result, e := me.client.UseTeoClient().DescribeAliasDomains(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			}
+			response = result
+			return nil
+		})
+		if err != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), err.Error())
+			errRet = err
+			return
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+			logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+		if response == nil || response.Response == nil || len(response.Response.AliasDomains) < 1 {
+			break
+		}
+		aliasDomains = append(aliasDomains, response.Response.AliasDomains...)
+		if len(response.Response.AliasDomains) < int(pageSize) {
+			break
+		}
+		offset += pageSize
+	}
+
+	if len(aliasDomains) < 1 {
+		return
+	}
+	aliasDomain = aliasDomains[0]
+
+	return
+}


### PR DESCRIPTION
Add support for managing Teo alias domain resources through Terraform.

This PR adds a new resource `tencentcloud_teo_alias_domain` that allows users to manage Teo alias domains.

**Changes:**
- Add `tencentcloud_teo_alias_domain` resource with full CRUD support
- Support creating, reading, updating, and deleting alias domains
- Support modifying the paused/active status of alias domains
- Implement asynchronous operation polling to ensure operations complete
- Support importing existing alias domains using terraform import

**Files:**
- `tencentcloud/services/teo/resource_tc_teo_alias_domain.go`: Resource implementation
- `tencentcloud/services/teo/resource_tc_teo_alias_domain_test.go`: Unit tests
- `tencentcloud/services/teo/resource_tc_teo_alias_domain.md`: Documentation
- `tencentcloud/provider.go`: Register the new resource
- `tencentcloud/services/teo/service_tencentcloud_teo.go`: Add helper method