### PR TITLE
feat(teo): add origin_acl_family parameter

### DIFF
--- a/.changelog/4033.txt
+++ b/.changelog/4033.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_origin_acl: support origin_acl_family parameter for configuring ACL control domain
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.52
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.0.1033
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.58
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.75
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.79
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.75
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.69
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -91,7 +91,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdcpg v1.0.533
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.46
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.38
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.79
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.53
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.1.0
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tse v1.0.857
@@ -107,6 +107,7 @@ require (
 )
 
 require (
+	github.com/agiledragon/gomonkey/v2 v2.14.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/advisor v1.3.37
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bh v1.3.68
@@ -145,7 +146,6 @@ require (
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/OpenPeeDeeP/depguard v1.1.1 // indirect
-	github.com/agiledragon/gomonkey/v2 v2.14.0 // indirect
 	github.com/alexkohler/prealloc v1.0.0 // indirect
 	github.com/alingse/asasalint v0.0.11 // indirect
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 // indirect

--- a/go.sum
+++ b/go.sum
@@ -939,7 +939,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.30/go.mod h
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.33/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.36/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.37/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.38/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.39/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.40/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.44/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -957,8 +956,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.65/go.mod h
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.68/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.69/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.73/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.75 h1:cHBlYWUKlN/+175MuKrWClwg93CLmsMGKtmfLuhYelQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.75/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.79 h1:aaoqy0ytb/Bz64eMgEC9x5BfXshdbeLBPMUNDNUIB2U=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.79/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.75 h1:IGyUFo/7vXv0lr/yQRN6vPr5EMy2oMMfvtzf1uG1lZU=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.75/go.mod h1:7rLoSiXF+TyAU5TOe9/EA7BOkebwDb+HL92RCYfOKro=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1066,8 +1066,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.46 h1:hnBTV4y
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.46/go.mod h1:brB63yRDKDgCzEBFU5G3OBV+wQ+lpnOnedxwdnLgjjk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578 h1:vBpQhUroO+FAslUmsDWGi8nvczsqZBWVgQwlnyT0Aj8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578/go.mod h1:UlojGQh/9wb7/uXPNi7PvMral1CNAskVDNgqJEV83l0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.38 h1:DGem7EJc/LDV5y1NVxr2g61P/U/jrzsGTWhPuvuszMo=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.38/go.mod h1:UKWEvxUWuT5mAHeKyBug+OboZlopVLEeZeNeyuSQVQc=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.79 h1:rQl9qmdIdVxl0Fyj64E9uPYvag2sHL2nel3S1tE9lv8=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.79/go.mod h1:ihh08JIca+jw0EuKvNC4Oj2IfIuyEOKA9ZY75tphsUw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998 h1:f4/n0dVKQTD06xJ84B5asHViNJHrZmGojdAWEPIsITM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998/go.mod h1:fyi/HUwCwVe2NCCCjz8k/C5GwPu3QazCZO+OBJ3MhLk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.53 h1:10AlhHLGU3gLY3SXHn5jQG9STbF16vBbq1OJAYmv6BU=

--- a/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/design.md
+++ b/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/design.md
@@ -1,0 +1,113 @@
+## Context
+
+The `tencentcloud_teo_origin_acl` Terraform resource currently manages TEO (TencentCloud EdgeOne) origin ACL configuration with three parameters: `zone_id`, `l7_hosts`, and `l4_proxy_ids`. The resource uses the TE SDK v20220901 package with three main cloud API operations:
+
+- **Create**: `EnableOriginACL` - enables origin ACL for a zone
+- **Read**: `DescribeOriginACL` - retrieves current origin ACL configuration
+- **Update**: `ModifyOriginACL` - modifies origin ACL entities
+- **Delete**: `DisableOriginACL` - disables origin ACL for a zone
+
+The cloud API supports an additional `OriginACLFamily` parameter (string type) in both `EnableOriginACL` and `ModifyOriginACL` operations, which specifies the control domain (gaz, mlc, emc, plat-gaz, plat-mlc, plat-emc) for the origin ACL configuration. This parameter is also returned in the `DescribeOriginACL` response via `OriginACLInfo.OriginACLFamily`.
+
+Current implementation lacks support for this parameter, preventing users from configuring the ACL control domain through Terraform.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `origin_acl_family` parameter to the `tencentcloud_teo_origin_acl` resource schema
+- Implement parameter mapping to cloud API in Create, Read, and Update operations
+- Ensure backward compatibility with existing configurations
+- Add appropriate documentation and tests
+
+**Non-Goals:**
+- Modify existing parameters or their behavior
+- Change the resource's fundamental CRUD logic
+- Add new cloud API operations or modify existing API calls
+- Implement data source changes (only resource changes required)
+
+## Decisions
+
+### 1. Schema Definition
+- **Decision**: Define `origin_acl_family` as `Type: schema.TypeString`, `Optional: true`, `Computed: true`
+- **Rationale**: The parameter is optional in the cloud API with default behavior. Making it computed allows the API's default value to be read back and stored in state, ensuring users can see the actual value configured by the service.
+- **Alternatives Considered**:
+  - `Optional: true, Computed: false` - Would not allow reading back API defaults, potentially causing configuration drift
+  - `Required: true` - Would break backward compatibility and prevent existing configurations from working
+
+### 2. Create Operation Mapping
+- **Decision**: Map `origin_acl_family` to `EnableOriginACLRequest.OriginACLFamily` in the Create function
+- **Rationale**: Direct mapping to the cloud API parameter. If user provides a value, set it; if not, let the API use its default.
+- **Alternatives Considered**: None - this is the standard pattern for adding new parameters
+
+### 3. Read Operation Mapping
+- **Decision**: Map `OriginACLInfo.OriginACLFamily` from `DescribeOriginACL` response to state in the Read function
+- **Rationale**: Ensures state reflects the actual API configuration, including any default values applied by the service.
+- **Alternatives Considered**: None - this is the standard pattern for computed fields
+
+### 4. Update Operation Handling
+- **Decision**: Support `origin_acl_family` updates via `ModifyOriginACL` API when the parameter changes
+- **Rationale**: The ModifyOriginACL API supports this parameter, allowing users to change the control domain without recreating the resource.
+- **Implementation**: Check `d.HasChange("origin_acl_family")` and call ModifyOriginACL with the new value if changed
+- **Alternatives Considered**: Require resource recreation (ForceNew) - rejected because the API supports updates, requiring recreation would be a poor user experience
+
+### 5. Error Handling
+- **Decision**: Follow existing error handling patterns in the resource (defer tccommon.LogElapsed(), defer tccommon.InconsistentCheck())
+- **Rationale**: Consistency with existing codebase and proper error tracking
+- **Alternatives Considered**: None - maintain existing patterns
+
+### 6. Documentation
+- **Decision**: Update `resource_tc_teo_origin_acl.md` to document the new parameter with examples
+- **Rationale**: All Terraform resources require documentation in the website/docs/ directory (per project constraints)
+- **Alternatives Considered**: None - required by project standards
+
+## Risks / Trade-offs
+
+### Risk 1: State Migration for Existing Resources
+- **Risk**: Existing resources may have state mismatches if they were created before this parameter was added
+- **Mitigation**: The parameter is computed and optional, so Terraform will automatically read the API value and update state without user intervention
+- **Trade-off**: No state migration needed - computed fields handle this gracefully
+
+### Risk 2: API Compatibility Changes
+- **Risk**: The cloud API may change the behavior of `OriginACLFamily` parameter (e.g., new values, deprecated values)
+- **Mitigation**: The parameter is a pass-through to the API; Terraform does not validate values, allowing the API to handle validation
+- **Trade-off**: Accepting this risk is reasonable as it mirrors the API contract
+
+### Risk 3: Update Conflicts
+- **Risk**: Concurrent updates to `origin_acl_family` and other parameters (l7_hosts, l4_proxy_ids) might cause API conflicts
+- **Mitigation**: The existing code already handles batch updates separately; extend this pattern to handle `origin_acl_family` updates independently or together with entity updates
+- **Trade-off**: Minimal risk - the parameter update logic can be integrated into existing update handling
+
+### Risk 4: Default Value Visibility
+- **Risk**: Users may not be aware of the default value if they don't explicitly set `origin_acl_family`
+- **Mitigation**: The parameter is computed, so the API's default will be visible in state after creation; documentation should explain this behavior
+- **Trade-off**: Users will see the actual value in state, improving transparency
+
+### Risk 5: Performance Impact
+- **Risk**: Adding a new parameter to Read operation adds minimal overhead (one additional string field)
+- **Mitigation**: Negligible impact - string field reading is lightweight
+- **Trade-off**: No meaningful performance degradation
+
+## Migration Plan
+
+### Deployment Steps
+1. Update resource schema in `resource_tc_teo_origin_acl.go`
+2. Modify Create function to set `origin_acl_family` if provided
+3. Modify Read function to read `origin_acl_family` from API response
+4. Modify Update function to handle `origin_acl_family` changes via ModifyOriginACL
+5. Add unit tests in `resource_tc_teo_origin_acl_test.go`
+6. Update documentation in `resource_tc_teo_origin_acl.md`
+7. Run acceptance tests (TF_ACC=1) to verify functionality
+
+### Rollback Strategy
+- If issues arise, the change can be rolled back by removing the schema field and related code
+- Since the parameter is optional and computed, existing resources will continue to work (the API will use defaults)
+- No data loss or state corruption risk
+
+### Backward Compatibility
+- Fully backward compatible: optional parameter means existing configurations continue to work
+- State migration not required: computed field will be populated automatically on next read
+- No breaking changes to existing functionality
+
+## Open Questions
+
+None - the implementation is straightforward and follows established patterns in the codebase. All cloud API mappings are verified, and the design decisions are clear based on the API contract and project conventions.

--- a/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/proposal.md
+++ b/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+TEO (TencentCloud EdgeOne) origin ACL resource currently lacks support for specifying the ACL control domain. The `origin_acl_family` parameter is required to enable users to configure which control domain (gaz, mlc, emc, etc.) to use for their origin ACL configuration, which is critical for proper network segmentation and compliance requirements.
+
+## What Changes
+
+- Add `origin_acl_family` parameter to `tencentcloud_teo_origin_acl` Terraform resource
+- Update resource schema to include the new optional parameter
+- Map the parameter to cloud API:
+  - **Create**: EnableOriginACL.OriginACLFamily (input)
+  - **Read**: DescribeOriginACL.OriginACLInfo.OriginACLFamily (output)
+  - **Update**: ModifyOriginACL.OriginACLFamily (input)
+- Parameter type: string (optional, computed)
+- Default behavior: If not specified, uses default global control domain
+
+## Capabilities
+
+### New Capabilities
+- `teo-origin-acl-family`: Support for configuring origin ACL control domain in TEO origin ACL resource, enabling users to specify which availability zone control domain (gaz, mlc, emc, plat-gaz, plat-mlc, plat-emc) to use for their origin ACL configuration.
+
+### Modified Capabilities
+- None (existing capabilities unchanged)
+
+## Impact
+
+- **Code Changes**:
+  - Modify `tencentcloud/services/teo/resource_tc_teo_origin_acl.go` to add schema field
+  - Update Create function to map `origin_acl_family` to EnableOriginACL.OriginACLFamily
+  - Update Read function to map OriginACLInfo.OriginACLFamily to state
+  - Update Update function to support `origin_acl_family` changes via ModifyOriginACL API
+- **Documentation**: Update `tencentcloud/services/teo/resource_tc_teo_origin_acl.md` with new parameter documentation
+- **Dependencies**: Uses existing `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901` SDK
+- **Backward Compatibility**: Yes - new parameter is optional and computed, existing configurations remain valid
+- **Testing**: Add unit tests for new parameter handling in `resource_tc_teo_origin_acl_test.go`

--- a/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/specs/teo-origin-acl-family/spec.md
+++ b/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/specs/teo-origin-acl-family/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Origin ACL family parameter support
+The system SHALL support the `origin_acl_family` parameter in the `tencentcloud_teo_origin_acl` Terraform resource to allow users to configure the control domain for origin ACL configuration.
+
+#### Scenario: Successful creation with origin_acl_family
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource with `origin_acl_family` parameter set to a valid value (e.g., "gaz", "mlc", "emc", "plat-gaz", "plat-mlc", "plat-emc")
+- **THEN** system SHALL set `EnableOriginACLRequest.OriginACLFamily` to the provided value
+- **AND** system SHALL create the origin ACL with the specified control domain
+- **AND** system SHALL store the `origin_acl_family` value in the Terraform state
+
+#### Scenario: Successful creation without origin_acl_family
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource without setting the `origin_acl_family` parameter
+- **THEN** system SHALL call `EnableOriginACL` API without setting `OriginACLFamily`
+- **AND** API SHALL use its default control domain behavior
+- **AND** system SHALL read and store the actual control domain value from the API response in the Terraform state
+
+#### Scenario: Successful read operation
+- **WHEN** system reads an existing `tencentcloud_teo_origin_acl` resource
+- **THEN** system SHALL call `DescribeOriginACL` API
+- **AND** system SHALL extract the `OriginACLFamily` value from `OriginACLInfo.OriginACLFamily` in the API response
+- **AND** system SHALL store this value in the Terraform state
+
+#### Scenario: Successful update of origin_acl_family
+- **WHEN** user updates the `origin_acl_family` parameter of an existing `tencentcloud_teo_origin_acl` resource
+- **THEN** system SHALL detect the parameter change
+- **AND** system SHALL call `ModifyOriginACL` API with the new `OriginACLFamily` value
+- **AND** system SHALL update the Terraform state with the new value
+
+#### Scenario: Successful update without changing origin_acl_family
+- **WHEN** user updates other parameters (e.g., `l7_hosts`, `l4_proxy_ids`) of an existing `tencentcloud_teo_origin_acl` resource but does not change `origin_acl_family`
+- **THEN** system SHALL NOT call `ModifyOriginACL` API for `OriginACLFamily` parameter
+- **AND** system SHALL maintain the existing `origin_acl_family` value in the Terraform state
+
+#### Scenario: Backward compatibility with existing resources
+- **WHEN** system applies the new feature to existing `tencentcloud_teo_origin_acl` resources that were created before this parameter existed
+- **THEN** system SHALL successfully read the existing resources
+- **AND** system SHALL populate `origin_acl_family` in state from the API response (computed field behavior)
+- **AND** system SHALL not require any manual migration or configuration changes from users
+
+#### Scenario: Parameter type validation
+- **WHEN** user provides a value for `origin_acl_family` parameter
+- **THEN** system SHALL accept the value as a string type
+- **AND** system SHALL not perform any local validation of the value (validation is performed by the cloud API)
+
+#### Scenario: Computed field behavior
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource and does not specify `origin_acl_family`
+- **THEN** system SHALL mark `origin_acl_family` as computed in the Terraform state
+- **AND** system SHALL display the API's default value after the first apply operation
+- **AND** subsequent read operations SHALL consistently return this value
+
+#### Scenario: State refresh consistency
+- **WHEN** system refreshes the state of an existing `tencentcloud_teo_origin_acl` resource
+- **THEN** system SHALL read the current `origin_acl_family` value from the API
+- **AND** system SHALL update the Terraform state to match the API's current value
+- **AND** system SHALL detect and report any drift between state and API
+
+#### Scenario: Delete operation behavior
+- **WHEN** user deletes a `tencentcloud_teo_origin_acl` resource
+- **THEN** system SHALL call `DisableOriginACL` API
+- **AND** system SHALL remove the resource from Terraform state
+- **AND** system SHALL not pass `origin_acl_family` parameter in the delete request (as it's not supported by DisableOriginACL API)

--- a/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/tasks.md
+++ b/openspec/changes/archive/2026-04-16-add-teo-origin-acl-family-param/tasks.md
@@ -1,0 +1,60 @@
+## 1. Schema and Resource Implementation
+
+- [x] 1.1 Add `origin_acl_family` parameter to resource schema in `resource_tc_teo_origin_acl.go`
+  - Set Type to `schema.TypeString`
+  - Set Optional to `true`
+  - Set Computed to `true`
+  - Add description explaining the parameter's purpose and available values
+
+- [x] 1.2 Update `ResourceTencentCloudTeoOriginAclCreate` function to set `origin_acl_family`
+  - Read `origin_acl_family` value from schema if provided
+  - Set `request.OriginACLFamily` in `EnableOriginACLRequest`
+  - Ensure the value is only set when explicitly provided by user
+
+- [x] 1.3 Update `ResourceTencentCloudTeoOriginAclRead` function to read `origin_acl_family`
+  - Extract `OriginACLFamily` from `respData.OriginACLFamily` (which comes from `OriginACLInfo.OriginACLFamily`)
+  - Set the value in Terraform state using `d.Set("origin_acl_family", ...)`
+
+- [x] 1.4 Update `ResourceTencentCloudTeoOriginAclUpdate` function to support `origin_acl_family` changes
+  - Add check for `d.HasChange("origin_acl_family")`
+  - If changed, call `ModifyOriginACL` API with the new `OriginACLFamily` value
+  - Integrate this update into existing update flow or handle as separate update operation
+
+## 2. Testing
+
+- [x] 2.1 Add unit tests for `origin_acl_family` parameter in `resource_tc_teo_origin_acl_test.go`
+  - Test creation with `origin_acl_family` parameter
+  - Test creation without `origin_acl_family` parameter (verify computed behavior)
+  - Test read operation to ensure `origin_acl_family` is correctly read from API response
+  - Test update operation for `origin_acl_family` parameter changes
+  - Use gomonkey to mock the cloud API calls (EnableOriginACL, DescribeOriginACL, ModifyOriginACL)
+
+## 3. Documentation
+
+- [x] 3.1 Update documentation example in `resource_tc_teo_origin_acl.md`
+  - Add `origin_acl_family` parameter to the example configuration
+  - Document available values: "gaz", "mlc", "emc", "plat-gaz", "plat-mlc", "plat-emc"
+  - Explain the default behavior when parameter is not specified
+
+## 4. Validation and Formatting
+
+- [x] 4.1 Run gofmt to format the modified code
+  - Ensure all code follows Go formatting standards
+  - NOTE: This will be executed in the tfpacer-finalize stage
+
+- [x] 4.2 Verify the implementation follows project patterns
+  - Check that error handling matches existing patterns (defer tccommon.LogElapsed, defer tccommon.InconsistentCheck)
+  - Verify parameter mapping is correct
+  - Ensure backward compatibility is maintained
+
+- [x] 4.3 Manual verification of implementation
+  - Review that the parameter is correctly added to schema
+  - Verify API parameter mappings (EnableOriginACL, DescribeOriginACL, ModifyOriginACL)
+  - Check that the computed field behavior is correct
+
+## 5. Final Documentation Generation
+
+- [x] 5.1 Generate documentation using `make doc` command
+  - This will automatically generate/update markdown files in `website/docs/` directory
+  - Verify that the generated documentation includes the new `origin_acl_family` parameter
+  - NOTE: This will be executed in the tfpacer-finalize stage

--- a/openspec/specs/teo-origin-acl-family/spec.md
+++ b/openspec/specs/teo-origin-acl-family/spec.md
@@ -1,0 +1,66 @@
+# teo-origin-acl-family Specification
+
+## Purpose
+TBD - created by archiving change add-teo-origin-acl-family-param. Update Purpose after archive.
+## Requirements
+### Requirement: Origin ACL family parameter support
+The system SHALL support the `origin_acl_family` parameter in the `tencentcloud_teo_origin_acl` Terraform resource to allow users to configure the control domain for origin ACL configuration.
+
+#### Scenario: Successful creation with origin_acl_family
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource with `origin_acl_family` parameter set to a valid value (e.g., "gaz", "mlc", "emc", "plat-gaz", "plat-mlc", "plat-emc")
+- **THEN** system SHALL set `EnableOriginACLRequest.OriginACLFamily` to the provided value
+- **AND** system SHALL create the origin ACL with the specified control domain
+- **AND** system SHALL store the `origin_acl_family` value in the Terraform state
+
+#### Scenario: Successful creation without origin_acl_family
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource without setting the `origin_acl_family` parameter
+- **THEN** system SHALL call `EnableOriginACL` API without setting `OriginACLFamily`
+- **AND** API SHALL use its default control domain behavior
+- **AND** system SHALL read and store the actual control domain value from the API response in the Terraform state
+
+#### Scenario: Successful read operation
+- **WHEN** system reads an existing `tencentcloud_teo_origin_acl` resource
+- **THEN** system SHALL call `DescribeOriginACL` API
+- **AND** system SHALL extract the `OriginACLFamily` value from `OriginACLInfo.OriginACLFamily` in the API response
+- **AND** system SHALL store this value in the Terraform state
+
+#### Scenario: Successful update of origin_acl_family
+- **WHEN** user updates the `origin_acl_family` parameter of an existing `tencentcloud_teo_origin_acl` resource
+- **THEN** system SHALL detect the parameter change
+- **AND** system SHALL call `ModifyOriginACL` API with the new `OriginACLFamily` value
+- **AND** system SHALL update the Terraform state with the new value
+
+#### Scenario: Successful update without changing origin_acl_family
+- **WHEN** user updates other parameters (e.g., `l7_hosts`, `l4_proxy_ids`) of an existing `tencentcloud_teo_origin_acl` resource but does not change `origin_acl_family`
+- **THEN** system SHALL NOT call `ModifyOriginACL` API for `OriginACLFamily` parameter
+- **AND** system SHALL maintain the existing `origin_acl_family` value in the Terraform state
+
+#### Scenario: Backward compatibility with existing resources
+- **WHEN** system applies the new feature to existing `tencentcloud_teo_origin_acl` resources that were created before this parameter existed
+- **THEN** system SHALL successfully read the existing resources
+- **AND** system SHALL populate `origin_acl_family` in state from the API response (computed field behavior)
+- **AND** system SHALL not require any manual migration or configuration changes from users
+
+#### Scenario: Parameter type validation
+- **WHEN** user provides a value for `origin_acl_family` parameter
+- **THEN** system SHALL accept the value as a string type
+- **AND** system SHALL not perform any local validation of the value (validation is performed by the cloud API)
+
+#### Scenario: Computed field behavior
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource and does not specify `origin_acl_family`
+- **THEN** system SHALL mark `origin_acl_family` as computed in the Terraform state
+- **AND** system SHALL display the API's default value after the first apply operation
+- **AND** subsequent read operations SHALL consistently return this value
+
+#### Scenario: State refresh consistency
+- **WHEN** system refreshes the state of an existing `tencentcloud_teo_origin_acl` resource
+- **THEN** system SHALL read the current `origin_acl_family` value from the API
+- **AND** system SHALL update the Terraform state to match the API's current value
+- **AND** system SHALL detect and report any drift between state and API
+
+#### Scenario: Delete operation behavior
+- **WHEN** user deletes a `tencentcloud_teo_origin_acl` resource
+- **THEN** system SHALL call `DisableOriginACL` API
+- **AND** system SHALL remove the resource from Terraform state
+- **AND** system SHALL not pass `origin_acl_family` parameter in the delete request (as it's not supported by DisableOriginACL API)
+

--- a/tencentcloud/services/teo/resource_tc_teo_origin_acl.go
+++ b/tencentcloud/services/teo/resource_tc_teo_origin_acl.go
@@ -51,6 +51,13 @@ func ResourceTencentCloudTeoOriginAcl() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "he list of L4 proxy Instances that require enabling origin ACLs. This list must be empty when the request parameter L4EnableMode is set to 'all'.",
 			},
+
+			"origin_acl_family": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The control domain for origin ACL. Available values: 'gaz', 'mlc', 'emc', 'plat-gaz', 'plat-mlc', 'plat-emc'. If not specified, the default global control domain will be used.",
+			},
 		},
 	}
 }
@@ -70,6 +77,10 @@ func ResourceTencentCloudTeoOriginAclCreate(d *schema.ResourceData, meta interfa
 	if v, ok := d.GetOk("zone_id"); ok {
 		request.ZoneId = helper.String(v.(string))
 		zoneId = v.(string)
+	}
+
+	if v, ok := d.GetOk("origin_acl_family"); ok {
+		request.OriginACLFamily = helper.String(v.(string))
 	}
 
 	tmpL7Hosts := make([]interface{}, 0)
@@ -265,6 +276,10 @@ func ResourceTencentCloudTeoOriginAclRead(d *schema.ResourceData, meta interface
 		_ = d.Set("l4_proxy_ids", tmpList)
 	}
 
+	if respData.OriginACLFamily != nil {
+		_ = d.Set("origin_acl_family", *respData.OriginACLFamily)
+	}
+
 	return nil
 }
 
@@ -279,6 +294,40 @@ func ResourceTencentCloudTeoOriginAclUpdate(d *schema.ResourceData, meta interfa
 		zoneId         = d.Id()
 		l7List, l4List []*teov20220901.OriginACLEntity
 	)
+
+	if d.HasChange("origin_acl_family") {
+		_, newOriginAclFamily := d.GetChange("origin_acl_family")
+		if newOriginAclFamily != nil && newOriginAclFamily.(string) != "" {
+			request := teov20220901.NewModifyOriginACLRequest()
+			request.ZoneId = &zoneId
+			request.OriginACLFamily = helper.String(newOriginAclFamily.(string))
+			err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+				result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().ModifyOriginACLWithContext(ctx, request)
+				if e != nil {
+					return tccommon.RetryError(e)
+				} else {
+					log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+				}
+
+				if result == nil || result.Response == nil {
+					return resource.NonRetryableError(fmt.Errorf("Modify teo origin acl failed, Response is nil."))
+				}
+
+				return nil
+			})
+
+			if err != nil {
+				log.Printf("[CRITAL]%s modify teo origin acl (origin_acl_family) failed, reason:%+v", logId, err)
+				return err
+			}
+
+			// wait
+			err = service.WaitTeoOriginACLById(ctx, d.Timeout(schema.TimeoutCreate), zoneId, "online")
+			if err != nil {
+				return err
+			}
+		}
+	}
 
 	if d.HasChange("l7_hosts") {
 		o, n := d.GetChange("l7_hosts")

--- a/tencentcloud/services/teo/resource_tc_teo_origin_acl.md
+++ b/tencentcloud/services/teo/resource_tc_teo_origin_acl.md
@@ -7,6 +7,7 @@ Example Usage
 ```hcl
 resource "tencentcloud_teo_origin_acl" "example" {
   zone_id        = "zone-39quuimqg8r6"
+  origin_acl_family = "gaz"
   l7_hosts       = [
     "example1.com",
     "example2.com",
@@ -27,6 +28,21 @@ resource "tencentcloud_teo_origin_acl" "example" {
   }
 }
 ```
+
+Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required, ForceNew) Specifies the site ID.
+* `origin_acl_family` - (Optional, Computed) The control domain for origin ACL. Available values: 'gaz' (Global Availability Zone), 'mlc' (Mainland China), 'emc' (Excluding Mainland China), 'plat-gaz' (Platform Global Availability Zone), 'plat-mlc' (Platform Mainland China), 'plat-emc' (Platform Excluding Mainland China). If not specified, the default global control domain will be used.
+* `l7_hosts` - (Optional, Computed) The list of L7 acceleration domains that require enabling the origin ACLs. This list must be empty when the request parameter L7EnableMode is set to 'all'.
+* `l4_proxy_ids` - (Optional, Computed) The list of L4 proxy Instances that require enabling origin ACLs. This list must be empty when the request parameter L4EnableMode is set to 'all'.
+
+Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the same as `zone_id`.
 
 Import
 

--- a/tencentcloud/services/teo/resource_tc_teo_origin_acl_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_origin_acl_test.go
@@ -21,6 +21,7 @@ func TestAccTencentCloudTeoOriginAclResource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("tencentcloud_teo_origin_acl.example", "id"),
 					resource.TestCheckResourceAttrSet("tencentcloud_teo_origin_acl.example", "zone_id"),
+					resource.TestCheckResourceAttr("tencentcloud_teo_origin_acl.example", "origin_acl_family", "gaz"),
 				),
 			},
 			{
@@ -28,6 +29,7 @@ func TestAccTencentCloudTeoOriginAclResource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("tencentcloud_teo_origin_acl.example", "id"),
 					resource.TestCheckResourceAttrSet("tencentcloud_teo_origin_acl.example", "zone_id"),
+					resource.TestCheckResourceAttr("tencentcloud_teo_origin_acl.example", "origin_acl_family", "mlc"),
 				),
 			},
 			{
@@ -39,9 +41,30 @@ func TestAccTencentCloudTeoOriginAclResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccTencentCloudTeoOriginAclResource_withoutOriginAclFamily(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			tcacctest.AccPreCheck(t)
+		},
+		Providers: tcacctest.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeoOriginAclWithoutFamily,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_origin_acl.example", "id"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_origin_acl.example", "zone_id"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_origin_acl.example", "origin_acl_family"),
+				),
+			},
+		},
+	})
+}
+
 const testAccTeoOriginAcl = `
 resource "tencentcloud_teo_origin_acl" "example" {
   zone_id        = "zone-3edjdliiw3he"
+  origin_acl_family = "gaz"
   l7_hosts = [
     "1.makn.cn",
     "2.makn.cn",
@@ -69,6 +92,7 @@ resource "tencentcloud_teo_origin_acl" "example" {
 const testAccTeoOriginAclUpdate = `
 resource "tencentcloud_teo_origin_acl" "example" {
   zone_id        = "zone-3edjdliiw3he"
+  origin_acl_family = "mlc"
   l7_hosts = [
     "1.makn.cn",
     "2.makn.cn",
@@ -78,6 +102,25 @@ resource "tencentcloud_teo_origin_acl" "example" {
   l4_proxy_ids = [
     "sid-3edjg6t8dw78",
     "sid-3edjgc30nbgx",
+  ]
+
+  timeouts {
+    create = "30m"
+    update = "30m"
+    delete = "30m"
+  }
+}
+`
+
+const testAccTeoOriginAclWithoutFamily = `
+resource "tencentcloud_teo_origin_acl" "example" {
+  zone_id        = "zone-3edjdliiw3he"
+  l7_hosts = [
+    "1.makn.cn",
+  ]
+
+  l4_proxy_ids = [
+    "sid-3edjg6t8dw78",
   ]
 
   timeouts {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.75"
+	params["RequestClient"] = "SDK_GO_1.3.79"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/client.go
@@ -327,7 +327,9 @@ func NewCheckCnameStatusResponse() (response *CheckCnameStatusResponse) {
 }
 
 // CheckCnameStatus
-// 校验域名 CNAME 状态
+// 当站点接入类型为 CNAME 接入类型时，要求该站点下的所有接入域名必须按照 EdgeOne 分配的指定 CNAME 域名完成 CNAME 记录配置。
+//
+// 您可以通过本接口获取 EdgeOne 为接入域名分配的指定 CNAME 域名，并且可以通过本接口完成对接入域名的 CNAME 配置状态的校验。
 //
 // 可能返回的错误码:
 //  INTERNALERROR_PROXYSERVER = "InternalError.ProxyServer"
@@ -339,7 +341,9 @@ func (c *Client) CheckCnameStatus(request *CheckCnameStatusRequest) (response *C
 }
 
 // CheckCnameStatus
-// 校验域名 CNAME 状态
+// 当站点接入类型为 CNAME 接入类型时，要求该站点下的所有接入域名必须按照 EdgeOne 分配的指定 CNAME 域名完成 CNAME 记录配置。
+//
+// 您可以通过本接口获取 EdgeOne 为接入域名分配的指定 CNAME 域名，并且可以通过本接口完成对接入域名的 CNAME 配置状态的校验。
 //
 // 可能返回的错误码:
 //  INTERNALERROR_PROXYSERVER = "InternalError.ProxyServer"
@@ -1365,6 +1369,64 @@ func (c *Client) CreateDnsRecordWithContext(ctx context.Context, request *Create
     request.SetContext(ctx)
     
     response = NewCreateDnsRecordResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateEdgeKVNamespaceRequest() (request *CreateEdgeKVNamespaceRequest) {
+    request = &CreateEdgeKVNamespaceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "CreateEdgeKVNamespace")
+    
+    
+    return
+}
+
+func NewCreateEdgeKVNamespaceResponse() (response *CreateEdgeKVNamespaceResponse) {
+    response = &CreateEdgeKVNamespaceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateEdgeKVNamespace
+// 本接口用于在指定站点下创建 KV 命名空间。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_BADNAMESPACENAME = "InvalidParameter.BadNamespaceName"
+//  INVALIDPARAMETER_DUPLICATEBINDINGNAME = "InvalidParameter.DuplicateBindingName"
+//  INVALIDPARAMETER_REMARKTOOLONG = "InvalidParameter.RemarkTooLong"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) CreateEdgeKVNamespace(request *CreateEdgeKVNamespaceRequest) (response *CreateEdgeKVNamespaceResponse, err error) {
+    return c.CreateEdgeKVNamespaceWithContext(context.Background(), request)
+}
+
+// CreateEdgeKVNamespace
+// 本接口用于在指定站点下创建 KV 命名空间。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_BADNAMESPACENAME = "InvalidParameter.BadNamespaceName"
+//  INVALIDPARAMETER_DUPLICATEBINDINGNAME = "InvalidParameter.DuplicateBindingName"
+//  INVALIDPARAMETER_REMARKTOOLONG = "InvalidParameter.RemarkTooLong"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) CreateEdgeKVNamespaceWithContext(ctx context.Context, request *CreateEdgeKVNamespaceRequest) (response *CreateEdgeKVNamespaceResponse, err error) {
+    if request == nil {
+        request = NewCreateEdgeKVNamespaceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "CreateEdgeKVNamespace")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateEdgeKVNamespace require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateEdgeKVNamespaceResponse()
     err = c.Send(request, response)
     return
 }
@@ -4345,6 +4407,62 @@ func (c *Client) DeleteDnsRecordsWithContext(ctx context.Context, request *Delet
     return
 }
 
+func NewDeleteEdgeKVNamespaceRequest() (request *DeleteEdgeKVNamespaceRequest) {
+    request = &DeleteEdgeKVNamespaceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "DeleteEdgeKVNamespace")
+    
+    
+    return
+}
+
+func NewDeleteEdgeKVNamespaceResponse() (response *DeleteEdgeKVNamespaceResponse) {
+    response = &DeleteEdgeKVNamespaceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteEdgeKVNamespace
+// 本接口用于删除指定的 KV 命名空间。删除后命名空间内的所有键值对数据将被清空且不可恢复。若命名空间正被边缘函数引用，需先解除绑定关系后方可删除。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_NAMESPACEINUSE = "InvalidParameter.NamespaceInUse"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) DeleteEdgeKVNamespace(request *DeleteEdgeKVNamespaceRequest) (response *DeleteEdgeKVNamespaceResponse, err error) {
+    return c.DeleteEdgeKVNamespaceWithContext(context.Background(), request)
+}
+
+// DeleteEdgeKVNamespace
+// 本接口用于删除指定的 KV 命名空间。删除后命名空间内的所有键值对数据将被清空且不可恢复。若命名空间正被边缘函数引用，需先解除绑定关系后方可删除。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_NAMESPACEINUSE = "InvalidParameter.NamespaceInUse"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) DeleteEdgeKVNamespaceWithContext(ctx context.Context, request *DeleteEdgeKVNamespaceRequest) (response *DeleteEdgeKVNamespaceResponse, err error) {
+    if request == nil {
+        request = NewDeleteEdgeKVNamespaceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "DeleteEdgeKVNamespace")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteEdgeKVNamespace require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteEdgeKVNamespaceResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteFunctionRequest() (request *DeleteFunctionRequest) {
     request = &DeleteFunctionRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -6671,6 +6789,66 @@ func (c *Client) DescribeDnsRecordsWithContext(ctx context.Context, request *Des
     return
 }
 
+func NewDescribeEdgeKVNamespacesRequest() (request *DescribeEdgeKVNamespacesRequest) {
+    request = &DescribeEdgeKVNamespacesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "DescribeEdgeKVNamespaces")
+    
+    
+    return
+}
+
+func NewDescribeEdgeKVNamespacesResponse() (response *DescribeEdgeKVNamespacesResponse) {
+    response = &DescribeEdgeKVNamespacesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeEdgeKVNamespaces
+// 查询指定站点下的 KV 命名空间列表，支持分页、排序和条件过滤。返回命名空间的基本信息、存储容量使用情况以及被引用关系。若查询不到数据，则返回空数组。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_INVALIDFILTERNAME = "InvalidParameter.InvalidFilterName"
+//  INVALIDPARAMETER_INVALIDSORTBY = "InvalidParameter.InvalidSortBy"
+//  INVALIDPARAMETER_INVALIDSORTORDER = "InvalidParameter.InvalidSortOrder"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED_NAMESPACELIMITEXCEEDED = "LimitExceeded.NamespaceLimitExceeded"
+func (c *Client) DescribeEdgeKVNamespaces(request *DescribeEdgeKVNamespacesRequest) (response *DescribeEdgeKVNamespacesResponse, err error) {
+    return c.DescribeEdgeKVNamespacesWithContext(context.Background(), request)
+}
+
+// DescribeEdgeKVNamespaces
+// 查询指定站点下的 KV 命名空间列表，支持分页、排序和条件过滤。返回命名空间的基本信息、存储容量使用情况以及被引用关系。若查询不到数据，则返回空数组。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_INVALIDFILTERNAME = "InvalidParameter.InvalidFilterName"
+//  INVALIDPARAMETER_INVALIDSORTBY = "InvalidParameter.InvalidSortBy"
+//  INVALIDPARAMETER_INVALIDSORTORDER = "InvalidParameter.InvalidSortOrder"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED_NAMESPACELIMITEXCEEDED = "LimitExceeded.NamespaceLimitExceeded"
+func (c *Client) DescribeEdgeKVNamespacesWithContext(ctx context.Context, request *DescribeEdgeKVNamespacesRequest) (response *DescribeEdgeKVNamespacesResponse, err error) {
+    if request == nil {
+        request = NewDescribeEdgeKVNamespacesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "DescribeEdgeKVNamespaces")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeEdgeKVNamespaces require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeEdgeKVNamespacesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeEnvironmentsRequest() (request *DescribeEnvironmentsRequest) {
     request = &DescribeEnvironmentsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -6694,7 +6872,12 @@ func NewDescribeEnvironmentsResponse() (response *DescribeEnvironmentsResponse) 
 // 在版本管理模式下，用于查询环境信息，可获取环境 ID、类型、当前生效版本等。版本管理功能内测中，当前仅白名单开放。
 //
 // 可能返回的错误码:
-//  RESOURCENOTFOUND = "ResourceNotFound"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_INVALIDFILTERNAME = "InvalidParameter.InvalidFilterName"
+//  INVALIDPARAMETER_INVALIDSORTBY = "InvalidParameter.InvalidSortBy"
+//  INVALIDPARAMETER_INVALIDSORTORDER = "InvalidParameter.InvalidSortOrder"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED_NAMESPACELIMITEXCEEDED = "LimitExceeded.NamespaceLimitExceeded"
 func (c *Client) DescribeEnvironments(request *DescribeEnvironmentsRequest) (response *DescribeEnvironmentsResponse, err error) {
     return c.DescribeEnvironmentsWithContext(context.Background(), request)
 }
@@ -6703,7 +6886,12 @@ func (c *Client) DescribeEnvironments(request *DescribeEnvironmentsRequest) (res
 // 在版本管理模式下，用于查询环境信息，可获取环境 ID、类型、当前生效版本等。版本管理功能内测中，当前仅白名单开放。
 //
 // 可能返回的错误码:
-//  RESOURCENOTFOUND = "ResourceNotFound"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_INVALIDFILTERNAME = "InvalidParameter.InvalidFilterName"
+//  INVALIDPARAMETER_INVALIDSORTBY = "InvalidParameter.InvalidSortBy"
+//  INVALIDPARAMETER_INVALIDSORTORDER = "InvalidParameter.InvalidSortOrder"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED_NAMESPACELIMITEXCEEDED = "LimitExceeded.NamespaceLimitExceeded"
 func (c *Client) DescribeEnvironmentsWithContext(ctx context.Context, request *DescribeEnvironmentsRequest) (response *DescribeEnvironmentsResponse, err error) {
     if request == nil {
         request = NewDescribeEnvironmentsRequest()
@@ -6717,6 +6905,60 @@ func (c *Client) DescribeEnvironmentsWithContext(ctx context.Context, request *D
     request.SetContext(ctx)
     
     response = NewDescribeEnvironmentsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeFunctionComponentBindingsRequest() (request *DescribeFunctionComponentBindingsRequest) {
+    request = &DescribeFunctionComponentBindingsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "DescribeFunctionComponentBindings")
+    
+    
+    return
+}
+
+func NewDescribeFunctionComponentBindingsResponse() (response *DescribeFunctionComponentBindingsResponse) {
+    response = &DescribeFunctionComponentBindingsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeFunctionComponentBindings
+// 本接口用于查询指定边缘函数的组件绑定列表，支持分页和条件过滤，返回绑定的组件类型、变量名及配置参数等详细信息。当前支持的绑定组件类型为 KV 命名空间（kv_namespace）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_INVALIDFILTERNAME = "InvalidParameter.InvalidFilterName"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeFunctionComponentBindings(request *DescribeFunctionComponentBindingsRequest) (response *DescribeFunctionComponentBindingsResponse, err error) {
+    return c.DescribeFunctionComponentBindingsWithContext(context.Background(), request)
+}
+
+// DescribeFunctionComponentBindings
+// 本接口用于查询指定边缘函数的组件绑定列表，支持分页和条件过滤，返回绑定的组件类型、变量名及配置参数等详细信息。当前支持的绑定组件类型为 KV 命名空间（kv_namespace）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_INVALIDFILTERNAME = "InvalidParameter.InvalidFilterName"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeFunctionComponentBindingsWithContext(ctx context.Context, request *DescribeFunctionComponentBindingsRequest) (response *DescribeFunctionComponentBindingsResponse, err error) {
+    if request == nil {
+        request = NewDescribeFunctionComponentBindingsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "DescribeFunctionComponentBindings")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeFunctionComponentBindings require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeFunctionComponentBindingsResponse()
     err = c.Send(request, response)
     return
 }
@@ -8959,6 +9201,56 @@ func (c *Client) DescribeSecurityTemplateBindingsWithContext(ctx context.Context
     return
 }
 
+func NewDescribeSharedCNAMERequest() (request *DescribeSharedCNAMERequest) {
+    request = &DescribeSharedCNAMERequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "DescribeSharedCNAME")
+    
+    
+    return
+}
+
+func NewDescribeSharedCNAMEResponse() (response *DescribeSharedCNAMEResponse) {
+    response = &DescribeSharedCNAMEResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeSharedCNAME
+// 查询共享CNAME列表，支持模糊搜索、分页、排序等。
+//
+// 可能返回的错误码:
+//  UNAUTHORIZEDOPERATION_UNKNOWN = "UnauthorizedOperation.Unknown"
+func (c *Client) DescribeSharedCNAME(request *DescribeSharedCNAMERequest) (response *DescribeSharedCNAMEResponse, err error) {
+    return c.DescribeSharedCNAMEWithContext(context.Background(), request)
+}
+
+// DescribeSharedCNAME
+// 查询共享CNAME列表，支持模糊搜索、分页、排序等。
+//
+// 可能返回的错误码:
+//  UNAUTHORIZEDOPERATION_UNKNOWN = "UnauthorizedOperation.Unknown"
+func (c *Client) DescribeSharedCNAMEWithContext(ctx context.Context, request *DescribeSharedCNAMERequest) (response *DescribeSharedCNAMEResponse, err error) {
+    if request == nil {
+        request = NewDescribeSharedCNAMERequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "DescribeSharedCNAME")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeSharedCNAME require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeSharedCNAMEResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeTimingL4DataRequest() (request *DescribeTimingL4DataRequest) {
     request = &DescribeTimingL4DataRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -8979,7 +9271,7 @@ func NewDescribeTimingL4DataResponse() (response *DescribeTimingL4DataResponse) 
 }
 
 // DescribeTimingL4Data
-// 本接口（DescribeTimingL4Data）用于查询四层时序流量数据列表。
+// <p>本接口（<code>DescribeTimingL4Data</code>）用于查询四层时序数据列表。</p>
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -8994,7 +9286,7 @@ func (c *Client) DescribeTimingL4Data(request *DescribeTimingL4DataRequest) (res
 }
 
 // DescribeTimingL4Data
-// 本接口（DescribeTimingL4Data）用于查询四层时序流量数据列表。
+// <p>本接口（<code>DescribeTimingL4Data</code>）用于查询四层时序数据列表。</p>
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -10119,6 +10411,220 @@ func (c *Client) DownloadL7LogsWithContext(ctx context.Context, request *Downloa
     return
 }
 
+func NewEdgeKVDeleteRequest() (request *EdgeKVDeleteRequest) {
+    request = &EdgeKVDeleteRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "EdgeKVDelete")
+    
+    
+    return
+}
+
+func NewEdgeKVDeleteResponse() (response *EdgeKVDeleteResponse) {
+    response = &EdgeKVDeleteResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// EdgeKVDelete
+// 本接口用于删除指定命名空间中的一个或多个键值对数据，支持批量删除。删除后数据不可恢复。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_KEYSTOOMANY = "InvalidParameter.KeysTooMany"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) EdgeKVDelete(request *EdgeKVDeleteRequest) (response *EdgeKVDeleteResponse, err error) {
+    return c.EdgeKVDeleteWithContext(context.Background(), request)
+}
+
+// EdgeKVDelete
+// 本接口用于删除指定命名空间中的一个或多个键值对数据，支持批量删除。删除后数据不可恢复。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_KEYSTOOMANY = "InvalidParameter.KeysTooMany"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) EdgeKVDeleteWithContext(ctx context.Context, request *EdgeKVDeleteRequest) (response *EdgeKVDeleteResponse, err error) {
+    if request == nil {
+        request = NewEdgeKVDeleteRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "EdgeKVDelete")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("EdgeKVDelete require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewEdgeKVDeleteResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewEdgeKVGetRequest() (request *EdgeKVGetRequest) {
+    request = &EdgeKVGetRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "EdgeKVGet")
+    
+    
+    return
+}
+
+func NewEdgeKVGetResponse() (response *EdgeKVGetResponse) {
+    response = &EdgeKVGetResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// EdgeKVGet
+// 本接口用于从指定命名空间中批量读取键的值，支持一次查询最多 20 个键。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_KEYSTOOMANY = "InvalidParameter.KeysTooMany"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) EdgeKVGet(request *EdgeKVGetRequest) (response *EdgeKVGetResponse, err error) {
+    return c.EdgeKVGetWithContext(context.Background(), request)
+}
+
+// EdgeKVGet
+// 本接口用于从指定命名空间中批量读取键的值，支持一次查询最多 20 个键。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_KEYSTOOMANY = "InvalidParameter.KeysTooMany"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) EdgeKVGetWithContext(ctx context.Context, request *EdgeKVGetRequest) (response *EdgeKVGetResponse, err error) {
+    if request == nil {
+        request = NewEdgeKVGetRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "EdgeKVGet")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("EdgeKVGet require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewEdgeKVGetResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewEdgeKVListRequest() (request *EdgeKVListRequest) {
+    request = &EdgeKVListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "EdgeKVList")
+    
+    
+    return
+}
+
+func NewEdgeKVListResponse() (response *EdgeKVListResponse) {
+    response = &EdgeKVListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// EdgeKVList
+// 本接口用于列出指定命名空间下的所有键名，支持前缀过滤。通过 Cursor 实现游标遍历，返回下一个游标用于继续查询。适用于遍历命名空间中的所有键。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) EdgeKVList(request *EdgeKVListRequest) (response *EdgeKVListResponse, err error) {
+    return c.EdgeKVListWithContext(context.Background(), request)
+}
+
+// EdgeKVList
+// 本接口用于列出指定命名空间下的所有键名，支持前缀过滤。通过 Cursor 实现游标遍历，返回下一个游标用于继续查询。适用于遍历命名空间中的所有键。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) EdgeKVListWithContext(ctx context.Context, request *EdgeKVListRequest) (response *EdgeKVListResponse, err error) {
+    if request == nil {
+        request = NewEdgeKVListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "EdgeKVList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("EdgeKVList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewEdgeKVListResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewEdgeKVPutRequest() (request *EdgeKVPutRequest) {
+    request = &EdgeKVPutRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "EdgeKVPut")
+    
+    
+    return
+}
+
+func NewEdgeKVPutResponse() (response *EdgeKVPutResponse) {
+    response = &EdgeKVPutResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// EdgeKVPut
+// 本接口用于向指定命名空间写入键值对数据，支持设置过期时间。若键已存在则覆盖原有值，若不存在则创建新键值对。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) EdgeKVPut(request *EdgeKVPutRequest) (response *EdgeKVPutResponse, err error) {
+    return c.EdgeKVPutWithContext(context.Background(), request)
+}
+
+// EdgeKVPut
+// 本接口用于向指定命名空间写入键值对数据，支持设置过期时间。若键已存在则覆盖原有值，若不存在则创建新键值对。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) EdgeKVPutWithContext(ctx context.Context, request *EdgeKVPutRequest) (response *EdgeKVPutResponse, err error) {
+    if request == nil {
+        request = NewEdgeKVPutRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "EdgeKVPut")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("EdgeKVPut require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewEdgeKVPutResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewEnableOriginACLRequest() (request *EnableOriginACLRequest) {
     request = &EnableOriginACLRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -10139,7 +10645,7 @@ func NewEnableOriginACLResponse() (response *EnableOriginACLResponse) {
 }
 
 // EnableOriginACL
-// 本接口用于站点首次开启源站防护，启用后 EdgeOne 将会使用特定的回源 IP 网段为七层加速域名/四层代理实例回源。单次支持提交的七层加速域名的数量最大为 200，四层代理实例的数量最大为 100，支持七层加速域名/四层代理实例混合提交，总实例个数最大为 200。如需要启用超过 200 个资源，可先通过指定资源的方式以最大数量启用，剩余资源通过 ModifyOriginACL 接口启用。后续新增七层加速域名/四层代理实例均请通过 ModifyOriginACL 接口配置。
+// 本接口用于站点首次开启源站防护，启用后 EdgeOne 将会使用特定的回源 IP 网段为七层加速域名/四层代理实例回源。单次支持提交的七层加速域名的数量最大为 200，四层代理实例的数量最大为 100，支持七层加速域名/四层代理实例混合提交，总实例个数最大为 200。如需要启用超过 200 个资源，可先通过指定资源的方式以最大数量启用，剩余资源通过 ModifyOriginACL 接口启用。后续新增七层加速域名/四层代理实例均请通过 ModifyOriginACL 接口配置。同时开启的时候对开白的账户支持选择其他回源 IP 网段版本，例如精简版，来达到使用更少的 IP 网段回源效果。
 //
 // 
 //
@@ -10155,6 +10661,7 @@ func NewEnableOriginACLResponse() (response *EnableOriginACLResponse) {
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETER_INVALIDDOMAINS = "InvalidParameter.InvalidDomains"
 //  INVALIDPARAMETER_INVALIDPROXIES = "InvalidParameter.InvalidProxies"
+//  INVALIDPARAMETER_SHIELDNOTSUPPORTHOSTORIGINWHITELIST = "InvalidParameter.ShieldNotSupportHostOriginWhitelist"
 //  OPERATIONDENIED = "OperationDenied"
 //  OPERATIONDENIED_UNSUPPORTEDPLAN = "OperationDenied.UnsupportedPlan"
 //  OPERATIONDENIED_VERSIONCONTROLISGRAYING = "OperationDenied.VersionControlIsGraying"
@@ -10164,7 +10671,7 @@ func (c *Client) EnableOriginACL(request *EnableOriginACLRequest) (response *Ena
 }
 
 // EnableOriginACL
-// 本接口用于站点首次开启源站防护，启用后 EdgeOne 将会使用特定的回源 IP 网段为七层加速域名/四层代理实例回源。单次支持提交的七层加速域名的数量最大为 200，四层代理实例的数量最大为 100，支持七层加速域名/四层代理实例混合提交，总实例个数最大为 200。如需要启用超过 200 个资源，可先通过指定资源的方式以最大数量启用，剩余资源通过 ModifyOriginACL 接口启用。后续新增七层加速域名/四层代理实例均请通过 ModifyOriginACL 接口配置。
+// 本接口用于站点首次开启源站防护，启用后 EdgeOne 将会使用特定的回源 IP 网段为七层加速域名/四层代理实例回源。单次支持提交的七层加速域名的数量最大为 200，四层代理实例的数量最大为 100，支持七层加速域名/四层代理实例混合提交，总实例个数最大为 200。如需要启用超过 200 个资源，可先通过指定资源的方式以最大数量启用，剩余资源通过 ModifyOriginACL 接口启用。后续新增七层加速域名/四层代理实例均请通过 ModifyOriginACL 接口配置。同时开启的时候对开白的账户支持选择其他回源 IP 网段版本，例如精简版，来达到使用更少的 IP 网段回源效果。
 //
 // 
 //
@@ -10180,6 +10687,7 @@ func (c *Client) EnableOriginACL(request *EnableOriginACLRequest) (response *Ena
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETER_INVALIDDOMAINS = "InvalidParameter.InvalidDomains"
 //  INVALIDPARAMETER_INVALIDPROXIES = "InvalidParameter.InvalidProxies"
+//  INVALIDPARAMETER_SHIELDNOTSUPPORTHOSTORIGINWHITELIST = "InvalidParameter.ShieldNotSupportHostOriginWhitelist"
 //  OPERATIONDENIED = "OperationDenied"
 //  OPERATIONDENIED_UNSUPPORTEDPLAN = "OperationDenied.UnsupportedPlan"
 //  OPERATIONDENIED_VERSIONCONTROLISGRAYING = "OperationDenied.VersionControlIsGraying"
@@ -10221,7 +10729,7 @@ func NewExportZoneConfigResponse() (response *ExportZoneConfigResponse) {
 }
 
 // ExportZoneConfig
-// 导出站点配置接口，本接口支持用户根据需要的配置项进行配置导出，导出的配置用于导入站点配置接口（ImportZoneConfig）进行配置导入。该功能仅支持标准版和企业版套餐站点使用。
+// 导出站点配置接口，本接口支持用户根据需要的配置项进行配置导出，导出的配置用于导入站点配置接口（ImportZoneConfig）进行配置导入。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -10229,6 +10737,7 @@ func NewExportZoneConfigResponse() (response *ExportZoneConfigResponse) {
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETER_INVALIDDOMAINS = "InvalidParameter.InvalidDomains"
 //  INVALIDPARAMETER_INVALIDPROXIES = "InvalidParameter.InvalidProxies"
+//  INVALIDPARAMETER_SHIELDNOTSUPPORTHOSTORIGINWHITELIST = "InvalidParameter.ShieldNotSupportHostOriginWhitelist"
 //  OPERATIONDENIED = "OperationDenied"
 //  OPERATIONDENIED_UNSUPPORTEDPLAN = "OperationDenied.UnsupportedPlan"
 //  OPERATIONDENIED_VERSIONCONTROLISGRAYING = "OperationDenied.VersionControlIsGraying"
@@ -10238,7 +10747,7 @@ func (c *Client) ExportZoneConfig(request *ExportZoneConfigRequest) (response *E
 }
 
 // ExportZoneConfig
-// 导出站点配置接口，本接口支持用户根据需要的配置项进行配置导出，导出的配置用于导入站点配置接口（ImportZoneConfig）进行配置导入。该功能仅支持标准版和企业版套餐站点使用。
+// 导出站点配置接口，本接口支持用户根据需要的配置项进行配置导出，导出的配置用于导入站点配置接口（ImportZoneConfig）进行配置导入。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -10246,6 +10755,7 @@ func (c *Client) ExportZoneConfig(request *ExportZoneConfigRequest) (response *E
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETER_INVALIDDOMAINS = "InvalidParameter.InvalidDomains"
 //  INVALIDPARAMETER_INVALIDPROXIES = "InvalidParameter.InvalidProxies"
+//  INVALIDPARAMETER_SHIELDNOTSUPPORTHOSTORIGINWHITELIST = "InvalidParameter.ShieldNotSupportHostOriginWhitelist"
 //  OPERATIONDENIED = "OperationDenied"
 //  OPERATIONDENIED_UNSUPPORTEDPLAN = "OperationDenied.UnsupportedPlan"
 //  OPERATIONDENIED_VERSIONCONTROLISGRAYING = "OperationDenied.VersionControlIsGraying"
@@ -11331,6 +11841,62 @@ func (c *Client) ModifyDnsRecordsStatusWithContext(ctx context.Context, request 
     return
 }
 
+func NewModifyEdgeKVNamespaceRequest() (request *ModifyEdgeKVNamespaceRequest) {
+    request = &ModifyEdgeKVNamespaceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "ModifyEdgeKVNamespace")
+    
+    
+    return
+}
+
+func NewModifyEdgeKVNamespaceResponse() (response *ModifyEdgeKVNamespaceResponse) {
+    response = &ModifyEdgeKVNamespaceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyEdgeKVNamespace
+// 本接口用于修改指定 KV 命名空间的属性信息，当前支持修改命名空间描述。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_REMARKTOOLONG = "InvalidParameter.RemarkTooLong"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) ModifyEdgeKVNamespace(request *ModifyEdgeKVNamespaceRequest) (response *ModifyEdgeKVNamespaceResponse, err error) {
+    return c.ModifyEdgeKVNamespaceWithContext(context.Background(), request)
+}
+
+// ModifyEdgeKVNamespace
+// 本接口用于修改指定 KV 命名空间的属性信息，当前支持修改命名空间描述。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_REMARKTOOLONG = "InvalidParameter.RemarkTooLong"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) ModifyEdgeKVNamespaceWithContext(ctx context.Context, request *ModifyEdgeKVNamespaceRequest) (response *ModifyEdgeKVNamespaceResponse, err error) {
+    if request == nil {
+        request = NewModifyEdgeKVNamespaceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "ModifyEdgeKVNamespace")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyEdgeKVNamespace require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyEdgeKVNamespaceResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyFunctionRequest() (request *ModifyFunctionRequest) {
     request = &ModifyFunctionRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -11393,6 +11959,70 @@ func (c *Client) ModifyFunctionWithContext(ctx context.Context, request *ModifyF
     request.SetContext(ctx)
     
     response = NewModifyFunctionResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyFunctionComponentBindingsRequest() (request *ModifyFunctionComponentBindingsRequest) {
+    request = &ModifyFunctionComponentBindingsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "ModifyFunctionComponentBindings")
+    
+    
+    return
+}
+
+func NewModifyFunctionComponentBindingsResponse() (response *ModifyFunctionComponentBindingsResponse) {
+    response = &ModifyFunctionComponentBindingsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyFunctionComponentBindings
+// 修改边缘函数与组件的绑定关系，支持绑定（bind）、覆盖绑定（bind-override）、解绑（unbind）和重置绑定（rebind）四种操作模式。通过指定操作类型和组件列表，可实现对函数组件绑定关系的管理。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_BINDINGNOTFOUND = "InvalidParameter.BindingNotFound"
+//  INVALIDPARAMETER_DUPLICATEBINDINGNAME = "InvalidParameter.DuplicateBindingName"
+//  INVALIDPARAMETER_FUNCTIONBINDVARIABLENAMECONFLICT = "InvalidParameter.FunctionBindVariableNameConflict"
+//  INVALIDPARAMETER_INVALIDOPERATION = "InvalidParameter.InvalidOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_FUNCTIONNOTFOUND = "ResourceUnavailable.FunctionNotFound"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) ModifyFunctionComponentBindings(request *ModifyFunctionComponentBindingsRequest) (response *ModifyFunctionComponentBindingsResponse, err error) {
+    return c.ModifyFunctionComponentBindingsWithContext(context.Background(), request)
+}
+
+// ModifyFunctionComponentBindings
+// 修改边缘函数与组件的绑定关系，支持绑定（bind）、覆盖绑定（bind-override）、解绑（unbind）和重置绑定（rebind）四种操作模式。通过指定操作类型和组件列表，可实现对函数组件绑定关系的管理。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_BINDINGNOTFOUND = "InvalidParameter.BindingNotFound"
+//  INVALIDPARAMETER_DUPLICATEBINDINGNAME = "InvalidParameter.DuplicateBindingName"
+//  INVALIDPARAMETER_FUNCTIONBINDVARIABLENAMECONFLICT = "InvalidParameter.FunctionBindVariableNameConflict"
+//  INVALIDPARAMETER_INVALIDOPERATION = "InvalidParameter.InvalidOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_FUNCTIONNOTFOUND = "ResourceUnavailable.FunctionNotFound"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) ModifyFunctionComponentBindingsWithContext(ctx context.Context, request *ModifyFunctionComponentBindingsRequest) (response *ModifyFunctionComponentBindingsResponse, err error) {
+    if request == nil {
+        request = NewModifyFunctionComponentBindingsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "ModifyFunctionComponentBindings")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyFunctionComponentBindings require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyFunctionComponentBindingsResponse()
     err = c.Send(request, response)
     return
 }
@@ -12727,13 +13357,14 @@ func NewModifyOriginACLResponse() (response *ModifyOriginACLResponse) {
 }
 
 // ModifyOriginACL
-// 本接口用于对七层加速域名/四层代理实例启用/关闭特定回源 IP 网段回源。单次支持提交的七层加速域名的数量最大为 200，四层代理实例的数量最大为 100，支持七层加速域名/四层代理实例混合提交，总实例个数最大为 200。如需变更超过 200 个实例，请通过本接口分批提交。
+// 本接口用于对七层加速域名/四层代理实例启用/关闭特定回源 IP 网段回源。单次支持提交的七层加速域名的数量最大为 200，四层代理实例的数量最大为 100，支持七层加速域名/四层代理实例混合提交，总实例个数最大为 200。如需变更超过 200 个实例，请通过本接口分批提交。同时对于开白的客户支持切换到其他可用的源站防护 IP 网段版本，例如精简版，可以减少回源 IP 网段。
 //
 // 可能返回的错误码:
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETER_INVALIDDOMAINS = "InvalidParameter.InvalidDomains"
 //  INVALIDPARAMETER_INVALIDPROXIES = "InvalidParameter.InvalidProxies"
+//  INVALIDPARAMETER_SHIELDNOTSUPPORTHOSTORIGINWHITELIST = "InvalidParameter.ShieldNotSupportHostOriginWhitelist"
 //  OPERATIONDENIED = "OperationDenied"
 //  OPERATIONDENIED_UNSUPPORTEDPLAN = "OperationDenied.UnsupportedPlan"
 //  OPERATIONDENIED_UPDATEIPWHITELISTFIRST = "OperationDenied.UpdateIPWhitelistFirst"
@@ -12742,13 +13373,14 @@ func (c *Client) ModifyOriginACL(request *ModifyOriginACLRequest) (response *Mod
 }
 
 // ModifyOriginACL
-// 本接口用于对七层加速域名/四层代理实例启用/关闭特定回源 IP 网段回源。单次支持提交的七层加速域名的数量最大为 200，四层代理实例的数量最大为 100，支持七层加速域名/四层代理实例混合提交，总实例个数最大为 200。如需变更超过 200 个实例，请通过本接口分批提交。
+// 本接口用于对七层加速域名/四层代理实例启用/关闭特定回源 IP 网段回源。单次支持提交的七层加速域名的数量最大为 200，四层代理实例的数量最大为 100，支持七层加速域名/四层代理实例混合提交，总实例个数最大为 200。如需变更超过 200 个实例，请通过本接口分批提交。同时对于开白的客户支持切换到其他可用的源站防护 IP 网段版本，例如精简版，可以减少回源 IP 网段。
 //
 // 可能返回的错误码:
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETER_INVALIDDOMAINS = "InvalidParameter.InvalidDomains"
 //  INVALIDPARAMETER_INVALIDPROXIES = "InvalidParameter.InvalidProxies"
+//  INVALIDPARAMETER_SHIELDNOTSUPPORTHOSTORIGINWHITELIST = "InvalidParameter.ShieldNotSupportHostOriginWhitelist"
 //  OPERATIONDENIED = "OperationDenied"
 //  OPERATIONDENIED_UNSUPPORTEDPLAN = "OperationDenied.UnsupportedPlan"
 //  OPERATIONDENIED_UPDATEIPWHITELISTFIRST = "OperationDenied.UpdateIPWhitelistFirst"
@@ -14157,6 +14789,64 @@ func (c *Client) ModifySecurityPolicyWithContext(ctx context.Context, request *M
     request.SetContext(ctx)
     
     response = NewModifySecurityPolicyResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifySharedCNAMERequest() (request *ModifySharedCNAMERequest) {
+    request = &ModifySharedCNAMERequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "ModifySharedCNAME")
+    
+    
+    return
+}
+
+func NewModifySharedCNAMEResponse() (response *ModifySharedCNAMEResponse) {
+    response = &ModifySharedCNAMEResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifySharedCNAME
+// 用于修改共享 CNAME。当前仅支持修改共享 CNAME 的描述和设置 IP SSL类型的共享CNAME关联IP SSL 域名，共享 CNAME 本身创建后不支持修改。该功能白名单内测中。
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  OPERATIONDENIED_DOMAINMUSTINIPSSLSHAREDCNAMEZONEANDINSHAREDCNAME = "OperationDenied.DomainMustInIPSSLSharedCNAMEZoneAndInSharedCNAME"
+//  OPERATIONDENIED_IPSSLALREADYBOUNDANOTHERDOMAIN = "OperationDenied.IPSSLAlreadyBoundAnotherDomain"
+//  OPERATIONDENIED_LASTIPSSLOPERATIONNOTCOMPLETE = "OperationDenied.LastIPSSLOperationNotComplete"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifySharedCNAME(request *ModifySharedCNAMERequest) (response *ModifySharedCNAMEResponse, err error) {
+    return c.ModifySharedCNAMEWithContext(context.Background(), request)
+}
+
+// ModifySharedCNAME
+// 用于修改共享 CNAME。当前仅支持修改共享 CNAME 的描述和设置 IP SSL类型的共享CNAME关联IP SSL 域名，共享 CNAME 本身创建后不支持修改。该功能白名单内测中。
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  OPERATIONDENIED_DOMAINMUSTINIPSSLSHAREDCNAMEZONEANDINSHAREDCNAME = "OperationDenied.DomainMustInIPSSLSharedCNAMEZoneAndInSharedCNAME"
+//  OPERATIONDENIED_IPSSLALREADYBOUNDANOTHERDOMAIN = "OperationDenied.IPSSLAlreadyBoundAnotherDomain"
+//  OPERATIONDENIED_LASTIPSSLOPERATIONNOTCOMPLETE = "OperationDenied.LastIPSSLOperationNotComplete"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifySharedCNAMEWithContext(ctx context.Context, request *ModifySharedCNAMERequest) (response *ModifySharedCNAMEResponse, err error) {
+    if request == nil {
+        request = NewModifySharedCNAMERequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "ModifySharedCNAME")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifySharedCNAME require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifySharedCNAMEResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/errors.go
@@ -194,6 +194,12 @@ const (
 	// 函数名称不符合命名规范。
 	INVALIDPARAMETER_BADFUNCTIONNAME = "InvalidParameter.BadFunctionName"
 
+	// 命名空间名称不合法。
+	INVALIDPARAMETER_BADNAMESPACENAME = "InvalidParameter.BadNamespaceName"
+
+	// 绑定变量不存在。
+	INVALIDPARAMETER_BINDINGNOTFOUND = "InvalidParameter.BindingNotFound"
+
 	// 无效的查询字符串。
 	INVALIDPARAMETER_CACHEKEYQUERYSTRINGREQUIRESFULLURLCACHEOFF = "InvalidParameter.CacheKeyQueryStringRequiresFullUrlCacheOff"
 
@@ -238,6 +244,9 @@ const (
 
 	// 当前域名已开启流量调度功能。
 	INVALIDPARAMETER_DOMAINONTRAFFICSCHEDULING = "InvalidParameter.DomainOnTrafficScheduling"
+
+	// 绑定变量名称已存在。
+	INVALIDPARAMETER_DUPLICATEBINDINGNAME = "InvalidParameter.DuplicateBindingName"
 
 	// 重复规则。
 	INVALIDPARAMETER_DUPLICATERULE = "InvalidParameter.DuplicateRule"
@@ -331,6 +340,9 @@ const (
 
 	// 条件为空。
 	INVALIDPARAMETER_ERRNILCONDITION = "InvalidParameter.ErrNilCondition"
+
+	// 绑定名已存在。如需覆盖，请使用 bind-override。
+	INVALIDPARAMETER_FUNCTIONBINDVARIABLENAMECONFLICT = "InvalidParameter.FunctionBindVariableNameConflict"
 
 	// 函数名称和本账号下其他函数冲突。
 	INVALIDPARAMETER_FUNCTIONNAMECONFLICT = "InvalidParameter.FunctionNameConflict"
@@ -494,6 +506,9 @@ const (
 	// 无效查询维度。
 	INVALIDPARAMETER_INVALIDMETRIC = "InvalidParameter.InvalidMetric"
 
+	// 操作类型不合法。
+	INVALIDPARAMETER_INVALIDOPERATION = "InvalidParameter.InvalidOperation"
+
 	// 无效的源站。
 	INVALIDPARAMETER_INVALIDORIGIN = "InvalidParameter.InvalidOrigin"
 
@@ -590,6 +605,12 @@ const (
 	// 无效的回源Host。
 	INVALIDPARAMETER_INVALIDSERVERNAME = "InvalidParameter.InvalidServerName"
 
+	// 排序字段不合法。
+	INVALIDPARAMETER_INVALIDSORTBY = "InvalidParameter.InvalidSortBy"
+
+	// 排序方向不合法。
+	INVALIDPARAMETER_INVALIDSORTORDER = "InvalidParameter.InvalidSortOrder"
+
 	// edgeone的debug配置无效。
 	INVALIDPARAMETER_INVALIDSTANDARDDEBUG = "InvalidParameter.InvalidStandardDebug"
 
@@ -619,6 +640,9 @@ const (
 
 	// 无效的缓存键。
 	INVALIDPARAMETER_KEYRULESINVALIDQUERYSTRINGVALUE = "InvalidParameter.KeyRulesInvalidQueryStringValue"
+
+	// 请求的Key数量超过限制。
+	INVALIDPARAMETER_KEYSTOOMANY = "InvalidParameter.KeysTooMany"
 
 	// 参数长度超过限制。
 	INVALIDPARAMETER_LENGTHEXCEEDSLIMIT = "InvalidParameter.LengthExceedsLimit"
@@ -652,6 +676,9 @@ const (
 
 	// 不支持智能路由
 	INVALIDPARAMETER_MULTIPLYLAYERNOTSUPPORTSMARTROUTING = "InvalidParameter.MultiplyLayerNotSupportSmartRouting"
+
+	// 命名空间正在使用中，无法删除。
+	INVALIDPARAMETER_NAMESPACEINUSE = "InvalidParameter.NamespaceInUse"
 
 	// 操作配置存在不支持的预设变量。
 	INVALIDPARAMETER_NOTSUPPORTTHISPRESET = "InvalidParameter.NotSupportThisPreset"
@@ -731,6 +758,9 @@ const (
 	// 实时日志推送任务数据超过了限制
 	INVALIDPARAMETER_REALTIMELOGNUMSEXCEEDLIMIT = "InvalidParameter.RealtimeLogNumsExceedLimit"
 
+	// 命名空间备注信息过长。
+	INVALIDPARAMETER_REMARKTOOLONG = "InvalidParameter.RemarkTooLong"
+
 	// 无效的响应头header。
 	INVALIDPARAMETER_RESPONSEHEADERCACHECONTROLNOTALLOWDELETE = "InvalidParameter.ResponseHeaderCacheControlNotAllowDelete"
 
@@ -760,6 +790,9 @@ const (
 
 	// 配置项参数错误。
 	INVALIDPARAMETER_SETTINGINVALIDPARAM = "InvalidParameter.SettingInvalidParam"
+
+	// 当前域名不支持同时开启EdgeOne Shield和源站防护。
+	INVALIDPARAMETER_SHIELDNOTSUPPORTHOSTORIGINWHITELIST = "InvalidParameter.ShieldNotSupportHostOriginWhitelist"
 
 	// 一些绑定的源站组不存在。
 	INVALIDPARAMETER_SOMEORIGINGROUPNOTEXIST = "InvalidParameter.SomeOriginGroupNotExist"
@@ -1016,6 +1049,9 @@ const (
 	// 负载均衡数量超过限制。
 	LIMITEXCEEDED_LOADBALANCINGCOUNTLIMITEXCEEDED = "LimitExceeded.LoadBalancingCountLimitExceeded"
 
+	// 站点下 KV 命名空间数量已达上限
+	LIMITEXCEEDED_NAMESPACELIMITEXCEEDED = "LimitExceeded.NamespaceLimitExceeded"
+
 	// 计费套餐不支持。
 	LIMITEXCEEDED_PACKNOTALLOW = "LimitExceeded.PackNotAllow"
 
@@ -1088,6 +1124,9 @@ const (
 	// 域名被封禁，暂时无法操作。
 	OPERATIONDENIED_DOMAINISBLOCKED = "OperationDenied.DomainIsBlocked"
 
+	// 域名必须在IP SSL共享CNAME所属站点中且必须在IP SSL共享CNAME中
+	OPERATIONDENIED_DOMAINMUSTINIPSSLSHAREDCNAMEZONEANDINSHAREDCNAME = "OperationDenied.DomainMustInIPSSLSharedCNAMEZoneAndInSharedCNAME"
+
 	// 域名尚未备案。
 	OPERATIONDENIED_DOMAINNOICP = "OperationDenied.DomainNoICP"
 
@@ -1123,6 +1162,9 @@ const (
 
 	// 待变更域名源站证书校验配置不一致，请确认变更域名配置一致后重试。
 	OPERATIONDENIED_HOSTSUPSTREAMCERTIFICATEVERIFYINCONSISTENCY = "OperationDenied.HostsUpstreamCertificateVerifyInconsistency"
+
+	// IP SSL已绑定到其他域名，不允许操作。
+	OPERATIONDENIED_IPSSLALREADYBOUNDANOTHERDOMAIN = "OperationDenied.IPSSLAlreadyBoundAnotherDomain"
 
 	// 开启高防时必须保证安全是开启状态。
 	OPERATIONDENIED_INVALIDADVANCEDDEFENSESECURITYTYPE = "OperationDenied.InvalidAdvancedDefenseSecurityType"
@@ -1168,6 +1210,9 @@ const (
 
 	// 存在加速域名处于部署中状态，暂不支持停用站点。
 	OPERATIONDENIED_L7HOSTINPROCESSSTATUS = "OperationDenied.L7HostInProcessStatus"
+
+	// 上一次 IP SSL 操作关联的域名尚未上线完成，请等待上线完成后再进行操作。
+	OPERATIONDENIED_LASTIPSSLOPERATIONNOTCOMPLETE = "OperationDenied.LastIPSSLOperationNotComplete"
 
 	// 回源白名单已经是最新版本，无需更新。
 	OPERATIONDENIED_LATESTVERSIONNOW = "OperationDenied.LatestVersionNow"
@@ -1396,6 +1441,9 @@ const (
 
 	// 域名不存在或未开启代理。
 	RESOURCEUNAVAILABLE_HOSTNOTFOUND = "ResourceUnavailable.HostNotFound"
+
+	// KV命名空间不存在。
+	RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
 
 	// 规则不存在或不属于该账号。
 	RESOURCEUNAVAILABLE_RULENOTFOUND = "ResourceUnavailable.RuleNotFound"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/models.go
@@ -20,6 +20,20 @@ import (
     "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/json"
 )
 
+type AICrawlerDetection struct {
+	// AI 爬虫检测是否开启。取值有：
+	// <li>on：开启；</li>
+	// <li>off：关闭。</li>
+	Enabled *string `json:"Enabled,omitnil,omitempty" name:"Enabled"`
+
+	// AI 爬虫检测的执行动作，当 Enabled 为 on 时，此字段必填。SecurityAction 的 Name 取值仅支持：
+	// <li>Deny：拦截；</li>
+	// <li>Monitor：观察；</li>
+	// <li>Allow：放行；</li>
+	// <li>Challenge：挑战，其中 ChallengeActionParameters 中的 ChallengeOption 仅支持 JSChallenge 和 ManagedChallenge。</li>
+	Action *SecurityAction `json:"Action,omitnil,omitempty" name:"Action"`
+}
+
 type APIResource struct {
 	// 资源 ID。
 	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
@@ -1223,6 +1237,14 @@ type BotManagementCustomRules struct {
 	Rules []*BotManagementCustomRule `json:"Rules,omitnil,omitempty" name:"Rules"`
 }
 
+type BotManagementLite struct {
+	// 人机校验页的具体配置。
+	CAPTCHAPageChallenge *CAPTCHAPageChallenge `json:"CAPTCHAPageChallenge,omitnil,omitempty" name:"CAPTCHAPageChallenge"`
+
+	// AI爬虫检测的具体配置。
+	AICrawlerDetection *AICrawlerDetection `json:"AICrawlerDetection,omitnil,omitempty" name:"AICrawlerDetection"`
+}
+
 type BotPortraitRule struct {
 	// 本功能的开关，取值有：
 	// <li>on：开启；</li>
@@ -1366,6 +1388,11 @@ type BrowserImpersonationDetectionRule struct {
 
 	// 浏览器伪造识别规则的处置方式，包括 Cookie 校验和会话跟踪配置以及客户端行为校验配置。
 	Action *BrowserImpersonationDetectionAction `json:"Action,omitnil,omitempty" name:"Action"`
+}
+
+type CAPTCHAPageChallenge struct {
+	// 人机校验页是否开启，取值有：<li>on：开启；</li><li>off：关闭。</li>
+	Enabled *string `json:"Enabled,omitnil,omitempty" name:"Enabled"`
 }
 
 type CC struct {
@@ -1644,7 +1671,7 @@ type CheckCnameStatusRequestParams struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 加速域名列表。
+	// 需要检测 CNAME 配置状态的域名列表，可以为：<li>加速域名;</li><li>别称域名。</li>
 	RecordNames []*string `json:"RecordNames,omitnil,omitempty" name:"RecordNames"`
 }
 
@@ -1654,7 +1681,7 @@ type CheckCnameStatusRequest struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 加速域名列表。
+	// 需要检测 CNAME 配置状态的域名列表，可以为：<li>加速域名;</li><li>别称域名。</li>
 	RecordNames []*string `json:"RecordNames,omitnil,omitempty" name:"RecordNames"`
 }
 
@@ -1680,7 +1707,7 @@ func (r *CheckCnameStatusRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CheckCnameStatusResponseParams struct {
-	// 加速域名 CNAME 状态信息列表。
+	// 接入域名的 CNAME 配置状态信息列表。
 	CnameStatus []*CnameStatus `json:"CnameStatus,omitnil,omitempty" name:"CnameStatus"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -1833,7 +1860,8 @@ type ClientAttester struct {
 
 	// 认证方法。取值有：
 	// <li>TC-RCE: 使用风险识别 RCE 进行认证；</li>
-	// <li>TC-CAPTCHA: 使用天御验证码进行认证。</li>
+	// <li>TC-CAPTCHA: 使用天御验证码进行认证；</li>
+	// <li>TC-EO-CAPTCHA: 使用 EdgeOne 人机校验进行认证。</li>
 	AttesterSource *string `json:"AttesterSource,omitnil,omitempty" name:"AttesterSource"`
 
 	// 认证有效时间。默认为 60s，支持的单位有：
@@ -1849,6 +1877,10 @@ type ClientAttester struct {
 	// TC-CAPTCHA 认证的配置信息。
 	// <li>当 AttesterSource 参数值为 TC-CAPTCHA 时，此字段必填。</li>
 	TCCaptchaOption *TCCaptchaOption `json:"TCCaptchaOption,omitnil,omitempty" name:"TCCaptchaOption"`
+
+	// TC-EO-CAPTCHA 认证的配置信息。
+	// <li>当 AttesterSource 参数值为 TC-EO-CAPTCHA 时，此字段必填。</li>
+	TCEOCaptchaOption *TCEOCaptchaOption `json:"TCEOCaptchaOption,omitnil,omitempty" name:"TCEOCaptchaOption"`
 }
 
 type ClientBehaviorDetection struct {
@@ -1924,16 +1956,16 @@ type ClientIpHeader struct {
 }
 
 type CnameStatus struct {
-	// 记录名称。
+	// 接入域名。
 	RecordName *string `json:"RecordName,omitnil,omitempty" name:"RecordName"`
 
-	// CNAME 地址。
-	// 注意：此字段可能返回 null，表示取不到有效值。
+	// EdgeOne 分配给接入域名的 CNAME。
 	Cname *string `json:"Cname,omitnil,omitempty" name:"Cname"`
 
-	// CNAME 状态信息，取值有：
-	// <li>active：生效；</li>
-	// <li>moved：不生效；</li>
+	// CNAME 配置状态校验结果，取值有：
+	// <li>active：表示接入域名已正确配置到 EdgeOne 为其分配的指定 CNAME；</li>
+	// <li>moved：表示接入域名未配置到 EdgeOne 为其分配的指定 CNAME；</li>
+	// <li>invalid：表示接入域名配置的 CNAME 为 EdgeOne 为其他域名分配的 CNAME，会导致服务异常，请修改为 EdgeOne 为该接入域名提供的指定 CNAME，您可通过本结构体的 Cname 字段获取 EdgeOne 为该接入域名提供的 CNAME。</li>
 	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
 }
 
@@ -1943,6 +1975,29 @@ type CodeAction struct {
 
 	// 操作参数。
 	Parameters []*RuleCodeActionParams `json:"Parameters,omitnil,omitempty" name:"Parameters"`
+}
+
+type ComponentReference struct {
+	// 引用的实例类型。取值有：
+	// <li>edge-function：边缘函数。</li>
+	ReferenceType *string `json:"ReferenceType,omitnil,omitempty" name:"ReferenceType"`
+
+	// 引用的实例 ID。根据 ReferenceType 的取值不同，返回对应的实例 ID：
+	// <li>当 ReferenceType 为 edge-function 时：返回边缘函数 ID，格式形如：ef-2vc5oe9mzqhm。</li>
+	ReferenceId *string `json:"ReferenceId,omitnil,omitempty" name:"ReferenceId"`
+
+	// 引用的实例名称。根据 ReferenceType 的取值不同，返回对应的实例名称：
+	// <li>当 ReferenceType 为 edge-function 时：返回边缘函数名称。</li>
+	ReferenceName *string `json:"ReferenceName,omitnil,omitempty" name:"ReferenceName"`
+
+	// 站点 ID。引用该命名空间的实例所属的站点标识。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 站点名称。引用该命名空间的实例所属的站点名称。
+	ZoneName *string `json:"ZoneName,omitnil,omitempty" name:"ZoneName"`
+
+	// 引用该命名空间的实例所属站点的别名。若未设置站点别名，则返回空字符串。
+	AliasZoneName *string `json:"AliasZoneName,omitnil,omitempty" name:"AliasZoneName"`
 }
 
 type Compression struct {
@@ -1979,9 +2034,7 @@ type ConfigGroupVersionInfo struct {
 	// 配置组 ID。
 	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
 
-	// 配置组类型。取值有：
-	// <li>l7_acceleration ：七层加速配置组。</li>
-	// <li>edge_functions ：边缘函数配置组。</li>
+	// 配置组类型，可选项如下：<li>l7_acceleration: 七层加速配置组；</li><li>edge_functions: 边缘函数配置组；</li><li>web_security: Web 防护配置组。</li>
 	GroupType *string `json:"GroupType,omitnil,omitempty" name:"GroupType"`
 
 	// 版本描述。
@@ -1998,7 +2051,7 @@ type ConfigGroupVersionInfo struct {
 }
 
 type ConfigGroupWorkModeInfo struct {
-	// 配置组类型，可选项如下：<li>l7_acceleration: 七层加速配置组；</li><li>edge_functions: 边缘函数配置组。</li>
+	// 配置组类型，可选项如下：<li>l7_acceleration: 七层加速配置组；</li><li>edge_functions: 边缘函数配置组。</li><li>web_security: Web 防护配置组。</li>
 	ConfigGroupType *string `json:"ConfigGroupType,omitnil,omitempty" name:"ConfigGroupType"`
 
 	// 工作模式，可选项如下：<li>immediate_effect: 即时生效模式；</li><li>version_control: 版本管理模式。</li>
@@ -2179,24 +2232,33 @@ type CreateAccelerationDomainRequestParams struct {
 	OriginInfo *OriginInfo `json:"OriginInfo,omitnil,omitempty" name:"OriginInfo"`
 
 	// 回源协议，取值有：
-	// <li>FOLLOW: 协议跟随；</li>
-	// <li>HTTP: HTTP协议回源；</li>
-	// <li>HTTPS: HTTPS协议回源。</li>
-	// <li>不填默认为： FOLLOW。</li>
+	// <li>FOLLOW：协议跟随；</li>
+	// <li>HTTP：HTTP 协议回源；</li>
+	// <li>HTTPS：HTTPS 协议回源。</li>不填默认为：FOLLOW。
 	OriginProtocol *string `json:"OriginProtocol,omitnil,omitempty" name:"OriginProtocol"`
 
-	// HTTP回源端口，取值为1-65535，当OriginProtocol=FOLLOW/HTTP时生效, 不填默认为80。
+	// HTTP 回源端口，默认值80，取值：1～65535。
+	// 当 OriginProtocol = FOLLOW 或 HTTP 时生效。
 	HttpOriginPort *uint64 `json:"HttpOriginPort,omitnil,omitempty" name:"HttpOriginPort"`
 
-	// HTTPS回源端口，取值为1-65535，当OriginProtocol=FOLLOW/HTTPS时生效，不填默认为443。
+	// HTTPS 回源端口，默认值443，取值：1～65535。
+	// 当 OriginProtocol = FOLLOW 或 HTTPS 时生效。
 	HttpsOriginPort *uint64 `json:"HttpsOriginPort,omitnil,omitempty" name:"HttpsOriginPort"`
 
-	// IPv6状态，取值有：
-	// <li>follow：遵循站点IPv6配置；</li>
+	// IPv6 状态，取值有：
+	// <li>follow：遵循站点 IPv6 配置；</li>
 	// <li>on：开启状态；</li>
-	// <li>off：关闭状态。</li>
-	// <li>不填默认为：follow。</li>
+	// <li>off：关闭状态。</li>不填默认为：follow。
 	IPv6Status *string `json:"IPv6Status,omitnil,omitempty" name:"IPv6Status"`
+
+	// 指定域名绑定的共享 CNAME 地址，不传时使用默认 CNAME。
+	// 绑定共享 CNAME 要求所有域名的调度策略保持一致，以下配置将影响调度策略，在不一致时绑定共享 CNAME 将按照以下方式处理：
+	// - IPv6 访问：不允许创建域名，请修改 IPv6Status 已保持与共享 CNAME 绑定的其余域名配置一致；
+	// - DDoS 防护：如果选择的共享 CNAME 已启用 DDoS 防护，则创建域名时，将默认为该域名启用 DDoS 防护。
+	// - 中国大陆网络优化（国际加速）：不允许创建域名，请保持当前域名的中国大陆网络优化（国际加速）配置与共享 CNAME 绑定的其余域名一致后重试。
+	// 
+	// 注：共享 CNAME 当前仍在内测中，如需使用，请联系我们开通。
+	SharedCNAME *string `json:"SharedCNAME,omitnil,omitempty" name:"SharedCNAME"`
 }
 
 type CreateAccelerationDomainRequest struct {
@@ -2212,24 +2274,33 @@ type CreateAccelerationDomainRequest struct {
 	OriginInfo *OriginInfo `json:"OriginInfo,omitnil,omitempty" name:"OriginInfo"`
 
 	// 回源协议，取值有：
-	// <li>FOLLOW: 协议跟随；</li>
-	// <li>HTTP: HTTP协议回源；</li>
-	// <li>HTTPS: HTTPS协议回源。</li>
-	// <li>不填默认为： FOLLOW。</li>
+	// <li>FOLLOW：协议跟随；</li>
+	// <li>HTTP：HTTP 协议回源；</li>
+	// <li>HTTPS：HTTPS 协议回源。</li>不填默认为：FOLLOW。
 	OriginProtocol *string `json:"OriginProtocol,omitnil,omitempty" name:"OriginProtocol"`
 
-	// HTTP回源端口，取值为1-65535，当OriginProtocol=FOLLOW/HTTP时生效, 不填默认为80。
+	// HTTP 回源端口，默认值80，取值：1～65535。
+	// 当 OriginProtocol = FOLLOW 或 HTTP 时生效。
 	HttpOriginPort *uint64 `json:"HttpOriginPort,omitnil,omitempty" name:"HttpOriginPort"`
 
-	// HTTPS回源端口，取值为1-65535，当OriginProtocol=FOLLOW/HTTPS时生效，不填默认为443。
+	// HTTPS 回源端口，默认值443，取值：1～65535。
+	// 当 OriginProtocol = FOLLOW 或 HTTPS 时生效。
 	HttpsOriginPort *uint64 `json:"HttpsOriginPort,omitnil,omitempty" name:"HttpsOriginPort"`
 
-	// IPv6状态，取值有：
-	// <li>follow：遵循站点IPv6配置；</li>
+	// IPv6 状态，取值有：
+	// <li>follow：遵循站点 IPv6 配置；</li>
 	// <li>on：开启状态；</li>
-	// <li>off：关闭状态。</li>
-	// <li>不填默认为：follow。</li>
+	// <li>off：关闭状态。</li>不填默认为：follow。
 	IPv6Status *string `json:"IPv6Status,omitnil,omitempty" name:"IPv6Status"`
+
+	// 指定域名绑定的共享 CNAME 地址，不传时使用默认 CNAME。
+	// 绑定共享 CNAME 要求所有域名的调度策略保持一致，以下配置将影响调度策略，在不一致时绑定共享 CNAME 将按照以下方式处理：
+	// - IPv6 访问：不允许创建域名，请修改 IPv6Status 已保持与共享 CNAME 绑定的其余域名配置一致；
+	// - DDoS 防护：如果选择的共享 CNAME 已启用 DDoS 防护，则创建域名时，将默认为该域名启用 DDoS 防护。
+	// - 中国大陆网络优化（国际加速）：不允许创建域名，请保持当前域名的中国大陆网络优化（国际加速）配置与共享 CNAME 绑定的其余域名一致后重试。
+	// 
+	// 注：共享 CNAME 当前仍在内测中，如需使用，请联系我们开通。
+	SharedCNAME *string `json:"SharedCNAME,omitnil,omitempty" name:"SharedCNAME"`
 }
 
 func (r *CreateAccelerationDomainRequest) ToJsonString() string {
@@ -2251,6 +2322,7 @@ func (r *CreateAccelerationDomainRequest) FromJsonString(s string) error {
 	delete(f, "HttpOriginPort")
 	delete(f, "HttpsOriginPort")
 	delete(f, "IPv6Status")
+	delete(f, "SharedCNAME")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateAccelerationDomainRequest has unknown keys!", "")
 	}
@@ -3078,6 +3150,74 @@ func (r *CreateDnsRecordResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateDnsRecordResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateEdgeKVNamespaceRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。输入内容有以下限制：支持输入 1-50 个字符，允许的字符为 a-z、A-Z、0-9、-，且 - 不能单独注册或连续使用，不能放在开头或结尾。在同站点下，名称需保证唯一。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 命名空间描述。用于说明命名空间的用途或业务含义。最大支持 256 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+}
+
+type CreateEdgeKVNamespaceRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。输入内容有以下限制：支持输入 1-50 个字符，允许的字符为 a-z、A-Z、0-9、-，且 - 不能单独注册或连续使用，不能放在开头或结尾。在同站点下，名称需保证唯一。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 命名空间描述。用于说明命名空间的用途或业务含义。最大支持 256 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+}
+
+func (r *CreateEdgeKVNamespaceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateEdgeKVNamespaceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Namespace")
+	delete(f, "Remark")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateEdgeKVNamespaceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateEdgeKVNamespaceResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateEdgeKVNamespaceResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateEdgeKVNamespaceResponseParams `json:"Response"`
+}
+
+func (r *CreateEdgeKVNamespaceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateEdgeKVNamespaceResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -4401,7 +4541,7 @@ type CreatePurgeTaskRequestParams struct {
 	// <li>purge_url：URL刷新；</li>
 	// <li>purge_prefix：目录刷新；</li>
 	// <li>purge_host：Hostname 刷新；</li>
-	// <li>purge_all：站点下全部缓存刷新；</li>
+	// <li>purge_all：站点下全部缓存刷新（取该值时不支持 ZoneId 入参为 *）；</li>
 	// <li>purge_cache_tag：cache-tag 刷新。</li>缓存清除类型详情请查看[清除缓存](https://cloud.tencent.com/document/product/1552/70759)。
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
@@ -4432,7 +4572,7 @@ type CreatePurgeTaskRequest struct {
 	// <li>purge_url：URL刷新；</li>
 	// <li>purge_prefix：目录刷新；</li>
 	// <li>purge_host：Hostname 刷新；</li>
-	// <li>purge_all：站点下全部缓存刷新；</li>
+	// <li>purge_all：站点下全部缓存刷新（取该值时不支持 ZoneId 入参为 *）；</li>
 	// <li>purge_cache_tag：cache-tag 刷新。</li>缓存清除类型详情请查看[清除缓存](https://cloud.tencent.com/document/product/1552/70759)。
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
@@ -5258,7 +5398,8 @@ type CreateZoneRequestParams struct {
 	// <li>partial：CNAME 接入；</li>
 	// <li>full：NS 接入；</li>
 	// <li>noDomainAccess：无域名接入；</li>
-	// <li>dnsPodAccess：DNSPod 托管接入，该接入模式要求您的域名已托管在 DNSPod 内。</li>
+	// <li>dnsPodAccess：DNSPod 托管接入，该接入模式要求您的域名已托管在 DNSPod 内；</li>
+	// <li>ai：边缘推理接入。</li>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
 	// 站点名称。CNAME/NS 接入的时，请传入二级域名（example.com）作为站点名称；无域名接入时，该值请保留为空。
@@ -5301,7 +5442,8 @@ type CreateZoneRequest struct {
 	// <li>partial：CNAME 接入；</li>
 	// <li>full：NS 接入；</li>
 	// <li>noDomainAccess：无域名接入；</li>
-	// <li>dnsPodAccess：DNSPod 托管接入，该接入模式要求您的域名已托管在 DNSPod 内。</li>
+	// <li>dnsPodAccess：DNSPod 托管接入，该接入模式要求您的域名已托管在 DNSPod 内；</li>
+	// <li>ai：边缘推理接入。</li>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
 	// 站点名称。CNAME/NS 接入的时，请传入二级域名（example.com）作为站点名称；无域名接入时，该值请保留为空。
@@ -5480,22 +5622,22 @@ type CustomRule struct {
 	// 自定义规则的名称。
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 自定义规则的具体内容，需符合表达式语法，详细规范参见产品文档。
+	// 自定义规则的具体内容，需符合表达式语法，详细规范参见 [产品文档](https://cloud.tencent.com/document/product/1552/125343) 。
 	Condition *string `json:"Condition,omitnil,omitempty" name:"Condition"`
 
-	// 自定义规则的执行动作。	SecurityAction 的 Name 取值支持：<li>Deny：拦截；</li><li>Monitor：观察；</li><li>ReturnCustomPage：使用指定页面拦截；</li><li>Redirect：重定向至 URL；</li><li>BlockIP：IP 封禁；</li><li>JSChallenge：JavaScript 挑战；</li><li>ManagedChallenge：托管挑战；</li><li>Allow：放行。</li>
+	// 自定义规则的处置动作。SecurityAction.Name 取值范围如下：<ul><li>Deny：拦截；</li><li>Monitor：观察；</li><li>ReturnCustomPage：使用指定页面拦截；</li><li>Redirect：重定向至 URL；</li><li>BlockIP：IP 封禁；</li><li>JSChallenge：JavaScript 挑战；</li><li>ManagedChallenge：托管挑战；</li><li>Allow：放行。</li></ul>
 	Action *SecurityAction `json:"Action,omitnil,omitempty" name:"Action"`
 
-	// 自定义规则是否开启。取值有：<li>on：开启</li><li>off：关闭</li>
+	// 自定义规则是否开启。取值有：<ul><li>on：开启</li><li>off：关闭</li></ul>
 	Enabled *string `json:"Enabled,omitnil,omitempty" name:"Enabled"`
 
-	// 自定义规则的 ID。<br>通过规则 ID 可支持不同的规则配置操作：<br> - 增加新规则：ID 为空或不指定 ID 参数；<br> - 修改已有规则：指定需要更新/修改的规则 ID；<br> - 删除已有规则：CustomRules 参数中，Rules 列表中未包含的已有规则将被删除。
+	// 自定义规则的 ID。通过规则 ID 可支持不同的规则配置操作：<ul><li>增加新规则：ID 为空或不指定 ID 参数；</li><li>修改已有规则：指定需要更新/修改的规则 ID；</li><li>删除已有规则：CustomRules 参数中，Rules 列表中未包含的已有规则将被删除。</li></ul>
 	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
 
-	// 自定义规则的类型。取值有：<li>BasicAccessRule：基础访问管控；</li><li>PreciseMatchRule：精准匹配规则，默认；</li><li>ManagedAccessRule：专家定制规则，仅出参。</li><br/>默认为PreciseMatchRule。
+	// 自定义规则的类型。取值有：<ul><li>BasicAccessRule：基础访问管控；</li><li>PreciseMatchRule：精准匹配规则；</li><li>ManagedAccessRule：专家定制规则，仅出参支持。</li></ul>说明：当未指定 RuleType 时，默认为 `PreciseMatchRule`。
 	RuleType *string `json:"RuleType,omitnil,omitempty" name:"RuleType"`
 
-	// 自定义规则的优先级，范围是 0 ~ 100，默认为 0，仅支持精准匹配规则（PreciseMatchRule）。
+	// 自定义规则的优先级，范围是 0 ~ 100，默认为 0，仅支持精准匹配规则（`PreciseMatchRule`）。
 	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
 }
 
@@ -5627,6 +5769,14 @@ type DNSPodDetail struct {
 	// <li> 0：非伪站点；</li>
 	// <li> 1：伪站点。</li>
 	IsFake *int64 `json:"IsFake,omitnil,omitempty" name:"IsFake"`
+}
+
+type DefaultDenySecurityActionParameters struct {
+	// 托管规则默认拦截处置动作配置。	DenyActionParameters 支持的配置参数：<li>ReturnCustomPage：是否使用自定义页面。</li><li>ResponseCode：自定义页面的状态码。</li><li>ErrorPageId：自定义页面的 PageId。</li>
+	ManagedRules *DenyActionParameters `json:"ManagedRules,omitnil,omitempty" name:"ManagedRules"`
+
+	// 除托管规则外的安全防护规则（自定义规则、速率限制 和 Bot 管理功能）默认拦截处置动作配置。	DenyActionParameters 支持的配置参数：<li>ReturnCustomPage：是否使用自定义页面。</li><li>ResponseCode：自定义页面的状态码。</li><li>ErrorPageId：自定义页面的 PageId。</li>
+	OtherModules *DenyActionParameters `json:"OtherModules,omitnil,omitempty" name:"OtherModules"`
 }
 
 type DefaultServerCertInfo struct {
@@ -6102,6 +6252,67 @@ func (r *DeleteDnsRecordsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteDnsRecordsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteEdgeKVNamespaceRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 要删除的命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+}
+
+type DeleteEdgeKVNamespaceRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 要删除的命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+}
+
+func (r *DeleteEdgeKVNamespaceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteEdgeKVNamespaceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Namespace")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteEdgeKVNamespaceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteEdgeKVNamespaceResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteEdgeKVNamespaceResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteEdgeKVNamespaceResponseParams `json:"Response"`
+}
+
+func (r *DeleteEdgeKVNamespaceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteEdgeKVNamespaceResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -9055,6 +9266,117 @@ func (r *DescribeDnsRecordsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeEdgeKVNamespacesRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 分页查询偏移量。默认值：0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 分页查询限制数目。默认值：20，最大值：1000。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 排序依据，取值有：
+	// <li>created-on：创建时间；</li>
+	// <li>updated-on：更新时间。</li>
+	// 默认值为 created-on。
+	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
+
+	// 列表排序方式，取值有：
+	// <li>asc：升序排列；</li>
+	// <li>desc：降序排列。</li>
+	// 默认值为 desc。
+	SortOrder *string `json:"SortOrder,omitnil,omitempty" name:"SortOrder"`
+
+	// 过滤条件，Filters.Values 的上限为 20。该参数不填写时，返回站点 ID 下全部 KV 命名空间。详细的过滤条件如下：
+	// <li>namespace：按照 KV 命名空间名称进行过滤，支持模糊查询；</li>
+	// <li>remark：按照命名空间描述进行过滤，支持模糊查询。</li>
+	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+type DescribeEdgeKVNamespacesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 分页查询偏移量。默认值：0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 分页查询限制数目。默认值：20，最大值：1000。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 排序依据，取值有：
+	// <li>created-on：创建时间；</li>
+	// <li>updated-on：更新时间。</li>
+	// 默认值为 created-on。
+	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
+
+	// 列表排序方式，取值有：
+	// <li>asc：升序排列；</li>
+	// <li>desc：降序排列。</li>
+	// 默认值为 desc。
+	SortOrder *string `json:"SortOrder,omitnil,omitempty" name:"SortOrder"`
+
+	// 过滤条件，Filters.Values 的上限为 20。该参数不填写时，返回站点 ID 下全部 KV 命名空间。详细的过滤条件如下：
+	// <li>namespace：按照 KV 命名空间名称进行过滤，支持模糊查询；</li>
+	// <li>remark：按照命名空间描述进行过滤，支持模糊查询。</li>
+	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+func (r *DescribeEdgeKVNamespacesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeEdgeKVNamespacesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	delete(f, "SortBy")
+	delete(f, "SortOrder")
+	delete(f, "Filters")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeEdgeKVNamespacesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeEdgeKVNamespacesResponseParams struct {
+	// 符合条件的命名空间总数。
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// KV 命名空间信息列表。若无符合条件的命名空间，则返回空数组。
+	KVNamespaces []*KVNamespace `json:"KVNamespaces,omitnil,omitempty" name:"KVNamespaces"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeEdgeKVNamespacesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeEdgeKVNamespacesResponseParams `json:"Response"`
+}
+
+func (r *DescribeEdgeKVNamespacesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeEdgeKVNamespacesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeEnvironmentsRequestParams struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
@@ -9111,6 +9433,98 @@ func (r *DescribeEnvironmentsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeEnvironmentsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeFunctionComponentBindingsRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 分页查询偏移量。默认值：0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 分页查询限制数目。默认值：20，最大值：1000。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 过滤条件，Filters.Values 的上限为 20。详细的过滤条件如下：
+	// <li>name：按照绑定的变量名进行过滤，支持模糊查询；</li>
+	// <li>type：按照绑定类型进行过滤，不支持模糊查询。</li>
+	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+type DescribeFunctionComponentBindingsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 分页查询偏移量。默认值：0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 分页查询限制数目。默认值：20，最大值：1000。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 过滤条件，Filters.Values 的上限为 20。详细的过滤条件如下：
+	// <li>name：按照绑定的变量名进行过滤，支持模糊查询；</li>
+	// <li>type：按照绑定类型进行过滤，不支持模糊查询。</li>
+	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+func (r *DescribeFunctionComponentBindingsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeFunctionComponentBindingsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "FunctionId")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	delete(f, "Filters")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeFunctionComponentBindingsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeFunctionComponentBindingsResponseParams struct {
+	// 符合条件的函数绑定总数。
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 函数组件绑定列表。
+	FunctionComponentBindings []*FunctionComponentBinding `json:"FunctionComponentBindings,omitnil,omitempty" name:"FunctionComponentBindings"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeFunctionComponentBindingsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeFunctionComponentBindingsResponseParams `json:"Response"`
+}
+
+func (r *DescribeFunctionComponentBindingsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeFunctionComponentBindingsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -12166,6 +12580,126 @@ func (r *DescribeSecurityTemplateBindingsResponse) FromJsonString(s string) erro
 }
 
 // Predefined struct for user
+type DescribeSharedCNAMERequestParams struct {
+	// 共享CNAME所属站点ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 过滤条件，Filters.Values的上限为20。详细的过滤条件如下：
+	// <li>shared-cname<br>   按照【<strong>共享CNAME</strong>】进行过滤。<br>   类型：String<br>   必选：否</li>
+	// <li>type<br>   按照【<strong>共享canme类型</strong>】进行过滤。<br>   类型：String<br>   必选：否</li>
+	// <li>description<br>   按照【<strong>描述</strong>】进行过滤。<br>   类型：String<br>   必选：否</li>
+	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 列表排序方式，取值有：
+	// <li>asc：升序排列；</li>
+	// <li>desc：降序排列。</li>默认值为asc。
+	Direction *string `json:"Direction,omitnil,omitempty" name:"Direction"`
+
+	// 匹配方式，取值有：
+	// <li>all：返回匹配所有查询条件的共享CNAME；</li>
+	// <li>any：返回匹配任意一个查询条件的共享CNAME。</li>默认值为all。
+	Match *string `json:"Match,omitnil,omitempty" name:"Match"`
+
+	// 排序依据，取值有：
+	// <li>create-time：创建时间；</li>
+	// <li>shared-cname：共享CNAME；</li>默认根据shared-cname属性排序。
+	Order *string `json:"Order,omitnil,omitempty" name:"Order"`
+
+	// 分页查询偏移量，默认为 0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 分页查询限制数目，默认值：20，上限：200。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeSharedCNAMERequest struct {
+	*tchttp.BaseRequest
+	
+	// 共享CNAME所属站点ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 过滤条件，Filters.Values的上限为20。详细的过滤条件如下：
+	// <li>shared-cname<br>   按照【<strong>共享CNAME</strong>】进行过滤。<br>   类型：String<br>   必选：否</li>
+	// <li>type<br>   按照【<strong>共享canme类型</strong>】进行过滤。<br>   类型：String<br>   必选：否</li>
+	// <li>description<br>   按照【<strong>描述</strong>】进行过滤。<br>   类型：String<br>   必选：否</li>
+	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 列表排序方式，取值有：
+	// <li>asc：升序排列；</li>
+	// <li>desc：降序排列。</li>默认值为asc。
+	Direction *string `json:"Direction,omitnil,omitempty" name:"Direction"`
+
+	// 匹配方式，取值有：
+	// <li>all：返回匹配所有查询条件的共享CNAME；</li>
+	// <li>any：返回匹配任意一个查询条件的共享CNAME。</li>默认值为all。
+	Match *string `json:"Match,omitnil,omitempty" name:"Match"`
+
+	// 排序依据，取值有：
+	// <li>create-time：创建时间；</li>
+	// <li>shared-cname：共享CNAME；</li>默认根据shared-cname属性排序。
+	Order *string `json:"Order,omitnil,omitempty" name:"Order"`
+
+	// 分页查询偏移量，默认为 0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 分页查询限制数目，默认值：20，上限：200。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *DescribeSharedCNAMERequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeSharedCNAMERequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Filters")
+	delete(f, "Direction")
+	delete(f, "Match")
+	delete(f, "Order")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeSharedCNAMERequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeSharedCNAMEResponseParams struct {
+	// 符合过滤条件的共享CNAME总数。
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 共享CNAME列表明细。
+	SharedCNAMEInfo []*SharedCNAMEInfo `json:"SharedCNAMEInfo,omitnil,omitempty" name:"SharedCNAMEInfo"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeSharedCNAMEResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeSharedCNAMEResponseParams `json:"Response"`
+}
+
+func (r *DescribeSharedCNAMEResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeSharedCNAMEResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeTimingL4DataRequestParams struct {
 	// 开始时间。
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
@@ -12174,12 +12708,14 @@ type DescribeTimingL4DataRequestParams struct {
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
 	// 查询指标，取值有：
-	// <li>l4Flow_connections: 访问并发连接数；</li>
-	// <li>l4Flow_flux: 访问总流量；</li>
-	// <li>l4Flow_inFlux: 访问入流量；</li>
-	// <li>l4Flow_outFlux: 访问出流量；</li>
-	// <li>l4Flow_inBandwidth: 访问入向带宽峰值；</li>
-	// <li>l4Flow_outBandwidth: 访问出向带宽峰值。</li>
+	// <ul><li>**l4Flow_flux**: 访问总流量，单位：Byte，指标值类型：Integer；</li>
+	// <li>**l4Flow_inFlux**: 访问入流量，单位：Byte，指标值类型：Integer；</li>
+	// <li>**l4Flow_outFlux**: 访问出流量，单位：Byte，指标值类型：Integer；</li>
+	// <li>**l4Flow_inBandwidth**: 访问入向带宽峰值，单位：bps，指标值类型：Integer；</li>
+	// <li>**l4Flow_outBandwidth**: 访问出向带宽峰值，单位：bps，指标值类型：Integer；</li>
+	// <li>**l4Flow_connections**: 访问并发连接数，单位：个，指标值类型：Integer ；</li>
+	// <li>**l4Flow_newConnectionsRate**: 新建连接数速率，单位：个/秒，指标值类型： Float，保留两位小数。</li></ul>**注意**：<ul><li><code> Integer</code> 值类型的指标将从  <code>Data.N.TypeValue</code> 返回对应时序数据；</li>
+	// <li><code>Float</code> 值类型的指标将从 <code>Data.N.FloatTypeValue</code> 返回对应时序数据。</li></ul>
 	MetricNames []*string `json:"MetricNames,omitnil,omitempty" name:"MetricNames"`
 
 	// 站点ID，此参数将于2024年05月30日后由可选改为必填，详见公告：[【腾讯云 EdgeOne】云 API 变更通知](https://cloud.tencent.com/document/product/1552/104902)。
@@ -12190,18 +12726,20 @@ type DescribeTimingL4DataRequestParams struct {
 	ProxyIds []*string `json:"ProxyIds,omitnil,omitempty" name:"ProxyIds"`
 
 	// 查询时间粒度，取值有：
-	// <li>min: 1分钟 ；</li>
-	// <li>5min: 5分钟 ；</li>
-	// <li>hour: 1小时 ；</li>
-	// <li>day: 1天 。</li>不填将根据开始时间跟结束时间的间距自动推算粒度，具体为：1小时范围内以min粒度查询，2天范围内以5min粒度查询，7天范围内以hour粒度查询，超过7天以day粒度查询。
+	// <ul><li>**min**: 1分钟 ；</li>
+	// <li>**5min**: 5分钟 ；</li>
+	// <li>**hour**: 1小时 ；</li>
+	// <li>**day**: 1天 。</li></ul>不填将根据开始时间跟结束时间的间距自动推算粒度，具体为：1小时范围内以 <code>min</code> 粒度查询，2天范围内以 <code>5min</code> 粒度查询，7天范围内以 <code>hour</code> 粒度查询，超过7天以 <code>day</code> 粒度查询。
 	Interval *string `json:"Interval,omitnil,omitempty" name:"Interval"`
 
 	// 过滤条件，详细的过滤条件Key值如下：
-	// <li>ruleId：按照转发规则 ID 进行过滤。</li>
-	// <li>proxyId：按照四层代理实例 ID 进行过滤。</li>
+	// <ul><li>**ruleId**：按照转发规则 ID 进行过滤。</li>
+	// <li>**proxyId**：按照四层代理实例 ID 进行过滤。</li></ul>
 	Filters []*QueryCondition `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 数据归属地区。该参数已废弃。请在 Filters.country 中按客户端地域过滤数据。
+	//
+	// Deprecated: Area is deprecated.
 	Area *string `json:"Area,omitnil,omitempty" name:"Area"`
 }
 
@@ -12215,12 +12753,14 @@ type DescribeTimingL4DataRequest struct {
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
 	// 查询指标，取值有：
-	// <li>l4Flow_connections: 访问并发连接数；</li>
-	// <li>l4Flow_flux: 访问总流量；</li>
-	// <li>l4Flow_inFlux: 访问入流量；</li>
-	// <li>l4Flow_outFlux: 访问出流量；</li>
-	// <li>l4Flow_inBandwidth: 访问入向带宽峰值；</li>
-	// <li>l4Flow_outBandwidth: 访问出向带宽峰值。</li>
+	// <ul><li>**l4Flow_flux**: 访问总流量，单位：Byte，指标值类型：Integer；</li>
+	// <li>**l4Flow_inFlux**: 访问入流量，单位：Byte，指标值类型：Integer；</li>
+	// <li>**l4Flow_outFlux**: 访问出流量，单位：Byte，指标值类型：Integer；</li>
+	// <li>**l4Flow_inBandwidth**: 访问入向带宽峰值，单位：bps，指标值类型：Integer；</li>
+	// <li>**l4Flow_outBandwidth**: 访问出向带宽峰值，单位：bps，指标值类型：Integer；</li>
+	// <li>**l4Flow_connections**: 访问并发连接数，单位：个，指标值类型：Integer ；</li>
+	// <li>**l4Flow_newConnectionsRate**: 新建连接数速率，单位：个/秒，指标值类型： Float，保留两位小数。</li></ul>**注意**：<ul><li><code> Integer</code> 值类型的指标将从  <code>Data.N.TypeValue</code> 返回对应时序数据；</li>
+	// <li><code>Float</code> 值类型的指标将从 <code>Data.N.FloatTypeValue</code> 返回对应时序数据。</li></ul>
 	MetricNames []*string `json:"MetricNames,omitnil,omitempty" name:"MetricNames"`
 
 	// 站点ID，此参数将于2024年05月30日后由可选改为必填，详见公告：[【腾讯云 EdgeOne】云 API 变更通知](https://cloud.tencent.com/document/product/1552/104902)。
@@ -12231,15 +12771,15 @@ type DescribeTimingL4DataRequest struct {
 	ProxyIds []*string `json:"ProxyIds,omitnil,omitempty" name:"ProxyIds"`
 
 	// 查询时间粒度，取值有：
-	// <li>min: 1分钟 ；</li>
-	// <li>5min: 5分钟 ；</li>
-	// <li>hour: 1小时 ；</li>
-	// <li>day: 1天 。</li>不填将根据开始时间跟结束时间的间距自动推算粒度，具体为：1小时范围内以min粒度查询，2天范围内以5min粒度查询，7天范围内以hour粒度查询，超过7天以day粒度查询。
+	// <ul><li>**min**: 1分钟 ；</li>
+	// <li>**5min**: 5分钟 ；</li>
+	// <li>**hour**: 1小时 ；</li>
+	// <li>**day**: 1天 。</li></ul>不填将根据开始时间跟结束时间的间距自动推算粒度，具体为：1小时范围内以 <code>min</code> 粒度查询，2天范围内以 <code>5min</code> 粒度查询，7天范围内以 <code>hour</code> 粒度查询，超过7天以 <code>day</code> 粒度查询。
 	Interval *string `json:"Interval,omitnil,omitempty" name:"Interval"`
 
 	// 过滤条件，详细的过滤条件Key值如下：
-	// <li>ruleId：按照转发规则 ID 进行过滤。</li>
-	// <li>proxyId：按照四层代理实例 ID 进行过滤。</li>
+	// <ul><li>**ruleId**：按照转发规则 ID 进行过滤。</li>
+	// <li>**proxyId**：按照四层代理实例 ID 进行过滤。</li></ul>
 	Filters []*QueryCondition `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 数据归属地区。该参数已废弃。请在 Filters.country 中按客户端地域过滤数据。
@@ -12277,7 +12817,8 @@ type DescribeTimingL4DataResponseParams struct {
 	// 查询结果的总条数。
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 四层时序流量数据列表。
+	// <p>四层时序流量数据列表。<br>对于不同的查询指标，根据指标值类型的不同，会从不同的参数返回时序数据。<br>目前存在的值类型有以下两种：</p><ul><li><strong>Integer</strong>：<code>Integer</code> 值类型的指标将从 <code>Data.N.TypeValue</code> 返回对应时序数据。<br>对应的查询指标 <code>MetricName</code> 有：<ul><li><code>l4Flow_flux</code>：访问总流量；</li><li><code>l4Flow_inFlux</code>：访问入流量；</li><li><code>l4Flow_outFlux</code>：访问出流量；</li><li><code>l4Flow_inBandwidth</code>：访问入向带宽峰值；</li><li><code>l4Flow_outBandwidth</code>：访问出向带宽峰值；</li><li><code>l4Flow_connections</code>：访问并发连接数。</li></ul></li><li><strong>Float</strong>：<code>Float</code> 值类型的指标将从 <code>Data.N.FloatTypeValue</code> 返回对应时序数据。<br>对应的查询指标 <code>MetricName</code> 有：<ul><li><code>l4Flow_newConnectionsRate</code>：新建连接数速率。</li></ul></li>
+	// </ul><p>本接口暂不支持指定维度查询，默认按主账号汇总返回数据，即 <code>Data.N.TypeKey = AppId</code>，AppId 是腾讯云主账号唯一标识，N 恒等于 1。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Data []*TimingDataRecord `json:"Data,omitnil,omitempty" name:"Data"`
 
@@ -13261,7 +13802,7 @@ type DescribeZonesRequestParams struct {
 	// 分页查询限制数目。默认值：20，最大值：100。
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 过滤条件，Filters.Values 的上限为 20。该参数不填写时，返回当前 appid 下有权限的所有站点信息。详细的过滤条件如下：<li>zone-name：按照站点名称进行过滤；</li><li>zone-type：按照站点类型进行过滤。可选项：<br>   full：NS 接入类型；<br>   partial：CNAME 接入类型；<br>   partialComposite：无域名接入类型；<br>   dnsPodAccess：DNSPod 托管接入类型；<br>   pages：Pages 接入类型。 </li><li>zone-id：按照站点 ID 进行过滤，站点 ID 形如：zone-2noz78a8ev6k；</li><li>status：按照站点状态进行过滤。可选项：<br>   active：NS 已切换；<br>   pending：NS 待切换；<br>   deleted：已删除。</li><li>tag-key：按照标签键进行过滤；</li><li>tag-value： 按照标签值进行过滤；</li><li>alias-zone-name： 按照同名站点标识进行过滤。</li>模糊查询时支持过滤字段名为 zone-name 或 alias-zone-name。
+	// 过滤条件，Filters.Values 的上限为 20。该参数不填写时，返回当前 appid 下有权限的所有站点信息。详细的过滤条件如下：<li>zone-name：按照站点名称进行过滤；</li><li>zone-type：按照站点类型进行过滤。可选项：<br>   full：NS 接入类型；<br>   partial：CNAME 接入类型；<br>   partialComposite：无域名接入类型；<br>   dnsPodAccess：DNSPod 托管接入类型；<br>   pages：Pages 接入类型；<br>   ai：边缘推理接入类型。</li><li>zone-id：按照站点 ID 进行过滤，站点 ID 形如：zone-2noz78a8ev6k；</li><li>status：按照站点状态进行过滤。可选项：<br>   active：NS 已切换；<br>   pending：NS 待切换；<br>   deleted：已删除。</li><li>tag-key：按照标签键进行过滤；</li><li>tag-value： 按照标签值进行过滤；</li><li>alias-zone-name： 按照同名站点标识进行过滤。</li>模糊查询时支持过滤字段名为 zone-name 或 alias-zone-name。
 	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 可根据该字段对返回结果进行排序，取值有：
@@ -13288,7 +13829,7 @@ type DescribeZonesRequest struct {
 	// 分页查询限制数目。默认值：20，最大值：100。
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 过滤条件，Filters.Values 的上限为 20。该参数不填写时，返回当前 appid 下有权限的所有站点信息。详细的过滤条件如下：<li>zone-name：按照站点名称进行过滤；</li><li>zone-type：按照站点类型进行过滤。可选项：<br>   full：NS 接入类型；<br>   partial：CNAME 接入类型；<br>   partialComposite：无域名接入类型；<br>   dnsPodAccess：DNSPod 托管接入类型；<br>   pages：Pages 接入类型。 </li><li>zone-id：按照站点 ID 进行过滤，站点 ID 形如：zone-2noz78a8ev6k；</li><li>status：按照站点状态进行过滤。可选项：<br>   active：NS 已切换；<br>   pending：NS 待切换；<br>   deleted：已删除。</li><li>tag-key：按照标签键进行过滤；</li><li>tag-value： 按照标签值进行过滤；</li><li>alias-zone-name： 按照同名站点标识进行过滤。</li>模糊查询时支持过滤字段名为 zone-name 或 alias-zone-name。
+	// 过滤条件，Filters.Values 的上限为 20。该参数不填写时，返回当前 appid 下有权限的所有站点信息。详细的过滤条件如下：<li>zone-name：按照站点名称进行过滤；</li><li>zone-type：按照站点类型进行过滤。可选项：<br>   full：NS 接入类型；<br>   partial：CNAME 接入类型；<br>   partialComposite：无域名接入类型；<br>   dnsPodAccess：DNSPod 托管接入类型；<br>   pages：Pages 接入类型；<br>   ai：边缘推理接入类型。</li><li>zone-id：按照站点 ID 进行过滤，站点 ID 形如：zone-2noz78a8ev6k；</li><li>status：按照站点状态进行过滤。可选项：<br>   active：NS 已切换；<br>   pending：NS 待切换；<br>   deleted：已删除。</li><li>tag-key：按照标签键进行过滤；</li><li>tag-value： 按照标签值进行过滤；</li><li>alias-zone-name： 按照同名站点标识进行过滤。</li>模糊查询时支持过滤字段名为 zone-name 或 alias-zone-name。
 	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 可根据该字段对返回结果进行排序，取值有：
@@ -13539,7 +14080,7 @@ type DetectLengthLimitRule struct {
 }
 
 type DeviceProfile struct {
-	// 客户端设备类型。取值有：<li>iOS；</li><li>Android；</li><li>WebView。</li>
+	// 客户端设备类型。取值有：<li>iOS；</li><li>Android；</li><li>WebView；</li><li>WeChatMiniProgram。</li>
 	ClientType *string `json:"ClientType,omitnil,omitempty" name:"ClientType"`
 
 	// 判定请求为高风险的最低值，取值范围为 1～99。数值越大请求风险越高越接近 Bot 客户端发起的请求。默认值为 50，对应含义 51～100 为高风险。
@@ -13913,25 +14454,351 @@ type DropPageDetail struct {
 }
 
 // Predefined struct for user
+type EdgeKVDeleteRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 键名列表。数组长度上限为 20。每个键名不能为空，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线。删除单个键时传入包含一个元素的数组。
+	Keys []*string `json:"Keys,omitnil,omitempty" name:"Keys"`
+}
+
+type EdgeKVDeleteRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 键名列表。数组长度上限为 20。每个键名不能为空，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线。删除单个键时传入包含一个元素的数组。
+	Keys []*string `json:"Keys,omitnil,omitempty" name:"Keys"`
+}
+
+func (r *EdgeKVDeleteRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *EdgeKVDeleteRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Namespace")
+	delete(f, "Keys")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "EdgeKVDeleteRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type EdgeKVDeleteResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type EdgeKVDeleteResponse struct {
+	*tchttp.BaseResponse
+	Response *EdgeKVDeleteResponseParams `json:"Response"`
+}
+
+func (r *EdgeKVDeleteResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *EdgeKVDeleteResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type EdgeKVGetRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。可通过 DescribeEdgeKVNamespaces 接口获取站点下的命名空间列表。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 键名列表。数组长度上限为 20。每个键名不能为空，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线。查询单个键时传入包含一个元素的数组。
+	Keys []*string `json:"Keys,omitnil,omitempty" name:"Keys"`
+}
+
+type EdgeKVGetRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。可通过 DescribeEdgeKVNamespaces 接口获取站点下的命名空间列表。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 键名列表。数组长度上限为 20。每个键名不能为空，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线。查询单个键时传入包含一个元素的数组。
+	Keys []*string `json:"Keys,omitnil,omitempty" name:"Keys"`
+}
+
+func (r *EdgeKVGetRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *EdgeKVGetRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Namespace")
+	delete(f, "Keys")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "EdgeKVGetRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type EdgeKVGetResponseParams struct {
+	// 键值对数据列表。按入参 Keys 的顺序依次返回结果，若某键不存在，则对应项的 Value 字段返回空字符串。
+	Data []*KeyValuePair `json:"Data,omitnil,omitempty" name:"Data"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type EdgeKVGetResponse struct {
+	*tchttp.BaseResponse
+	Response *EdgeKVGetResponseParams `json:"Response"`
+}
+
+func (r *EdgeKVGetResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *EdgeKVGetResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type EdgeKVListRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 键名前缀过滤。只返回以指定前缀开头的键名，长度为 1-512 个字符。不填写表示返回所有键名；不允许传入空字符串。
+	Prefix *string `json:"Prefix,omitnil,omitempty" name:"Prefix"`
+
+	// 游标位置。标识当前查询的起始位置，用于遍历大量数据。首次查询时不填写，从头开始遍历；后续查询时填写上一次返回的 Cursor 值，从该位置继续向后遍历。
+	Cursor *string `json:"Cursor,omitnil,omitempty" name:"Cursor"`
+
+	// 返回的键名数量。默认值：20，最大值：1000。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type EdgeKVListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 键名前缀过滤。只返回以指定前缀开头的键名，长度为 1-512 个字符。不填写表示返回所有键名；不允许传入空字符串。
+	Prefix *string `json:"Prefix,omitnil,omitempty" name:"Prefix"`
+
+	// 游标位置。标识当前查询的起始位置，用于遍历大量数据。首次查询时不填写，从头开始遍历；后续查询时填写上一次返回的 Cursor 值，从该位置继续向后遍历。
+	Cursor *string `json:"Cursor,omitnil,omitempty" name:"Cursor"`
+
+	// 返回的键名数量。默认值：20，最大值：1000。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *EdgeKVListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *EdgeKVListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Namespace")
+	delete(f, "Prefix")
+	delete(f, "Cursor")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "EdgeKVListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type EdgeKVListResponseParams struct {
+	// 键名列表。
+	Keys []*string `json:"Keys,omitnil,omitempty" name:"Keys"`
+
+	// 游标位置。标识当前遍历的位置，用于获取下一批数据。将此值填入下次请求的 Cursor 参数中，可继续向后遍历。若为空字符串，表示已遍历完所有数据。
+	Cursor *string `json:"Cursor,omitnil,omitempty" name:"Cursor"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type EdgeKVListResponse struct {
+	*tchttp.BaseResponse
+	Response *EdgeKVListResponseParams `json:"Response"`
+}
+
+func (r *EdgeKVListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *EdgeKVListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type EdgeKVPutRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 键名，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线。
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// 键值。不能为空，最大支持 1 MB。支持存储字符串数据。
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+
+	// 过期时间，绝对时间。表示从 1970 年 1 月 1 日（UTC/GMT 的午夜）开始所经过的秒数，不能小于当前时间。若 Expiration 和 ExpirationTTL 都填写，以 ExpirationTTL 为准。若 Expiration 和 ExpirationTTL 都不填写，则该键值对永不过期。
+	Expiration *int64 `json:"Expiration,omitnil,omitempty" name:"Expiration"`
+
+	// 过期时间，相对时间，单位为秒。表示数据将在指定秒数后过期，必须大于 0。若 Expiration 和 ExpirationTTL 都填写，以 ExpirationTTL 为准。若 Expiration 和 ExpirationTTL 都不填写，则该键值对永不过期。
+	ExpirationTTL *int64 `json:"ExpirationTTL,omitnil,omitempty" name:"ExpirationTTL"`
+}
+
+type EdgeKVPutRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 键名，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线。
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// 键值。不能为空，最大支持 1 MB。支持存储字符串数据。
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+
+	// 过期时间，绝对时间。表示从 1970 年 1 月 1 日（UTC/GMT 的午夜）开始所经过的秒数，不能小于当前时间。若 Expiration 和 ExpirationTTL 都填写，以 ExpirationTTL 为准。若 Expiration 和 ExpirationTTL 都不填写，则该键值对永不过期。
+	Expiration *int64 `json:"Expiration,omitnil,omitempty" name:"Expiration"`
+
+	// 过期时间，相对时间，单位为秒。表示数据将在指定秒数后过期，必须大于 0。若 Expiration 和 ExpirationTTL 都填写，以 ExpirationTTL 为准。若 Expiration 和 ExpirationTTL 都不填写，则该键值对永不过期。
+	ExpirationTTL *int64 `json:"ExpirationTTL,omitnil,omitempty" name:"ExpirationTTL"`
+}
+
+func (r *EdgeKVPutRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *EdgeKVPutRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Namespace")
+	delete(f, "Key")
+	delete(f, "Value")
+	delete(f, "Expiration")
+	delete(f, "ExpirationTTL")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "EdgeKVPutRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type EdgeKVPutResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type EdgeKVPutResponse struct {
+	*tchttp.BaseResponse
+	Response *EdgeKVPutResponseParams `json:"Response"`
+}
+
+func (r *EdgeKVPutResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *EdgeKVPutResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type EnableOriginACLRequestParams struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 七层加速域名开启源站防护的模式。
-	// <li>all：针对站点下的所有七层加速域名开启。</li>
-	// <li>specific：针对站点下指定的七层加速域名开启。</li>当参数为空时，默认为 specific。
+	// 站点首次开启源站防护时，为七层加速域名配置特定回源 IP 网段的模式。
+	// <li>all：针对当前站点下的所有七层加速域名开启，当域名数量超过 200 时，请先通过 specific 模式启用 200 个域名，剩余资源通过 ModifyOriginACL 接口启用。</li>
+	// <li>specific：针对站点下指定的七层加速域名开启。</li>注意：当参数为空时，默认为 specific。后续新增七层加速域名/四层代理实例均请通过 ModifyOriginACL 接口配置。
 	L7EnableMode *string `json:"L7EnableMode,omitnil,omitempty" name:"L7EnableMode"`
 
 	// 开启源站防护的七层加速域名列表，仅当参数 L7EnableMode 为 specific 时生效。L7EnableMode 为 all 时，请保留此参数为空。单次最大仅支持填写 200 个七层加速域名。
 	L7Hosts []*string `json:"L7Hosts,omitnil,omitempty" name:"L7Hosts"`
 
-	// 四层代理实例开启源站防护的模式。
-	// <li>all：针对站点下的所有四层代理实例开启。</li>
-	// <li>specific：针对站点下指定的四层代理实例开启。</li>当参数为空时，默认为 specific。
+	// 站点首次开启源站防护时，为四层代理实例配置特定回源 IP 网段的模式。
+	// <li>all：针对当前站点下的所有四层代理实例开启，当实例数量超过 100 时，请先通过 specific 模式启用 100 个域名，剩余资源通过 ModifyOriginACL 接口启用。</li>
+	// <li>specific：针对站点下指定的四层代理实例开启。</li>注意：当参数为空时，默认为 specific。后续新增七层加速域名/四层代理实例均请通过 ModifyOriginACL 接口配置。
 	L4EnableMode *string `json:"L4EnableMode,omitnil,omitempty" name:"L4EnableMode"`
 
 	// 开启源站防护的四层代理实例列表，仅当参数 L4EnableMode 为 specific 时生效。L4EnableMode 为 all 时，请保留此参数为空。单次最大仅支持填写 100 个四层代理实例。
 	L4ProxyIds []*string `json:"L4ProxyIds,omitnil,omitempty" name:"L4ProxyIds"`
+
+	// 源站防护回源ACL控制域，不填则默认用标准全球控制域；可用控制域信息可以通过DescribeAvailableOriginACLFamily接口查询获得。
+	// 具体取值说明如下：
+	// <li>gaz：标准全球可用区控制域；</li>
+	// <li>mlc：标准中国大陆可用区控制域；</li>
+	// <li>emc：标准全球(不含中国大陆)可用区控制域；</li>
+	// <li>plat-gaz：精简全球可用区控制域；</li>
+	// <li>plat-mlc：精简中国大陆可用区控制域；</li>
+	// <li>plat-emc：精简全球(不含中国大陆)可用区控制域；</li>
+	OriginACLFamily *string `json:"OriginACLFamily,omitnil,omitempty" name:"OriginACLFamily"`
 }
 
 type EnableOriginACLRequest struct {
@@ -13940,21 +14807,31 @@ type EnableOriginACLRequest struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 七层加速域名开启源站防护的模式。
-	// <li>all：针对站点下的所有七层加速域名开启。</li>
-	// <li>specific：针对站点下指定的七层加速域名开启。</li>当参数为空时，默认为 specific。
+	// 站点首次开启源站防护时，为七层加速域名配置特定回源 IP 网段的模式。
+	// <li>all：针对当前站点下的所有七层加速域名开启，当域名数量超过 200 时，请先通过 specific 模式启用 200 个域名，剩余资源通过 ModifyOriginACL 接口启用。</li>
+	// <li>specific：针对站点下指定的七层加速域名开启。</li>注意：当参数为空时，默认为 specific。后续新增七层加速域名/四层代理实例均请通过 ModifyOriginACL 接口配置。
 	L7EnableMode *string `json:"L7EnableMode,omitnil,omitempty" name:"L7EnableMode"`
 
 	// 开启源站防护的七层加速域名列表，仅当参数 L7EnableMode 为 specific 时生效。L7EnableMode 为 all 时，请保留此参数为空。单次最大仅支持填写 200 个七层加速域名。
 	L7Hosts []*string `json:"L7Hosts,omitnil,omitempty" name:"L7Hosts"`
 
-	// 四层代理实例开启源站防护的模式。
-	// <li>all：针对站点下的所有四层代理实例开启。</li>
-	// <li>specific：针对站点下指定的四层代理实例开启。</li>当参数为空时，默认为 specific。
+	// 站点首次开启源站防护时，为四层代理实例配置特定回源 IP 网段的模式。
+	// <li>all：针对当前站点下的所有四层代理实例开启，当实例数量超过 100 时，请先通过 specific 模式启用 100 个域名，剩余资源通过 ModifyOriginACL 接口启用。</li>
+	// <li>specific：针对站点下指定的四层代理实例开启。</li>注意：当参数为空时，默认为 specific。后续新增七层加速域名/四层代理实例均请通过 ModifyOriginACL 接口配置。
 	L4EnableMode *string `json:"L4EnableMode,omitnil,omitempty" name:"L4EnableMode"`
 
 	// 开启源站防护的四层代理实例列表，仅当参数 L4EnableMode 为 specific 时生效。L4EnableMode 为 all 时，请保留此参数为空。单次最大仅支持填写 100 个四层代理实例。
 	L4ProxyIds []*string `json:"L4ProxyIds,omitnil,omitempty" name:"L4ProxyIds"`
+
+	// 源站防护回源ACL控制域，不填则默认用标准全球控制域；可用控制域信息可以通过DescribeAvailableOriginACLFamily接口查询获得。
+	// 具体取值说明如下：
+	// <li>gaz：标准全球可用区控制域；</li>
+	// <li>mlc：标准中国大陆可用区控制域；</li>
+	// <li>emc：标准全球(不含中国大陆)可用区控制域；</li>
+	// <li>plat-gaz：精简全球可用区控制域；</li>
+	// <li>plat-mlc：精简中国大陆可用区控制域；</li>
+	// <li>plat-emc：精简全球(不含中国大陆)可用区控制域；</li>
+	OriginACLFamily *string `json:"OriginACLFamily,omitnil,omitempty" name:"OriginACLFamily"`
 }
 
 func (r *EnableOriginACLRequest) ToJsonString() string {
@@ -13974,6 +14851,7 @@ func (r *EnableOriginACLRequest) FromJsonString(s string) error {
 	delete(f, "L7Hosts")
 	delete(f, "L4EnableMode")
 	delete(f, "L4ProxyIds")
+	delete(f, "OriginACLFamily")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "EnableOriginACLRequest has unknown keys!", "")
 	}
@@ -14206,8 +15084,7 @@ type ExportZoneConfigRequestParams struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 导出配置项的类型列表，不填表示导出所有类型的配置，当前支持的取值有：<li>L7AccelerationConfig：表示导出七层加速配置，对应控制台「站点加速-全局加速配置」和「站点加速-规则引擎」。</li>
-	// 需注意：后续支持导出的类型会随着迭代增加，导出所有类型时需要注意导出文件大小，建议使用时指定需要导出的配置类型，以便控制请求响应包负载大小。
+	// 导出配置项的类型列表，不填表示导出所有类型的配置，当前支持的取值有：<li>L7AccelerationConfig：表示导出七层加速配置，对应控制台「站点加速-全局加速配置」和「站点加速-规则引擎」。</li><li>WebSecurity：表示导出 Web 防护配置。</li> 需注意：后续支持导出的类型会随着迭代增加，导出所有类型时需要注意导出文件大小，建议使用时指定需要导出的配置类型，以便控制请求响应包负载大小。
 	Types []*string `json:"Types,omitnil,omitempty" name:"Types"`
 }
 
@@ -14217,8 +15094,7 @@ type ExportZoneConfigRequest struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 导出配置项的类型列表，不填表示导出所有类型的配置，当前支持的取值有：<li>L7AccelerationConfig：表示导出七层加速配置，对应控制台「站点加速-全局加速配置」和「站点加速-规则引擎」。</li>
-	// 需注意：后续支持导出的类型会随着迭代增加，导出所有类型时需要注意导出文件大小，建议使用时指定需要导出的配置类型，以便控制请求响应包负载大小。
+	// 导出配置项的类型列表，不填表示导出所有类型的配置，当前支持的取值有：<li>L7AccelerationConfig：表示导出七层加速配置，对应控制台「站点加速-全局加速配置」和「站点加速-规则引擎」。</li><li>WebSecurity：表示导出 Web 防护配置。</li> 需注意：后续支持导出的类型会随着迭代增加，导出所有类型时需要注意导出文件大小，建议使用时指定需要导出的配置类型，以便控制请求响应包负载大小。
 	Types []*string `json:"Types,omitnil,omitempty" name:"Types"`
 }
 
@@ -14309,6 +15185,31 @@ type FirstPartConfig struct {
 	StatTime *uint64 `json:"StatTime,omitnil,omitempty" name:"StatTime"`
 }
 
+type FloatTimingDataItem struct {
+	// 返回数据对应时间点，采用 unix 秒级时间戳。
+	Timestamp *int64 `json:"Timestamp,omitnil,omitempty" name:"Timestamp"`
+
+	// 具体数值。
+	Value *float64 `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
+type FloatTimingTypeValue struct {
+	// 数据和。
+	Sum *float64 `json:"Sum,omitnil,omitempty" name:"Sum"`
+
+	// 最大值。
+	Max *float64 `json:"Max,omitnil,omitempty" name:"Max"`
+
+	// 平均值。
+	Avg *float64 `json:"Avg,omitnil,omitempty" name:"Avg"`
+
+	// 指标名。
+	MetricName *string `json:"MetricName,omitnil,omitempty" name:"MetricName"`
+
+	// 详细数据。
+	Detail []*FloatTimingDataItem `json:"Detail,omitnil,omitempty" name:"Detail"`
+}
+
 type FollowOrigin struct {
 	// 遵循源站配置开关，取值有：
 	// <li>on：开启；</li>
@@ -14397,6 +15298,22 @@ type Function struct {
 
 	// 修改时间。时间为世界标准时间（UTC）， 遵循 ISO 8601 标准的日期和时间格式。
 	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+}
+
+type FunctionComponentBinding struct {
+	// 绑定的组件类型。取值有：
+	// <li>kv_namespace：KV 命名空间。</li>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// 用于绑定的变量名。限制 1-50 个字符，允许的字符为字母、数字和下划线，其中数字不能在开头。在边缘函数代码中通过该变量名访问绑定的组件。根据 Type 的取值不同，使用方式如下：
+	// <li>当 Type 为 kv_namespace 时：在代码中可通过该变量名访问 KV 命名空间，例如设置为 "MY_KV" 时，可通过 MY_KV.get("key") 进行读写操作。</li>
+	VariableName *string `json:"VariableName,omitnil,omitempty" name:"VariableName"`
+
+	// KV 命名空间配置参数。用于指定绑定的 KV 命名空间详情。当 Type 为 kv_namespace 时，此字段必填。
+	// 
+	// 
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	KVNamespaceParameters *KVNamespaceParameters `json:"KVNamespaceParameters,omitnil,omitempty" name:"KVNamespaceParameters"`
 }
 
 type FunctionEnvironmentVariable struct {
@@ -14840,6 +15757,27 @@ type IPReputationGroup struct {
 	BotManagementActionOverrides []*BotManagementActionOverrides `json:"BotManagementActionOverrides,omitnil,omitempty" name:"BotManagementActionOverrides"`
 }
 
+type IPSSLConfig struct {
+	// IP SSL关联的域名。如果Status值为 unbound 时，该字段为空值。
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AssociatedDomain *string `json:"AssociatedDomain,omitnil,omitempty" name:"AssociatedDomain"`
+
+	// 关联状态， 取值如下：
+	// <li>bound：IP SSL配置已绑定</li>
+	// <li>binding：IP SSL配置绑定中</li>
+	// <li>unbinding：IP SSL配置解绑中</li>
+	// <li>unbound：IP SSL配置未绑定</li>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+type IPSSLSetting struct {
+	// 操作类型， 取值如下： <li>bind：绑定</li> <li>unbind：解绑</li>
+	Operation *string `json:"Operation,omitnil,omitempty" name:"Operation"`
+
+	// 要绑定的IP SSL的所属域名。
+	AssociatedDomain *string `json:"AssociatedDomain,omitnil,omitempty" name:"AssociatedDomain"`
+}
+
 type IPWhitelist struct {
 	// IPv4列表。
 	IPv4 []*string `json:"IPv4,omitnil,omitempty" name:"IPv4"`
@@ -15239,6 +16177,48 @@ type JustInTimeTranscodeTemplate struct {
 
 	// 模板最后修改时间，使用 [ISO 日期格式](https://cloud.tencent.com/document/product/266/11732#I)。
 	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+}
+
+type KVNamespace struct {
+	// 命名空间名称。在同站点下具有唯一性。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 命名空间描述。创建时填写的备注信息，用于说明命名空间的用途或业务含义。最大支持 256 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+
+	// KV 存储空间可用容量，单位为字节（Byte）。表示该命名空间可存储数据的最大容量上限，当前默认为 1 GB。
+	Capacity *int64 `json:"Capacity,omitnil,omitempty" name:"Capacity"`
+
+	// KV 存储空间已用容量，单位为字节（Byte）。表示该命名空间当前已使用的存储空间大小。
+	CapacityUsed *int64 `json:"CapacityUsed,omitnil,omitempty" name:"CapacityUsed"`
+
+	// 命名空间被引用实例的列表。展示当前命名空间被哪些边缘函数实例引用，以及引用的站点信息。若未被引用，则返回空数组。
+	References []*ComponentReference `json:"References,omitnil,omitempty" name:"References"`
+
+	// 命名空间的创建时间，遵循 ISO 8601 标准，格式为 YYYY-MM-DDThh:mm:ssZ（UTC 时间）。
+	CreatedOn *string `json:"CreatedOn,omitnil,omitempty" name:"CreatedOn"`
+
+	// 命名空间的最后修改时间，遵循 ISO 8601 标准，格式为 YYYY-MM-DDThh:mm:ssZ（UTC 时间）。
+	ModifiedOn *string `json:"ModifiedOn,omitnil,omitempty" name:"ModifiedOn"`
+}
+
+type KVNamespaceParameters struct {
+	// KV 命名空间所属的站点 ID。指定要绑定的 KV 命名空间所在的站点，支持跨站点绑定。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// KV 命名空间名称。指定要绑定的具体命名空间，可通过 DescribeKVNamespace 接口获取站点下的命名空间列表。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+}
+
+type KeyValuePair struct {
+	// 键名。每个键名不能为空，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线。
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// 键值。入参时不能为空，最大支持 1 MB。出参时若键不存在，则返回空字符串。
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+
+	// 过期时间，遵循 ISO 8601 标准，格式为 YYYY-MM-DDThh:mm:ssZ（UTC 时间）。出参时若为空字符串，表示该键值对永不过期。
+	Expiration *string `json:"Expiration,omitnil,omitempty" name:"Expiration"`
 }
 
 type KnownBotCategories struct {
@@ -16767,6 +17747,157 @@ func (r *ModifyDnsRecordsStatusResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ModifyEdgeKVNamespaceRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 命名空间描述。用于说明命名空间的用途或业务含义。最大支持 256 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+}
+
+type ModifyEdgeKVNamespaceRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 命名空间名称。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// 命名空间描述。用于说明命名空间的用途或业务含义。最大支持 256 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+}
+
+func (r *ModifyEdgeKVNamespaceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyEdgeKVNamespaceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "Namespace")
+	delete(f, "Remark")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyEdgeKVNamespaceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyEdgeKVNamespaceResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyEdgeKVNamespaceResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyEdgeKVNamespaceResponseParams `json:"Response"`
+}
+
+func (r *ModifyEdgeKVNamespaceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyEdgeKVNamespaceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyFunctionComponentBindingsRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 操作类型，取值有：
+	// <li>bind：绑定组件；</li>
+	// <li>bind-override：绑定组件。若绑定已存在则为重绑定行为，否则为绑定行为；</li>
+	// <li>unbind：解绑组件；</li>
+	// <li>rebind：重置绑定关系。清空所有现有绑定，并设置为传入的绑定列表。若传入空列表，则清空所有绑定。</li>
+	Operation *string `json:"Operation,omitnil,omitempty" name:"Operation"`
+
+	// 操作的函数组件绑定列表。当 Operation 为 rebind 且传入空列表时，表示清空所有绑定。
+	FunctionComponentBindings []*FunctionComponentBinding `json:"FunctionComponentBindings,omitnil,omitempty" name:"FunctionComponentBindings"`
+}
+
+type ModifyFunctionComponentBindingsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 操作类型，取值有：
+	// <li>bind：绑定组件；</li>
+	// <li>bind-override：绑定组件。若绑定已存在则为重绑定行为，否则为绑定行为；</li>
+	// <li>unbind：解绑组件；</li>
+	// <li>rebind：重置绑定关系。清空所有现有绑定，并设置为传入的绑定列表。若传入空列表，则清空所有绑定。</li>
+	Operation *string `json:"Operation,omitnil,omitempty" name:"Operation"`
+
+	// 操作的函数组件绑定列表。当 Operation 为 rebind 且传入空列表时，表示清空所有绑定。
+	FunctionComponentBindings []*FunctionComponentBinding `json:"FunctionComponentBindings,omitnil,omitempty" name:"FunctionComponentBindings"`
+}
+
+func (r *ModifyFunctionComponentBindingsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyFunctionComponentBindingsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "FunctionId")
+	delete(f, "Operation")
+	delete(f, "FunctionComponentBindings")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyFunctionComponentBindingsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyFunctionComponentBindingsResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyFunctionComponentBindingsResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyFunctionComponentBindingsResponseParams `json:"Response"`
+}
+
+func (r *ModifyFunctionComponentBindingsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyFunctionComponentBindingsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyFunctionRequestParams struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
@@ -18046,6 +19177,16 @@ type ModifyOriginACLRequestParams struct {
 
 	// 需要启用/关闭特定回源 IP 网段回源的实例。
 	OriginACLEntities []*OriginACLEntity `json:"OriginACLEntities,omitnil,omitempty" name:"OriginACLEntities"`
+
+	// 源站防护回源ACL控制域，不填则默认不变；控制域信息可以通过DescribeAvailableOriginACLFamily接口查询获得。
+	// 具体取值说明如下：
+	// <li>gaz：标准全球可用区控制域；</li>
+	// <li>mlc：标准中国大陆可用区控制域；</li>
+	// <li>emc：标准全球(不含中国大陆)可用区控制域；</li>
+	// <li>plat-gaz：精简全球可用区控制域；</li>
+	// <li>plat-mlc：精简中国大陆可用区控制域；</li>
+	// <li>plat-emc：精简全球(不含中国大陆)可用区控制域；</li>
+	OriginACLFamily *string `json:"OriginACLFamily,omitnil,omitempty" name:"OriginACLFamily"`
 }
 
 type ModifyOriginACLRequest struct {
@@ -18056,6 +19197,16 @@ type ModifyOriginACLRequest struct {
 
 	// 需要启用/关闭特定回源 IP 网段回源的实例。
 	OriginACLEntities []*OriginACLEntity `json:"OriginACLEntities,omitnil,omitempty" name:"OriginACLEntities"`
+
+	// 源站防护回源ACL控制域，不填则默认不变；控制域信息可以通过DescribeAvailableOriginACLFamily接口查询获得。
+	// 具体取值说明如下：
+	// <li>gaz：标准全球可用区控制域；</li>
+	// <li>mlc：标准中国大陆可用区控制域；</li>
+	// <li>emc：标准全球(不含中国大陆)可用区控制域；</li>
+	// <li>plat-gaz：精简全球可用区控制域；</li>
+	// <li>plat-mlc：精简中国大陆可用区控制域；</li>
+	// <li>plat-emc：精简全球(不含中国大陆)可用区控制域；</li>
+	OriginACLFamily *string `json:"OriginACLFamily,omitnil,omitempty" name:"OriginACLFamily"`
 }
 
 func (r *ModifyOriginACLRequest) ToJsonString() string {
@@ -18072,6 +19223,7 @@ func (r *ModifyOriginACLRequest) FromJsonString(s string) error {
 	}
 	delete(f, "ZoneId")
 	delete(f, "OriginACLEntities")
+	delete(f, "OriginACLFamily")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyOriginACLRequest has unknown keys!", "")
 	}
@@ -19040,6 +20192,81 @@ func (r *ModifySecurityPolicyResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ModifySharedCNAMERequestParams struct {
+	// 共享 CNAME 所属站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 共享 CNAME。
+	SharedCNAME *string `json:"SharedCNAME,omitnil,omitempty" name:"SharedCNAME"`
+
+	// 请输入调整后的描述。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 设置IP SSL 类型的共享CNAME 的 IP SSL 信息。
+	IPSSLSetting *IPSSLSetting `json:"IPSSLSetting,omitnil,omitempty" name:"IPSSLSetting"`
+}
+
+type ModifySharedCNAMERequest struct {
+	*tchttp.BaseRequest
+	
+	// 共享 CNAME 所属站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 共享 CNAME。
+	SharedCNAME *string `json:"SharedCNAME,omitnil,omitempty" name:"SharedCNAME"`
+
+	// 请输入调整后的描述。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 设置IP SSL 类型的共享CNAME 的 IP SSL 信息。
+	IPSSLSetting *IPSSLSetting `json:"IPSSLSetting,omitnil,omitempty" name:"IPSSLSetting"`
+}
+
+func (r *ModifySharedCNAMERequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifySharedCNAMERequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "SharedCNAME")
+	delete(f, "Description")
+	delete(f, "IPSSLSetting")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifySharedCNAMERequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifySharedCNAMEResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifySharedCNAMEResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifySharedCNAMEResponseParams `json:"Response"`
+}
+
+func (r *ModifySharedCNAMEResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifySharedCNAMEResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyWebSecurityTemplateRequestParams struct {
 	// 站点 ID。需要传入目标策略模板在访问权限上归属的站点，可使用 DescribeWebSecurityTemplates 接口查询策略模板归属的站点。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
@@ -19855,6 +21082,9 @@ type OriginACLInfo struct {
 	// <li>offline：已停用；</li>
 	// <li>updating: 配置部署中。</li>
 	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// 源站防护回源ACL控制域。
+	OriginACLFamily *string `json:"OriginACLFamily,omitnil,omitempty" name:"OriginACLFamily"`
 }
 
 type OriginAuthenticationParameters struct {
@@ -20056,19 +21286,19 @@ type OriginInfo struct {
 	// <li>COS：腾讯云 COS 对象存储源站；</li>
 	// <li>AWS_S3：AWS S3 对象存储源站；</li>
 	// <li>ORIGIN_GROUP：源站组类型源站；</li>
-	//  <li>VOD：云点播；</li>
+	// <li>VOD：云点播；</li>
 	// <li>SPACE：源站卸载，当前仅白名单开放；</li>
 	// <li>LB：负载均衡，当前仅白名单开放。</li>
 	OriginType *string `json:"OriginType,omitnil,omitempty" name:"OriginType"`
 
 	// 源站地址，根据 OriginType 的取值分为以下情况：
-	// <li>当 OriginType = IP_DOMAIN 时，该参数请填写 IPv4、IPv6 地址或域名；</li>
-	// <li>当 OriginType = COS 时，该参数请填写 COS 桶的访问域名；</li>
-	// <li>当 OriginType = AWS_S3，该参数请填写 S3 桶的访问域名；</li>
-	// <li>当 OriginType = ORIGIN_GROUP 时，该参数请填写源站组 ID；</li>
-	// <li>当 OriginType = VOD 时，该参数请填写云点播应用 ID ；</li>
-	// <li>当 OriginType = LB 时，该参数请填写负载均衡实例 ID，该功能当前仅白名单开放；</li>
-	// <li>当 OriginType = SPACE 时，该参数请填写源站卸载空间 ID，该功能当前仅白名单开放。</li>
+	// <li>当 OriginType = IP_DOMAIN 时，该参数为 IPv4、IPv6 地址或域名；</li>
+	// <li>当 OriginType = COS 时，该参数为 COS 桶的访问域名；</li>
+	// <li>当 OriginType = AWS_S3，该参数为 S3 桶的访问域名；</li>
+	// <li>当 OriginType = ORIGIN_GROUP 时，该参数为源站组 ID；如果引用了其它站点的源站组，格式为{源站组 ID}@{ZoneID}。例如：og-testorigin@zone-38moq1z10wwwy；</li>
+	// <li>当 OriginType = VOD 时，该参数为云点播应用 ID；</li>
+	// <li>当 OriginType = LB 时，该参数为负载均衡实例 ID，该功能当前仅白名单开放；如果引用了其它站点的负载均衡，格式为{负载均衡 ID}@{ZoneID}。例如：lb-2rxpamcyqfzg@zone-38moq1z10wwwy；</li>
+	// <li>当 OriginType = SPACE 时，该参数为源站卸载空间 ID，该功能当前仅白名单开放。</li>
 	Origin *string `json:"Origin,omitnil,omitempty" name:"Origin"`
 
 	// 备用源站组 ID，该参数仅在 OriginType = ORIGIN_GROUP 时生效，该字段为旧版能力，调用后控制台无法进行配置修改，如需使用请提交工单咨询。
@@ -20076,17 +21306,16 @@ type OriginInfo struct {
 
 	// 指定是否允许访问私有对象存储源站，该参数仅当源站类型 OriginType = COS 或 AWS_S3 时会生效，取值有：
 	// <li>on：使用私有鉴权；</li>
-	// <li>off：不使用私有鉴权。</li>
-	// 不填写时，默认值为off。
+	// <li>off：不使用私有鉴权。</li>不填写时，默认值为off。
 	PrivateAccess *string `json:"PrivateAccess,omitnil,omitempty" name:"PrivateAccess"`
 
 	// 私有鉴权使用参数，该参数仅当源站类型 PrivateAccess = on 时会生效。
 	PrivateParameters []*PrivateParameter `json:"PrivateParameters,omitnil,omitempty" name:"PrivateParameters"`
 
-	// 自定义回源 HOST 头，该参数仅当 OriginType=IP_DOMAIN 时生效。
-	// 如果 OriginType=COS 或 AWS_S3 时，回源 HOST 头将与源站域名保持一致。
-	// 如果OriginType=ORIGIN_GROUP 时，回源 HOST 头遵循源站组内配置，如果没有配置则默认为加速域名。
-	// 如果 OriginType=VOD 或 SPACE 时，无需配置该头部，按对应的回源域名生效。
+	// 自定义回源 HOST 头，该参数仅当 OriginType = IP_DOMAIN 时生效。当 OriginType 是其它类型源站时，不需要传入该参数，否则会报错。
+	// 当 OriginType = COS 或 AWS_S3 时，回源 HOST 头将与源站域名保持一致。
+	// 当 OriginType = ORIGIN_GROUP 时，回源 HOST 头遵循源站组内配置，如果没有配置则默认为加速域名。
+	// 当 OriginType = VOD 或 SPACE 时，无需配置该头部，按对应的回源域名生效。
 	HostHeader *string `json:"HostHeader,omitnil,omitempty" name:"HostHeader"`
 
 	// VODEO 子应用 ID。该参数当 OriginType = VODEO 时必填。
@@ -20106,8 +21335,7 @@ type OriginInfo struct {
 	// Deprecated: VodeoBucketId is deprecated.
 	VodeoBucketId *string `json:"VodeoBucketId,omitnil,omitempty" name:"VodeoBucketId"`
 
-	// 云点播回源范围，该参数当 OriginType = VOD 时生效。取值有：<li>all：当前源站对应的云点播应用内所有文件，默认值为 all；</li><li>bucket：当前源站对应的云点播应用下指定某一个存储桶内的文件。通过参数 VodBucketId 来指定存储桶。
-	// </li>
+	// 云点播回源范围，该参数当 OriginType = VOD 时生效。取值有：<li>all：当前源站对应的云点播应用内所有文件；</li><li>bucket：当前源站对应的云点播应用下指定某一个存储桶内的文件，通过参数 VodBucketId 来指定存储桶。</li>不填写时，默认值为 all。
 	VodOriginScope *string `json:"VodOriginScope,omitnil,omitempty" name:"VodOriginScope"`
 
 	// VOD 存储桶 ID，该参数当 OriginType = VOD 且 VodOriginScope = bucket 时必填。数据来源：云点播专业版应用下存储桶的存储 ID 。
@@ -20649,10 +21877,10 @@ type RateLimitingRule struct {
 	// 精准速率限制的名称。
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 精准速率限制的具体内容，需符合表达式语法，详细规范参见产品文档。
+	// 精准速率限制的具体内容，需符合表达式语法，详细规范参见[产品文档](https://cloud.tencent.com/document/product/1552/125343)。
 	Condition *string `json:"Condition,omitnil,omitempty" name:"Condition"`
 
-	// 速率阈值请求特征的匹配方式， 当 Enabled 为 on 时，此字段必填。<br /><br />当条件有多个时，将组合多个条件共同进行统计计算，条件最多不可超过5条。取值有：<br/><li><b>http.request.ip</b>：客户端 IP；</li><li><b>http.request.xff_header_ip</b>：客户端 IP（优先匹配 XFF 头部）；</li><li><b>http.request.uri.path</b>：请求的访问路径；</li><li><b>http.request.cookies['session']</b>：名称为session的Cookie，其中session可替换为自己指定的参数；</li><li><b>http.request.headers['user-agent']</b>：名称为user-agent的HTTP头部，其中user-agent可替换为自己指定的参数；</li><li><b>http.request.ja3</b>：请求的JA3指纹；</li><li><b>http.request.uri.query['test']</b>：名称为test的URL查询参数，其中test可替换为自己指定的参数。</li> 
+	// 速率阈值请求特征的匹配方式， 当 Enabled 为 on 时，此字段必填。<br /><br />当条件有多个时，将组合多个条件共同进行统计计算，条件最多不可超过5条。取值有：<br/><li><b>http.request.ip</b>：客户端 IP；</li><li><b>http.request.xff_header_ip</b>：客户端 IP（优先匹配 XFF 头部）；</li><li><b>http.request.uri.path</b>：请求的访问路径；</li><li><b>http.request.cookies['session']</b>：名称为 session 的 Cookie，其中 session 可替换为自己指定的参数；</li><li><b>http.request.headers['user-agent']</b>：名称为 user-agent 的 HTTP 头部，其中 user-agent 可替换为自己指定的参数；</li><li><b>http.request.ja3</b>：请求的 JA3 指纹；</li><li><b>http.request.ja4</b>：请求的 JA4 指纹；</li><li><b>http.request.uri.query['test']</b>：名称为 test 的 URL 查询参数，其中 test 可替换为自己指定的参数。</li> 
 	CountBy []*string `json:"CountBy,omitnil,omitempty" name:"CountBy"`
 
 	// 精准速率限制在时间范围内的累计拦截次数，取值范围 1 ~ 100000。
@@ -20741,6 +21969,18 @@ type RealtimeLogDeliveryTask struct {
 type RedirectActionParameters struct {
 	// 重定向的URL。
 	URL *string `json:"URL,omitnil,omitempty" name:"URL"`
+}
+
+type ReferenceHolder struct {
+	// 站点ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 实例类型，取值如下：
+	// <li>acceleration-domain：加速域名；</li>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// 被引用/引用的实例信息。
+	Instance *string `json:"Instance,omitnil,omitempty" name:"Instance"`
 }
 
 // Predefined struct for user
@@ -21614,6 +22854,12 @@ type SecurityPolicy struct {
 
 	// Bot 管理配置。
 	BotManagement *BotManagement `json:"BotManagement,omitnil,omitempty" name:"BotManagement"`
+
+	// 基础 Bot 管理配置。
+	BotManagementLite *BotManagementLite `json:"BotManagementLite,omitnil,omitempty" name:"BotManagementLite"`
+
+	// 默认拦截动作配置。
+	DefaultDenySecurityActionParameters *DefaultDenySecurityActionParameters `json:"DefaultDenySecurityActionParameters,omitnil,omitempty" name:"DefaultDenySecurityActionParameters"`
 }
 
 type SecurityPolicyTemplateInfo struct {
@@ -21696,6 +22942,28 @@ type SessionRateControl struct {
 type SetContentIdentifierParameters struct {
 	// 内容标识id
 	ContentIdentifier *string `json:"ContentIdentifier,omitnil,omitempty" name:"ContentIdentifier"`
+}
+
+type SharedCNAMEInfo struct {
+	// 共享CNAME类型：取值范围如下：
+	// <li>custom：由用户创建的自定义共享CNAME</li>
+	// <li>ip-ssl：IP SSL类型的共享CNAME</li>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// 共享CNAME名称。
+	SharedCNAME *string `json:"SharedCNAME,omitnil,omitempty" name:"SharedCNAME"`
+
+	// 描述。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 当type为ip-ssl时，展示该共享CNAME关联的 IP SSL 配置信息。
+	IPSSLConfig *IPSSLConfig `json:"IPSSLConfig,omitnil,omitempty" name:"IPSSLConfig"`
+
+	// 共享CNAME绑定的加速域名数量。
+	BindDomainCount *int64 `json:"BindDomainCount,omitnil,omitempty" name:"BindDomainCount"`
+
+	// 加入该共享CNAME的加速域名列表。当加入的域名数量超过100个时，只返回前100个加速域名。
+	AccelerationDomains []*ReferenceHolder `json:"AccelerationDomains,omitnil,omitempty" name:"AccelerationDomains"`
 }
 
 type SkipCondition struct {
@@ -21902,9 +23170,17 @@ type TCCaptchaOption struct {
 	AppSecretKey *string `json:"AppSecretKey,omitnil,omitempty" name:"AppSecretKey"`
 }
 
+type TCEOCaptchaOption struct {
+	// EdgeOne 人机校验模式，取值有：<li> Invisible：无感验证；</li><li>Adaptive：自适应交互验证。</li>
+	CaptchaMode *string `json:"CaptchaMode,omitnil,omitempty" name:"CaptchaMode"`
+}
+
 type TCRCEOption struct {
 	// Channel 信息。
 	Channel *string `json:"Channel,omitnil,omitempty" name:"Channel"`
+
+	// RCE Channel 的开通地域，目前可选的取值范围：<li>ap-beijing：华北地区（北京）；</li><li>ap-jakarta：亚太东南（雅加达）；</li><li>ap-singapore：亚太东南（新加坡）；</li><li>eu-frankfurt：欧洲地区（法兰克福）；</li><li>na-siliconvalley：美国西部（硅谷）。</li>
+	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 }
 
 type TLSConfigParameters struct {
@@ -21996,8 +23272,11 @@ type TimingDataRecord struct {
 	// 查询维度值。
 	TypeKey *string `json:"TypeKey,omitnil,omitempty" name:"TypeKey"`
 
-	// 详细时序数据。
+	// <code>Integer</code> 类型的详细时序数据，查询指标值类型为 <code>Integer</code> 指标会由本字段返回对应时序数据。<br> **注意**：若查询指标未明确说明指标值类型，默认由本字段返回数据。
 	TypeValue []*TimingTypeValue `json:"TypeValue,omitnil,omitempty" name:"TypeValue"`
+
+	// <code>Float</code> 类型的详细时序数据，查询指标值类型为 <code>Float</code> 指标会由本字段返回对应时序数据。
+	FloatTypeValue []*FloatTimingTypeValue `json:"FloatTypeValue,omitnil,omitempty" name:"FloatTypeValue"`
 }
 
 type TimingTypeValue struct {
@@ -22438,7 +23717,8 @@ type Zone struct {
 	// <li> partial：CNAME 接入类型；</li>
 	// <li> noDomainAccess：无域名接入类型；</li>
 	// <li>dnsPodAccess：DNSPod 托管类型，该类型要求您的域名已托管在腾讯云 DNSPod；</li>
-	// <li> pages：Pages 类型。</li>
+	// <li> pages：Pages 类型；</li>
+	// <li> ai：边缘推理接入类型。</li>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
 	// 站点关联的标签。

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1182,7 +1182,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.58
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.75
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.79
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1350,7 +1350,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq/v20200217
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem/v20210701
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.38
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.79
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998

--- a/website/docs/r/teo_origin_acl.html.markdown
+++ b/website/docs/r/teo_origin_acl.html.markdown
@@ -17,7 +17,8 @@ Provides a resource to create a TEO origin acl
 
 ```hcl
 resource "tencentcloud_teo_origin_acl" "example" {
-  zone_id = "zone-39quuimqg8r6"
+  zone_id           = "zone-39quuimqg8r6"
+  origin_acl_family = "gaz"
   l7_hosts = [
     "example1.com",
     "example2.com",
@@ -46,6 +47,7 @@ The following arguments are supported:
 * `zone_id` - (Required, String, ForceNew) Specifies the site ID.
 * `l4_proxy_ids` - (Optional, Set: [`String`]) he list of L4 proxy Instances that require enabling origin ACLs. This list must be empty when the request parameter L4EnableMode is set to 'all'.
 * `l7_hosts` - (Optional, Set: [`String`]) The list of L7 acceleration domains that require enabling the origin ACLs. This list must be empty when the request parameter L7EnableMode is set to 'all'.
+* `origin_acl_family` - (Optional, String) The control domain for origin ACL. Available values: 'gaz', 'mlc', 'emc', 'plat-gaz', 'plat-mlc', 'plat-emc'. If not specified, the default global control domain will be used.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add origin_acl_family parameter to tencentcloud_teo_origin_acl resource to support configuring ACL control domain (gaz, mlc, emc, etc.). The parameter is optional and computed, mapped to EnableOriginACL, DescribeOriginACL, and ModifyOriginACL APIs.