### PR TITLE
docs(teo): update L7AccRulePriorityOperation zone_id description

### DIFF
--- a/.changelog/4054.txt
+++ b/.changelog/4054.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_l7_acc_rule_priority_operation: update zone_id field description
+```

--- a/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_priority_operation.go
+++ b/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_priority_operation.go
@@ -21,7 +21,7 @@ func ResourceTencentCloudTeoL7AccRulePriorityOperation() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Zone id.",
+				Description: "Zone id. Required field, cannot be null or empty string.",
 			},
 			"rule_ids": {
 				Type:        schema.TypeList,

--- a/website/docs/r/teo_l7_acc_rule_priority_operation.html.markdown
+++ b/website/docs/r/teo_l7_acc_rule_priority_operation.html.markdown
@@ -147,7 +147,7 @@ resource "tencentcloud_teo_l7_acc_rule_priority_operation" "teo_l7_acc_rule_prio
 The following arguments are supported:
 
 * `rule_ids` - (Required, List: [`String`], ForceNew) Complete list of rule IDs under site ID.
-* `zone_id` - (Required, String, ForceNew) Zone id.
+* `zone_id` - (Required, String, ForceNew) Zone id. Required field, cannot be null or empty string.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Update the zone_id field description in tencentcloud_teo_l7_acc_rule_priority_operation resource to clarify that it is a required field and cannot be null or empty string.