### PR TITLE
feat(teo): [132864288] add new resource tencentcloud_teo_confirm_origin_acl_update_operation

### DIFF
--- a/.changelog/4060.txt
+++ b/.changelog/4060.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_teo_confirm_origin_acl_update_operation
+```

--- a/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/.openspec.yaml
+++ b/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/design.md
+++ b/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/design.md
@@ -1,0 +1,35 @@
+## Context
+
+TencentCloud TEO (EdgeOne) 产品在回源 IP 网段发生变更时会向用户推送通知。用户需要确认已将最新回源 IP 网段更新至源站防火墙，以停止推送变更通知。云 API 提供 `ConfirmOriginACLUpdate` 接口用于此确认操作。
+
+当前 Terraform Provider 中缺少该操作对应的资源，用户无法通过 Terraform 自动化完成回源 IP 网段更新确认。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 新增 `tencentcloud_teo_confirm_origin_acl_update_operation` 一次性操作资源
+- Create 阶段调用 `ConfirmOriginACLUpdate` API，传入 `ZoneId` 参数
+- Read / Delete 为 no-op，无 Update 操作
+- 在 provider.go 中注册资源
+- 提供单元测试（使用 gomonkey mock）
+- 生成 .md 文档
+
+**Non-Goals:**
+- 不实现 Read / Update / Delete 的实际逻辑（一次性操作无持久状态）
+- 不支持 Import（一次性操作无需导入）
+- 不处理异步轮询（API 为同步接口）
+
+## Decisions
+
+1. **资源类型选择 RESOURCE_KIND_OPERATION**：该接口仅为确认操作，不创建持久化资源，符合一次性操作资源的定义。Create 调用 API 后设置 ID 为 `helper.BuildToken()`。
+
+2. **Schema 设计**：仅暴露 `zone_id` 作为 Required + ForceNew 参数，与 API 入参 `ZoneId` 一一对应。无需 Computed 字段，因为 API 响应仅返回 `RequestId`。
+
+3. **重试策略**：Create 阶段使用 `tccommon.WriteRetryTimeout` 和 `resource.Retry` 包装 API 调用，失败时使用 `tccommon.RetryError()` 包装错误。
+
+4. **代码风格参考**：参考同产品下的 `resource_tc_teo_identify_zone_operation.go` 和 config 产品的 `resource_tc_config_start_config_rule_evaluation_operation.go`。
+
+## Risks / Trade-offs
+
+- **[API 调用幂等性]** → `ConfirmOriginACLUpdate` 多次调用对同一 ZoneId 是安全的（仅确认操作），不存在副作用风险
+- **[无状态追踪]** → 由于是操作型资源，Terraform state 中仅存储 token ID，无法通过 Read 刷新状态，这是 OPERATION 类型的预期行为

--- a/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/proposal.md
+++ b/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+TencentCloud TEO (EdgeOne) 回源 IP 网段会发生变更，变更后会推送通知。用户需要在将最新回源 IP 网段更新至源站防火墙后，调用确认接口停止推送变更通知。当前 Terraform Provider 中缺少该操作的资源，用户无法通过 Terraform 自动化完成此确认步骤。
+
+## What Changes
+
+- 新增一次性操作资源 `tencentcloud_teo_confirm_origin_acl_update_operation`，调用 `ConfirmOriginACLUpdate` API 确认回源 IP 网段已更新至源站防火墙
+- Create 调用 `ConfirmOriginACLUpdate`，设置 ID 为 `helper.BuildToken()`
+- Read / Update / Delete 为 no-op
+- 在 `provider.go` 和 `provider.md` 中注册该资源
+
+## Capabilities
+
+### New Capabilities
+- `teo-confirm-origin-acl-update-operation`: TEO 确认回源 IP 网段更新的一次性操作资源，调用 ConfirmOriginACLUpdate API
+
+### Modified Capabilities
+
+## Impact
+
+- 新增文件: `tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation.go`
+- 新增测试: `tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation_test.go`
+- 新增文档: `tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation.md`
+- 修改文件: `tencentcloud/provider.go`（注册资源）、`tencentcloud/provider.md`（添加资源条目）
+- 依赖云 API: `ConfirmOriginACLUpdate`（teo v20220901）

--- a/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/specs/teo-confirm-origin-acl-update-operation/spec.md
+++ b/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/specs/teo-confirm-origin-acl-update-operation/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: ConfirmOriginACLUpdate operation resource
+The system SHALL provide a Terraform operation resource `tencentcloud_teo_confirm_origin_acl_update_operation` that calls the `ConfirmOriginACLUpdate` API to confirm that the latest origin IP ACL ranges have been updated on the origin firewall for a given TEO zone.
+
+#### Scenario: Successful confirmation of origin ACL update
+- **WHEN** user creates a `tencentcloud_teo_confirm_origin_acl_update_operation` resource with a valid `zone_id`
+- **THEN** the system SHALL call `ConfirmOriginACLUpdate` API with the provided `zone_id`
+- **AND** the resource ID SHALL be set to a generated token via `helper.BuildToken()`
+
+#### Scenario: Create with retry on transient failure
+- **WHEN** the `ConfirmOriginACLUpdate` API call fails with a transient error
+- **THEN** the system SHALL retry the API call using `tccommon.WriteRetryTimeout` and `resource.Retry`
+
+### Requirement: Zone ID schema parameter
+The resource SHALL expose a `zone_id` parameter of type string that is Required and ForceNew.
+
+#### Scenario: Zone ID is required
+- **WHEN** user creates the resource without specifying `zone_id`
+- **THEN** the Terraform plan SHALL fail with a required field error
+
+#### Scenario: Zone ID changes trigger recreation
+- **WHEN** user changes the `zone_id` value in an existing resource configuration
+- **THEN** the system SHALL destroy and recreate the resource
+
+### Requirement: No-op Read handler
+The Read handler SHALL be a no-op that returns nil without making any API calls.
+
+#### Scenario: Read operation
+- **WHEN** Terraform performs a refresh/read on the resource
+- **THEN** the system SHALL return nil without calling any cloud API
+
+### Requirement: No-op Delete handler
+The Delete handler SHALL be a no-op that returns nil without making any API calls.
+
+#### Scenario: Delete operation
+- **WHEN** user destroys the resource
+- **THEN** the system SHALL return nil without calling any cloud API
+
+### Requirement: Provider registration
+The resource SHALL be registered in `provider.go` ResourcesMap and documented in `provider.md`.
+
+#### Scenario: Resource available in provider
+- **WHEN** the Terraform provider is initialized
+- **THEN** the resource `tencentcloud_teo_confirm_origin_acl_update_operation` SHALL be available for use

--- a/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/tasks.md
+++ b/openspec/changes/archive/2025-07-11-add-teo-confirm-origin-acl-update-operation/tasks.md
@@ -1,0 +1,18 @@
+## 1. Resource Implementation
+
+- [x] 1.1 Create `tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation.go` with schema definition (zone_id: Required, ForceNew) and Create/Read/Delete handlers
+- [x] 1.2 Create handler: call `ConfirmOriginACLUpdate` with ZoneId, set ID to `helper.BuildToken()`
+- [x] 1.3 Read/Delete handlers: no-op (return nil)
+
+## 2. Unit Tests
+
+- [x] 2.1 Create `tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation_test.go` with gomonkey mock unit tests for Create handler
+
+## 3. Provider Registration
+
+- [x] 3.1 Register `tencentcloud_teo_confirm_origin_acl_update_operation` in `tencentcloud/provider.go` ResourcesMap
+- [x] 3.2 Add resource entry in `tencentcloud/provider.md`
+
+## 4. Documentation
+
+- [x] 4.1 Create `tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation.md` with usage example

--- a/openspec/specs/teo-confirm-origin-acl-update-operation/spec.md
+++ b/openspec/specs/teo-confirm-origin-acl-update-operation/spec.md
@@ -1,0 +1,43 @@
+### Requirement: ConfirmOriginACLUpdate operation resource
+The system SHALL provide a Terraform operation resource `tencentcloud_teo_confirm_origin_acl_update_operation` that calls the `ConfirmOriginACLUpdate` API to confirm that the latest origin IP ACL ranges have been updated on the origin firewall for a given TEO zone.
+
+#### Scenario: Successful confirmation of origin ACL update
+- **WHEN** user creates a `tencentcloud_teo_confirm_origin_acl_update_operation` resource with a valid `zone_id`
+- **THEN** the system SHALL call `ConfirmOriginACLUpdate` API with the provided `zone_id`
+- **AND** the resource ID SHALL be set to a generated token via `helper.BuildToken()`
+
+#### Scenario: Create with retry on transient failure
+- **WHEN** the `ConfirmOriginACLUpdate` API call fails with a transient error
+- **THEN** the system SHALL retry the API call using `tccommon.WriteRetryTimeout` and `resource.Retry`
+
+### Requirement: Zone ID schema parameter
+The resource SHALL expose a `zone_id` parameter of type string that is Required and ForceNew.
+
+#### Scenario: Zone ID is required
+- **WHEN** user creates the resource without specifying `zone_id`
+- **THEN** the Terraform plan SHALL fail with a required field error
+
+#### Scenario: Zone ID changes trigger recreation
+- **WHEN** user changes the `zone_id` value in an existing resource configuration
+- **THEN** the system SHALL destroy and recreate the resource
+
+### Requirement: No-op Read handler
+The Read handler SHALL be a no-op that returns nil without making any API calls.
+
+#### Scenario: Read operation
+- **WHEN** Terraform performs a refresh/read on the resource
+- **THEN** the system SHALL return nil without calling any cloud API
+
+### Requirement: No-op Delete handler
+The Delete handler SHALL be a no-op that returns nil without making any API calls.
+
+#### Scenario: Delete operation
+- **WHEN** user destroys the resource
+- **THEN** the system SHALL return nil without calling any cloud API
+
+### Requirement: Provider registration
+The resource SHALL be registered in `provider.go` ResourcesMap and documented in `provider.md`.
+
+#### Scenario: Resource available in provider
+- **WHEN** the Terraform provider is initialized
+- **THEN** the resource `tencentcloud_teo_confirm_origin_acl_update_operation` SHALL be available for use

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -2096,6 +2096,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_teo_ddos_protection_config":                                               teo.ResourceTencentCloudTeoDdosProtectionConfig(),
 			"tencentcloud_teo_config_group_version":                                                 teo.ResourceTencentCloudTeoConfigGroupVersion(),
 			"tencentcloud_teo_deploy_config_group_version":                                          teo.ResourceTencentCloudTeoDeployConfigGroupVersion(),
+			"tencentcloud_teo_confirm_origin_acl_update_operation":                                  teo.ResourceTencentCloudTeoConfirmOriginAclUpdateOperation(),
 			"tencentcloud_tcm_mesh":                                                                 tcm.ResourceTencentCloudTcmMesh(),
 			"tencentcloud_tcm_cluster_attachment":                                                   tcm.ResourceTencentCloudTcmClusterAttachment(),
 			"tencentcloud_tcm_prometheus_attachment":                                                tcm.ResourceTencentCloudTcmPrometheusAttachment(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1584,6 +1584,7 @@ tencentcloud_teo_import_zone_config_operation
 tencentcloud_teo_deploy_config_group_version
 tencentcloud_teo_identify_zone_operation
 tencentcloud_teo_just_in_time_transcode_template
+tencentcloud_teo_confirm_origin_acl_update_operation
 
 TencentCloud ServiceMesh(TCM)
 Data Source

--- a/tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation.go
+++ b/tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation.go
@@ -1,0 +1,73 @@
+package teo
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudTeoConfirmOriginAclUpdateOperation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudTeoConfirmOriginAclUpdateOperationCreate,
+		Read:   resourceTencentCloudTeoConfirmOriginAclUpdateOperationRead,
+		Delete: resourceTencentCloudTeoConfirmOriginAclUpdateOperationDelete,
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Zone ID.",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudTeoConfirmOriginAclUpdateOperationCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_confirm_origin_acl_update_operation.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = teov20220901.NewConfirmOriginACLUpdateRequest()
+	)
+
+	zoneId := d.Get("zone_id").(string)
+	request.ZoneId = helper.String(zoneId)
+
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().ConfirmOriginACLUpdateWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s confirm origin acl update failed, reason:%+v", logId, err)
+		return err
+	}
+
+	d.SetId(helper.BuildToken())
+	return resourceTencentCloudTeoConfirmOriginAclUpdateOperationRead(d, meta)
+}
+
+func resourceTencentCloudTeoConfirmOriginAclUpdateOperationRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_confirm_origin_acl_update_operation.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	return nil
+}
+
+func resourceTencentCloudTeoConfirmOriginAclUpdateOperationDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_confirm_origin_acl_update_operation.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	return nil
+}

--- a/tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation.md
+++ b/tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation.md
@@ -1,0 +1,9 @@
+Provides a resource to confirm TEO origin ACL update for a zone. When the origin IP ranges of TEO change, you can use this resource to confirm that the latest origin IP ranges have been updated to the origin firewall, and the change notification will stop being pushed.
+
+Example Usage
+
+```hcl
+resource "tencentcloud_teo_confirm_origin_acl_update_operation" "example" {
+  zone_id = "zone-12345678"
+}
+```

--- a/tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_confirm_origin_acl_update_operation_test.go
@@ -1,0 +1,132 @@
+package teo_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+)
+
+// mockMetaConfirmOriginAclUpdate implements tccommon.ProviderMeta
+type mockMetaConfirmOriginAclUpdate struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaConfirmOriginAclUpdate) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaConfirmOriginAclUpdate{}
+
+func newMockMetaConfirmOriginAclUpdate() *mockMetaConfirmOriginAclUpdate {
+	return &mockMetaConfirmOriginAclUpdate{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringConfirmOriginAclUpdate(s string) *string {
+	return &s
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestConfirmOriginAclUpdateOperation" -v -count=1 -gcflags="all=-l"
+
+// TestConfirmOriginAclUpdateOperation_Success tests successful confirmation
+func TestConfirmOriginAclUpdateOperation_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaConfirmOriginAclUpdate().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "ConfirmOriginACLUpdateWithContext", func(_ context.Context, request *teov20220901.ConfirmOriginACLUpdateRequest) (*teov20220901.ConfirmOriginACLUpdateResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+
+		resp := teov20220901.NewConfirmOriginACLUpdateResponse()
+		resp.Response = &teov20220901.ConfirmOriginACLUpdateResponseParams{
+			RequestId: ptrStringConfirmOriginAclUpdate("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaConfirmOriginAclUpdate()
+	res := teo.ResourceTencentCloudTeoConfirmOriginAclUpdateOperation()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+}
+
+// TestConfirmOriginAclUpdateOperation_APIError tests API error handling
+func TestConfirmOriginAclUpdateOperation_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaConfirmOriginAclUpdate().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "ConfirmOriginACLUpdateWithContext", func(_ context.Context, request *teov20220901.ConfirmOriginACLUpdateRequest) (*teov20220901.ConfirmOriginACLUpdateResponse, error) {
+		return nil, fmt.Errorf("[TencentCloudSDKError] Code=ResourceNotFound, Message=Zone not found")
+	})
+
+	meta := newMockMetaConfirmOriginAclUpdate()
+	res := teo.ResourceTencentCloudTeoConfirmOriginAclUpdateOperation()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-invalid",
+	})
+
+	err := res.Create(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ResourceNotFound")
+}
+
+// TestConfirmOriginAclUpdateOperation_Read tests Read is no-op
+func TestConfirmOriginAclUpdateOperation_Read(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoConfirmOriginAclUpdateOperation()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+	})
+	d.SetId("test-id")
+
+	err := res.Read(d, nil)
+	assert.NoError(t, err)
+}
+
+// TestConfirmOriginAclUpdateOperation_Delete tests Delete is no-op
+func TestConfirmOriginAclUpdateOperation_Delete(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoConfirmOriginAclUpdateOperation()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+	})
+	d.SetId("test-id")
+
+	err := res.Delete(d, nil)
+	assert.NoError(t, err)
+}
+
+// TestConfirmOriginAclUpdateOperation_Schema validates schema definition
+func TestConfirmOriginAclUpdateOperation_Schema(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoConfirmOriginAclUpdateOperation()
+
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Create)
+	assert.NotNil(t, res.Read)
+	assert.Nil(t, res.Update)
+	assert.NotNil(t, res.Delete)
+
+	assert.Contains(t, res.Schema, "zone_id")
+
+	zoneId := res.Schema["zone_id"]
+	assert.Equal(t, schema.TypeString, zoneId.Type)
+	assert.True(t, zoneId.Required)
+	assert.True(t, zoneId.ForceNew)
+}

--- a/website/docs/r/teo_confirm_origin_acl_update_operation.html.markdown
+++ b/website/docs/r/teo_confirm_origin_acl_update_operation.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "TencentCloud EdgeOne(TEO)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_teo_confirm_origin_acl_update_operation"
+sidebar_current: "docs-tencentcloud-resource-teo_confirm_origin_acl_update_operation"
+description: |-
+  Provides a resource to confirm TEO origin ACL update for a zone. When the origin IP ranges of TEO change, you can use this resource to confirm that the latest origin IP ranges have been updated to the origin firewall, and the change notification will stop being pushed.
+---
+
+# tencentcloud_teo_confirm_origin_acl_update_operation
+
+Provides a resource to confirm TEO origin ACL update for a zone. When the origin IP ranges of TEO change, you can use this resource to confirm that the latest origin IP ranges have been updated to the origin firewall, and the change notification will stop being pushed.
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_teo_confirm_origin_acl_update_operation" "example" {
+  zone_id = "zone-12345678"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required, String, ForceNew) Zone ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+
+
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -5871,6 +5871,9 @@
                                     <a href="/docs/providers/tencentcloud/r/teo_config_group_version.html">tencentcloud_teo_config_group_version</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/r/teo_confirm_origin_acl_update_operation.html">tencentcloud_teo_confirm_origin_acl_update_operation</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/r/teo_content_identifier.html">tencentcloud_teo_content_identifier</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
## Summary
- Add new resource `tencentcloud_teo_confirm_origin_acl_update_operation` for TEO (EdgeOne) product
- This resource allows confirming origin ACL update operations for TEO zones
- Includes resource definition, test file, and provider registration