### PR TITLE
feat(teo): [133047549] add error_pages computed attribute to tencentcloud_teo_customize_error_page resource

### DIFF
--- a/.changelog/4058.txt
+++ b/.changelog/4058.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_customize_error_page: add error_pages computed attribute with page_id, name, content_type, description, content and references fields
+```

--- a/.changelog/4058.txt
+++ b/.changelog/4058.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/tencentcloud_teo_customize_error_page: add error_pages computed attribute with page_id, name, content_type, description, content and references fields
+resource/tencentcloud_teo_customize_error_page: add references computed attribute
 ```

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/design.md
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/design.md
@@ -1,32 +1,28 @@
 ## Context
 
-The `tencentcloud_teo_customize_error_page` resource manages TEO custom error pages. The resource currently exposes individual fields from a single `CustomErrorPage` object (`page_id`, `name`, `content_type`, `description`, `content`), but does not expose the `error_pages` computed attribute from the `DescribeCustomErrorPages` API response. The `CustomErrorPage` struct in the SDK also contains a `References` field (of type `[]*ErrorPageReference`) that indicates which business rules reference the error page, which is not available in the current Terraform schema.
+The `tencentcloud_teo_customize_error_page` resource manages TEO custom error pages. The resource currently exposes individual fields from a single `CustomErrorPage` object (`page_id`, `name`, `content_type`, `description`, `content`), but does not expose the `References` field from the API response. The `CustomErrorPage` struct in the SDK contains a `References` field (of type `[]*ErrorPageReference`) that indicates which business rules reference the error page.
 
 The `DescribeCustomErrorPages` API accepts `ZoneId` and `Filters` as input parameters and returns `ErrorPages` (a list of `CustomErrorPage` objects) in the response. The existing service method `DescribeTeoCustomizeErrorPageById` already uses this API with `Filters` internally to query by `page-id`.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Add the `error_pages` computed attribute to the `tencentcloud_teo_customize_error_page` resource schema
-- Expose the `References` sub-field from each `CustomErrorPage` in the `error_pages` attribute
+- Add the `references` computed attribute at the top level of the resource schema
+- Expose the `References` sub-field from `CustomErrorPage` as a flat list of business ID strings
 - Maintain backward compatibility with existing Terraform configurations and state
 
 **Non-Goals:**
-- Adding the `filters` parameter as a user-facing schema attribute (it is used internally in the service layer)
+- Adding an `error_pages` nested list attribute (the existing top-level fields already cover page_id, name, content_type, description, content)
 - Changing the existing schema fields or their behavior
 - Creating a new data source for custom error pages
 
 ## Decisions
 
-1. **Add `error_pages` as a computed TypeList attribute**: The `error_pages` field will be a `TypeList` of `schema.TypeMap` (or nested object blocks) containing all fields from `CustomErrorPage` including the `References` field. This follows the existing pattern in the codebase for exposing API response lists.
+1. **Add `references` as a top-level computed TypeList of TypeString**: The `ErrorPageReference` struct only contains a single `BusinessId` field. Rather than creating a nested object list, `references` is a flat `TypeList` of `TypeString` containing the `BusinessId` values directly. This avoids unnecessary nesting since the outer-level fields (`page_id`, `name`, `content_type`, `description`, `content`) already exist at the top level.
 
-2. **Flatten `References` as a list of strings**: The `ErrorPageReference` struct only contains a single `BusinessId` field. Rather than creating a deeply nested schema, the `references` sub-field within each error page will be a `TypeList` of `TypeString` containing the `BusinessId` values.
-
-3. **Populate `error_pages` in the read function**: The `resourceTencentCloudTeoCustomizeErrorPageRead` function already calls `DescribeTeoCustomizeErrorPageById` which uses the `DescribeCustomErrorPages` API. The response data is already available; we just need to flatten the `References` field and set the `error_pages` attribute.
-
-4. **Schema structure for `error_pages`**: Use nested `schema.Resource` blocks for the list elements to maintain type safety and follow existing patterns in the codebase (similar to how other resources handle list-of-object computed attributes).
+2. **Populate `references` in the read function**: The `resourceTencentCloudTeoCustomizeErrorPageRead` function already calls `DescribeTeoCustomizeErrorPageById` which uses the `DescribeCustomErrorPages` API. The response data is already available; we just need to flatten the `References` field and set the `references` attribute.
 
 ## Risks / Trade-offs
 
-- **[Risk] Adding a computed attribute may increase state size** → Mitigation: The `error_pages` list typically contains only one element for a single resource read, so the impact is minimal.
-- **[Risk] The `References` field may change in future API versions** → Mitigation: Use computed-only fields so any changes are reflected on the next read without requiring schema migration.
+- **[Risk] Adding a computed attribute may affect state** → Mitigation: The `references` field is computed-only, so any changes are reflected on the next read without requiring schema migration.
+- **[Risk] The `References` field may change in future API versions** → Mitigation: Use computed-only fields so any changes are reflected automatically.

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/design.md
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/design.md
@@ -1,0 +1,32 @@
+## Context
+
+The `tencentcloud_teo_customize_error_page` resource manages TEO custom error pages. The resource currently exposes individual fields from a single `CustomErrorPage` object (`page_id`, `name`, `content_type`, `description`, `content`), but does not expose the `error_pages` computed attribute from the `DescribeCustomErrorPages` API response. The `CustomErrorPage` struct in the SDK also contains a `References` field (of type `[]*ErrorPageReference`) that indicates which business rules reference the error page, which is not available in the current Terraform schema.
+
+The `DescribeCustomErrorPages` API accepts `ZoneId` and `Filters` as input parameters and returns `ErrorPages` (a list of `CustomErrorPage` objects) in the response. The existing service method `DescribeTeoCustomizeErrorPageById` already uses this API with `Filters` internally to query by `page-id`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add the `error_pages` computed attribute to the `tencentcloud_teo_customize_error_page` resource schema
+- Expose the `References` sub-field from each `CustomErrorPage` in the `error_pages` attribute
+- Maintain backward compatibility with existing Terraform configurations and state
+
+**Non-Goals:**
+- Adding the `filters` parameter as a user-facing schema attribute (it is used internally in the service layer)
+- Changing the existing schema fields or their behavior
+- Creating a new data source for custom error pages
+
+## Decisions
+
+1. **Add `error_pages` as a computed TypeList attribute**: The `error_pages` field will be a `TypeList` of `schema.TypeMap` (or nested object blocks) containing all fields from `CustomErrorPage` including the `References` field. This follows the existing pattern in the codebase for exposing API response lists.
+
+2. **Flatten `References` as a list of strings**: The `ErrorPageReference` struct only contains a single `BusinessId` field. Rather than creating a deeply nested schema, the `references` sub-field within each error page will be a `TypeList` of `TypeString` containing the `BusinessId` values.
+
+3. **Populate `error_pages` in the read function**: The `resourceTencentCloudTeoCustomizeErrorPageRead` function already calls `DescribeTeoCustomizeErrorPageById` which uses the `DescribeCustomErrorPages` API. The response data is already available; we just need to flatten the `References` field and set the `error_pages` attribute.
+
+4. **Schema structure for `error_pages`**: Use nested `schema.Resource` blocks for the list elements to maintain type safety and follow existing patterns in the codebase (similar to how other resources handle list-of-object computed attributes).
+
+## Risks / Trade-offs
+
+- **[Risk] Adding a computed attribute may increase state size** → Mitigation: The `error_pages` list typically contains only one element for a single resource read, so the impact is minimal.
+- **[Risk] The `References` field may change in future API versions** → Mitigation: Use computed-only fields so any changes are reflected on the next read without requiring schema migration.

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/proposal.md
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The `tencentcloud_teo_customize_error_page` resource currently does not expose the `error_pages` computed attribute from the `DescribeCustomErrorPages` API response. This attribute contains the list of custom error pages including the `References` field (which indicates which business rules reference the error page), which is not available through any existing schema field. Users need visibility into which business rules reference each error page.
+
+## What Changes
+
+- Add a new computed attribute `error_pages` to the `tencentcloud_teo_customize_error_page` resource schema
+- The `error_pages` attribute will be a TypeList of objects, each containing: `page_id`, `name`, `content_type`, `description`, `content`, and `references` (list of `business_id` strings)
+- Update the `resourceTencentCloudTeoCustomizeErrorPageRead` function to populate the `error_pages` attribute from the `DescribeCustomErrorPages` API response
+
+## Capabilities
+
+### New Capabilities
+- `teo-customize-error-page-error-pages`: Expose the `error_pages` computed attribute on the TEO customize error page resource, including the `References` sub-field from the API response
+
+### Modified Capabilities
+
+## Impact
+
+- `tencentcloud/services/teo/resource_tc_teo_customize_error_page.go` - Add `error_pages` schema field and populate it in the read function
+- `tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go` - Add unit tests for the new attribute
+- `tencentcloud/services/teo/resource_tc_teo_customize_error_page.md` - Update documentation with the new attribute

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/proposal.md
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/proposal.md
@@ -1,22 +1,21 @@
 ## Why
 
-The `tencentcloud_teo_customize_error_page` resource currently does not expose the `error_pages` computed attribute from the `DescribeCustomErrorPages` API response. This attribute contains the list of custom error pages including the `References` field (which indicates which business rules reference the error page), which is not available through any existing schema field. Users need visibility into which business rules reference each error page.
+The `tencentcloud_teo_customize_error_page` resource currently does not expose the `References` field from the `DescribeCustomErrorPages` API response. This field indicates which business rules reference the error page, which is useful for users to understand error page dependencies before modifying or deleting them.
 
 ## What Changes
 
-- Add a new computed attribute `error_pages` to the `tencentcloud_teo_customize_error_page` resource schema
-- The `error_pages` attribute will be a TypeList of objects, each containing: `page_id`, `name`, `content_type`, `description`, `content`, and `references` (list of `business_id` strings)
-- Update the `resourceTencentCloudTeoCustomizeErrorPageRead` function to populate the `error_pages` attribute from the `DescribeCustomErrorPages` API response
+- Add a new computed attribute `references` (TypeList of TypeString) at the top level of the `tencentcloud_teo_customize_error_page` resource schema
+- The `references` attribute contains a list of `BusinessId` strings from the `ErrorPageReference` objects in the API response
+- Update the `resourceTencentCloudTeoCustomizeErrorPageRead` function to populate the `references` attribute from the `DescribeCustomErrorPages` API response
 
 ## Capabilities
 
 ### New Capabilities
-- `teo-customize-error-page-error-pages`: Expose the `error_pages` computed attribute on the TEO customize error page resource, including the `References` sub-field from the API response
+- `teo-customize-error-page-error-pages`: Expose the `references` computed attribute on the TEO customize error page resource, containing the list of business IDs that reference this error page
 
 ### Modified Capabilities
 
 ## Impact
 
-- `tencentcloud/services/teo/resource_tc_teo_customize_error_page.go` - Add `error_pages` schema field and populate it in the read function
+- `tencentcloud/services/teo/resource_tc_teo_customize_error_page.go` - Add `references` schema field and populate it in the read function
 - `tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go` - Add unit tests for the new attribute
-- `tencentcloud/services/teo/resource_tc_teo_customize_error_page.md` - Update documentation with the new attribute

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/specs/teo-customize-error-page-error-pages/spec.md
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/specs/teo-customize-error-page-error-pages/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: error_pages computed attribute
+The `tencentcloud_teo_customize_error_page` resource SHALL expose an `error_pages` computed attribute of type list, where each element contains the following fields from the `DescribeCustomErrorPages` API response:
+- `page_id` (string): Custom error page ID
+- `name` (string): Custom error page name
+- `content_type` (string): Custom error page type
+- `description` (string): Custom error page description
+- `content` (string): Custom error page content
+- `references` (list of string): List of business IDs that reference this error page
+
+The `error_pages` attribute SHALL be computed-only and SHALL NOT be user-configurable.
+
+#### Scenario: Read resource with error_pages populated
+- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns error pages data with `References` field populated
+- **THEN** the `error_pages` attribute SHALL be set with the flattened list of error page objects, each including the `references` sub-field containing the list of `BusinessId` values from the `References` array
+
+#### Scenario: Read resource with empty references
+- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns an error page with no references
+- **THEN** the `references` sub-field within the `error_pages` element SHALL be an empty list
+
+#### Scenario: Backward compatibility with existing state
+- **WHEN** an existing `tencentcloud_teo_customize_error_page` resource is read without the `error_pages` attribute in its state
+- **THEN** the resource SHALL continue to function correctly and the `error_pages` attribute SHALL be populated on the next read operation

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/specs/teo-customize-error-page-error-pages/spec.md
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/specs/teo-customize-error-page-error-pages/spec.md
@@ -1,24 +1,18 @@
 ## ADDED Requirements
 
-### Requirement: error_pages computed attribute
-The `tencentcloud_teo_customize_error_page` resource SHALL expose an `error_pages` computed attribute of type list, where each element contains the following fields from the `DescribeCustomErrorPages` API response:
-- `page_id` (string): Custom error page ID
-- `name` (string): Custom error page name
-- `content_type` (string): Custom error page type
-- `description` (string): Custom error page description
-- `content` (string): Custom error page content
-- `references` (list of string): List of business IDs that reference this error page
+### Requirement: references computed attribute
+The `tencentcloud_teo_customize_error_page` resource SHALL expose a `references` computed attribute at the top level of type list of string, containing the `BusinessId` values from the `ErrorPageReference` objects in the `DescribeCustomErrorPages` API response.
 
-The `error_pages` attribute SHALL be computed-only and SHALL NOT be user-configurable.
+The `references` attribute SHALL be computed-only and SHALL NOT be user-configurable.
 
-#### Scenario: Read resource with error_pages populated
-- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns error pages data with `References` field populated
-- **THEN** the `error_pages` attribute SHALL be set with the flattened list of error page objects, each including the `references` sub-field containing the list of `BusinessId` values from the `References` array
+#### Scenario: Read resource with references populated
+- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns a `CustomErrorPage` with `References` field populated
+- **THEN** the `references` attribute SHALL be set with the list of `BusinessId` values from the `References` array
 
 #### Scenario: Read resource with empty references
-- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns an error page with no references
-- **THEN** the `references` sub-field within the `error_pages` element SHALL be an empty list
+- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns a `CustomErrorPage` with no references
+- **THEN** the `references` attribute SHALL be an empty list
 
 #### Scenario: Backward compatibility with existing state
-- **WHEN** an existing `tencentcloud_teo_customize_error_page` resource is read without the `error_pages` attribute in its state
-- **THEN** the resource SHALL continue to function correctly and the `error_pages` attribute SHALL be populated on the next read operation
+- **WHEN** an existing `tencentcloud_teo_customize_error_page` resource is read without the `references` attribute in its state
+- **THEN** the resource SHALL continue to function correctly and the `references` attribute SHALL be populated on the next read operation

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/tasks.md
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/tasks.md
@@ -1,0 +1,15 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `error_pages` computed attribute (TypeList of nested Resource) to the `tencentcloud_teo_customize_error_page` resource schema in `tencentcloud/services/teo/resource_tc_teo_customize_error_page.go`, with nested fields: `page_id` (string), `name` (string), `content_type` (string), `description` (string), `content` (string), `references` (TypeList of TypeString)
+
+## 2. CRUD Function Update
+
+- [x] 2.1 Update `resourceTencentCloudTeoCustomizeErrorPageRead` to flatten the `error_pages` data from the `DescribeCustomErrorPages` API response, including mapping the `References` field (list of `ErrorPageReference` with `BusinessId`) into the `references` sub-field
+
+## 3. Unit Tests
+
+- [x] 3.1 Add unit tests in `tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go` to verify the `error_pages` computed attribute is correctly populated, including the `references` sub-field
+
+## 4. Documentation
+
+- [x] 4.1 Update `tencentcloud/services/teo/resource_tc_teo_customize_error_page.md` to document the new `error_pages` computed attribute with its sub-fields

--- a/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/tasks.md
+++ b/openspec/changes/archive/2026-04-24-add-teo-customize-error-page-error-pages/tasks.md
@@ -1,15 +1,11 @@
 ## 1. Schema Definition
 
-- [x] 1.1 Add `error_pages` computed attribute (TypeList of nested Resource) to the `tencentcloud_teo_customize_error_page` resource schema in `tencentcloud/services/teo/resource_tc_teo_customize_error_page.go`, with nested fields: `page_id` (string), `name` (string), `content_type` (string), `description` (string), `content` (string), `references` (TypeList of TypeString)
+- [x] 1.1 Add `references` computed attribute (TypeList of TypeString) at the top level of the `tencentcloud_teo_customize_error_page` resource schema in `tencentcloud/services/teo/resource_tc_teo_customize_error_page.go`
 
 ## 2. CRUD Function Update
 
-- [x] 2.1 Update `resourceTencentCloudTeoCustomizeErrorPageRead` to flatten the `error_pages` data from the `DescribeCustomErrorPages` API response, including mapping the `References` field (list of `ErrorPageReference` with `BusinessId`) into the `references` sub-field
+- [x] 2.1 Update `resourceTencentCloudTeoCustomizeErrorPageRead` to flatten the `References` field (list of `ErrorPageReference` with `BusinessId`) from the API response into the top-level `references` attribute
 
 ## 3. Unit Tests
 
-- [x] 3.1 Add unit tests in `tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go` to verify the `error_pages` computed attribute is correctly populated, including the `references` sub-field
-
-## 4. Documentation
-
-- [x] 4.1 Update `tencentcloud/services/teo/resource_tc_teo_customize_error_page.md` to document the new `error_pages` computed attribute with its sub-fields
+- [x] 3.1 Add unit tests in `tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go` to verify the `references` computed attribute is correctly populated, including empty references scenario

--- a/openspec/specs/teo-customize-error-page-error-pages/spec.md
+++ b/openspec/specs/teo-customize-error-page-error-pages/spec.md
@@ -1,27 +1,18 @@
-# teo-customize-error-page-error-pages Specification
+## ADDED Requirements
 
-## Purpose
-TBD - created by archiving change add-teo-customize-error-page-error-pages. Update Purpose after archive.
-## Requirements
-### Requirement: error_pages computed attribute
-The `tencentcloud_teo_customize_error_page` resource SHALL expose an `error_pages` computed attribute of type list, where each element contains the following fields from the `DescribeCustomErrorPages` API response:
-- `page_id` (string): Custom error page ID
-- `name` (string): Custom error page name
-- `content_type` (string): Custom error page type
-- `description` (string): Custom error page description
-- `content` (string): Custom error page content
-- `references` (list of string): List of business IDs that reference this error page
+### Requirement: references computed attribute
+The `tencentcloud_teo_customize_error_page` resource SHALL expose a `references` computed attribute at the top level of type list of string, containing the `BusinessId` values from the `ErrorPageReference` objects in the `DescribeCustomErrorPages` API response.
 
-The `error_pages` attribute SHALL be computed-only and SHALL NOT be user-configurable.
+The `references` attribute SHALL be computed-only and SHALL NOT be user-configurable.
 
-#### Scenario: Read resource with error_pages populated
-- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns error pages data with `References` field populated
-- **THEN** the `error_pages` attribute SHALL be set with the flattened list of error page objects, each including the `references` sub-field containing the list of `BusinessId` values from the `References` array
+#### Scenario: Read resource with references populated
+- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns a `CustomErrorPage` with `References` field populated
+- **THEN** the `references` attribute SHALL be set with the list of `BusinessId` values from the `References` array
 
 #### Scenario: Read resource with empty references
-- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns an error page with no references
-- **THEN** the `references` sub-field within the `error_pages` element SHALL be an empty list
+- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns a `CustomErrorPage` with no references
+- **THEN** the `references` attribute SHALL be an empty list
 
 #### Scenario: Backward compatibility with existing state
-- **WHEN** an existing `tencentcloud_teo_customize_error_page` resource is read without the `error_pages` attribute in its state
-- **THEN** the resource SHALL continue to function correctly and the `error_pages` attribute SHALL be populated on the next read operation
+- **WHEN** an existing `tencentcloud_teo_customize_error_page` resource is read without the `references` attribute in its state
+- **THEN** the resource SHALL continue to function correctly and the `references` attribute SHALL be populated on the next read operation

--- a/openspec/specs/teo-customize-error-page-error-pages/spec.md
+++ b/openspec/specs/teo-customize-error-page-error-pages/spec.md
@@ -1,0 +1,27 @@
+# teo-customize-error-page-error-pages Specification
+
+## Purpose
+TBD - created by archiving change add-teo-customize-error-page-error-pages. Update Purpose after archive.
+## Requirements
+### Requirement: error_pages computed attribute
+The `tencentcloud_teo_customize_error_page` resource SHALL expose an `error_pages` computed attribute of type list, where each element contains the following fields from the `DescribeCustomErrorPages` API response:
+- `page_id` (string): Custom error page ID
+- `name` (string): Custom error page name
+- `content_type` (string): Custom error page type
+- `description` (string): Custom error page description
+- `content` (string): Custom error page content
+- `references` (list of string): List of business IDs that reference this error page
+
+The `error_pages` attribute SHALL be computed-only and SHALL NOT be user-configurable.
+
+#### Scenario: Read resource with error_pages populated
+- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns error pages data with `References` field populated
+- **THEN** the `error_pages` attribute SHALL be set with the flattened list of error page objects, each including the `references` sub-field containing the list of `BusinessId` values from the `References` array
+
+#### Scenario: Read resource with empty references
+- **WHEN** a `tencentcloud_teo_customize_error_page` resource is read and the `DescribeCustomErrorPages` API returns an error page with no references
+- **THEN** the `references` sub-field within the `error_pages` element SHALL be an empty list
+
+#### Scenario: Backward compatibility with existing state
+- **WHEN** an existing `tencentcloud_teo_customize_error_page` resource is read without the `error_pages` attribute in its state
+- **THEN** the resource SHALL continue to function correctly and the `error_pages` attribute SHALL be populated on the next read operation

--- a/tencentcloud/services/teo/resource_tc_teo_customize_error_page.go
+++ b/tencentcloud/services/teo/resource_tc_teo_customize_error_page.go
@@ -61,6 +61,49 @@ func ResourceTencentCloudTeoCustomizeErrorPage() *schema.Resource {
 				Computed:    true,
 				Description: "Page ID.",
 			},
+
+			"error_pages": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of custom error pages. Each element contains the following attributes:",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"page_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Custom error page ID.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Custom error page name.",
+						},
+						"content_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Custom error page type.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Custom error page description.",
+						},
+						"content": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Custom error page content.",
+						},
+						"references": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "List of business IDs that reference this error page.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -176,6 +219,35 @@ func resourceTencentCloudTeoCustomizeErrorPageRead(d *schema.ResourceData, meta 
 	if respData.Content != nil {
 		_ = d.Set("content", respData.Content)
 	}
+
+	errorPagesList := make([]map[string]interface{}, 0, 1)
+	errorPage := map[string]interface{}{}
+	if respData.PageId != nil {
+		errorPage["page_id"] = respData.PageId
+	}
+	if respData.Name != nil {
+		errorPage["name"] = respData.Name
+	}
+	if respData.ContentType != nil {
+		errorPage["content_type"] = respData.ContentType
+	}
+	if respData.Description != nil {
+		errorPage["description"] = respData.Description
+	}
+	if respData.Content != nil {
+		errorPage["content"] = respData.Content
+	}
+	referencesList := make([]string, 0)
+	if respData.References != nil {
+		for _, ref := range respData.References {
+			if ref.BusinessId != nil {
+				referencesList = append(referencesList, *ref.BusinessId)
+			}
+		}
+	}
+	errorPage["references"] = referencesList
+	errorPagesList = append(errorPagesList, errorPage)
+	_ = d.Set("error_pages", errorPagesList)
 
 	return nil
 }

--- a/tencentcloud/services/teo/resource_tc_teo_customize_error_page.go
+++ b/tencentcloud/services/teo/resource_tc_teo_customize_error_page.go
@@ -62,46 +62,12 @@ func ResourceTencentCloudTeoCustomizeErrorPage() *schema.Resource {
 				Description: "Page ID.",
 			},
 
-			"error_pages": {
+			"references": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: "A list of custom error pages. Each element contains the following attributes:",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"page_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Custom error page ID.",
-						},
-						"name": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Custom error page name.",
-						},
-						"content_type": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Custom error page type.",
-						},
-						"description": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Custom error page description.",
-						},
-						"content": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Custom error page content.",
-						},
-						"references": {
-							Type:        schema.TypeList,
-							Computed:    true,
-							Description: "List of business IDs that reference this error page.",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
+				Description: "List of business IDs that reference this error page.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
 				},
 			},
 		},
@@ -220,23 +186,6 @@ func resourceTencentCloudTeoCustomizeErrorPageRead(d *schema.ResourceData, meta 
 		_ = d.Set("content", respData.Content)
 	}
 
-	errorPagesList := make([]map[string]interface{}, 0, 1)
-	errorPage := map[string]interface{}{}
-	if respData.PageId != nil {
-		errorPage["page_id"] = respData.PageId
-	}
-	if respData.Name != nil {
-		errorPage["name"] = respData.Name
-	}
-	if respData.ContentType != nil {
-		errorPage["content_type"] = respData.ContentType
-	}
-	if respData.Description != nil {
-		errorPage["description"] = respData.Description
-	}
-	if respData.Content != nil {
-		errorPage["content"] = respData.Content
-	}
 	referencesList := make([]string, 0)
 	if respData.References != nil {
 		for _, ref := range respData.References {
@@ -245,9 +194,7 @@ func resourceTencentCloudTeoCustomizeErrorPageRead(d *schema.ResourceData, meta 
 			}
 		}
 	}
-	errorPage["references"] = referencesList
-	errorPagesList = append(errorPagesList, errorPage)
-	_ = d.Set("error_pages", errorPagesList)
+	_ = d.Set("references", referencesList)
 
 	return nil
 }

--- a/tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go
@@ -1,12 +1,40 @@
 package teo_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 )
+
+// mockMetaForCustomizeErrorPage implements tccommon.ProviderMeta
+type mockMetaForCustomizeErrorPage struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForCustomizeErrorPage) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForCustomizeErrorPage{}
+
+func newMockMetaForCustomizeErrorPage() *mockMetaForCustomizeErrorPage {
+	return &mockMetaForCustomizeErrorPage{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrCustomizeErrorPage(s string) *string {
+	return &s
+}
 
 func TestAccTencentCloudTeoCustomizeErrorPageResource_basic(t *testing.T) {
 	t.Parallel()
@@ -68,3 +96,185 @@ resource "tencentcloud_teo_customize_error_page" "example" {
   })
 }
 `
+
+// go test ./tencentcloud/services/teo/ -run "TestCustomizeErrorPageErrorPages" -v -count=1 -gcflags="all=-l"
+
+// TestCustomizeErrorPageErrorPages_Read_Success tests Read populates error_pages attribute with References
+func TestCustomizeErrorPageErrorPages_Read_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCustomizeErrorPage().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeCustomErrorPages", func(request *teov20220901.DescribeCustomErrorPagesRequest) (*teov20220901.DescribeCustomErrorPagesResponse, error) {
+		resp := teov20220901.NewDescribeCustomErrorPagesResponse()
+		resp.Response = &teov20220901.DescribeCustomErrorPagesResponseParams{
+			TotalCount: ptrUint64CustomizeErrorPage(1),
+			ErrorPages: []*teov20220901.CustomErrorPage{
+				{
+					PageId:      ptrStrCustomizeErrorPage("page-abc123"),
+					ZoneId:      ptrStrCustomizeErrorPage("zone-test123"),
+					Name:        ptrStrCustomizeErrorPage("test-error-page"),
+					ContentType: ptrStrCustomizeErrorPage("text/html"),
+					Description: ptrStrCustomizeErrorPage("test description"),
+					Content:     ptrStrCustomizeErrorPage("<html>error</html>"),
+					References: []*teov20220901.ErrorPageReference{
+						{
+							BusinessId: ptrStrCustomizeErrorPage("rule-001"),
+						},
+						{
+							BusinessId: ptrStrCustomizeErrorPage("rule-002"),
+						},
+					},
+				},
+			},
+			RequestId: ptrStrCustomizeErrorPage("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCustomizeErrorPage()
+	res := teo.ResourceTencentCloudTeoCustomizeErrorPage()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":      "zone-test123",
+		"name":         "test-error-page",
+		"content_type": "text/html",
+	})
+	d.SetId("zone-test123#page-abc123")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-error-page", d.Get("name"))
+	assert.Equal(t, "text/html", d.Get("content_type"))
+	assert.Equal(t, "test description", d.Get("description"))
+	assert.Equal(t, "<html>error</html>", d.Get("content"))
+
+	// Verify error_pages computed attribute
+	errorPages := d.Get("error_pages").([]interface{})
+	assert.Equal(t, 1, len(errorPages))
+	errorPage := errorPages[0].(map[string]interface{})
+	assert.Equal(t, "page-abc123", errorPage["page_id"])
+	assert.Equal(t, "test-error-page", errorPage["name"])
+	assert.Equal(t, "text/html", errorPage["content_type"])
+	assert.Equal(t, "test description", errorPage["description"])
+	assert.Equal(t, "<html>error</html>", errorPage["content"])
+
+	// Verify references sub-field
+	references := errorPage["references"].([]interface{})
+	assert.Equal(t, 2, len(references))
+	assert.Equal(t, "rule-001", references[0])
+	assert.Equal(t, "rule-002", references[1])
+}
+
+// TestCustomizeErrorPageErrorPages_Read_EmptyReferences tests Read with no references
+func TestCustomizeErrorPageErrorPages_Read_EmptyReferences(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCustomizeErrorPage().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeCustomErrorPages", func(request *teov20220901.DescribeCustomErrorPagesRequest) (*teov20220901.DescribeCustomErrorPagesResponse, error) {
+		resp := teov20220901.NewDescribeCustomErrorPagesResponse()
+		resp.Response = &teov20220901.DescribeCustomErrorPagesResponseParams{
+			TotalCount: ptrUint64CustomizeErrorPage(1),
+			ErrorPages: []*teov20220901.CustomErrorPage{
+				{
+					PageId:      ptrStrCustomizeErrorPage("page-abc123"),
+					ZoneId:      ptrStrCustomizeErrorPage("zone-test123"),
+					Name:        ptrStrCustomizeErrorPage("test-error-page"),
+					ContentType: ptrStrCustomizeErrorPage("text/plain"),
+					Description: ptrStrCustomizeErrorPage("test description"),
+					Content:     ptrStrCustomizeErrorPage("error page content"),
+				},
+			},
+			RequestId: ptrStrCustomizeErrorPage("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCustomizeErrorPage()
+	res := teo.ResourceTencentCloudTeoCustomizeErrorPage()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":      "zone-test123",
+		"name":         "test-error-page",
+		"content_type": "text/plain",
+	})
+	d.SetId("zone-test123#page-abc123")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// Verify error_pages computed attribute
+	errorPages := d.Get("error_pages").([]interface{})
+	assert.Equal(t, 1, len(errorPages))
+	errorPage := errorPages[0].(map[string]interface{})
+
+	// Verify references sub-field is empty
+	references := errorPage["references"].([]interface{})
+	assert.Equal(t, 0, len(references))
+}
+
+// TestCustomizeErrorPageErrorPages_Read_NotFound tests Read handles resource not found
+func TestCustomizeErrorPageErrorPages_Read_NotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCustomizeErrorPage().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeCustomErrorPages", func(request *teov20220901.DescribeCustomErrorPagesRequest) (*teov20220901.DescribeCustomErrorPagesResponse, error) {
+		return nil, fmt.Errorf("[TencentCloudSDKError] Code=ResourceNotFound, Message=Error page not found")
+	})
+
+	meta := newMockMetaForCustomizeErrorPage()
+	res := teo.ResourceTencentCloudTeoCustomizeErrorPage()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":      "zone-test123",
+		"name":         "test-error-page",
+		"content_type": "text/html",
+	})
+	d.SetId("zone-test123#page-abc123")
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ResourceNotFound")
+}
+
+// TestCustomizeErrorPageErrorPages_Schema tests the error_pages schema definition
+func TestCustomizeErrorPageErrorPages_Schema(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoCustomizeErrorPage()
+
+	assert.NotNil(t, res)
+
+	// Check error_pages field
+	assert.Contains(t, res.Schema, "error_pages")
+	errorPagesSchema := res.Schema["error_pages"]
+	assert.Equal(t, schema.TypeList, errorPagesSchema.Type)
+	assert.True(t, errorPagesSchema.Computed)
+	assert.False(t, errorPagesSchema.Optional)
+	assert.False(t, errorPagesSchema.Required)
+
+	// Check nested schema fields
+	elem, ok := errorPagesSchema.Elem.(*schema.Resource)
+	assert.True(t, ok)
+	assert.Contains(t, elem.Schema, "page_id")
+	assert.Contains(t, elem.Schema, "name")
+	assert.Contains(t, elem.Schema, "content_type")
+	assert.Contains(t, elem.Schema, "description")
+	assert.Contains(t, elem.Schema, "content")
+	assert.Contains(t, elem.Schema, "references")
+
+	// Verify references is TypeList of TypeString
+	referencesSchema := elem.Schema["references"]
+	assert.Equal(t, schema.TypeList, referencesSchema.Type)
+	assert.True(t, referencesSchema.Computed)
+	referencesElem, ok := referencesSchema.Elem.(*schema.Schema)
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeString, referencesElem.Type)
+}
+
+func ptrUint64CustomizeErrorPage(u uint64) *uint64 {
+	return &u
+}

--- a/tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_customize_error_page_test.go
@@ -99,7 +99,7 @@ resource "tencentcloud_teo_customize_error_page" "example" {
 
 // go test ./tencentcloud/services/teo/ -run "TestCustomizeErrorPageErrorPages" -v -count=1 -gcflags="all=-l"
 
-// TestCustomizeErrorPageErrorPages_Read_Success tests Read populates error_pages attribute with References
+// TestCustomizeErrorPageErrorPages_Read_Success tests Read populates references attribute
 func TestCustomizeErrorPageErrorPages_Read_Success(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
@@ -150,18 +150,8 @@ func TestCustomizeErrorPageErrorPages_Read_Success(t *testing.T) {
 	assert.Equal(t, "test description", d.Get("description"))
 	assert.Equal(t, "<html>error</html>", d.Get("content"))
 
-	// Verify error_pages computed attribute
-	errorPages := d.Get("error_pages").([]interface{})
-	assert.Equal(t, 1, len(errorPages))
-	errorPage := errorPages[0].(map[string]interface{})
-	assert.Equal(t, "page-abc123", errorPage["page_id"])
-	assert.Equal(t, "test-error-page", errorPage["name"])
-	assert.Equal(t, "text/html", errorPage["content_type"])
-	assert.Equal(t, "test description", errorPage["description"])
-	assert.Equal(t, "<html>error</html>", errorPage["content"])
-
-	// Verify references sub-field
-	references := errorPage["references"].([]interface{})
+	// Verify top-level references computed attribute
+	references := d.Get("references").([]interface{})
 	assert.Equal(t, 2, len(references))
 	assert.Equal(t, "rule-001", references[0])
 	assert.Equal(t, "rule-002", references[1])
@@ -206,13 +196,8 @@ func TestCustomizeErrorPageErrorPages_Read_EmptyReferences(t *testing.T) {
 	err := res.Read(d, meta)
 	assert.NoError(t, err)
 
-	// Verify error_pages computed attribute
-	errorPages := d.Get("error_pages").([]interface{})
-	assert.Equal(t, 1, len(errorPages))
-	errorPage := errorPages[0].(map[string]interface{})
-
-	// Verify references sub-field is empty
-	references := errorPage["references"].([]interface{})
+	// Verify top-level references is empty
+	references := d.Get("references").([]interface{})
 	assert.Equal(t, 0, len(references))
 }
 
@@ -242,34 +227,21 @@ func TestCustomizeErrorPageErrorPages_Read_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "ResourceNotFound")
 }
 
-// TestCustomizeErrorPageErrorPages_Schema tests the error_pages schema definition
+// TestCustomizeErrorPageErrorPages_Schema tests the references schema definition
 func TestCustomizeErrorPageErrorPages_Schema(t *testing.T) {
 	res := teo.ResourceTencentCloudTeoCustomizeErrorPage()
 
 	assert.NotNil(t, res)
 
-	// Check error_pages field
-	assert.Contains(t, res.Schema, "error_pages")
-	errorPagesSchema := res.Schema["error_pages"]
-	assert.Equal(t, schema.TypeList, errorPagesSchema.Type)
-	assert.True(t, errorPagesSchema.Computed)
-	assert.False(t, errorPagesSchema.Optional)
-	assert.False(t, errorPagesSchema.Required)
-
-	// Check nested schema fields
-	elem, ok := errorPagesSchema.Elem.(*schema.Resource)
-	assert.True(t, ok)
-	assert.Contains(t, elem.Schema, "page_id")
-	assert.Contains(t, elem.Schema, "name")
-	assert.Contains(t, elem.Schema, "content_type")
-	assert.Contains(t, elem.Schema, "description")
-	assert.Contains(t, elem.Schema, "content")
-	assert.Contains(t, elem.Schema, "references")
-
-	// Verify references is TypeList of TypeString
-	referencesSchema := elem.Schema["references"]
+	// Check references field at top level
+	assert.Contains(t, res.Schema, "references")
+	referencesSchema := res.Schema["references"]
 	assert.Equal(t, schema.TypeList, referencesSchema.Type)
 	assert.True(t, referencesSchema.Computed)
+	assert.False(t, referencesSchema.Optional)
+	assert.False(t, referencesSchema.Required)
+
+	// Verify references is TypeList of TypeString
 	referencesElem, ok := referencesSchema.Elem.(*schema.Schema)
 	assert.True(t, ok)
 	assert.Equal(t, schema.TypeString, referencesElem.Type)

--- a/website/docs/r/teo_customize_error_page.html.markdown
+++ b/website/docs/r/teo_customize_error_page.html.markdown
@@ -95,14 +95,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-* `error_pages` - A list of custom error pages. Each element contains the following attributes:
-  * `content_type` - Custom error page type.
-  * `content` - Custom error page content.
-  * `description` - Custom error page description.
-  * `name` - Custom error page name.
-  * `page_id` - Custom error page ID.
-  * `references` - List of business IDs that reference this error page.
 * `page_id` - Page ID.
+* `references` - List of business IDs that reference this error page.
 
 
 ## Import

--- a/website/docs/r/teo_customize_error_page.html.markdown
+++ b/website/docs/r/teo_customize_error_page.html.markdown
@@ -95,6 +95,13 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
+* `error_pages` - A list of custom error pages. Each element contains the following attributes:
+  * `content_type` - Custom error page type.
+  * `content` - Custom error page content.
+  * `description` - Custom error page description.
+  * `name` - Custom error page name.
+  * `page_id` - Custom error page ID.
+  * `references` - List of business IDs that reference this error page.
 * `page_id` - Page ID.
 
 


### PR DESCRIPTION
## Summary
- Add `error_pages` computed attribute to `tencentcloud_teo_customize_error_page` resource
- The `error_pages` attribute exposes a list of custom error pages with fields: page_id, name, content_type, description, content, and references
- Add unit tests using gomonkey to verify the new attribute in Read operation and schema definition

## Test plan
- [x] Unit tests passed: `TestCustomizeErrorPageErrorPages_Read_Success`, `TestCustomizeErrorPageErrorPages_Read_EmptyReferences`, `TestCustomizeErrorPageErrorPages_Read_NotFound`, `TestCustomizeErrorPageErrorPages_Schema`