### PR TITLE
docs(teo): [133023437] update certificate config mode description with eofreecert_manual option

### DIFF
--- a/.changelog/4057.txt
+++ b/.changelog/4057.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_certificate_config: update certificate config mode description with eofreecert_manual option
+```

--- a/tencentcloud/services/teo/resource_tc_teo_certificate_config.go
+++ b/tencentcloud/services/teo/resource_tc_teo_certificate_config.go
@@ -165,7 +165,7 @@ func ResourceTencentCloudTeoCertificateConfig() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "Mode of configuring the certificate, the values are: `disable`: Do not configure the certificate; `eofreecert`: Configure EdgeOne free certificate; `sslcert`: Configure SSL certificate. If not filled in, the default value is `disable`.",
+				Description: "Mode of configuring the certificate, the values are: `disable`: Do not configure the certificate; `eofreecert`: Configure EdgeOne free certificate; `eofreecert_manual`: Deploy a free certificate applied for through DNS delegation validation or file validation; `sslcert`: Configure SSL certificate. If not filled in, the default value is `disable`.",
 			},
 		},
 	}

--- a/website/docs/r/teo_certificate_config.html.markdown
+++ b/website/docs/r/teo_certificate_config.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `host` - (Required, String, ForceNew) Acceleration domain name that needs to modify the certificate configuration.
 * `zone_id` - (Required, String, ForceNew) Site ID.
-* `mode` - (Optional, String) Mode of configuring the certificate, the values are: `disable`: Do not configure the certificate; `eofreecert`: Configure EdgeOne free certificate; `sslcert`: Configure SSL certificate. If not filled in, the default value is `disable`.
+* `mode` - (Optional, String) Mode of configuring the certificate, the values are: `disable`: Do not configure the certificate; `eofreecert`: Configure EdgeOne free certificate; `eofreecert_manual`: Deploy a free certificate applied for through DNS delegation validation or file validation; `sslcert`: Configure SSL certificate. If not filled in, the default value is `disable`.
 * `server_cert_info` - (Optional, List) SSL certificate configuration, this parameter takes effect only when mode = sslcert, just enter the corresponding CertId. You can go to the SSL certificate list to view the CertId.
 * `upstream_cert_info` - (Optional, List) Configures the certificate presented by the EO node during origin-pull for mutual TLS authentication. Disabled by default; leaving the field blank will retain the current configuration. This feature is currently in beta testing. please [contact us](https://cloud.tencent.com/online-service) to request access.
 


### PR DESCRIPTION
Update the certificate config mode description in tencentcloud_teo_certificate_config resource to include the new eofreecert_manual option, which represents deploying a free certificate applied through DNS delegation validation or file validation.