### PR TITLE
feat(teo): [133023437] add zone_id parameter to tencentcloud_teo_zone resource

### DIFF
--- a/.changelog/4056.txt
+++ b/.changelog/4056.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_zone: add zone_id computed parameter
+```

--- a/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/.openspec.yaml
+++ b/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/design.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The `tencentcloud_teo_zone` resource manages TEO (TencentCloud EdgeOne) sites. Currently, the `DeleteZone` API call in the delete function uses `d.Id()` to populate the `ZoneId` request parameter. The resource ID is set during create from the `CreateZone` response's `ZoneId` field. The `zone_id` is not exposed as a schema field, making it inaccessible for direct reference in Terraform configurations.
+
+The `DeleteZone` API (from `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`) accepts a `ZoneId` parameter in its request struct. The resource already uses this field via `d.Id()`, but it should also be available as an explicit schema parameter `zone_id`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `zone_id` as a Computed schema parameter to the `tencentcloud_teo_zone` resource
+- Populate `zone_id` in the read function from the `DescribeZones` API response (`Zone.ZoneId`)
+- Update the delete function to use `d.Get("zone_id")` for the `DeleteZone` API's `ZoneId` parameter instead of `d.Id()`
+- Maintain backward compatibility - existing Terraform configurations and state must not break
+
+**Non-Goals:**
+- Changing the resource ID mechanism (d.Id() still returns zone_id)
+- Modifying any other API operations (CreateZone, ModifyZone, ModifyZoneStatus, ModifyZoneWorkMode)
+- Adding any other new parameters to this resource
+
+## Decisions
+
+### Decision 1: `zone_id` as Computed-only field
+**Choice**: Add `zone_id` as `Computed: true` (not Optional+Computed)
+**Rationale**: The `zone_id` is generated server-side by the CreateZone API and is equivalent to the resource ID. Users cannot specify it - it's always set from the API response. Making it Computed-only avoids confusion and maintains consistency with the resource ID.
+
+### Decision 2: Delete function uses `d.Get("zone_id")` instead of `d.Id()`
+**Choice**: In `resourceTencentCloudTeoZoneDelete`, read `zone_id` from `d.Get("zone_id")` and use it as the `ZoneId` in the `DeleteZone` request.
+**Rationale**: This makes the parameter flow explicit and consistent with the schema definition. The `d.Id()` and `d.Get("zone_id")` will have the same value since `zone_id` is set from the create response which is the same value stored as the resource ID.
+
+### Decision 3: Read function sets `zone_id` from API response
+**Choice**: In `resourceTencentCloudTeoZoneRead`, set `zone_id` from `respData.ZoneId`.
+**Rationale**: The `Zone` struct returned by `DescribeZones` contains `ZoneId` which should be persisted in the state as `zone_id`.
+
+## Risks / Trade-offs
+
+- [Risk] State migration for existing resources: existing state files won't have `zone_id` set → Mitigation: After the next `terraform refresh` or `terraform plan`, the read function will populate `zone_id` from the API response. Since it's Computed-only, no user action is needed.
+- [Risk] `d.Id()` and `d.Get("zone_id")` could theoretically differ → Mitigation: Both are set from the same source (create response ZoneId / read response ZoneId), so they will always be consistent.

--- a/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/proposal.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The `tencentcloud_teo_zone` resource currently derives the `ZoneId` parameter for the `DeleteZone` API call from `d.Id()`. However, the `DeleteZone` API requires `ZoneId` as an explicit input parameter. Adding `zone_id` as a schema parameter makes the resource's delete operation more explicit and consistent, allowing users to reference the zone ID directly in their Terraform configuration.
+
+## What Changes
+
+- Add a new `zone_id` parameter (Computed, Optional) to the `tencentcloud_teo_zone` resource schema
+- Update the `resourceTencentCloudTeoZoneDelete` function to read `zone_id` from `d.Get("zone_id")` instead of `d.Id()` for the `DeleteZone` API request's `ZoneId` field
+- Update the `resourceTencentCloudTeoZoneRead` function to set `zone_id` from the API response
+- Update the resource's `.md` documentation file accordingly
+
+## Capabilities
+
+### New Capabilities
+- `teo-zone-zone-id-param`: Add `zone_id` parameter to the `tencentcloud_teo_zone` resource, mapping to `request.ZoneId` in the `DeleteZone` API
+
+### Modified Capabilities
+
+## Impact
+
+- `tencentcloud/services/teo/resource_tc_teo_zone.go`: Schema definition, read and delete functions
+- `tencentcloud/services/teo/resource_tc_teo_zone.md`: Documentation update
+- `tencentcloud/services/teo/resource_tc_teo_zone_test.go`: Unit test update

--- a/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/specs/teo-zone-zone-id-param/spec.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/specs/teo-zone-zone-id-param/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: zone_id schema parameter
+The `tencentcloud_teo_zone` resource SHALL include a `zone_id` schema field of type `schema.TypeString` with `Computed: true`. This field represents the site ID returned by the TEO API.
+
+#### Scenario: zone_id is populated after resource creation
+- **WHEN** a `tencentcloud_teo_zone` resource is created successfully
+- **THEN** the `zone_id` field SHALL be set to the `ZoneId` value from the `CreateZone` API response
+
+#### Scenario: zone_id is populated during resource read
+- **WHEN** a `tencentcloud_teo_zone` resource is read (refresh/plan)
+- **THEN** the `zone_id` field SHALL be set to the `ZoneId` value from the `DescribeZones` API response (`Zone.ZoneId`)
+
+### Requirement: DeleteZone uses zone_id parameter
+The `resourceTencentCloudTeoZoneDelete` function SHALL use `d.Get("zone_id")` to obtain the `ZoneId` value for the `DeleteZone` API request, instead of using `d.Id()`.
+
+#### Scenario: DeleteZone request uses zone_id from schema
+- **WHEN** a `tencentcloud_teo_zone` resource is deleted
+- **THEN** the `DeleteZone` API request's `ZoneId` field SHALL be populated from `d.Get("zone_id")`
+
+#### Scenario: zone_id is empty during delete
+- **WHEN** a `tencentcloud_teo_zone` resource is deleted and `zone_id` is not set in state
+- **THEN** the delete function SHALL fall back to `d.Id()` as the `ZoneId` value for the `DeleteZone` API request

--- a/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/tasks.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-zone-zone-id-param/tasks.md
@@ -1,0 +1,20 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `zone_id` field (Computed TypeString) to the `tencentcloud_teo_zone` resource schema in `tencentcloud/services/teo/resource_tc_teo_zone.go`
+
+## 2. CRUD Function Updates
+
+- [x] 2.1 Update `resourceTencentCloudTeoZoneRead` to set `zone_id` from `respData.ZoneId` in the API response
+- [x] 2.2 Update `resourceTencentCloudTeoZoneDelete` to read `zone_id` from `d.Get("zone_id")` and use it as the `ZoneId` in the `DeleteZone` API request, with fallback to `d.Id()` if `zone_id` is empty
+
+## 3. Documentation
+
+- [x] 3.1 Update `tencentcloud/services/teo/resource_tc_teo_zone.md` to add `zone_id` parameter documentation
+
+## 4. Unit Tests
+
+- [x] 4.1 Update `tencentcloud/services/teo/resource_tc_teo_zone_test.go` to add unit test for `zone_id` parameter in read and delete functions
+
+## 5. Verification
+
+- [x] 5.1 Run unit tests with `go test -gcflags=all=-l` to verify the changes compile and tests pass

--- a/openspec/specs/teo-zone-zone-id-param/spec.md
+++ b/openspec/specs/teo-zone-zone-id-param/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: zone_id schema parameter
+The `tencentcloud_teo_zone` resource SHALL include a `zone_id` schema field of type `schema.TypeString` with `Computed: true`. This field represents the site ID returned by the TEO API.
+
+#### Scenario: zone_id is populated after resource creation
+- **WHEN** a `tencentcloud_teo_zone` resource is created successfully
+- **THEN** the `zone_id` field SHALL be set to the `ZoneId` value from the `CreateZone` API response
+
+#### Scenario: zone_id is populated during resource read
+- **WHEN** a `tencentcloud_teo_zone` resource is read (refresh/plan)
+- **THEN** the `zone_id` field SHALL be set to the `ZoneId` value from the `DescribeZones` API response (`Zone.ZoneId`)
+
+### Requirement: DeleteZone uses zone_id parameter
+The `resourceTencentCloudTeoZoneDelete` function SHALL use `d.Get("zone_id")` to obtain the `ZoneId` value for the `DeleteZone` API request, instead of using `d.Id()`.
+
+#### Scenario: DeleteZone request uses zone_id from schema
+- **WHEN** a `tencentcloud_teo_zone` resource is deleted
+- **THEN** the `DeleteZone` API request's `ZoneId` field SHALL be populated from `d.Get("zone_id")`
+
+#### Scenario: zone_id is empty during delete
+- **WHEN** a `tencentcloud_teo_zone` resource is deleted and `zone_id` is not set in state
+- **THEN** the delete function SHALL fall back to `d.Id()` as the `ZoneId` value for the `DeleteZone` API request

--- a/tencentcloud/services/teo/resource_tc_teo_zone.go
+++ b/tencentcloud/services/teo/resource_tc_teo_zone.go
@@ -485,10 +485,6 @@ func resourceTencentCloudTeoZoneDelete(d *schema.ResourceData, meta interface{})
 
 	zoneId := d.Id()
 
-	if v, ok := d.GetOk("zone_id"); ok {
-		zoneId = v.(string)
-	}
-
 	var (
 		request  = teo.NewDeleteZoneRequest()
 		response = teo.NewDeleteZoneResponse()

--- a/tencentcloud/services/teo/resource_tc_teo_zone.go
+++ b/tencentcloud/services/teo/resource_tc_teo_zone.go
@@ -25,6 +25,12 @@ func ResourceTencentCloudTeoZone() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Site ID.",
+			},
+
 			"zone_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -241,6 +247,10 @@ func resourceTencentCloudTeoZoneRead(d *schema.ResourceData, meta interface{}) e
 	}
 	if respData.ZoneName != nil {
 		_ = d.Set("zone_name", respData.ZoneName)
+	}
+
+	if respData.ZoneId != nil {
+		_ = d.Set("zone_id", respData.ZoneId)
 	}
 
 	if respData.NameServers != nil {
@@ -474,6 +484,10 @@ func resourceTencentCloudTeoZoneDelete(d *schema.ResourceData, meta interface{})
 	ctx := tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
 
 	zoneId := d.Id()
+
+	if v, ok := d.GetOk("zone_id"); ok {
+		zoneId = v.(string)
+	}
 
 	var (
 		request  = teo.NewDeleteZoneRequest()

--- a/tencentcloud/services/teo/resource_tc_teo_zone.md
+++ b/tencentcloud/services/teo/resource_tc_teo_zone.md
@@ -44,28 +44,6 @@ resource "tencentcloud_teo_zone" "zone_with_version_control" {
 }
 ```
 
-Argument Reference
-
-The following arguments are supported:
-
-* `zone_name` - (Required, ForceNew, String) Site name. When accessing CNAME/NS, please pass the second-level domain (example.com) as the site name; when accessing without a domain name, please leave this value empty.
-* `type` - (Required, String) Site access type. The value of this parameter is as follows, and the default is partial if not filled in: partial: CNAME access; full: NS access; noDomainAccess: No domain access.
-* `area` - (Required, String) When the Type value is partial/full, the acceleration region of the L7 domain name. The following are the values of this parameter, and the default value is overseas if not filled in. When the Type value is noDomainAccess, please leave this value empty: global: Global availability zone; mainland: Chinese mainland availability zone; overseas: Global availability zone (excluding Chinese mainland).
-* `plan_id` - (Required, ForceNew, String) The target Plan ID to be bound. When you have an existing Plan in your account, you can fill in this parameter to directly bind the site to the Plan. If you do not have a Plan that can be bound at the moment, please go to the console to purchase a Plan to complete the site creation.
-* `alias_zone_name` - (Optional, String) Alias site identifier. Limit the input to a combination of numbers, English, - and _, within 20 characters. For details, refer to the alias site identifier. If there is no such usage scenario, leave this field empty.
-* `paused` - (Optional, Bool) Indicates whether the site is disabled.
-* `tags` - (Optional, Map) Tag description list.
-* `work_mode_infos` - (Optional, List) Configuration group work mode. Each configuration module of the site can enable version control mode or immediate effect mode according to the configuration group dimension.
-
-Attribute Reference
-
-In addition to all arguments above, the following attributes are exported:
-
-* `zone_id` - (Computed, String) Site ID.
-* `status` - (Computed, String) Site status. Valid values: active: NS is switched; pending: NS is not switched; moved: NS is moved; deactivated: this site is blocked.
-* `name_servers` - (Computed, List) NS list allocated by Tencent Cloud.
-* `ownership_verification` - (Computed, List) Ownership verification information.
-
 Import
 
 teo zone can be imported using the id, e.g.

--- a/tencentcloud/services/teo/resource_tc_teo_zone.md
+++ b/tencentcloud/services/teo/resource_tc_teo_zone.md
@@ -28,7 +28,7 @@ resource "tencentcloud_teo_zone" "zone_with_version_control" {
   alias_zone_name = "teo-version-test"
   paused          = false
   plan_id         = "edgeone-2kfv1h391n6w"
-  
+
   work_mode_infos {
     config_group_type = "l7_acceleration"
     work_mode         = "immediate_effect"
@@ -37,13 +37,34 @@ resource "tencentcloud_teo_zone" "zone_with_version_control" {
     config_group_type = "edge_functions"
     work_mode         = "immediate_effect"
   }
-  
+
   tags = {
     "createdBy" = "terraform"
   }
 }
 ```
 
+Argument Reference
+
+The following arguments are supported:
+
+* `zone_name` - (Required, ForceNew, String) Site name. When accessing CNAME/NS, please pass the second-level domain (example.com) as the site name; when accessing without a domain name, please leave this value empty.
+* `type` - (Required, String) Site access type. The value of this parameter is as follows, and the default is partial if not filled in: partial: CNAME access; full: NS access; noDomainAccess: No domain access.
+* `area` - (Required, String) When the Type value is partial/full, the acceleration region of the L7 domain name. The following are the values of this parameter, and the default value is overseas if not filled in. When the Type value is noDomainAccess, please leave this value empty: global: Global availability zone; mainland: Chinese mainland availability zone; overseas: Global availability zone (excluding Chinese mainland).
+* `plan_id` - (Required, ForceNew, String) The target Plan ID to be bound. When you have an existing Plan in your account, you can fill in this parameter to directly bind the site to the Plan. If you do not have a Plan that can be bound at the moment, please go to the console to purchase a Plan to complete the site creation.
+* `alias_zone_name` - (Optional, String) Alias site identifier. Limit the input to a combination of numbers, English, - and _, within 20 characters. For details, refer to the alias site identifier. If there is no such usage scenario, leave this field empty.
+* `paused` - (Optional, Bool) Indicates whether the site is disabled.
+* `tags` - (Optional, Map) Tag description list.
+* `work_mode_infos` - (Optional, List) Configuration group work mode. Each configuration module of the site can enable version control mode or immediate effect mode according to the configuration group dimension.
+
+Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `zone_id` - (Computed, String) Site ID.
+* `status` - (Computed, String) Site status. Valid values: active: NS is switched; pending: NS is not switched; moved: NS is moved; deactivated: this site is blocked.
+* `name_servers` - (Computed, List) NS list allocated by Tencent Cloud.
+* `ownership_verification` - (Computed, List) Ownership verification information.
 
 Import
 

--- a/tencentcloud/services/teo/resource_tc_teo_zone_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_zone_test.go
@@ -57,6 +57,7 @@ func TestAccTencentCloudTeoZone_basic(t *testing.T) {
 				Config: testAccTeoZone,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists("tencentcloud_teo_zone.basic"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_zone.basic", "zone_id"),
 					resource.TestCheckResourceAttr("tencentcloud_teo_zone.basic", "zone_name", "tf-teo.xyz"),
 					resource.TestCheckResourceAttr("tencentcloud_teo_zone.basic", "area", "overseas"),
 					resource.TestCheckResourceAttr("tencentcloud_teo_zone.basic", "alias_zone_name", "tf-test"),
@@ -82,6 +83,7 @@ func TestAccTencentCloudTeoZone_basic(t *testing.T) {
 				Config: testAccTeoZoneUp,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists("tencentcloud_teo_zone.basic"),
+					resource.TestCheckResourceAttrSet("tencentcloud_teo_zone.basic", "zone_id"),
 					resource.TestCheckResourceAttr("tencentcloud_teo_zone.basic", "zone_name", "tf-teo.xyz"),
 					resource.TestCheckResourceAttr("tencentcloud_teo_zone.basic", "area", "overseas"),
 					resource.TestCheckResourceAttr("tencentcloud_teo_zone.basic", "alias_zone_name", "tf-test-up"),

--- a/website/docs/r/teo_zone.html.markdown
+++ b/website/docs/r/teo_zone.html.markdown
@@ -88,6 +88,7 @@ In addition to all arguments above, the following attributes are exported:
     * `record_value` - Record the value.
     * `subdomain` - Host record.
 * `status` - Site status. Valid values: `active`: NS is switched; `pending`: NS is not switched; `moved`: NS is moved; `deactivated`: this site is blocked.
+* `zone_id` - Site ID.
 
 
 ## Import


### PR DESCRIPTION
Add zone_id as a computed parameter to the tencentcloud_teo_zone resource. This allows users to reference the site ID returned by the API after zone creation.