### PR TITLE
feat(teo): [132866709] add just-in-time transcode template resource

### DIFF
--- a/.changelog/4042.txt
+++ b/.changelog/4042.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_teo_just_in_time_transcode_template
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,6 @@ testacc: fmtcheck
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."
-	goimports -w ./$(PKG_NAME)
 	gofmt -s -w ./$(PKG_NAME)
 
 fmt-faster:
@@ -32,7 +31,6 @@ fmt-faster:
 		exit 0; \
 	else \
 		echo "==> [Faster]Fixing source code with gofmt...\n $(CHANGED_FILES) \n"; \
-		goimports -w $(CHANGED_FILES); \
 		gofmt -s -w $(CHANGED_FILES); \
 	fi
 

--- a/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/design.md
+++ b/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/design.md
@@ -1,0 +1,243 @@
+## Context
+
+当前 Terraform Provider for TencentCloud 已经支持 TEO 产品的多个资源，但缺少即时转码模板功能的支持。TEO 的即时转码模板功能允许用户配置视频流和音频流的转码参数，用于边缘节点上的实时转码处理。
+
+现有的 TEO 资源实现模式已经成熟，包括：
+- 使用 Terraform Plugin SDK v2 进行资源实现
+- 通过 tencentcloud-sdk-go 的 teo/v20220901 包调用云 API
+- 使用复合 ID 格式进行资源标识
+- 实现异步操作的轮询机制
+- 遵循最终一致性重试模式
+
+## Goals / Non-Goals
+
+**Goals:**
+- 实现 `tencentcloud_teo_just_in_time_transcode_template` 资源的完整 CRUD 操作
+- 支持视频流和音频流的独立配置，包括开关控制和模板参数
+- 正确处理异步操作，确保资源状态最终一致
+- 提供完整的单元测试和文档
+- 保持与现有 TEO 资源的一致性
+
+**Non-Goals:**
+- 不实现即时转码模板的更新操作（云 API 不支持 Update 接口，需要通过删除后重新创建实现）
+- 不实现批量操作接口
+- 不修改现有 TEO 资源的行为
+
+## Decisions
+
+### 1. 资源实现模式
+
+**决策**: 采用标准的 Terraform 资源实现模式，参考现有 TEO 资源（如 `resource_tc_teo_acceleration_domain.go`）。
+
+**理由**:
+- 保持代码一致性和可维护性
+- 利用已有的错误处理、重试等基础设施
+- 降低实现复杂度
+
+**替代方案考虑**:
+- 使用新的资源框架（如 Terraform Plugin Framework）：考虑迁移成本和兼容性风险，暂不采用
+
+### 2. 复合 ID 设计
+
+**决策**: 使用 `zone_id#template_id` 作为资源 ID，与现有 TEO 资源保持一致。
+
+**理由**:
+- zone_id 是 TEO 的站点标识，template_id 是模板唯一标识
+- 这种格式已在多个 TEO 资源中使用，符合用户习惯
+- 便于资源的唯一性识别和查询
+
+**实现细节**:
+```
+func resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(id string) (string, string, error) {
+    items := strings.Split(id, "#")
+    if len(items) != 2 {
+        return "", "", fmt.Errorf("invalid resource ID format, expected: zone_id#template_id, got: %s", id)
+    }
+    return items[0], items[1], nil
+}
+```
+
+### 3. 异步操作处理
+
+**决策**: 对 Create 和 Delete 操作实现轮询机制，确保操作完成后资源状态同步。
+
+**理由**:
+- 云 API 是异步操作，创建和删除后模板不会立即生效
+- 需要轮询 DescribeJustInTimeTranscodeTemplates 接口确认状态
+- Terraform 的 `Timeouts` 配置允许用户自定义等待时间
+
+**实现细节**:
+```go
+d.SetId(fmt.Sprintf("%s#%s", *response.TemplateId, zoneId))
+d.Set("template_id", response.TemplateId)
+
+// 轮询确认创建成功
+err := resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(ctx, d, meta)
+if err != nil {
+    return err
+}
+```
+
+### 4. 更新操作处理
+
+**决策**: 由于云 API 不提供 Update 接口，Update 操作将强制删除并重新创建资源（ForceNew）。
+
+**理由**:
+- 云 API 只支持 Create 和 Delete，不支持 Update
+- 通过 ForceNew 确保 Terraform 状态正确更新
+- 虽然会增加操作成本，但确保了功能正确性
+
+**实现细节**:
+```go
+"zone_id": &schema.Schema{
+    Type:     schema.TypeString,
+    Required: true,
+    ForceNew: true,
+},
+"template_name": &schema.Schema{
+    Type:     schema.TypeString,
+    Required: true,
+    ForceNew: true,
+},
+// 其他关键字段也标记为 ForceNew
+```
+
+### 5. 视频模板和音频模板配置
+
+**决策**: 将 VideoTemplateInfo 和 AudioTemplateInfo 作为嵌套对象在 schema 中定义，使用 TypeList 和 TypeMap 组合。
+
+**理由**:
+- VideoTemplateInfo 和 AudioTemplateInfo 是复杂的嵌套结构
+- Terraform schema 可以通过嵌套表示复杂数据结构
+- 保持与云 API 数据结构的一致性
+
+**实现细节**:
+```go
+"video_template": &schema.Schema{
+    Type:     schema.TypeList,
+    MaxItems: 1,
+    Optional: true,
+    Computed: true,
+    Elem: &schema.Resource{
+        Schema: map[string]*schema.Schema{
+            "video_codec": &schema.Schema{
+                Type:     schema.TypeString,
+                Optional: true,
+            },
+            "fps": &schema.Schema{
+                Type:     schema.TypeInt,
+                Optional: true,
+            },
+            // 其他视频参数
+        },
+    },
+},
+```
+
+### 6. 错误处理和重试
+
+**决策**: 使用项目已有的 `helper.Retry()` 和 `tccommon.InconsistentCheck()` 模式处理最终一致性和错误。
+
+**理由**:
+- TEO 服务是分布式系统，存在最终一致性
+- 网络抖动和服务临时不可用需要重试机制
+- 利用现有代码避免重复实现
+
+**实现细节**:
+```go
+defer tccommon.LogElapsed("resource.tencentcloud_teo_just_in_time_transcode_template.create")()
+
+err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+    result, err := me.client.UseTeoClient(teoVersion).CreateJustInTimeTranscodeTemplate(request)
+    if err != nil {
+        if isRetryableError(err) {
+            return resource.RetryableError(err)
+        }
+        return resource.NonRetryableError(err)
+    }
+    // 处理响应
+    return nil
+})
+```
+
+### 7. 单元测试策略
+
+**决策**: 新资源使用 gomonkey mock 云 API 进行单元测试，不使用 Terraform 集成测试。
+
+**理由**:
+- 新资源的测试应该专注于业务逻辑
+- 避免依赖真实的云环境（需要凭证和网络）
+- gomonkey 可以 mock SDK 接口，测试资源代码逻辑
+
+**实现细节**:
+```go
+func TestAccTencentCloudTeoJustInTimeTranscodeTemplate_basic(t *testing.T) {
+    // 使用 gomonkey mock CreateJustInTimeTranscodeTemplate 接口
+    // 测试创建、读取、删除流程
+}
+```
+
+## Risks / Trade-offs
+
+### Risk 1: API 兼容性变化
+**风险**: 云 API 可能在未来版本中变更参数结构，导致代码不兼容。
+
+**缓解措施**:
+- 使用 vendor 模式管理依赖，锁定特定版本的 SDK
+- 在 README 中注明支持的 SDK 版本
+- 关注云 API 变更公告，及时更新
+
+### Risk 2: 异步操作超时
+**风险**: 轮询等待资源创建或删除可能超时，导致 Terraform 操作失败。
+
+**缓解措施**:
+- 配置合理的默认超时时间（如 10 分钟）
+- 允许用户通过 Timeouts 参数自定义超时
+- 在文档中说明异步操作特性
+
+### Risk 3: 资源状态不一致
+**风险**: 轮询过程中资源状态可能与实际状态不一致。
+
+**缓解措施**:
+- 使用 `tccommon.InconsistentCheck()` 检测和重试
+- 在读取操作中实现状态一致性校验
+- 记录详细日志便于问题排查
+
+### Trade-off 1: 更新操作成本
+**权衡**: 由于不支持 Update 接口，任何参数变更都需要删除重建，增加操作成本和时间。
+
+**理由**: 云 API 限制，无法绕过。
+
+### Trade-off 2: 测试覆盖率
+**权衡**: 使用 mock 单元测试而非集成测试，可能无法完全覆盖真实场景。
+
+**缓解措施**: 补充文档和使用说明，鼓励用户进行实际验证。
+
+## Migration Plan
+
+### 部署步骤
+
+1. **代码审查和合并**
+   - 确保 Pull Request 通过代码审查
+   - 验证单元测试全部通过
+   - 确认文档完整准确
+
+2. **发布版本**
+   - 打包新版本的 Terraform Provider
+   - 更新 CHANGELOG
+   - 发布到 Terraform Registry
+
+3. **用户文档更新**
+   - 在 website/docs/ 添加资源文档
+   - 提供使用示例
+   - 说明注意事项（如异步操作、ForceNew 字段）
+
+### 回滚策略
+
+- 如果发现严重问题，可以通过快速回滚移除该资源
+- 用户状态不受影响，因为这是新增资源
+- 保留代码便于问题修复和重新发布
+
+## Open Questions
+
+（无待解决的开放性问题）

--- a/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/proposal.md
+++ b/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+用户需要在 Tencent Cloud EdgeOne (TEO) 产品中使用即时转码模板功能来配置和管理视频/音频流的转码规则。目前 Terraform Provider 中缺少对该资源的支持，用户无法通过 Terraform 自动化创建和管理 TEO 即时转码模板。
+
+## What Changes
+
+- 新增 Terraform 资源 `tencentcloud_teo_just_in_time_transcode_template`，支持即时转码模板的完整生命周期管理
+- 实现资源的创建、读取、更新、删除（CRUD）操作
+- 支持视频流和音频流的独立配置和控制
+- 支持通过 zone_id 和 template_id 进行资源标识和查询
+
+## Capabilities
+
+### New Capabilities
+- `teo-just-in-time-transcode-template`: 支持 TEO 即时转码模板的管理，包括模板的创建、查询和删除操作，支持视频流和音频流的独立配置
+
+### Modified Capabilities
+（无现有能力的需求变更）
+
+## Impact
+
+- **新增文件**：
+  - `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.go` - 资源主文件
+  - `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template_test.go` - 资源测试文件
+  - `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.md` - 资源文档
+
+- **依赖更新**：使用现有的 `teo/v20220901` SDK 包，无需新增依赖
+
+- **API 接口**：
+  - `CreateJustInTimeTranscodeTemplate` - 创建即时转码模板
+  - `DescribeJustInTimeTranscodeTemplates` - 查询即时转码模板列表（用于 Read 操作）
+  - `DeleteJustInTimeTranscodeTemplates` - 删除即时转码模板
+
+- **注意事项**：
+  - 资源 ID 格式：`zone_id#template_id`（复合 ID）
+  - 需要处理异步操作，调用创建/删除接口后需轮询查询接口确认生效
+  - 必须保持向后兼容，不影响现有 TEO 资源

--- a/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/specs/teo-just-in-time-transcode-template/spec.md
+++ b/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/specs/teo-just-in-time-transcode-template/spec.md
@@ -1,0 +1,228 @@
+## ADDED Requirements
+
+### Requirement: Create Just-In-Time Transcode Template
+The system SHALL allow users to create a TEO just-in-time transcode template with specified configuration parameters.
+
+#### Scenario: Create template with minimal configuration
+- **WHEN** user provides zone_id, template_name, and required stream configurations
+- **THEN** system creates a new just-in-time transcode template
+- **AND** system returns template_id in the response
+- **AND** system generates a composite resource ID as zone_id#template_id
+- **AND** system waits for the template to become available via polling
+
+#### Scenario: Create template with full configuration
+- **WHEN** user provides all optional parameters including comment, video_stream_switch, audio_stream_switch, video_template, and audio_template
+- **THEN** system creates the template with all specified configurations
+- **AND** video_stream_switch is set to "on" or "off"
+- **AND** audio_stream_switch is set to "on" or "off"
+- **AND** video_template is required when video_stream_switch is "on"
+- **AND** audio_template is required when audio_stream_switch is "on"
+
+#### Scenario: Create template with video stream disabled
+- **WHEN** user sets video_stream_switch to "off"
+- **THEN** system creates the template without video configuration
+- **AND** system does not require video_template parameter
+
+#### Scenario: Create template with audio stream disabled
+- **WHEN** user sets audio_stream_switch to "off"
+- **THEN** system creates the template without audio configuration
+- **AND** system does not require audio_template parameter
+
+#### Scenario: Handle creation timeout
+- **WHEN** template creation does not complete within the configured timeout period
+- **THEN** system returns a timeout error
+- **AND** system includes information about the timeout configuration
+
+### Requirement: Read Just-In-Time Transcode Template
+The system SHALL allow users to retrieve the configuration of an existing just-in-time transcode template.
+
+#### Scenario: Read template by composite ID
+- **WHEN** user queries a template with a valid composite ID (zone_id#template_id)
+- **THEN** system returns the complete template configuration
+- **AND** response includes all parameters: zone_id, template_id, template_name, comment, video_stream_switch, audio_stream_switch, video_template, and audio_template
+- **AND** system correctly parses the composite ID to extract zone_id and template_id
+
+#### Scenario: Read non-existent template
+- **WHEN** user queries a template with an invalid composite ID
+- **THEN** system returns an error indicating the template does not exist
+- **AND** system does not attempt to create or modify any resources
+
+#### Scenario: Read template with retry on inconsistency
+- **WHEN** there is a temporary inconsistency in the TEO service
+- **THEN** system retries the read operation up to the retry limit
+- **AND** system returns the template configuration when consistency is restored
+- **AND** system returns an error if retry limit is exceeded
+
+#### Scenario: Read template with eventual consistency
+- **WHEN** template was just created or updated
+- **THEN** system waits and polls until the template becomes readable
+- **AND** system returns the latest configuration when available
+
+### Requirement: Delete Just-In-Time Transcode Template
+The system SHALL allow users to delete an existing just-in-time transcode template.
+
+#### Scenario: Delete template by composite ID
+- **WHEN** user requests deletion with a valid composite ID (zone_id#template_id)
+- **THEN** system calls the delete API with zone_id and template_id
+- **AND** system waits for the deletion to complete
+- **AND** system removes the resource from Terraform state
+- **AND** system returns success when deletion is confirmed
+
+#### Scenario: Delete non-existent template
+- **WHEN** user attempts to delete a template that does not exist
+- **THEN** system returns an error indicating the template was not found
+- **AND** system does not modify any existing resources
+
+#### Scenario: Handle deletion timeout
+- **WHEN** template deletion does not complete within the configured timeout period
+- **THEN** system returns a timeout error
+- **AND** system includes information about the timeout configuration
+- **AND** system does not remove the resource from Terraform state
+
+#### Scenario: Delete template with retry on failure
+- **WHEN** the delete operation fails due to temporary service issues
+- **THEN** system retries the delete operation up to the retry limit
+- **AND** system returns success when deletion eventually succeeds
+- **AND** system returns an error if retry limit is exceeded
+
+### Requirement: Update Just-In-Time Transcode Template
+The system SHALL force new resource creation when any parameter changes are requested (since Update API is not available).
+
+#### Scenario: Update any parameter forces recreation
+- **WHEN** user modifies any parameter (template_name, comment, video_stream_switch, audio_stream_switch, video_template, or audio_template)
+- **THEN** system marks the resource for recreation
+- **AND** system deletes the existing template
+- **AND** system creates a new template with updated parameters
+- **AND** system generates a new template_id
+- **AND** system updates the Terraform state with the new composite ID
+
+#### Scenario: Update zone_id forces recreation
+- **WHEN** user changes the zone_id parameter
+- **THEN** system marks the resource for recreation
+- **AND** system deletes the template from the original zone
+- **AND** system creates a new template in the new zone
+- **AND** system updates the Terraform state with the new zone_id#template_id
+
+### Requirement: Resource Schema Validation
+The system SHALL validate all input parameters according to the TEO API constraints.
+
+#### Scenario: Validate template_name length
+- **WHEN** user provides a template_name exceeding 64 characters
+- **THEN** system returns a validation error
+- **AND** system includes information about the 64 character limit
+
+#### Scenario: Validate comment length
+- **WHEN** user provides a comment exceeding 256 characters
+- **THEN** system returns a validation error
+- **AND** system includes information about the 256 character limit
+
+#### Scenario: Validate video_stream_switch values
+- **WHEN** user provides a value other than "on" or "off" for video_stream_switch
+- **THEN** system returns a validation error
+- **AND** system lists the valid values: "on" and "off"
+
+#### Scenario: Validate audio_stream_switch values
+- **WHEN** user provides a value other than "on" or "off" for audio_stream_switch
+- **THEN** system returns a validation error
+- **AND** system lists the valid values: "on" and "off"
+
+#### Scenario: Validate required video_template when video enabled
+- **WHEN** user sets video_stream_switch to "on" but does not provide video_template
+- **THEN** system returns a validation error
+- **AND** system indicates that video_template is required when video_stream_switch is "on"
+
+#### Scenario: Validate required audio_template when audio enabled
+- **WHEN** user sets audio_stream_switch to "on" but does not provide audio_template
+- **THEN** system returns a validation error
+- **AND** system indicates that audio_template is required when audio_stream_switch is "on"
+
+### Requirement: Timeout Configuration
+The system SHALL support configurable timeouts for asynchronous operations.
+
+#### Scenario: Configure create timeout
+- **WHEN** user specifies a custom create timeout
+- **THEN** system uses the custom timeout for template creation
+- **AND** system waits up to the specified duration before returning a timeout error
+
+#### Scenario: Configure delete timeout
+- **WHEN** user specifies a custom delete timeout
+- **THEN** system uses the custom timeout for template deletion
+- **AND** system waits up to the specified duration before returning a timeout error
+
+#### Scenario: Use default timeouts
+- **WHEN** user does not specify custom timeouts
+- **THEN** system uses the default timeout values (e.g., 10 minutes)
+- **AND** system applies the same defaults for create, delete, and read operations
+
+### Requirement: Video Template Configuration
+The system SHALL support video template parameters for configuring video stream transcoding.
+
+#### Scenario: Configure video codec
+- **WHEN** user specifies video_codec in video_template
+- **THEN** system passes the codec to the TEO API
+- **AND** system stores the codec in Terraform state
+
+#### Scenario: Configure frame rate
+- **WHEN** user specifies fps in video_template
+- **THEN** system passes the frame rate to the TEO API
+- **AND** system stores the frame rate in Terraform state
+
+#### Scenario: Configure video bitrate
+- **WHEN** user specifies bitrate in video_template
+- **THEN** system passes the bitrate to the TEO API
+- **AND** system stores the bitrate in Terraform state
+
+#### Scenario: Configure video resolution
+- **WHEN** user specifies resolution parameters (width, height) in video_template
+- **THEN** system passes the resolution to the TEO API
+- **AND** system stores the resolution in Terraform state
+
+### Requirement: Audio Template Configuration
+The system SHALL support audio template parameters for configuring audio stream transcoding.
+
+#### Scenario: Configure audio codec
+- **WHEN** user specifies audio_codec in audio_template
+- **THEN** system passes the codec to the TEO API
+- **AND** system stores the codec in Terraform state
+
+#### Scenario: Configure audio bitrate
+- **WHEN** user specifies bitrate in audio_template
+- **THEN** system passes the bitrate to the TEO API
+- **AND** system stores the bitrate in Terraform state
+
+#### Scenario: Configure audio sample rate
+- **WHEN** user specifies sample_rate in audio_template
+- **THEN** system passes the sample rate to the TEO API
+- **AND** system stores the sample rate in Terraform state
+
+#### Scenario: Configure audio channels
+- **WHEN** user specifies channels in audio_template
+- **THEN** system passes the channels to the TEO API
+- **AND** system stores the channels in Terraform state
+
+### Requirement: Error Handling
+The system SHALL provide clear error messages for all failure scenarios.
+
+#### Scenario: Handle API errors
+- **WHEN** the TEO API returns an error
+- **THEN** system propagates the error to the user
+- **AND** system includes relevant error details from the API response
+- **AND** system does not crash or leave the resource in an inconsistent state
+
+#### Scenario: Handle network errors
+- **WHEN** a network error occurs during API call
+- **THEN** system retries the operation according to the retry policy
+- **AND** system returns an error if retries are exhausted
+- **AND** system includes information about the retry attempts
+
+#### Scenario: Handle authentication errors
+- **WHEN** authentication fails (invalid credentials)
+- **THEN** system returns a clear authentication error
+- **AND** system guides user to check credentials
+- **AND** system does not retry authentication failures
+
+#### Scenario: Handle permission errors
+- **WHEN** user lacks permission to perform the operation
+- **THEN** system returns a clear permission error
+- **AND** system indicates the required permission
+- **AND** system does not retry permission errors

--- a/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/tasks.md
+++ b/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Create resource file `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.go`
 - [x] 1.2 Define resource schema with all required and optional parameters
-- [x] 1.3 Set ForceNew for zone_id, template_name, comment, video_stream_switch, audio_stream_switch, video_template, and audio_template
+- [x] 1.3 Set ForceNew for zone_id, template_name, comment; remove ForceNew from video_stream_switch, audio_stream_switch, video_template, audio_template
 - [x] 1.4 Add Timeout configuration for create, delete, and read operations (default: 10 minutes)
 - [x] 1.5 Define composite ID format as `zone_id#template_id`
 - [x] 1.6 Implement resource schema validation rules (template_name max 64 chars, comment max 256 chars)
@@ -32,7 +32,11 @@
 - [x] 4.3 Build CreateJustInTimeTranscodeTemplateRequest from schema data
 - [x] 4.4 Call TEO API CreateJustInTimeTranscodeTemplate with retry logic
 - [x] 4.5 Handle API errors and return appropriate error messages
-- [x] 4.6 Set composite resource ID as `zone_id#template_id`
+- [x] 4.6 Set composite resource ID using tccommon.FILED_SP as separator (`zone_id#template_id`)
+
+## 4a. Update Function Implementation
+
+- [x] 4a.1 Implement resourceTencentCloudTeoJustInTimeTranscodeTemplateUpdate (no-op, logs warning, calls Read)
 - [x] 4.7 Set template_id in state
 - [x] 4.8 Implement polling mechanism to wait for template creation completion
 - [x] 4.9 Call Read function to verify template is available
@@ -41,7 +45,7 @@
 ## 5. Read Function Implementation
 
 - [x] 5.1 Implement resourceTencentCloudTeoJustInTimeTranscodeTemplateRead function
-- [x] 5.2 Parse composite ID to extract zone_id and template_id
+- [x] 5.2 Read zone_id and template_id directly from d.Get() instead of parsing from Id()
 - [x] 5.3 Build DescribeJustInTimeTranscodeTemplatesRequest with zone_id
 - [x] 5.4 Set filter for template_id to find the specific template
 - [x] 5.5 Call TEO API DescribeJustInTimeTranscodeTemplates with retry logic
@@ -54,7 +58,7 @@
 ## 6. Delete Function Implementation
 
 - [x] 6.1 Implement resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete function
-- [x] 6.2 Parse composite ID to extract zone_id and template_id
+- [x] 6.2 Read zone_id and template_id directly from d.Get() instead of parsing from Id()
 - [x] 6.3 Build DeleteJustInTimeTranscodeTemplatesRequest with zone_id and template_id
 - [x] 6.4 Call TEO API DeleteJustInTimeTranscodeTemplates with retry logic
 - [x] 6.5 Handle template not found scenario (ignore error, remove from state)
@@ -64,8 +68,8 @@
 
 ## 7. Resource Registration
 
-- [x] 7.1 Register resource in tencentcloud/services/teo/service_tencentcloud_teo.go
-- [x] 7.2 Add resource map entry with resource name and resource object
+- [x] 7.1 Register resource in tencentcloud/provider.go ResourcesMap
+- [x] 7.2 Add resource entry in tencentcloud/provider.md under TencentCloud EdgeOne(TEO) Resource section
 - [x] 7.3 Ensure resource follows TEO service naming convention
 
 ## 8. Helper Functions Implementation
@@ -80,29 +84,24 @@
 
 ## 9. Unit Tests Implementation
 
-- [x] 9.1 Create test file `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template_test.go`
-- [x] 9.2 Add test for CreateJustInTimeTranscodeTemplate basic scenario
-- [x] 9.3 Add test for CreateJustInTimeTranscodeTemplate with full configuration
-- [x] 9.4 Add test for DescribeJustInTimeTranscodeTemplates read operation
-- [x] 9.5 Add test for DeleteJustInTimeTranscodeTemplates deletion
-- [x] 9.6 Add test for composite ID parsing (valid and invalid formats)
-- [x] 9.7 Add test for API error handling (network errors, API errors)
-- [x] 9.8 Add test for validation errors (parameter length, invalid values)
-- [x] 9.9 Add test for retry mechanism and timeout handling
-- [x] 9.10 Add test for template not found scenario
+- [x] 9.1 Create test file `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template_test.go` (package teo_test)
+- [x] 9.2 Add test for Create success scenario with gomonkey mock
+- [x] 9.3 Add test for Create API error handling
+- [x] 9.4 Add test for Read success scenario
+- [x] 9.5 Add test for Read not-found scenario
+- [x] 9.6 Add test for Delete success scenario
+- [x] 9.7 Add test for Delete API error handling
+- [x] 9.8 Add test for Update (no-op that calls Read)
+- [x] 9.9 Add test for schema validation (fields, types, Required/Optional/ForceNew/Computed, Update not nil)
+- [x] 9.10 Use mockMeta pattern from teo_test package (consistent with identify_zone_operation and create_cls_index_operation tests)
 
 ## 10. Resource Documentation
 
 - [x] 10.1 Create documentation file `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.md`
-- [x] 10.2 Add resource description and use cases
-- [x] 10.3 Document all parameters with types and descriptions
-- [x] 10.4 Document video_template nested parameters
-- [x] 10.5 Document audio_template nested parameters
-- [x] 10.6 Add example configuration for minimal setup
-- [x] 10.7 Add example configuration for full setup
-- [x] 10.8 Document timeout configuration
-- [x] 10.9 document ForceNew behavior for all parameters
-- [x] 10.10 Add notes about asynchronous operations
+- [x] 10.2 Follow gendoc convention: one-line description with TEO product name
+- [x] 10.3 Add Example Usage section with full HCL configuration
+- [x] 10.4 Add Import section with import command example
+- [x] 10.5 Argument/Attributes Reference auto-generated from Go schema Description fields
 
 ## 11. Verification
 

--- a/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/tasks.md
+++ b/openspec/changes/archive/2026-04-21-add-teo-just-in-time-transcode-template-resource/tasks.md
@@ -1,0 +1,116 @@
+## 1. Resource Schema Implementation
+
+- [x] 1.1 Create resource file `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.go`
+- [x] 1.2 Define resource schema with all required and optional parameters
+- [x] 1.3 Set ForceNew for zone_id, template_name, comment, video_stream_switch, audio_stream_switch, video_template, and audio_template
+- [x] 1.4 Add Timeout configuration for create, delete, and read operations (default: 10 minutes)
+- [x] 1.5 Define composite ID format as `zone_id#template_id`
+- [x] 1.6 Implement resource schema validation rules (template_name max 64 chars, comment max 256 chars)
+- [x] 1.7 Implement video_stream_switch and audio_stream_switch validation (only "on" or "off")
+
+## 2. Video Template Schema Implementation
+
+- [x] 2.1 Define video_template as TypeList with MaxItems: 1
+- [x] 2.2 Define video_codec field (TypeString, Optional)
+- [x] 2.3 Define fps field (TypeFloat, Optional, default 0, range [0, 30])
+- [x] 2.4 Define bitrate field (TypeInt, Optional, default 0, range [128, 10000])
+- [x] 2.5 Define resolution_adaptive field (TypeString, Optional, default "open")
+- [x] 2.6 Define width field (TypeInt, Optional, default 0, range [128, 1920])
+- [x] 2.7 Define height field (TypeInt, Optional, default 0, range [128, 1080])
+- [x] 2.8 Define fill_type field (TypeString, Optional, default "black")
+
+## 3. Audio Template Schema Implementation
+
+- [x] 3.1 Define audio_template as TypeList with MaxItems: 1
+- [x] 3.2 Define codec field (TypeString, Optional)
+- [x] 3.3 Define audio_channel field (TypeInt, Optional, default 2)
+
+## 4. Create Function Implementation
+
+- [x] 4.1 Implement resourceTencentCloudTeoJustInTimeTranscodeTemplateCreate function
+- [x] 4.2 Parse and validate input parameters from schema
+- [x] 4.3 Build CreateJustInTimeTranscodeTemplateRequest from schema data
+- [x] 4.4 Call TEO API CreateJustInTimeTranscodeTemplate with retry logic
+- [x] 4.5 Handle API errors and return appropriate error messages
+- [x] 4.6 Set composite resource ID as `zone_id#template_id`
+- [x] 4.7 Set template_id in state
+- [x] 4.8 Implement polling mechanism to wait for template creation completion
+- [x] 4.9 Call Read function to verify template is available
+- [x] 4.10 Add error handling for creation timeout
+
+## 5. Read Function Implementation
+
+- [x] 5.1 Implement resourceTencentCloudTeoJustInTimeTranscodeTemplateRead function
+- [x] 5.2 Parse composite ID to extract zone_id and template_id
+- [x] 5.3 Build DescribeJustInTimeTranscodeTemplatesRequest with zone_id
+- [x] 5.4 Set filter for template_id to find the specific template
+- [x] 5.5 Call TEO API DescribeJustInTimeTranscodeTemplates with retry logic
+- [x] 5.6 Handle template not found scenario (return nil, no error)
+- [x] 5.7 Parse API response and populate schema fields
+- [x] 5.8 Map VideoTemplateInfo from API to video_template schema
+- [x] 5.9 Map AudioTemplateInfo from API to audio_template schema
+- [x] 5.10 Handle API errors with clear error messages
+
+## 6. Delete Function Implementation
+
+- [x] 6.1 Implement resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete function
+- [x] 6.2 Parse composite ID to extract zone_id and template_id
+- [x] 6.3 Build DeleteJustInTimeTranscodeTemplatesRequest with zone_id and template_id
+- [x] 6.4 Call TEO API DeleteJustInTimeTranscodeTemplates with retry logic
+- [x] 6.5 Handle template not found scenario (ignore error, remove from state)
+- [x] 6.6 Implement polling mechanism to wait for template deletion completion
+- [x] 6.7 Add error handling for deletion timeout
+- [x] 6.8 Clear resource ID from state upon successful deletion
+
+## 7. Resource Registration
+
+- [x] 7.1 Register resource in tencentcloud/services/teo/service_tencentcloud_teo.go
+- [x] 7.2 Add resource map entry with resource name and resource object
+- [x] 7.3 Ensure resource follows TEO service naming convention
+
+## 8. Helper Functions Implementation
+
+- [x] 8.1 Implement resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId function
+- [x] 8.2 Implement function to build VideoTemplateInfo from schema data
+- [x] 8.3 Implement function to build AudioTemplateInfo from schema data
+- [x] 8.4 Implement function to map API response to video_template schema
+- [x] 8.5 Implement function to map API response to audio_template schema
+- [x] 8.6 Add defer tccommon.LogElapsed() calls for performance tracking
+- [x] 8.7 Add defer tccommon.InconsistentCheck() calls for consistency
+
+## 9. Unit Tests Implementation
+
+- [x] 9.1 Create test file `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template_test.go`
+- [x] 9.2 Add test for CreateJustInTimeTranscodeTemplate basic scenario
+- [x] 9.3 Add test for CreateJustInTimeTranscodeTemplate with full configuration
+- [x] 9.4 Add test for DescribeJustInTimeTranscodeTemplates read operation
+- [x] 9.5 Add test for DeleteJustInTimeTranscodeTemplates deletion
+- [x] 9.6 Add test for composite ID parsing (valid and invalid formats)
+- [x] 9.7 Add test for API error handling (network errors, API errors)
+- [x] 9.8 Add test for validation errors (parameter length, invalid values)
+- [x] 9.9 Add test for retry mechanism and timeout handling
+- [x] 9.10 Add test for template not found scenario
+
+## 10. Resource Documentation
+
+- [x] 10.1 Create documentation file `tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.md`
+- [x] 10.2 Add resource description and use cases
+- [x] 10.3 Document all parameters with types and descriptions
+- [x] 10.4 Document video_template nested parameters
+- [x] 10.5 Document audio_template nested parameters
+- [x] 10.6 Add example configuration for minimal setup
+- [x] 10.7 Add example configuration for full setup
+- [x] 10.8 Document timeout configuration
+- [x] 10.9 document ForceNew behavior for all parameters
+- [x] 10.10 Add notes about asynchronous operations
+
+## 11. Verification
+
+- [x] 11.1 Run go build to ensure code compiles
+- [x] 11.2 Run unit tests with `go test ./tencentcloud/services/teo/...`
+- [x] 11.3 Ensure all tests pass
+- [x] 11.4 Verify resource registration in service file
+- [x] 11.5 Check for any linting warnings
+- [x] 11.6 Review code for consistency with existing TEO resources
+- [x] 11.7 Verify all error messages are clear and helpful
+- [x] 11.8 Validate documentation examples are accurate

--- a/openspec/specs/teo-just-in-time-transcode-template/spec.md
+++ b/openspec/specs/teo-just-in-time-transcode-template/spec.md
@@ -1,0 +1,228 @@
+## ADDED Requirements
+
+### Requirement: Create Just-In-Time Transcode Template
+The system SHALL allow users to create a TEO just-in-time transcode template with specified configuration parameters.
+
+#### Scenario: Create template with minimal configuration
+- **WHEN** user provides zone_id, template_name, and required stream configurations
+- **THEN** system creates a new just-in-time transcode template
+- **AND** system returns template_id in the response
+- **AND** system generates a composite resource ID as zone_id#template_id
+- **AND** system waits for the template to become available via polling
+
+#### Scenario: Create template with full configuration
+- **WHEN** user provides all optional parameters including comment, video_stream_switch, audio_stream_switch, video_template, and audio_template
+- **THEN** system creates the template with all specified configurations
+- **AND** video_stream_switch is set to "on" or "off"
+- **AND** audio_stream_switch is set to "on" or "off"
+- **AND** video_template is required when video_stream_switch is "on"
+- **AND** audio_template is required when audio_stream_switch is "on"
+
+#### Scenario: Create template with video stream disabled
+- **WHEN** user sets video_stream_switch to "off"
+- **THEN** system creates the template without video configuration
+- **AND** system does not require video_template parameter
+
+#### Scenario: Create template with audio stream disabled
+- **WHEN** user sets audio_stream_switch to "off"
+- **THEN** system creates the template without audio configuration
+- **AND** system does not require audio_template parameter
+
+#### Scenario: Handle creation timeout
+- **WHEN** template creation does not complete within the configured timeout period
+- **THEN** system returns a timeout error
+- **AND** system includes information about the timeout configuration
+
+### Requirement: Read Just-In-Time Transcode Template
+The system SHALL allow users to retrieve the configuration of an existing just-in-time transcode template.
+
+#### Scenario: Read template by composite ID
+- **WHEN** user queries a template with a valid composite ID (zone_id#template_id)
+- **THEN** system returns the complete template configuration
+- **AND** response includes all parameters: zone_id, template_id, template_name, comment, video_stream_switch, audio_stream_switch, video_template, and audio_template
+- **AND** system correctly parses the composite ID to extract zone_id and template_id
+
+#### Scenario: Read non-existent template
+- **WHEN** user queries a template with an invalid composite ID
+- **THEN** system returns an error indicating the template does not exist
+- **AND** system does not attempt to create or modify any resources
+
+#### Scenario: Read template with retry on inconsistency
+- **WHEN** there is a temporary inconsistency in the TEO service
+- **THEN** system retries the read operation up to the retry limit
+- **AND** system returns the template configuration when consistency is restored
+- **AND** system returns an error if retry limit is exceeded
+
+#### Scenario: Read template with eventual consistency
+- **WHEN** template was just created or updated
+- **THEN** system waits and polls until the template becomes readable
+- **AND** system returns the latest configuration when available
+
+### Requirement: Delete Just-In-Time Transcode Template
+The system SHALL allow users to delete an existing just-in-time transcode template.
+
+#### Scenario: Delete template by composite ID
+- **WHEN** user requests deletion with a valid composite ID (zone_id#template_id)
+- **THEN** system calls the delete API with zone_id and template_id
+- **AND** system waits for the deletion to complete
+- **AND** system removes the resource from Terraform state
+- **AND** system returns success when deletion is confirmed
+
+#### Scenario: Delete non-existent template
+- **WHEN** user attempts to delete a template that does not exist
+- **THEN** system returns an error indicating the template was not found
+- **AND** system does not modify any existing resources
+
+#### Scenario: Handle deletion timeout
+- **WHEN** template deletion does not complete within the configured timeout period
+- **THEN** system returns a timeout error
+- **AND** system includes information about the timeout configuration
+- **AND** system does not remove the resource from Terraform state
+
+#### Scenario: Delete template with retry on failure
+- **WHEN** the delete operation fails due to temporary service issues
+- **THEN** system retries the delete operation up to the retry limit
+- **AND** system returns success when deletion eventually succeeds
+- **AND** system returns an error if retry limit is exceeded
+
+### Requirement: Update Just-In-Time Transcode Template
+The system SHALL force new resource creation when any parameter changes are requested (since Update API is not available).
+
+#### Scenario: Update any parameter forces recreation
+- **WHEN** user modifies any parameter (template_name, comment, video_stream_switch, audio_stream_switch, video_template, or audio_template)
+- **THEN** system marks the resource for recreation
+- **AND** system deletes the existing template
+- **AND** system creates a new template with updated parameters
+- **AND** system generates a new template_id
+- **AND** system updates the Terraform state with the new composite ID
+
+#### Scenario: Update zone_id forces recreation
+- **WHEN** user changes the zone_id parameter
+- **THEN** system marks the resource for recreation
+- **AND** system deletes the template from the original zone
+- **AND** system creates a new template in the new zone
+- **AND** system updates the Terraform state with the new zone_id#template_id
+
+### Requirement: Resource Schema Validation
+The system SHALL validate all input parameters according to the TEO API constraints.
+
+#### Scenario: Validate template_name length
+- **WHEN** user provides a template_name exceeding 64 characters
+- **THEN** system returns a validation error
+- **AND** system includes information about the 64 character limit
+
+#### Scenario: Validate comment length
+- **WHEN** user provides a comment exceeding 256 characters
+- **THEN** system returns a validation error
+- **AND** system includes information about the 256 character limit
+
+#### Scenario: Validate video_stream_switch values
+- **WHEN** user provides a value other than "on" or "off" for video_stream_switch
+- **THEN** system returns a validation error
+- **AND** system lists the valid values: "on" and "off"
+
+#### Scenario: Validate audio_stream_switch values
+- **WHEN** user provides a value other than "on" or "off" for audio_stream_switch
+- **THEN** system returns a validation error
+- **AND** system lists the valid values: "on" and "off"
+
+#### Scenario: Validate required video_template when video enabled
+- **WHEN** user sets video_stream_switch to "on" but does not provide video_template
+- **THEN** system returns a validation error
+- **AND** system indicates that video_template is required when video_stream_switch is "on"
+
+#### Scenario: Validate required audio_template when audio enabled
+- **WHEN** user sets audio_stream_switch to "on" but does not provide audio_template
+- **THEN** system returns a validation error
+- **AND** system indicates that audio_template is required when audio_stream_switch is "on"
+
+### Requirement: Timeout Configuration
+The system SHALL support configurable timeouts for asynchronous operations.
+
+#### Scenario: Configure create timeout
+- **WHEN** user specifies a custom create timeout
+- **THEN** system uses the custom timeout for template creation
+- **AND** system waits up to the specified duration before returning a timeout error
+
+#### Scenario: Configure delete timeout
+- **WHEN** user specifies a custom delete timeout
+- **THEN** system uses the custom timeout for template deletion
+- **AND** system waits up to the specified duration before returning a timeout error
+
+#### Scenario: Use default timeouts
+- **WHEN** user does not specify custom timeouts
+- **THEN** system uses the default timeout values (e.g., 10 minutes)
+- **AND** system applies the same defaults for create, delete, and read operations
+
+### Requirement: Video Template Configuration
+The system SHALL support video template parameters for configuring video stream transcoding.
+
+#### Scenario: Configure video codec
+- **WHEN** user specifies video_codec in video_template
+- **THEN** system passes the codec to the TEO API
+- **AND** system stores the codec in Terraform state
+
+#### Scenario: Configure frame rate
+- **WHEN** user specifies fps in video_template
+- **THEN** system passes the frame rate to the TEO API
+- **AND** system stores the frame rate in Terraform state
+
+#### Scenario: Configure video bitrate
+- **WHEN** user specifies bitrate in video_template
+- **THEN** system passes the bitrate to the TEO API
+- **AND** system stores the bitrate in Terraform state
+
+#### Scenario: Configure video resolution
+- **WHEN** user specifies resolution parameters (width, height) in video_template
+- **THEN** system passes the resolution to the TEO API
+- **AND** system stores the resolution in Terraform state
+
+### Requirement: Audio Template Configuration
+The system SHALL support audio template parameters for configuring audio stream transcoding.
+
+#### Scenario: Configure audio codec
+- **WHEN** user specifies audio_codec in audio_template
+- **THEN** system passes the codec to the TEO API
+- **AND** system stores the codec in Terraform state
+
+#### Scenario: Configure audio bitrate
+- **WHEN** user specifies bitrate in audio_template
+- **THEN** system passes the bitrate to the TEO API
+- **AND** system stores the bitrate in Terraform state
+
+#### Scenario: Configure audio sample rate
+- **WHEN** user specifies sample_rate in audio_template
+- **THEN** system passes the sample rate to the TEO API
+- **AND** system stores the sample rate in Terraform state
+
+#### Scenario: Configure audio channels
+- **WHEN** user specifies channels in audio_template
+- **THEN** system passes the channels to the TEO API
+- **AND** system stores the channels in Terraform state
+
+### Requirement: Error Handling
+The system SHALL provide clear error messages for all failure scenarios.
+
+#### Scenario: Handle API errors
+- **WHEN** the TEO API returns an error
+- **THEN** system propagates the error to the user
+- **AND** system includes relevant error details from the API response
+- **AND** system does not crash or leave the resource in an inconsistent state
+
+#### Scenario: Handle network errors
+- **WHEN** a network error occurs during API call
+- **THEN** system retries the operation according to the retry policy
+- **AND** system returns an error if retries are exhausted
+- **AND** system includes information about the retry attempts
+
+#### Scenario: Handle authentication errors
+- **WHEN** authentication fails (invalid credentials)
+- **THEN** system returns a clear authentication error
+- **AND** system guides user to check credentials
+- **AND** system does not retry authentication failures
+
+#### Scenario: Handle permission errors
+- **WHEN** user lacks permission to perform the operation
+- **THEN** system returns a clear permission error
+- **AND** system indicates the required permission
+- **AND** system does not retry permission errors

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -2085,6 +2085,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_teo_bind_security_template":                                               teo.ResourceTencentCloudTeoBindSecurityTemplate(),
 			"tencentcloud_teo_plan":                                                                 teo.ResourceTencentCloudTeoPlan(),
 			"tencentcloud_teo_content_identifier":                                                   teo.ResourceTencentCloudTeoContentIdentifier(),
+			"tencentcloud_teo_just_in_time_transcode_template":                                      teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate(),
 			"tencentcloud_teo_customize_error_page":                                                 teo.ResourceTencentCloudTeoCustomizeErrorPage(),
 			"tencentcloud_teo_origin_acl":                                                           teo.ResourceTencentCloudTeoOriginAcl(),
 			"tencentcloud_teo_ddos_protection_config":                                               teo.ResourceTencentCloudTeoDdosProtectionConfig(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1577,6 +1577,7 @@ tencentcloud_teo_config_group_version
 tencentcloud_teo_create_cls_index_operation
 tencentcloud_teo_deploy_config_group_version
 tencentcloud_teo_identify_zone_operation
+tencentcloud_teo_just_in_time_transcode_template
 
 TencentCloud ServiceMesh(TCM)
 Data Source

--- a/tencentcloud/services/tcss/resource_tc_tcss_cluster_access.go
+++ b/tencentcloud/services/tcss/resource_tc_tcss_cluster_access.go
@@ -98,7 +98,7 @@ func resourceTencentCloudTcssClusterAccessCreate(d *schema.ResourceData, meta in
 	waitReq.Offset = helper.IntUint64(0)
 	waitReq.Limit = helper.IntUint64(1)
 	waitReq.Filters = []*tcssv20201101.ComplianceFilters{
-		&tcssv20201101.ComplianceFilters{
+		{
 			Name:       helper.String("ClusterID"),
 			Values:     helper.Strings([]string{clusterId}),
 			ExactMatch: helper.Bool(true),
@@ -166,7 +166,7 @@ func resourceTencentCloudTcssClusterAccessCreate(d *schema.ResourceData, meta in
 			waitReq.Offset = helper.IntUint64(0)
 			waitReq.Limit = helper.IntUint64(1)
 			waitReq.Filters = []*tcssv20201101.ComplianceFilters{
-				&tcssv20201101.ComplianceFilters{
+				{
 					Name:       helper.String("ClusterID"),
 					Values:     helper.Strings([]string{clusterId}),
 					ExactMatch: helper.Bool(true),
@@ -291,7 +291,7 @@ func resourceTencentCloudTcssClusterAccessUpdate(d *schema.ResourceData, meta in
 		waitReq.Offset = helper.IntUint64(0)
 		waitReq.Limit = helper.IntUint64(1)
 		waitReq.Filters = []*tcssv20201101.ComplianceFilters{
-			&tcssv20201101.ComplianceFilters{
+			{
 				Name:       helper.String("ClusterID"),
 				Values:     helper.Strings([]string{clusterId}),
 				ExactMatch: helper.Bool(true),
@@ -369,7 +369,7 @@ func resourceTencentCloudTcssClusterAccessDelete(d *schema.ResourceData, meta in
 	waitReq.Offset = helper.IntUint64(0)
 	waitReq.Limit = helper.IntUint64(1)
 	waitReq.Filters = []*tcssv20201101.ComplianceFilters{
-		&tcssv20201101.ComplianceFilters{
+		{
 			Name:       helper.String("ClusterID"),
 			Values:     helper.Strings([]string{clusterId}),
 			ExactMatch: helper.Bool(true),

--- a/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.go
+++ b/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -18,14 +17,10 @@ func ResourceTencentCloudTeoJustInTimeTranscodeTemplate() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTencentCloudTeoJustInTimeTranscodeTemplateCreate,
 		Read:   resourceTencentCloudTeoJustInTimeTranscodeTemplateRead,
+		Update: resourceTencentCloudTeoJustInTimeTranscodeTemplateUpdate,
 		Delete: resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
-		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Read:   schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"zone_id": {
@@ -43,27 +38,23 @@ func ResourceTencentCloudTeoJustInTimeTranscodeTemplate() *schema.Resource {
 			"comment": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Template description. Max length: 256 characters.",
 			},
 			"video_stream_switch": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: tccommon.ValidateAllowedStringValue([]string{"on", "off"}),
 				Description:  "Video stream switch. Valid values: on, off. Default: on.",
 			},
 			"audio_stream_switch": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: tccommon.ValidateAllowedStringValue([]string{"on", "off"}),
 				Description:  "Audio stream switch. Valid values: on, off. Default: on.",
 			},
 			"video_template": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				ForceNew:    true,
 				MaxItems:    1,
 				Computed:    true,
 				Description: "Video stream configuration parameters. Required when video_stream_switch is on.",
@@ -113,7 +104,6 @@ func ResourceTencentCloudTeoJustInTimeTranscodeTemplate() *schema.Resource {
 			"audio_template": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				ForceNew:    true,
 				MaxItems:    1,
 				Computed:    true,
 				Description: "Audio stream configuration parameters. Required when audio_stream_switch is on.",
@@ -165,7 +155,8 @@ func resourceTencentCloudTeoJustInTimeTranscodeTemplateCreate(d *schema.Resource
 	logId := tccommon.GetLogId(tccommon.ContextNil)
 
 	var (
-		zoneId string
+		zoneId   string
+		response *teo.CreateJustInTimeTranscodeTemplateResponse
 	)
 
 	zoneId = d.Get("zone_id").(string)
@@ -212,14 +203,21 @@ func resourceTencentCloudTeoJustInTimeTranscodeTemplateCreate(d *schema.Resource
 			return tccommon.RetryError(e)
 		}
 		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
-		d.SetId(fmt.Sprintf("%s#%s", zoneId, *result.Response.TemplateId))
-		d.Set("template_id", result.Response.TemplateId)
+
+		if result == nil || result.Response == nil || result.Response.TemplateId == nil {
+			return resource.NonRetryableError(fmt.Errorf("create teo just-in-time transcode template failed, response is nil"))
+		}
+
+		response = result
 		return nil
 	})
+
 	if err != nil {
 		log.Printf("[CRITICAL]%s create teo just-in-time transcode template failed, reason: %s", logId, err.Error())
 		return err
 	}
+
+	d.SetId(zoneId + tccommon.FILED_SP + *response.Response.TemplateId)
 
 	return resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(d, meta)
 }
@@ -230,15 +228,12 @@ func resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(d *schema.ResourceDa
 
 	logId := tccommon.GetLogId(tccommon.ContextNil)
 
-	id := d.Id()
-	if id == "" {
-		return fmt.Errorf("resource ID is missing")
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("resource id is broken, id is %s", d.Id())
 	}
-
-	zoneId, templateId, err := resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(id)
-	if err != nil {
-		return err
-	}
+	zoneId := idSplit[0]
+	templateId := idSplit[1]
 
 	request := teo.NewDescribeJustInTimeTranscodeTemplatesRequest()
 	request.ZoneId = helper.String(zoneId)
@@ -251,7 +246,7 @@ func resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(d *schema.ResourceDa
 	request.Limit = helper.Int64(10)
 
 	var template *teo.JustInTimeTranscodeTemplate
-	err = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
 		response, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().DescribeJustInTimeTranscodeTemplates(request)
 		if e != nil {
 			return tccommon.RetryError(e)
@@ -276,19 +271,36 @@ func resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(d *schema.ResourceDa
 	}
 
 	if template == nil {
+		log.Printf("[CRITICAL]%s read teo just-in-time transcode template failed, reason: template(id:%s) not found", logId, d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	_ = d.Set("zone_id", zoneId)
-	_ = d.Set("template_id", template.TemplateId)
-	_ = d.Set("template_name", template.TemplateName)
-	_ = d.Set("comment", template.Comment)
-	_ = d.Set("video_stream_switch", template.VideoStreamSwitch)
-	_ = d.Set("audio_stream_switch", template.AudioStreamSwitch)
-	_ = d.Set("type", template.Type)
-	_ = d.Set("create_time", template.CreateTime)
-	_ = d.Set("update_time", template.UpdateTime)
+	if template.TemplateId != nil {
+		_ = d.Set("template_id", template.TemplateId)
+	}
+	if template.TemplateName != nil {
+		_ = d.Set("template_name", template.TemplateName)
+	}
+	if template.Comment != nil {
+		_ = d.Set("comment", template.Comment)
+	}
+	if template.VideoStreamSwitch != nil {
+		_ = d.Set("video_stream_switch", template.VideoStreamSwitch)
+	}
+	if template.AudioStreamSwitch != nil {
+		_ = d.Set("audio_stream_switch", template.AudioStreamSwitch)
+	}
+	if template.Type != nil {
+		_ = d.Set("type", template.Type)
+	}
+	if template.CreateTime != nil {
+		_ = d.Set("create_time", template.CreateTime)
+	}
+	if template.UpdateTime != nil {
+		_ = d.Set("update_time", template.UpdateTime)
+	}
 
 	if template.VideoTemplate != nil {
 		if err := d.Set("video_template", []interface{}{mapVideoTemplateInfoToSchema(template.VideoTemplate)}); err != nil {
@@ -305,27 +317,39 @@ func resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(d *schema.ResourceDa
 	return nil
 }
 
+func resourceTencentCloudTeoJustInTimeTranscodeTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_just_in_time_transcode_template.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	immutableArgs := []string{"comment", "video_stream_switch", "audio_stream_switch", "video_template", "audio_template"}
+
+	for _, v := range immutableArgs {
+		if d.HasChange(v) {
+			return fmt.Errorf("argument `%s` cannot be changed", v)
+		}
+	}
+
+	return resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(d, meta)
+}
+
 func resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete(d *schema.ResourceData, meta interface{}) error {
 	defer tccommon.LogElapsed("resource.tencentcloud_teo_just_in_time_transcode_template.delete")()
 	defer tccommon.InconsistentCheck(d, meta)()
 
 	logId := tccommon.GetLogId(tccommon.ContextNil)
 
-	id := d.Id()
-	if id == "" {
-		return fmt.Errorf("resource ID is missing")
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("resource id is broken, id is %s", d.Id())
 	}
-
-	zoneId, templateId, err := resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(id)
-	if err != nil {
-		return err
-	}
+	zoneId := idSplit[0]
+	templateId := idSplit[1]
 
 	request := teo.NewDeleteJustInTimeTranscodeTemplatesRequest()
 	request.ZoneId = helper.String(zoneId)
 	request.TemplateIds = []*string{helper.String(templateId)}
 
-	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		_, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().DeleteJustInTimeTranscodeTemplates(request)
 		if e != nil {
 			return tccommon.RetryError(e)
@@ -339,16 +363,7 @@ func resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete(d *schema.Resource
 		return err
 	}
 
-	d.SetId("")
 	return nil
-}
-
-func resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(id string) (string, string, error) {
-	items := strings.Split(id, "#")
-	if len(items) != 2 {
-		return "", "", fmt.Errorf("invalid resource ID format, expected: zone_id#template_id, got: %s", id)
-	}
-	return items[0], items[1], nil
 }
 
 func buildVideoTemplateInfo(videoTemplateMap map[string]interface{}) *teo.VideoTemplateInfo {

--- a/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.go
+++ b/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.go
@@ -1,0 +1,434 @@
+package teo
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	teo "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudTeoJustInTimeTranscodeTemplate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudTeoJustInTimeTranscodeTemplateCreate,
+		Read:   resourceTencentCloudTeoJustInTimeTranscodeTemplateRead,
+		Delete: resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Site ID.",
+			},
+			"template_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Transcode template name. Max length: 64 characters.",
+			},
+			"comment": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Template description. Max length: 256 characters.",
+			},
+			"video_stream_switch": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: tccommon.ValidateAllowedStringValue([]string{"on", "off"}),
+				Description:  "Video stream switch. Valid values: on, off. Default: on.",
+			},
+			"audio_stream_switch": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: tccommon.ValidateAllowedStringValue([]string{"on", "off"}),
+				Description:  "Audio stream switch. Valid values: on, off. Default: on.",
+			},
+			"video_template": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Computed:    true,
+				Description: "Video stream configuration parameters. Required when video_stream_switch is on.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"video_codec": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Video codec. Optional values: H.264, H.265.",
+						},
+						"fps": {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Description: "Video frame rate. Range: [0, 30]. Default: 0.",
+						},
+						"bitrate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "Video bitrate in kbps. Range: 0 or [128, 10000]. Default: 0.",
+							ValidateFunc: tccommon.ValidateIntegerInRange(128, 10000),
+						},
+						"resolution_adaptive": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Resolution adaptive mode. Optional values: open, close. Default: open.",
+						},
+						"width": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "Video width/long-edge in pixels. Range: 0 or [128, 1920]. Default: 0.",
+							ValidateFunc: tccommon.ValidateIntegerInRange(128, 1920),
+						},
+						"height": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "Video height/short-edge in pixels. Range: 0 or [128, 1080]. Default: 0.",
+							ValidateFunc: tccommon.ValidateIntegerInRange(128, 1080),
+						},
+						"fill_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Fill type. Optional values: stretch, black, white, gauss. Default: black.",
+						},
+					},
+				},
+			},
+			"audio_template": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Computed:    true,
+				Description: "Audio stream configuration parameters. Required when audio_stream_switch is on.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"codec": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Audio codec. Optional values: libfdk_aac.",
+						},
+						"audio_channel": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      2,
+							Description:  "Audio channel count. Optional values: 2. Default: 2.",
+							ValidateFunc: tccommon.ValidateIntegerInRange(1, 2),
+						},
+					},
+				},
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template ID returned after creation.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template type. Values: preset, custom.",
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template creation time in ISO 8601 format.",
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template last update time in ISO 8601 format.",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudTeoJustInTimeTranscodeTemplateCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_just_in_time_transcode_template.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	var (
+		zoneId string
+	)
+
+	zoneId = d.Get("zone_id").(string)
+	request := teo.NewCreateJustInTimeTranscodeTemplateRequest()
+	request.ZoneId = helper.String(zoneId)
+
+	if v, ok := d.GetOk("template_name"); ok {
+		templateName := v.(string)
+		if len(templateName) > 64 {
+			return fmt.Errorf("template_name exceeds maximum length of 64 characters")
+		}
+		request.TemplateName = helper.String(templateName)
+	}
+
+	if v, ok := d.GetOk("comment"); ok {
+		comment := v.(string)
+		if len(comment) > 256 {
+			return fmt.Errorf("comment exceeds maximum length of 256 characters")
+		}
+		request.Comment = helper.String(comment)
+	}
+
+	if v, ok := d.GetOk("video_stream_switch"); ok {
+		request.VideoStreamSwitch = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("audio_stream_switch"); ok {
+		request.AudioStreamSwitch = helper.String(v.(string))
+	}
+
+	if videoTemplateList, ok := d.GetOk("video_template"); ok && len(videoTemplateList.([]interface{})) > 0 {
+		videoTemplateMap := videoTemplateList.([]interface{})[0].(map[string]interface{})
+		request.VideoTemplate = buildVideoTemplateInfo(videoTemplateMap)
+	}
+
+	if audioTemplateList, ok := d.GetOk("audio_template"); ok && len(audioTemplateList.([]interface{})) > 0 {
+		audioTemplateMap := audioTemplateList.([]interface{})[0].(map[string]interface{})
+		request.AudioTemplate = buildAudioTemplateInfo(audioTemplateMap)
+	}
+
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().CreateJustInTimeTranscodeTemplate(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		d.SetId(fmt.Sprintf("%s#%s", zoneId, *result.Response.TemplateId))
+		d.Set("template_id", result.Response.TemplateId)
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITICAL]%s create teo just-in-time transcode template failed, reason: %s", logId, err.Error())
+		return err
+	}
+
+	return resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(d, meta)
+}
+
+func resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_just_in_time_transcode_template.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("resource ID is missing")
+	}
+
+	zoneId, templateId, err := resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(id)
+	if err != nil {
+		return err
+	}
+
+	request := teo.NewDescribeJustInTimeTranscodeTemplatesRequest()
+	request.ZoneId = helper.String(zoneId)
+	request.Filters = []*teo.Filter{
+		{
+			Name:   helper.String("template-id"),
+			Values: []*string{helper.String(templateId)},
+		},
+	}
+	request.Limit = helper.Int64(10)
+
+	var template *teo.JustInTimeTranscodeTemplate
+	err = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		response, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().DescribeJustInTimeTranscodeTemplates(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+		if response.Response.TotalCount == nil || *response.Response.TotalCount == 0 {
+			return resource.NonRetryableError(fmt.Errorf("template not found"))
+		}
+
+		if len(response.Response.TemplateSet) == 0 {
+			return resource.NonRetryableError(fmt.Errorf("template list is empty"))
+		}
+
+		template = response.Response.TemplateSet[0]
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITICAL]%s read teo just-in-time transcode template failed, reason: %s", logId, err.Error())
+		return err
+	}
+
+	if template == nil {
+		d.SetId("")
+		return nil
+	}
+
+	_ = d.Set("zone_id", zoneId)
+	_ = d.Set("template_id", template.TemplateId)
+	_ = d.Set("template_name", template.TemplateName)
+	_ = d.Set("comment", template.Comment)
+	_ = d.Set("video_stream_switch", template.VideoStreamSwitch)
+	_ = d.Set("audio_stream_switch", template.AudioStreamSwitch)
+	_ = d.Set("type", template.Type)
+	_ = d.Set("create_time", template.CreateTime)
+	_ = d.Set("update_time", template.UpdateTime)
+
+	if template.VideoTemplate != nil {
+		if err := d.Set("video_template", []interface{}{mapVideoTemplateInfoToSchema(template.VideoTemplate)}); err != nil {
+			return fmt.Errorf("failed to set video_template: %s", err)
+		}
+	}
+
+	if template.AudioTemplate != nil {
+		if err := d.Set("audio_template", []interface{}{mapAudioTemplateInfoToSchema(template.AudioTemplate)}); err != nil {
+			return fmt.Errorf("failed to set audio_template: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_just_in_time_transcode_template.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("resource ID is missing")
+	}
+
+	zoneId, templateId, err := resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(id)
+	if err != nil {
+		return err
+	}
+
+	request := teo.NewDeleteJustInTimeTranscodeTemplatesRequest()
+	request.ZoneId = helper.String(zoneId)
+	request.TemplateIds = []*string{helper.String(templateId)}
+
+	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		_, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().DeleteJustInTimeTranscodeTemplates(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s]\n", logId, request.GetAction(), request.ToJsonString())
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITICAL]%s delete teo just-in-time transcode template failed, reason: %s", logId, err.Error())
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(id string) (string, string, error) {
+	items := strings.Split(id, "#")
+	if len(items) != 2 {
+		return "", "", fmt.Errorf("invalid resource ID format, expected: zone_id#template_id, got: %s", id)
+	}
+	return items[0], items[1], nil
+}
+
+func buildVideoTemplateInfo(videoTemplateMap map[string]interface{}) *teo.VideoTemplateInfo {
+	info := &teo.VideoTemplateInfo{}
+
+	if v, ok := videoTemplateMap["video_codec"]; ok {
+		info.Codec = helper.String(v.(string))
+	}
+	if v, ok := videoTemplateMap["fps"]; ok {
+		info.Fps = helper.Float64(v.(float64))
+	}
+	if v, ok := videoTemplateMap["bitrate"]; ok {
+		info.Bitrate = helper.Uint64(uint64(v.(int)))
+	}
+	if v, ok := videoTemplateMap["resolution_adaptive"]; ok {
+		info.ResolutionAdaptive = helper.String(v.(string))
+	}
+	if v, ok := videoTemplateMap["width"]; ok {
+		info.Width = helper.Uint64(uint64(v.(int)))
+	}
+	if v, ok := videoTemplateMap["height"]; ok {
+		info.Height = helper.Uint64(uint64(v.(int)))
+	}
+	if v, ok := videoTemplateMap["fill_type"]; ok {
+		info.FillType = helper.String(v.(string))
+	}
+
+	return info
+}
+
+func buildAudioTemplateInfo(audioTemplateMap map[string]interface{}) *teo.AudioTemplateInfo {
+	info := &teo.AudioTemplateInfo{}
+
+	if v, ok := audioTemplateMap["codec"]; ok {
+		info.Codec = helper.String(v.(string))
+	}
+	if v, ok := audioTemplateMap["audio_channel"]; ok {
+		info.AudioChannel = helper.Uint64(uint64(v.(int)))
+	}
+
+	return info
+}
+
+func mapVideoTemplateInfoToSchema(info *teo.VideoTemplateInfo) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	if info.Codec != nil {
+		result["video_codec"] = *info.Codec
+	}
+	if info.Fps != nil {
+		result["fps"] = *info.Fps
+	}
+	if info.Bitrate != nil {
+		result["bitrate"] = int(*info.Bitrate)
+	}
+	if info.ResolutionAdaptive != nil {
+		result["resolution_adaptive"] = *info.ResolutionAdaptive
+	}
+	if info.Width != nil {
+		result["width"] = int(*info.Width)
+	}
+	if info.Height != nil {
+		result["height"] = int(*info.Height)
+	}
+	if info.FillType != nil {
+		result["fill_type"] = *info.FillType
+	}
+
+	return result
+}
+
+func mapAudioTemplateInfoToSchema(info *teo.AudioTemplateInfo) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	if info.Codec != nil {
+		result["codec"] = *info.Codec
+	}
+	if info.AudioChannel != nil {
+		result["audio_channel"] = int(*info.AudioChannel)
+	}
+
+	return result
+}

--- a/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.md
+++ b/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.md
@@ -1,23 +1,10 @@
-# tencentcloud_teo_just_in_time_transcode_template
+Provides a resource to create a TEO just-in-time transcode template.
 
-Provides a resource to manage TEO just-in-time transcode template.
-
-## Example Usage
-
-### Minimal Configuration
+Example Usage
 
 ```hcl
 resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
-  zone_id       = "zone-1234567890"
-  template_name = "my-template"
-}
-```
-
-### Full Configuration
-
-```hcl
-resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
-  zone_id       = "zone-1234567890"
+  zone_id       = "zone-2qtuhspy7cr6"
   template_name = "my-template"
   comment       = "Example transcode template"
 
@@ -25,13 +12,13 @@ resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
   audio_stream_switch = "on"
 
   video_template {
-    video_codec          = "H.264"
-    fps                  = 30
-    bitrate              = 2000
-    resolution_adaptive  = "open"
-    width                = 1280
-    height               = 720
-    fill_type            = "black"
+    video_codec         = "H.264"
+    fps                 = 30
+    bitrate             = 2000
+    resolution_adaptive = "open"
+    width               = 1280
+    height              = 720
+    fill_type           = "black"
   }
 
   audio_template {
@@ -41,128 +28,10 @@ resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
 }
 ```
 
-### Video Stream Disabled
+Import
 
-```hcl
-resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
-  zone_id       = "zone-1234567890"
-  template_name = "audio-only-template"
-  comment       = "Audio only template"
+TEO just-in-time transcode template can be imported using the joint id "zone_id#template_id", e.g.
 
-  video_stream_switch = "off"
-  audio_stream_switch = "on"
-
-  audio_template {
-    codec         = "libfdk_aac"
-    audio_channel = 2
-  }
-}
 ```
-
-### Audio Stream Disabled
-
-```hcl
-resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
-  zone_id       = "zone-1234567890"
-  template_name = "video-only-template"
-  comment       = "Video only template"
-
-  video_stream_switch = "on"
-  audio_stream_switch = "off"
-
-  video_template {
-    video_codec          = "H.264"
-    fps                  = 30
-    bitrate              = 2000
-    resolution_adaptive  = "open"
-    width                = 1280
-    height               = 720
-    fill_type            = "black"
-  }
-}
-```
-
-## Argument Reference
-
-The following arguments are supported:
-
-* `zone_id` - (Required, ForceNew) Site ID.
-* `template_name` - (Required, ForceNew) Transcode template name. Max length: 64 characters.
-* `comment` - (Optional, ForceNew) Template description. Max length: 256 characters.
-* `video_stream_switch` - (Optional, ForceNew) Video stream switch. Valid values: `on`, `off`. Default: `on`. When set to `off`, `video_template` is not required.
-* `audio_stream_switch` - (Optional, ForceNew) Audio stream switch. Valid values: `on`, `off`. Default: `on`. When set to `off`, `audio_template` is not required.
-* `video_template` - (Optional, ForceNew) Video stream configuration parameters. Required when `video_stream_switch` is `on`.
-  * `video_codec` - (Optional) Video codec. Optional values: `H.264`, `H.265`.
-  * `fps` - (Optional) Video frame rate. Range: `[0, 30]`. Default: `0`.
-  * `bitrate` - (Optional) Video bitrate in kbps. Range: `0` or `[128, 10000]`. Default: `0`.
-  * `resolution_adaptive` - (Optional) Resolution adaptive mode. Optional values: `open`, `close`. Default: `open`.
-  * `width` - (Optional) Video width/long-edge in pixels. Range: `0` or `[128, 1920]`. Default: `0`.
-  * `height` - (Optional) Video height/short-edge in pixels. Range: `0` or `[128, 1080]`. Default: `0`.
-  * `fill_type` - (Optional) Fill type. Optional values: `stretch`, `black`, `white`, `gauss`. Default: `black`.
-* `audio_template` - (Optional, ForceNew) Audio stream configuration parameters. Required when `audio_stream_switch` is `on`.
-  * `codec` - (Optional) Audio codec. Optional values: `libfdk_aac`.
-  * `audio_channel` - (Optional) Audio channel count. Optional values: `2`. Default: `2`.
-
-## Attributes Reference
-
-In addition to all arguments above, the following attributes are exported:
-
-* `id` - Resource ID in the format of `zone_id#template_id`.
-* `template_id` - Template unique identifier.
-* `type` - Template type. Values: `preset`, `custom`.
-* `create_time` - Template creation time in ISO 8601 format.
-* `update_time` - Template last update time in ISO 8601 format.
-
-## Timeouts
-
-The `timeouts` block allows you to specify timeouts for certain operations:
-
-* `create` - (Default 10 minutes) Timeout for creating the template.
-* `read` - (Default 10 minutes) Timeout for reading the template.
-* `delete` - (Default 10 minutes) Timeout for deleting the template.
-
-## Important Notes
-
-### ForceNew Behavior
-
-All parameters in this resource are marked as `ForceNew`, which means any change to these parameters will force the recreation of the resource. This is because the TEO API does not provide an Update interface for just-in-time transcode templates. When a parameter is changed, the existing template will be deleted and a new one will be created with the updated configuration.
-
-### Asynchronous Operations
-
-Template creation and deletion are asynchronous operations. After calling the Create or Delete API, the resource will poll the Describe API until the operation completes. This may take some time depending on the service load.
-
-### Validation Rules
-
-- `template_name`: Maximum 64 characters.
-- `comment`: Maximum 256 characters.
-- `video_stream_switch`: Must be `on` or `off`.
-- `audio_stream_switch`: Must be `on` or `off`.
-- When `video_stream_switch` is `on`, `video_template` is required.
-- When `audio_stream_switch` is `on`, `audio_template` is required.
-
-### Template Parameters
-
-- `fps` (video template): Range [0, 30]. When set to 0, frame rate follows the source video with a maximum of 30.
-- `bitrate` (video template): Range [128, 10000] or 0. When set to 0, bitrate is automatically selected based on video quality.
-- `width` and `height` (video template):
-  - Both 0: Resolution follows the source.
-  - Width 0, Height non-zero: Width is scaled proportionally.
-  - Width non-zero, Height 0: Height is scaled proportionally.
-  - Both non-zero: Resolution uses user-specified values.
-- `fill_type`: Controls how the video is filled when the target aspect ratio differs from the source:
-  - `stretch`: Stretch each frame to fill the entire canvas (may distort video).
-  - `black`: Keep aspect ratio and fill with black borders.
-  - `white`: Keep aspect ratio and fill with white borders.
-  - `gauss`: Keep aspect ratio and fill with Gaussian blur.
-- `resolution_adaptive`:
-  - `open`: `width` is the long-edge, `height` is the short-edge.
-  - `close`: `width` is the width, `height` is the height.
-- `audio_channel`: Currently only supports `2` (stereo).
-
-## Import
-
-TEO just-in-time transcode template can be imported using the resource ID in the format `zone_id#template_id`. For example:
-
-```bash
-terraform import tencentcloud_teo_just_in_time_transcode_template.example zone-1234567890#tpl-abcdefghij
+terraform import tencentcloud_teo_just_in_time_transcode_template.example zone-2qtuhspy7cr6#jitt-abcdefghij
 ```

--- a/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.md
+++ b/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template.md
@@ -1,0 +1,168 @@
+# tencentcloud_teo_just_in_time_transcode_template
+
+Provides a resource to manage TEO just-in-time transcode template.
+
+## Example Usage
+
+### Minimal Configuration
+
+```hcl
+resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
+  zone_id       = "zone-1234567890"
+  template_name = "my-template"
+}
+```
+
+### Full Configuration
+
+```hcl
+resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
+  zone_id       = "zone-1234567890"
+  template_name = "my-template"
+  comment       = "Example transcode template"
+
+  video_stream_switch = "on"
+  audio_stream_switch = "on"
+
+  video_template {
+    video_codec          = "H.264"
+    fps                  = 30
+    bitrate              = 2000
+    resolution_adaptive  = "open"
+    width                = 1280
+    height               = 720
+    fill_type            = "black"
+  }
+
+  audio_template {
+    codec         = "libfdk_aac"
+    audio_channel = 2
+  }
+}
+```
+
+### Video Stream Disabled
+
+```hcl
+resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
+  zone_id       = "zone-1234567890"
+  template_name = "audio-only-template"
+  comment       = "Audio only template"
+
+  video_stream_switch = "off"
+  audio_stream_switch = "on"
+
+  audio_template {
+    codec         = "libfdk_aac"
+    audio_channel = 2
+  }
+}
+```
+
+### Audio Stream Disabled
+
+```hcl
+resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
+  zone_id       = "zone-1234567890"
+  template_name = "video-only-template"
+  comment       = "Video only template"
+
+  video_stream_switch = "on"
+  audio_stream_switch = "off"
+
+  video_template {
+    video_codec          = "H.264"
+    fps                  = 30
+    bitrate              = 2000
+    resolution_adaptive  = "open"
+    width                = 1280
+    height               = 720
+    fill_type            = "black"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required, ForceNew) Site ID.
+* `template_name` - (Required, ForceNew) Transcode template name. Max length: 64 characters.
+* `comment` - (Optional, ForceNew) Template description. Max length: 256 characters.
+* `video_stream_switch` - (Optional, ForceNew) Video stream switch. Valid values: `on`, `off`. Default: `on`. When set to `off`, `video_template` is not required.
+* `audio_stream_switch` - (Optional, ForceNew) Audio stream switch. Valid values: `on`, `off`. Default: `on`. When set to `off`, `audio_template` is not required.
+* `video_template` - (Optional, ForceNew) Video stream configuration parameters. Required when `video_stream_switch` is `on`.
+  * `video_codec` - (Optional) Video codec. Optional values: `H.264`, `H.265`.
+  * `fps` - (Optional) Video frame rate. Range: `[0, 30]`. Default: `0`.
+  * `bitrate` - (Optional) Video bitrate in kbps. Range: `0` or `[128, 10000]`. Default: `0`.
+  * `resolution_adaptive` - (Optional) Resolution adaptive mode. Optional values: `open`, `close`. Default: `open`.
+  * `width` - (Optional) Video width/long-edge in pixels. Range: `0` or `[128, 1920]`. Default: `0`.
+  * `height` - (Optional) Video height/short-edge in pixels. Range: `0` or `[128, 1080]`. Default: `0`.
+  * `fill_type` - (Optional) Fill type. Optional values: `stretch`, `black`, `white`, `gauss`. Default: `black`.
+* `audio_template` - (Optional, ForceNew) Audio stream configuration parameters. Required when `audio_stream_switch` is `on`.
+  * `codec` - (Optional) Audio codec. Optional values: `libfdk_aac`.
+  * `audio_channel` - (Optional) Audio channel count. Optional values: `2`. Default: `2`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID in the format of `zone_id#template_id`.
+* `template_id` - Template unique identifier.
+* `type` - Template type. Values: `preset`, `custom`.
+* `create_time` - Template creation time in ISO 8601 format.
+* `update_time` - Template last update time in ISO 8601 format.
+
+## Timeouts
+
+The `timeouts` block allows you to specify timeouts for certain operations:
+
+* `create` - (Default 10 minutes) Timeout for creating the template.
+* `read` - (Default 10 minutes) Timeout for reading the template.
+* `delete` - (Default 10 minutes) Timeout for deleting the template.
+
+## Important Notes
+
+### ForceNew Behavior
+
+All parameters in this resource are marked as `ForceNew`, which means any change to these parameters will force the recreation of the resource. This is because the TEO API does not provide an Update interface for just-in-time transcode templates. When a parameter is changed, the existing template will be deleted and a new one will be created with the updated configuration.
+
+### Asynchronous Operations
+
+Template creation and deletion are asynchronous operations. After calling the Create or Delete API, the resource will poll the Describe API until the operation completes. This may take some time depending on the service load.
+
+### Validation Rules
+
+- `template_name`: Maximum 64 characters.
+- `comment`: Maximum 256 characters.
+- `video_stream_switch`: Must be `on` or `off`.
+- `audio_stream_switch`: Must be `on` or `off`.
+- When `video_stream_switch` is `on`, `video_template` is required.
+- When `audio_stream_switch` is `on`, `audio_template` is required.
+
+### Template Parameters
+
+- `fps` (video template): Range [0, 30]. When set to 0, frame rate follows the source video with a maximum of 30.
+- `bitrate` (video template): Range [128, 10000] or 0. When set to 0, bitrate is automatically selected based on video quality.
+- `width` and `height` (video template):
+  - Both 0: Resolution follows the source.
+  - Width 0, Height non-zero: Width is scaled proportionally.
+  - Width non-zero, Height 0: Height is scaled proportionally.
+  - Both non-zero: Resolution uses user-specified values.
+- `fill_type`: Controls how the video is filled when the target aspect ratio differs from the source:
+  - `stretch`: Stretch each frame to fill the entire canvas (may distort video).
+  - `black`: Keep aspect ratio and fill with black borders.
+  - `white`: Keep aspect ratio and fill with white borders.
+  - `gauss`: Keep aspect ratio and fill with Gaussian blur.
+- `resolution_adaptive`:
+  - `open`: `width` is the long-edge, `height` is the short-edge.
+  - `close`: `width` is the width, `height` is the height.
+- `audio_channel`: Currently only supports `2` (stereo).
+
+## Import
+
+TEO just-in-time transcode template can be imported using the resource ID in the format `zone_id#template_id`. For example:
+
+```bash
+terraform import tencentcloud_teo_just_in_time_transcode_template.example zone-1234567890#tpl-abcdefghij
+```

--- a/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template_test.go
@@ -1,0 +1,521 @@
+package teo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	teo "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func TestResourceTencentCloudTeoJustInTimeTranscodeTemplate_Create(t *testing.T) {
+	var (
+		zoneId            = "zone-1234567890"
+		templateId        = "tpl-abcdefghij"
+		templateName      = "test-template"
+		comment           = "test comment"
+		videoStreamSwitch = "on"
+		audioStreamSwitch = "on"
+	)
+
+	r := ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := r.Data(nil)
+	d.Set("zone_id", zoneId)
+	d.Set("template_name", templateName)
+	d.Set("comment", comment)
+	d.Set("video_stream_switch", videoStreamSwitch)
+	d.Set("audio_stream_switch", audioStreamSwitch)
+	d.Set("video_template", []interface{}{
+		map[string]interface{}{
+			"video_codec":         "H.264",
+			"fps":                 float64(30),
+			"bitrate":             2000,
+			"resolution_adaptive": "open",
+			"width":               1280,
+			"height":              720,
+			"fill_type":           "black",
+		},
+	})
+	d.Set("audio_template", []interface{}{
+		map[string]interface{}{
+			"codec":         "libfdk_aac",
+			"audio_channel": 2,
+		},
+	})
+
+	createResp := &teo.CreateJustInTimeTranscodeTemplateResponse{
+		Response: &teo.CreateJustInTimeTranscodeTemplateResponseParams{
+			TemplateId: helper.String(templateId),
+			RequestId:  helper.String("test-request-id"),
+		},
+	}
+
+	describeResp := &teo.DescribeJustInTimeTranscodeTemplatesResponse{
+		Response: &teo.DescribeJustInTimeTranscodeTemplatesResponseParams{
+			TotalCount: helper.Uint64(1),
+			TemplateSet: []*teo.JustInTimeTranscodeTemplate{
+				{
+					TemplateId:        helper.String(templateId),
+					TemplateName:      helper.String(templateName),
+					Comment:           helper.String(comment),
+					VideoStreamSwitch: helper.String(videoStreamSwitch),
+					AudioStreamSwitch: helper.String(audioStreamSwitch),
+					Type:              helper.String("custom"),
+					VideoTemplate: &teo.VideoTemplateInfo{
+						Codec:              helper.String("H.264"),
+						Fps:                helper.Float64(30),
+						Bitrate:            helper.Uint64(2000),
+						ResolutionAdaptive: helper.String("open"),
+						Width:              helper.Uint64(1280),
+						Height:             helper.Uint64(720),
+						FillType:           helper.String("black"),
+					},
+					AudioTemplate: &teo.AudioTemplateInfo{
+						Codec:        helper.String("libfdk_aac"),
+						AudioChannel: helper.Uint64(2),
+					},
+				},
+			},
+			RequestId: helper.String("test-request-id"),
+		},
+	}
+
+	// Mock CreateJustInTimeTranscodeTemplate
+	patch1 := gomonkey.ApplyFunc(common.NewClient, func(region string, secretId, secretKey, token string, clientProfile *common.ClientProfile) (client *common.Client, err error) {
+		return nil, nil
+	})
+	defer patch1.Reset()
+
+	// Mock the client method
+	patch2 := gomonkey.ApplyMethod((*resource.ResourceData)(nil), "Id", func(_ *resource.ResourceData) string {
+		return ""
+	})
+	defer patch2.Reset()
+
+	// Test Create
+	createFunc := func() (interface{}, error) {
+		meta := &tccommon.ProviderMeta{
+			TencentV2Client: &tencentcloudV2Client{
+				teoClient: &teo.Client{},
+			},
+		}
+		return nil, resourceTencentCloudTeoJustInTimeTranscodeTemplateCreate(d, meta)
+	}
+
+	// Mock API call
+	patch3 := gomonkey.ApplyMethod(&teo.Client{}, "CreateJustInTimeTranscodeTemplate", func(_ *teo.Client, req *teo.CreateJustInTimeTranscodeTemplateRequest) (resp *teo.CreateJustInTimeTranscodeTemplateResponse, err error) {
+		return createResp, nil
+	})
+	defer patch3.Reset()
+
+	patch4 := gomonkey.ApplyMethod(&teo.Client{}, "DescribeJustInTimeTranscodeTemplates", func(_ *teo.Client, req *teo.DescribeJustInTimeTranscodeTemplatesRequest) (resp *teo.DescribeJustInTimeTranscodeTemplatesResponse, err error) {
+		return describeResp, nil
+	})
+	defer patch4.Reset()
+
+	err := createFunc()
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	expectedId := fmt.Sprintf("%s#%s", zoneId, templateId)
+	if d.Id() != expectedId {
+		t.Errorf("expected id %s, got %s", expectedId, d.Id())
+	}
+}
+
+func TestResourceTencentCloudTeoJustInTimeTranscodeTemplate_Read(t *testing.T) {
+	var (
+		zoneId            = "zone-1234567890"
+		templateId        = "tpl-abcdefghij"
+		templateName      = "test-template"
+		comment           = "test comment"
+		videoStreamSwitch = "on"
+		audioStreamSwitch = "on"
+	)
+
+	describeResp := &teo.DescribeJustInTimeTranscodeTemplatesResponse{
+		Response: &teo.DescribeJustInTimeTranscodeTemplatesResponseParams{
+			TotalCount: helper.Uint64(1),
+			TemplateSet: []*teo.JustInTimeTranscodeTemplate{
+				{
+					TemplateId:        helper.String(templateId),
+					TemplateName:      helper.String(templateName),
+					Comment:           helper.String(comment),
+					VideoStreamSwitch: helper.String(videoStreamSwitch),
+					AudioStreamSwitch: helper.String(audioStreamSwitch),
+					Type:              helper.String("custom"),
+					VideoTemplate: &teo.VideoTemplateInfo{
+						Codec:              helper.String("H.264"),
+						Fps:                helper.Float64(30),
+						Bitrate:            helper.Uint64(2000),
+						ResolutionAdaptive: helper.String("open"),
+						Width:              helper.Uint64(1280),
+						Height:             helper.Uint64(720),
+						FillType:           helper.String("black"),
+					},
+					AudioTemplate: &teo.AudioTemplateInfo{
+						Codec:        helper.String("libfdk_aac"),
+						AudioChannel: helper.Uint64(2),
+					},
+				},
+			},
+			RequestId: helper.String("test-request-id"),
+		},
+	}
+
+	r := ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := r.Data(nil)
+	d.SetId(fmt.Sprintf("%s#%s", zoneId, templateId))
+
+	// Mock API call
+	patch := gomonkey.ApplyMethod(&teo.Client{}, "DescribeJustInTimeTranscodeTemplates", func(_ *teo.Client, req *teo.DescribeJustInTimeTranscodeTemplatesRequest) (resp *teo.DescribeJustInTimeTranscodeTemplatesResponse, err error) {
+		return describeResp, nil
+	})
+	defer patch.Reset()
+
+	readFunc := func() error {
+		meta := &tccommon.ProviderMeta{
+			TencentV2Client: &tencentcloudV2Client{
+				teoClient: &teo.Client{},
+			},
+		}
+		return resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(context.Background(), d, meta)
+	}
+
+	err := readFunc()
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	// Verify schema values
+	if d.Get("template_name") != templateName {
+		t.Errorf("expected template_name %s, got %s", templateName, d.Get("template_name"))
+	}
+	if d.Get("comment") != comment {
+		t.Errorf("expected comment %s, got %s", comment, d.Get("comment"))
+	}
+	if d.Get("video_stream_switch") != videoStreamSwitch {
+		t.Errorf("expected video_stream_switch %s, got %s", videoStreamSwitch, d.Get("video_stream_switch"))
+	}
+	if d.Get("audio_stream_switch") != audioStreamSwitch {
+		t.Errorf("expected audio_stream_switch %s, got %s", audioStreamSwitch, d.Get("audio_stream_switch"))
+	}
+}
+
+func TestResourceTencentCloudTeoJustInTimeTranscodeTemplate_Delete(t *testing.T) {
+	var (
+		zoneId     = "zone-1234567890"
+		templateId = "tpl-abcdefghij"
+	)
+
+	deleteResp := &teo.DeleteJustInTimeTranscodeTemplatesResponse{
+		Response: &teo.DeleteJustInTimeTranscodeTemplatesResponseParams{
+			RequestId: helper.String("test-request-id"),
+		},
+	}
+
+	r := ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := r.Data(nil)
+	d.SetId(fmt.Sprintf("%s#%s", zoneId, templateId))
+
+	// Mock API call
+	patch := gomonkey.ApplyMethod(&teo.Client{}, "DeleteJustInTimeTranscodeTemplates", func(_ *teo.Client, req *teo.DeleteJustInTimeTranscodeTemplatesRequest) (resp *teo.DeleteJustInTimeTranscodeTemplatesResponse, err error) {
+		return deleteResp, nil
+	})
+	defer patch.Reset()
+
+	deleteFunc := func() error {
+		meta := &tccommon.ProviderMeta{
+			TencentV2Client: &tencentcloudV2Client{
+				teoClient: &teo.Client{},
+			},
+		}
+		return resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete(context.Background(), d, meta)
+	}
+
+	err := deleteFunc()
+	if err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+
+	if d.Id() != "" {
+		t.Errorf("expected id to be empty after delete, got %s", d.Id())
+	}
+}
+
+func TestResourceTencentCloudTeoJustInTimeTranscodeTemplate_ParseId(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		wantZone string
+		wantTemp string
+		wantErr  bool
+	}{
+		{
+			name:     "valid id",
+			id:       "zone-123#tpl-456",
+			wantZone: "zone-123",
+			wantTemp: "tpl-456",
+			wantErr:  false,
+		},
+		{
+			name:     "valid id with special chars",
+			id:       "zone_abc-123#tpl_xyz-456",
+			wantZone: "zone_abc-123",
+			wantTemp: "tpl_xyz-456",
+			wantErr:  false,
+		},
+		{
+			name:    "invalid id - no separator",
+			id:      "zone-123",
+			wantErr: true,
+		},
+		{
+			name:    "invalid id - too many separators",
+			id:      "zone-123#tpl-456#extra",
+			wantErr: true,
+		},
+		{
+			name:    "invalid id - empty parts",
+			id:      "#",
+			wantErr: true,
+		},
+		{
+			name:    "invalid id - empty first part",
+			id:      "#tpl-456",
+			wantErr: true,
+		},
+		{
+			name:    "invalid id - empty second part",
+			id:      "zone-123#",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zone, temp, err := resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(tt.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseId() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if zone != tt.wantZone {
+					t.Errorf("ParseId() zone = %v, want %v", zone, tt.wantZone)
+				}
+				if temp != tt.wantTemp {
+					t.Errorf("ParseId() template = %v, want %v", temp, tt.wantTemp)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildVideoTemplateInfo(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]interface{}
+		want *teo.VideoTemplateInfo
+	}{
+		{
+			name: "full configuration",
+			data: map[string]interface{}{
+				"video_codec":         "H.264",
+				"fps":                 float64(30),
+				"bitrate":             2000,
+				"resolution_adaptive": "open",
+				"width":               1280,
+				"height":              720,
+				"fill_type":           "black",
+			},
+			want: &teo.VideoTemplateInfo{
+				Codec:              helper.String("H.264"),
+				Fps:                helper.Float64(30),
+				Bitrate:            helper.Uint64(2000),
+				ResolutionAdaptive: helper.String("open"),
+				Width:              helper.Uint64(1280),
+				Height:             helper.Uint64(720),
+				FillType:           helper.String("black"),
+			},
+		},
+		{
+			name: "minimal configuration",
+			data: map[string]interface{}{
+				"video_codec": "H.265",
+			},
+			want: &teo.VideoTemplateInfo{
+				Codec: helper.String("H.265"),
+			},
+		},
+		{
+			name: "empty configuration",
+			data: map[string]interface{}{},
+			want: &teo.VideoTemplateInfo{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildVideoTemplateInfo(tt.data)
+			if got.Codec != nil && tt.want.Codec != nil && *got.Codec != *tt.want.Codec {
+				t.Errorf("Codec mismatch, got %v, want %v", *got.Codec, *tt.want.Codec)
+			}
+			if got.Fps != nil && tt.want.Fps != nil && *got.Fps != *tt.want.Fps {
+				t.Errorf("Fps mismatch, got %v, want %v", *got.Fps, *tt.want.Fps)
+			}
+			if got.Bitrate != nil && tt.want.Bitrate != nil && *got.Bitrate != *tt.want.Bitrate {
+				t.Errorf("Bitrate mismatch, got %v, want %v", *got.Bitrate, *tt.want.Bitrate)
+			}
+		})
+	}
+}
+
+func TestBuildAudioTemplateInfo(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]interface{}
+		want *teo.AudioTemplateInfo
+	}{
+		{
+			name: "full configuration",
+			data: map[string]interface{}{
+				"codec":         "libfdk_aac",
+				"audio_channel": 2,
+			},
+			want: &teo.AudioTemplateInfo{
+				Codec:        helper.String("libfdk_aac"),
+				AudioChannel: helper.Uint64(2),
+			},
+		},
+		{
+			name: "minimal configuration",
+			data: map[string]interface{}{
+				"codec": "libfdk_aac",
+			},
+			want: &teo.AudioTemplateInfo{
+				Codec: helper.String("libfdk_aac"),
+			},
+		},
+		{
+			name: "empty configuration",
+			data: map[string]interface{}{},
+			want: &teo.AudioTemplateInfo{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildAudioTemplateInfo(tt.data)
+			if got.Codec != nil && tt.want.Codec != nil && *got.Codec != *tt.want.Codec {
+				t.Errorf("Codec mismatch, got %v, want %v", *got.Codec, *tt.want.Codec)
+			}
+			if got.AudioChannel != nil && tt.want.AudioChannel != nil && *got.AudioChannel != *tt.want.AudioChannel {
+				t.Errorf("AudioChannel mismatch, got %v, want %v", *got.AudioChannel, *tt.want.AudioChannel)
+			}
+		})
+	}
+}
+
+func TestMapVideoTemplateInfoToSchema(t *testing.T) {
+	tests := []struct {
+		name string
+		info *teo.VideoTemplateInfo
+		want map[string]interface{}
+	}{
+		{
+			name: "full configuration",
+			info: &teo.VideoTemplateInfo{
+				Codec:              helper.String("H.264"),
+				Fps:                helper.Float64(30),
+				Bitrate:            helper.Uint64(2000),
+				ResolutionAdaptive: helper.String("open"),
+				Width:              helper.Uint64(1280),
+				Height:             helper.Uint64(720),
+				FillType:           helper.String("black"),
+			},
+			want: map[string]interface{}{
+				"video_codec":         "H.264",
+				"fps":                 float64(30),
+				"bitrate":             2000,
+				"resolution_adaptive": "open",
+				"width":               1280,
+				"height":              720,
+				"fill_type":           "black",
+			},
+		},
+		{
+			name: "nil values",
+			info: &teo.VideoTemplateInfo{},
+			want: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapVideoTemplateInfoToSchema(tt.info)
+			if got["video_codec"] != tt.want["video_codec"] {
+				t.Errorf("video_codec mismatch, got %v, want %v", got["video_codec"], tt.want["video_codec"])
+			}
+			if got["fps"] != tt.want["fps"] {
+				t.Errorf("fps mismatch, got %v, want %v", got["fps"], tt.want["fps"])
+			}
+			if got["bitrate"] != tt.want["bitrate"] {
+				t.Errorf("bitrate mismatch, got %v, want %v", got["bitrate"], tt.want["bitrate"])
+			}
+		})
+	}
+}
+
+func TestMapAudioTemplateInfoToSchema(t *testing.T) {
+	tests := []struct {
+		name string
+		info *teo.AudioTemplateInfo
+		want map[string]interface{}
+	}{
+		{
+			name: "full configuration",
+			info: &teo.AudioTemplateInfo{
+				Codec:        helper.String("libfdk_aac"),
+				AudioChannel: helper.Uint64(2),
+			},
+			want: map[string]interface{}{
+				"codec":         "libfdk_aac",
+				"audio_channel": 2,
+			},
+		},
+		{
+			name: "nil values",
+			info: &teo.AudioTemplateInfo{},
+			want: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAudioTemplateInfoToSchema(tt.info)
+			if got["codec"] != tt.want["codec"] {
+				t.Errorf("codec mismatch, got %v, want %v", got["codec"], tt.want["codec"])
+			}
+			if got["audio_channel"] != tt.want["audio_channel"] {
+				t.Errorf("audio_channel mismatch, got %v, want %v", got["audio_channel"], tt.want["audio_channel"])
+			}
+		})
+	}
+}
+
+// Mock structs for testing
+type tccommon struct {
+	TencentV2Client *tencentcloudV2Client
+}
+
+type tencentcloudV2Client struct {
+	teoClient interface{}
+}

--- a/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_just_in_time_transcode_template_test.go
@@ -1,521 +1,364 @@
-package teo
+package teo_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
-	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
-	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
-	teo "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
 )
 
-func TestResourceTencentCloudTeoJustInTimeTranscodeTemplate_Create(t *testing.T) {
-	var (
-		zoneId            = "zone-1234567890"
-		templateId        = "tpl-abcdefghij"
-		templateName      = "test-template"
-		comment           = "test comment"
-		videoStreamSwitch = "on"
-		audioStreamSwitch = "on"
-	)
+// go test ./tencentcloud/services/teo/ -run "TestJustInTimeTranscodeTemplate" -v -count=1 -gcflags="all=-l"
 
-	r := ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
-	d := r.Data(nil)
-	d.Set("zone_id", zoneId)
-	d.Set("template_name", templateName)
-	d.Set("comment", comment)
-	d.Set("video_stream_switch", videoStreamSwitch)
-	d.Set("audio_stream_switch", audioStreamSwitch)
-	d.Set("video_template", []interface{}{
-		map[string]interface{}{
-			"video_codec":         "H.264",
-			"fps":                 float64(30),
-			"bitrate":             2000,
-			"resolution_adaptive": "open",
-			"width":               1280,
-			"height":              720,
-			"fill_type":           "black",
-		},
-	})
-	d.Set("audio_template", []interface{}{
-		map[string]interface{}{
-			"codec":         "libfdk_aac",
-			"audio_channel": 2,
-		},
+// TestJustInTimeTranscodeTemplate_Create_Success tests Create calls API and sets ID
+func TestJustInTimeTranscodeTemplate_Create_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "CreateJustInTimeTranscodeTemplate", func(request *teov20220901.CreateJustInTimeTranscodeTemplateRequest) (*teov20220901.CreateJustInTimeTranscodeTemplateResponse, error) {
+		resp := teov20220901.NewCreateJustInTimeTranscodeTemplateResponse()
+		resp.Response = &teov20220901.CreateJustInTimeTranscodeTemplateResponseParams{
+			TemplateId: ptrString("tpl-abcdefghij"),
+			RequestId:  ptrString("fake-request-id"),
+		}
+		return resp, nil
 	})
 
-	createResp := &teo.CreateJustInTimeTranscodeTemplateResponse{
-		Response: &teo.CreateJustInTimeTranscodeTemplateResponseParams{
-			TemplateId: helper.String(templateId),
-			RequestId:  helper.String("test-request-id"),
-		},
-	}
-
-	describeResp := &teo.DescribeJustInTimeTranscodeTemplatesResponse{
-		Response: &teo.DescribeJustInTimeTranscodeTemplatesResponseParams{
-			TotalCount: helper.Uint64(1),
-			TemplateSet: []*teo.JustInTimeTranscodeTemplate{
+	patches.ApplyMethodFunc(teoClient, "DescribeJustInTimeTranscodeTemplates", func(request *teov20220901.DescribeJustInTimeTranscodeTemplatesRequest) (*teov20220901.DescribeJustInTimeTranscodeTemplatesResponse, error) {
+		resp := teov20220901.NewDescribeJustInTimeTranscodeTemplatesResponse()
+		resp.Response = &teov20220901.DescribeJustInTimeTranscodeTemplatesResponseParams{
+			TotalCount: ptrUint64(1),
+			TemplateSet: []*teov20220901.JustInTimeTranscodeTemplate{
 				{
-					TemplateId:        helper.String(templateId),
-					TemplateName:      helper.String(templateName),
-					Comment:           helper.String(comment),
-					VideoStreamSwitch: helper.String(videoStreamSwitch),
-					AudioStreamSwitch: helper.String(audioStreamSwitch),
-					Type:              helper.String("custom"),
-					VideoTemplate: &teo.VideoTemplateInfo{
-						Codec:              helper.String("H.264"),
-						Fps:                helper.Float64(30),
-						Bitrate:            helper.Uint64(2000),
-						ResolutionAdaptive: helper.String("open"),
-						Width:              helper.Uint64(1280),
-						Height:             helper.Uint64(720),
-						FillType:           helper.String("black"),
+					TemplateId:        ptrString("tpl-abcdefghij"),
+					TemplateName:      ptrString("test-template"),
+					Comment:           ptrString("test comment"),
+					VideoStreamSwitch: ptrString("on"),
+					AudioStreamSwitch: ptrString("on"),
+					Type:              ptrString("custom"),
+					VideoTemplate: &teov20220901.VideoTemplateInfo{
+						Codec:              ptrString("H.264"),
+						Fps:                ptrFloat64(30),
+						Bitrate:            ptrUint64(2000),
+						ResolutionAdaptive: ptrString("open"),
+						Width:              ptrUint64(1280),
+						Height:             ptrUint64(720),
+						FillType:           ptrString("black"),
 					},
-					AudioTemplate: &teo.AudioTemplateInfo{
-						Codec:        helper.String("libfdk_aac"),
-						AudioChannel: helper.Uint64(2),
+					AudioTemplate: &teov20220901.AudioTemplateInfo{
+						Codec:        ptrString("libfdk_aac"),
+						AudioChannel: ptrUint64(2),
 					},
 				},
 			},
-			RequestId: helper.String("test-request-id"),
-		},
-	}
-
-	// Mock CreateJustInTimeTranscodeTemplate
-	patch1 := gomonkey.ApplyFunc(common.NewClient, func(region string, secretId, secretKey, token string, clientProfile *common.ClientProfile) (client *common.Client, err error) {
-		return nil, nil
-	})
-	defer patch1.Reset()
-
-	// Mock the client method
-	patch2 := gomonkey.ApplyMethod((*resource.ResourceData)(nil), "Id", func(_ *resource.ResourceData) string {
-		return ""
-	})
-	defer patch2.Reset()
-
-	// Test Create
-	createFunc := func() (interface{}, error) {
-		meta := &tccommon.ProviderMeta{
-			TencentV2Client: &tencentcloudV2Client{
-				teoClient: &teo.Client{},
-			},
+			RequestId: ptrString("fake-request-id"),
 		}
-		return nil, resourceTencentCloudTeoJustInTimeTranscodeTemplateCreate(d, meta)
-	}
-
-	// Mock API call
-	patch3 := gomonkey.ApplyMethod(&teo.Client{}, "CreateJustInTimeTranscodeTemplate", func(_ *teo.Client, req *teo.CreateJustInTimeTranscodeTemplateRequest) (resp *teo.CreateJustInTimeTranscodeTemplateResponse, err error) {
-		return createResp, nil
+		return resp, nil
 	})
-	defer patch3.Reset()
 
-	patch4 := gomonkey.ApplyMethod(&teo.Client{}, "DescribeJustInTimeTranscodeTemplates", func(_ *teo.Client, req *teo.DescribeJustInTimeTranscodeTemplatesRequest) (resp *teo.DescribeJustInTimeTranscodeTemplatesResponse, err error) {
-		return describeResp, nil
+	meta := newMockMeta()
+	res := teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":             "zone-1234567890",
+		"template_name":       "test-template",
+		"comment":             "test comment",
+		"video_stream_switch": "on",
+		"audio_stream_switch": "on",
 	})
-	defer patch4.Reset()
 
-	err := createFunc()
-	if err != nil {
-		t.Fatalf("create failed: %v", err)
-	}
-
-	expectedId := fmt.Sprintf("%s#%s", zoneId, templateId)
-	if d.Id() != expectedId {
-		t.Errorf("expected id %s, got %s", expectedId, d.Id())
-	}
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "zone-1234567890#tpl-abcdefghij", d.Id())
 }
 
-func TestResourceTencentCloudTeoJustInTimeTranscodeTemplate_Read(t *testing.T) {
-	var (
-		zoneId            = "zone-1234567890"
-		templateId        = "tpl-abcdefghij"
-		templateName      = "test-template"
-		comment           = "test comment"
-		videoStreamSwitch = "on"
-		audioStreamSwitch = "on"
-	)
+// TestJustInTimeTranscodeTemplate_Create_APIError tests Create handles API error
+func TestJustInTimeTranscodeTemplate_Create_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
 
-	describeResp := &teo.DescribeJustInTimeTranscodeTemplatesResponse{
-		Response: &teo.DescribeJustInTimeTranscodeTemplatesResponseParams{
-			TotalCount: helper.Uint64(1),
-			TemplateSet: []*teo.JustInTimeTranscodeTemplate{
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "CreateJustInTimeTranscodeTemplate", func(request *teov20220901.CreateJustInTimeTranscodeTemplateRequest) (*teov20220901.CreateJustInTimeTranscodeTemplateResponse, error) {
+		return nil, fmt.Errorf("[TencentCloudSDKError] Code=InvalidParameter, Message=Invalid zone_id")
+	})
+
+	meta := newMockMeta()
+	res := teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":       "zone-invalid",
+		"template_name": "test-template",
+	})
+
+	err := res.Create(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidParameter")
+}
+
+// TestJustInTimeTranscodeTemplate_Read_Success tests Read retrieves template data
+func TestJustInTimeTranscodeTemplate_Read_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeJustInTimeTranscodeTemplates", func(request *teov20220901.DescribeJustInTimeTranscodeTemplatesRequest) (*teov20220901.DescribeJustInTimeTranscodeTemplatesResponse, error) {
+		resp := teov20220901.NewDescribeJustInTimeTranscodeTemplatesResponse()
+		resp.Response = &teov20220901.DescribeJustInTimeTranscodeTemplatesResponseParams{
+			TotalCount: ptrUint64(1),
+			TemplateSet: []*teov20220901.JustInTimeTranscodeTemplate{
 				{
-					TemplateId:        helper.String(templateId),
-					TemplateName:      helper.String(templateName),
-					Comment:           helper.String(comment),
-					VideoStreamSwitch: helper.String(videoStreamSwitch),
-					AudioStreamSwitch: helper.String(audioStreamSwitch),
-					Type:              helper.String("custom"),
-					VideoTemplate: &teo.VideoTemplateInfo{
-						Codec:              helper.String("H.264"),
-						Fps:                helper.Float64(30),
-						Bitrate:            helper.Uint64(2000),
-						ResolutionAdaptive: helper.String("open"),
-						Width:              helper.Uint64(1280),
-						Height:             helper.Uint64(720),
-						FillType:           helper.String("black"),
+					TemplateId:        ptrString("tpl-abcdefghij"),
+					TemplateName:      ptrString("test-template"),
+					Comment:           ptrString("test comment"),
+					VideoStreamSwitch: ptrString("on"),
+					AudioStreamSwitch: ptrString("on"),
+					Type:              ptrString("custom"),
+					VideoTemplate: &teov20220901.VideoTemplateInfo{
+						Codec:              ptrString("H.264"),
+						Fps:                ptrFloat64(30),
+						Bitrate:            ptrUint64(2000),
+						ResolutionAdaptive: ptrString("open"),
+						Width:              ptrUint64(1280),
+						Height:             ptrUint64(720),
+						FillType:           ptrString("black"),
 					},
-					AudioTemplate: &teo.AudioTemplateInfo{
-						Codec:        helper.String("libfdk_aac"),
-						AudioChannel: helper.Uint64(2),
+					AudioTemplate: &teov20220901.AudioTemplateInfo{
+						Codec:        ptrString("libfdk_aac"),
+						AudioChannel: ptrUint64(2),
 					},
 				},
 			},
-			RequestId: helper.String("test-request-id"),
-		},
-	}
-
-	r := ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
-	d := r.Data(nil)
-	d.SetId(fmt.Sprintf("%s#%s", zoneId, templateId))
-
-	// Mock API call
-	patch := gomonkey.ApplyMethod(&teo.Client{}, "DescribeJustInTimeTranscodeTemplates", func(_ *teo.Client, req *teo.DescribeJustInTimeTranscodeTemplatesRequest) (resp *teo.DescribeJustInTimeTranscodeTemplatesResponse, err error) {
-		return describeResp, nil
-	})
-	defer patch.Reset()
-
-	readFunc := func() error {
-		meta := &tccommon.ProviderMeta{
-			TencentV2Client: &tencentcloudV2Client{
-				teoClient: &teo.Client{},
-			},
+			RequestId: ptrString("fake-request-id"),
 		}
-		return resourceTencentCloudTeoJustInTimeTranscodeTemplateRead(context.Background(), d, meta)
-	}
-
-	err := readFunc()
-	if err != nil {
-		t.Fatalf("read failed: %v", err)
-	}
-
-	// Verify schema values
-	if d.Get("template_name") != templateName {
-		t.Errorf("expected template_name %s, got %s", templateName, d.Get("template_name"))
-	}
-	if d.Get("comment") != comment {
-		t.Errorf("expected comment %s, got %s", comment, d.Get("comment"))
-	}
-	if d.Get("video_stream_switch") != videoStreamSwitch {
-		t.Errorf("expected video_stream_switch %s, got %s", videoStreamSwitch, d.Get("video_stream_switch"))
-	}
-	if d.Get("audio_stream_switch") != audioStreamSwitch {
-		t.Errorf("expected audio_stream_switch %s, got %s", audioStreamSwitch, d.Get("audio_stream_switch"))
-	}
-}
-
-func TestResourceTencentCloudTeoJustInTimeTranscodeTemplate_Delete(t *testing.T) {
-	var (
-		zoneId     = "zone-1234567890"
-		templateId = "tpl-abcdefghij"
-	)
-
-	deleteResp := &teo.DeleteJustInTimeTranscodeTemplatesResponse{
-		Response: &teo.DeleteJustInTimeTranscodeTemplatesResponseParams{
-			RequestId: helper.String("test-request-id"),
-		},
-	}
-
-	r := ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
-	d := r.Data(nil)
-	d.SetId(fmt.Sprintf("%s#%s", zoneId, templateId))
-
-	// Mock API call
-	patch := gomonkey.ApplyMethod(&teo.Client{}, "DeleteJustInTimeTranscodeTemplates", func(_ *teo.Client, req *teo.DeleteJustInTimeTranscodeTemplatesRequest) (resp *teo.DeleteJustInTimeTranscodeTemplatesResponse, err error) {
-		return deleteResp, nil
+		return resp, nil
 	})
-	defer patch.Reset()
 
-	deleteFunc := func() error {
-		meta := &tccommon.ProviderMeta{
-			TencentV2Client: &tencentcloudV2Client{
-				teoClient: &teo.Client{},
-			},
+	meta := newMockMeta()
+	res := teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":       "zone-1234567890",
+		"template_name": "test-template",
+		"template_id":   "tpl-abcdefghij",
+	})
+	d.SetId("zone-1234567890#tpl-abcdefghij")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-template", d.Get("template_name"))
+	assert.Equal(t, "test comment", d.Get("comment"))
+	assert.Equal(t, "on", d.Get("video_stream_switch"))
+	assert.Equal(t, "on", d.Get("audio_stream_switch"))
+}
+
+// TestJustInTimeTranscodeTemplate_Read_NotFound tests Read handles template not found
+func TestJustInTimeTranscodeTemplate_Read_NotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeJustInTimeTranscodeTemplates", func(request *teov20220901.DescribeJustInTimeTranscodeTemplatesRequest) (*teov20220901.DescribeJustInTimeTranscodeTemplatesResponse, error) {
+		resp := teov20220901.NewDescribeJustInTimeTranscodeTemplatesResponse()
+		resp.Response = &teov20220901.DescribeJustInTimeTranscodeTemplatesResponseParams{
+			TotalCount:  ptrUint64(0),
+			TemplateSet: []*teov20220901.JustInTimeTranscodeTemplate{},
+			RequestId:   ptrString("fake-request-id"),
 		}
-		return resourceTencentCloudTeoJustInTimeTranscodeTemplateDelete(context.Background(), d, meta)
-	}
+		return resp, nil
+	})
 
-	err := deleteFunc()
-	if err != nil {
-		t.Fatalf("delete failed: %v", err)
-	}
+	meta := newMockMeta()
+	res := teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":       "zone-1234567890",
+		"template_name": "test-template",
+		"template_id":   "tpl-abcdefghij",
+	})
+	d.SetId("zone-1234567890#tpl-abcdefghij")
 
-	if d.Id() != "" {
-		t.Errorf("expected id to be empty after delete, got %s", d.Id())
-	}
+	err := res.Read(d, meta)
+	assert.Error(t, err)
 }
 
-func TestResourceTencentCloudTeoJustInTimeTranscodeTemplate_ParseId(t *testing.T) {
-	tests := []struct {
-		name     string
-		id       string
-		wantZone string
-		wantTemp string
-		wantErr  bool
-	}{
-		{
-			name:     "valid id",
-			id:       "zone-123#tpl-456",
-			wantZone: "zone-123",
-			wantTemp: "tpl-456",
-			wantErr:  false,
-		},
-		{
-			name:     "valid id with special chars",
-			id:       "zone_abc-123#tpl_xyz-456",
-			wantZone: "zone_abc-123",
-			wantTemp: "tpl_xyz-456",
-			wantErr:  false,
-		},
-		{
-			name:    "invalid id - no separator",
-			id:      "zone-123",
-			wantErr: true,
-		},
-		{
-			name:    "invalid id - too many separators",
-			id:      "zone-123#tpl-456#extra",
-			wantErr: true,
-		},
-		{
-			name:    "invalid id - empty parts",
-			id:      "#",
-			wantErr: true,
-		},
-		{
-			name:    "invalid id - empty first part",
-			id:      "#tpl-456",
-			wantErr: true,
-		},
-		{
-			name:    "invalid id - empty second part",
-			id:      "zone-123#",
-			wantErr: true,
-		},
-	}
+// TestJustInTimeTranscodeTemplate_Update tests Update is a no-op that calls Read
+func TestJustInTimeTranscodeTemplate_Update(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			zone, temp, err := resourceTencentCloudTeoJustInTimeTranscodeTemplateParseId(tt.id)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseId() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !tt.wantErr {
-				if zone != tt.wantZone {
-					t.Errorf("ParseId() zone = %v, want %v", zone, tt.wantZone)
-				}
-				if temp != tt.wantTemp {
-					t.Errorf("ParseId() template = %v, want %v", temp, tt.wantTemp)
-				}
-			}
-		})
-	}
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeJustInTimeTranscodeTemplates", func(request *teov20220901.DescribeJustInTimeTranscodeTemplatesRequest) (*teov20220901.DescribeJustInTimeTranscodeTemplatesResponse, error) {
+		resp := teov20220901.NewDescribeJustInTimeTranscodeTemplatesResponse()
+		resp.Response = &teov20220901.DescribeJustInTimeTranscodeTemplatesResponseParams{
+			TotalCount: ptrUint64(1),
+			TemplateSet: []*teov20220901.JustInTimeTranscodeTemplate{
+				{
+					TemplateId:        ptrString("tpl-abcdefghij"),
+					TemplateName:      ptrString("test-template"),
+					Comment:           ptrString("test comment"),
+					VideoStreamSwitch: ptrString("on"),
+					AudioStreamSwitch: ptrString("on"),
+					Type:              ptrString("custom"),
+				},
+			},
+			RequestId: ptrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMeta()
+	res := teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":       "zone-1234567890",
+		"template_name": "test-template",
+		"template_id":   "tpl-abcdefghij",
+	})
+	d.SetId("zone-1234567890#tpl-abcdefghij")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
 }
 
-func TestBuildVideoTemplateInfo(t *testing.T) {
-	tests := []struct {
-		name string
-		data map[string]interface{}
-		want *teo.VideoTemplateInfo
-	}{
-		{
-			name: "full configuration",
-			data: map[string]interface{}{
-				"video_codec":         "H.264",
-				"fps":                 float64(30),
-				"bitrate":             2000,
-				"resolution_adaptive": "open",
-				"width":               1280,
-				"height":              720,
-				"fill_type":           "black",
-			},
-			want: &teo.VideoTemplateInfo{
-				Codec:              helper.String("H.264"),
-				Fps:                helper.Float64(30),
-				Bitrate:            helper.Uint64(2000),
-				ResolutionAdaptive: helper.String("open"),
-				Width:              helper.Uint64(1280),
-				Height:             helper.Uint64(720),
-				FillType:           helper.String("black"),
-			},
-		},
-		{
-			name: "minimal configuration",
-			data: map[string]interface{}{
-				"video_codec": "H.265",
-			},
-			want: &teo.VideoTemplateInfo{
-				Codec: helper.String("H.265"),
-			},
-		},
-		{
-			name: "empty configuration",
-			data: map[string]interface{}{},
-			want: &teo.VideoTemplateInfo{},
-		},
-	}
+// TestJustInTimeTranscodeTemplate_Delete_Success tests Delete removes template
+func TestJustInTimeTranscodeTemplate_Delete_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := buildVideoTemplateInfo(tt.data)
-			if got.Codec != nil && tt.want.Codec != nil && *got.Codec != *tt.want.Codec {
-				t.Errorf("Codec mismatch, got %v, want %v", *got.Codec, *tt.want.Codec)
-			}
-			if got.Fps != nil && tt.want.Fps != nil && *got.Fps != *tt.want.Fps {
-				t.Errorf("Fps mismatch, got %v, want %v", *got.Fps, *tt.want.Fps)
-			}
-			if got.Bitrate != nil && tt.want.Bitrate != nil && *got.Bitrate != *tt.want.Bitrate {
-				t.Errorf("Bitrate mismatch, got %v, want %v", *got.Bitrate, *tt.want.Bitrate)
-			}
-		})
-	}
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DeleteJustInTimeTranscodeTemplates", func(request *teov20220901.DeleteJustInTimeTranscodeTemplatesRequest) (*teov20220901.DeleteJustInTimeTranscodeTemplatesResponse, error) {
+		resp := teov20220901.NewDeleteJustInTimeTranscodeTemplatesResponse()
+		resp.Response = &teov20220901.DeleteJustInTimeTranscodeTemplatesResponseParams{
+			RequestId: ptrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMeta()
+	res := teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":       "zone-1234567890",
+		"template_name": "test-template",
+		"template_id":   "tpl-abcdefghij",
+	})
+	d.SetId("zone-1234567890#tpl-abcdefghij")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
 }
 
-func TestBuildAudioTemplateInfo(t *testing.T) {
-	tests := []struct {
-		name string
-		data map[string]interface{}
-		want *teo.AudioTemplateInfo
-	}{
-		{
-			name: "full configuration",
-			data: map[string]interface{}{
-				"codec":         "libfdk_aac",
-				"audio_channel": 2,
-			},
-			want: &teo.AudioTemplateInfo{
-				Codec:        helper.String("libfdk_aac"),
-				AudioChannel: helper.Uint64(2),
-			},
-		},
-		{
-			name: "minimal configuration",
-			data: map[string]interface{}{
-				"codec": "libfdk_aac",
-			},
-			want: &teo.AudioTemplateInfo{
-				Codec: helper.String("libfdk_aac"),
-			},
-		},
-		{
-			name: "empty configuration",
-			data: map[string]interface{}{},
-			want: &teo.AudioTemplateInfo{},
-		},
-	}
+// TestJustInTimeTranscodeTemplate_Delete_APIError tests Delete handles API error
+func TestJustInTimeTranscodeTemplate_Delete_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := buildAudioTemplateInfo(tt.data)
-			if got.Codec != nil && tt.want.Codec != nil && *got.Codec != *tt.want.Codec {
-				t.Errorf("Codec mismatch, got %v, want %v", *got.Codec, *tt.want.Codec)
-			}
-			if got.AudioChannel != nil && tt.want.AudioChannel != nil && *got.AudioChannel != *tt.want.AudioChannel {
-				t.Errorf("AudioChannel mismatch, got %v, want %v", *got.AudioChannel, *tt.want.AudioChannel)
-			}
-		})
-	}
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DeleteJustInTimeTranscodeTemplates", func(request *teov20220901.DeleteJustInTimeTranscodeTemplatesRequest) (*teov20220901.DeleteJustInTimeTranscodeTemplatesResponse, error) {
+		return nil, fmt.Errorf("[TencentCloudSDKError] Code=ResourceNotFound, Message=Template not found")
+	})
+
+	meta := newMockMeta()
+	res := teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":       "zone-1234567890",
+		"template_name": "test-template",
+		"template_id":   "tpl-abcdefghij",
+	})
+	d.SetId("zone-1234567890#tpl-abcdefghij")
+
+	err := res.Delete(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ResourceNotFound")
 }
 
-func TestMapVideoTemplateInfoToSchema(t *testing.T) {
-	tests := []struct {
-		name string
-		info *teo.VideoTemplateInfo
-		want map[string]interface{}
-	}{
-		{
-			name: "full configuration",
-			info: &teo.VideoTemplateInfo{
-				Codec:              helper.String("H.264"),
-				Fps:                helper.Float64(30),
-				Bitrate:            helper.Uint64(2000),
-				ResolutionAdaptive: helper.String("open"),
-				Width:              helper.Uint64(1280),
-				Height:             helper.Uint64(720),
-				FillType:           helper.String("black"),
-			},
-			want: map[string]interface{}{
-				"video_codec":         "H.264",
-				"fps":                 float64(30),
-				"bitrate":             2000,
-				"resolution_adaptive": "open",
-				"width":               1280,
-				"height":              720,
-				"fill_type":           "black",
-			},
-		},
-		{
-			name: "nil values",
-			info: &teo.VideoTemplateInfo{},
-			want: map[string]interface{}{},
-		},
-	}
+// TestJustInTimeTranscodeTemplate_Schema validates schema definition
+func TestJustInTimeTranscodeTemplate_Schema(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoJustInTimeTranscodeTemplate()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := mapVideoTemplateInfoToSchema(tt.info)
-			if got["video_codec"] != tt.want["video_codec"] {
-				t.Errorf("video_codec mismatch, got %v, want %v", got["video_codec"], tt.want["video_codec"])
-			}
-			if got["fps"] != tt.want["fps"] {
-				t.Errorf("fps mismatch, got %v, want %v", got["fps"], tt.want["fps"])
-			}
-			if got["bitrate"] != tt.want["bitrate"] {
-				t.Errorf("bitrate mismatch, got %v, want %v", got["bitrate"], tt.want["bitrate"])
-			}
-		})
-	}
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Create)
+	assert.NotNil(t, res.Read)
+	assert.NotNil(t, res.Update)
+	assert.NotNil(t, res.Delete)
+	assert.NotNil(t, res.Importer)
+
+	// Check required fields with ForceNew
+	assert.Contains(t, res.Schema, "zone_id")
+	zoneId := res.Schema["zone_id"]
+	assert.Equal(t, schema.TypeString, zoneId.Type)
+	assert.True(t, zoneId.Required)
+	assert.True(t, zoneId.ForceNew)
+
+	assert.Contains(t, res.Schema, "template_name")
+	templateName := res.Schema["template_name"]
+	assert.Equal(t, schema.TypeString, templateName.Type)
+	assert.True(t, templateName.Required)
+	assert.True(t, templateName.ForceNew)
+
+	// Check optional fields WITHOUT ForceNew
+	assert.Contains(t, res.Schema, "comment")
+	comment := res.Schema["comment"]
+	assert.Equal(t, schema.TypeString, comment.Type)
+	assert.True(t, comment.Optional)
+	assert.False(t, comment.ForceNew)
+
+	assert.Contains(t, res.Schema, "video_stream_switch")
+	videoSwitch := res.Schema["video_stream_switch"]
+	assert.Equal(t, schema.TypeString, videoSwitch.Type)
+	assert.True(t, videoSwitch.Optional)
+	assert.False(t, videoSwitch.ForceNew)
+
+	assert.Contains(t, res.Schema, "audio_stream_switch")
+	audioSwitch := res.Schema["audio_stream_switch"]
+	assert.Equal(t, schema.TypeString, audioSwitch.Type)
+	assert.True(t, audioSwitch.Optional)
+	assert.False(t, audioSwitch.ForceNew)
+
+	assert.Contains(t, res.Schema, "video_template")
+	videoTemplate := res.Schema["video_template"]
+	assert.Equal(t, schema.TypeList, videoTemplate.Type)
+	assert.True(t, videoTemplate.Optional)
+	assert.False(t, videoTemplate.ForceNew)
+
+	assert.Contains(t, res.Schema, "audio_template")
+	audioTemplate := res.Schema["audio_template"]
+	assert.Equal(t, schema.TypeList, audioTemplate.Type)
+	assert.True(t, audioTemplate.Optional)
+	assert.False(t, audioTemplate.ForceNew)
+
+	// Check computed fields
+	assert.Contains(t, res.Schema, "template_id")
+	templateId := res.Schema["template_id"]
+	assert.Equal(t, schema.TypeString, templateId.Type)
+	assert.True(t, templateId.Computed)
+
+	assert.Contains(t, res.Schema, "type")
+	typeField := res.Schema["type"]
+	assert.Equal(t, schema.TypeString, typeField.Type)
+	assert.True(t, typeField.Computed)
+
+	assert.Contains(t, res.Schema, "create_time")
+	assert.Contains(t, res.Schema, "update_time")
 }
 
-func TestMapAudioTemplateInfoToSchema(t *testing.T) {
-	tests := []struct {
-		name string
-		info *teo.AudioTemplateInfo
-		want map[string]interface{}
-	}{
-		{
-			name: "full configuration",
-			info: &teo.AudioTemplateInfo{
-				Codec:        helper.String("libfdk_aac"),
-				AudioChannel: helper.Uint64(2),
-			},
-			want: map[string]interface{}{
-				"codec":         "libfdk_aac",
-				"audio_channel": 2,
-			},
-		},
-		{
-			name: "nil values",
-			info: &teo.AudioTemplateInfo{},
-			want: map[string]interface{}{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := mapAudioTemplateInfoToSchema(tt.info)
-			if got["codec"] != tt.want["codec"] {
-				t.Errorf("codec mismatch, got %v, want %v", got["codec"], tt.want["codec"])
-			}
-			if got["audio_channel"] != tt.want["audio_channel"] {
-				t.Errorf("audio_channel mismatch, got %v, want %v", got["audio_channel"], tt.want["audio_channel"])
-			}
-		})
-	}
+func ptrFloat64(f float64) *float64 {
+	return &f
 }
 
-// Mock structs for testing
-type tccommon struct {
-	TencentV2Client *tencentcloudV2Client
-}
-
-type tencentcloudV2Client struct {
-	teoClient interface{}
+func ptrUint64(u uint64) *uint64 {
+	return &u
 }

--- a/website/docs/r/teo_just_in_time_transcode_template.html.markdown
+++ b/website/docs/r/teo_just_in_time_transcode_template.html.markdown
@@ -1,0 +1,87 @@
+---
+subcategory: "TencentCloud EdgeOne(TEO)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_teo_just_in_time_transcode_template"
+sidebar_current: "docs-tencentcloud-resource-teo_just_in_time_transcode_template"
+description: |-
+  Provides a resource to create a TEO just-in-time transcode template.
+---
+
+# tencentcloud_teo_just_in_time_transcode_template
+
+Provides a resource to create a TEO just-in-time transcode template.
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_teo_just_in_time_transcode_template" "example" {
+  zone_id       = "zone-2qtuhspy7cr6"
+  template_name = "my-template"
+  comment       = "Example transcode template"
+
+  video_stream_switch = "on"
+  audio_stream_switch = "on"
+
+  video_template {
+    video_codec         = "H.264"
+    fps                 = 30
+    bitrate             = 2000
+    resolution_adaptive = "open"
+    width               = 1280
+    height              = 720
+    fill_type           = "black"
+  }
+
+  audio_template {
+    codec         = "libfdk_aac"
+    audio_channel = 2
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `template_name` - (Required, String, ForceNew) Transcode template name. Max length: 64 characters.
+* `zone_id` - (Required, String, ForceNew) Site ID.
+* `audio_stream_switch` - (Optional, String) Audio stream switch. Valid values: on, off. Default: on.
+* `audio_template` - (Optional, List) Audio stream configuration parameters. Required when audio_stream_switch is on.
+* `comment` - (Optional, String) Template description. Max length: 256 characters.
+* `video_stream_switch` - (Optional, String) Video stream switch. Valid values: on, off. Default: on.
+* `video_template` - (Optional, List) Video stream configuration parameters. Required when video_stream_switch is on.
+
+The `audio_template` object supports the following:
+
+* `audio_channel` - (Optional, Int) Audio channel count. Optional values: 2. Default: 2.
+* `codec` - (Optional, String) Audio codec. Optional values: libfdk_aac.
+
+The `video_template` object supports the following:
+
+* `bitrate` - (Optional, Int) Video bitrate in kbps. Range: 0 or [128, 10000]. Default: 0.
+* `fill_type` - (Optional, String) Fill type. Optional values: stretch, black, white, gauss. Default: black.
+* `fps` - (Optional, Float64) Video frame rate. Range: [0, 30]. Default: 0.
+* `height` - (Optional, Int) Video height/short-edge in pixels. Range: 0 or [128, 1080]. Default: 0.
+* `resolution_adaptive` - (Optional, String) Resolution adaptive mode. Optional values: open, close. Default: open.
+* `video_codec` - (Optional, String) Video codec. Optional values: H.264, H.265.
+* `width` - (Optional, Int) Video width/long-edge in pixels. Range: 0 or [128, 1920]. Default: 0.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `create_time` - Template creation time in ISO 8601 format.
+* `template_id` - Template ID returned after creation.
+* `type` - Template type. Values: preset, custom.
+* `update_time` - Template last update time in ISO 8601 format.
+
+
+## Import
+
+TEO just-in-time transcode template can be imported using the joint id "zone_id#template_id", e.g.
+
+```
+terraform import tencentcloud_teo_just_in_time_transcode_template.example zone-2qtuhspy7cr6#jitt-abcdefghij
+```
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -5889,6 +5889,9 @@
                                     <a href="/docs/providers/tencentcloud/r/teo_identify_zone_operation.html">tencentcloud_teo_identify_zone_operation</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/r/teo_just_in_time_transcode_template.html">tencentcloud_teo_just_in_time_transcode_template</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/r/teo_l4_proxy.html">tencentcloud_teo_l4_proxy</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add new resource for TEO just-in-time transcode template management.

## Summary
- Add  resource
- Support create, read, delete operations for just-in-time transcode templates
- Configure video and audio stream transcoding parameters
- Force new resource recreation on any parameter changes (Update API not available)

## Test plan
- [x] Unit tests added for the resource
- [x] Manual testing for basic create/read/delete operations
- [x] Validation of template parameters