### PR TITLE
feat(teo): use d.Get() for zone_id and proxy_id in application proxy delete

### DIFF
--- a/.changelog/4072.txt
+++ b/.changelog/4072.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_application_proxy: use d.Get() for zone_id and proxy_id in delete function and call DeleteApplicationProxy API directly with retry logic
+```

--- a/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/design.md
+++ b/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The `tencentcloud_teo_application_proxy` resource manages TEO (TencentCloud EdgeOne) application proxies. It uses a composite ID (`zone_id#proxy_id`) to uniquely identify each proxy instance. The current delete function `resourceTencentCloudTeoApplicationProxyDelete` parses `zone_id` and `proxy_id` from `d.Id()` by splitting on the `FILED_SP` separator, then passes them to `service.DeleteTeoApplicationProxyById()`.
+
+Per the project coding guidelines, when a resource uses a composite ID with `FILED_SP` as separator, the read, update, and delete methods MUST obtain the individual ID component fields from `d.Get()` rather than parsing `d.Id()`. The `DeleteApplicationProxy` cloud API already supports `ZoneId` and `ProxyId` as request parameters in the SDK (`DeleteApplicationProxyRequest`), so this change only requires updating the Go resource code.
+
+Current delete function flow:
+1. Parse `d.Id()` → split by `FILED_SP` → get `zoneId`, `proxyId`
+2. Call `service.DeleteTeoApplicationProxyById(ctx, zoneId, proxyId)`
+
+Target delete function flow:
+1. Get `zone_id` from `d.Get("zone_id")` and `proxy_id` from `d.Get("proxy_id")`
+2. Construct `DeleteApplicationProxyRequest` directly with `ZoneId` and `ProxyId`
+3. Call the API with retry logic using `tccommon.WriteRetryTimeout`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Modify the delete function to read `zone_id` and `proxy_id` from `d.Get()` instead of parsing from `d.Id()`
+- Construct and call the `DeleteApplicationProxy` API request directly in the delete function (instead of delegating to the service helper method), following the standard CRUD pattern
+- Add retry logic (`tccommon.WriteRetryTimeout`) for the delete API call
+- Update unit tests to verify the new delete function behavior
+
+**Non-Goals:**
+- Do not modify the resource schema (both `zone_id` and `proxy_id` already exist)
+- Do not modify the read, create, or update functions
+- Do not modify the `DeleteTeoApplicationProxyById` service method (it can remain for backward compatibility)
+
+## Decisions
+
+1. **Use `d.Get()` over `d.Id()` parsing**: Per coding guidelines, obtain `zone_id` and `proxy_id` from `d.Get()` rather than splitting `d.Id()`. This is the standard pattern for composite ID resources.
+
+2. **Call API directly in delete function**: Instead of delegating to `service.DeleteTeoApplicationProxyById()`, construct the `DeleteApplicationProxyRequest` and call the API directly within the delete function with proper retry logic. This aligns with the pattern where each CRUD function directly manages its API interaction.
+
+3. **Keep the offline-then-delete flow**: The current delete function first sets the proxy status to `offline` via `ModifyApplicationProxyStatus`, then calls `DeleteApplicationProxy`. This two-step flow must be preserved.
+
+## Risks / Trade-offs
+
+- [Risk] `d.Get("proxy_id")` returns empty string if the state is corrupted → Mitigation: The `proxy_id` field is always set during the read operation and is part of the composite ID, so it should always be available in state.
+- [Risk] Changing the delete function could break existing behavior → Mitigation: The delete logic remains the same; only the source of `zone_id` and `proxy_id` values changes (from `d.Id()` parsing to `d.Get()`).

--- a/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/proposal.md
+++ b/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+The `DeleteApplicationProxy` cloud API requires `ZoneId` and `ProxyId` as input parameters. Currently, the `tencentcloud_teo_application_proxy` resource's delete function retrieves these values by parsing the composite ID (`d.Id()`) instead of using `d.Get()`. Per the coding guidelines, when using composite IDs with `FILED_SP` as separator, the read, update, and delete methods should obtain ID component fields from `d.Get()` rather than parsing `d.Id()`. This change aligns the delete operation with the established pattern.
+
+## What Changes
+
+- Modify `resourceTencentCloudTeoApplicationProxyDelete` to read `zone_id` and `proxy_id` from `d.Get()` instead of parsing from `d.Id()`, and pass them as explicit input parameters to the `DeleteApplicationProxy` API request.
+
+## Capabilities
+
+### New Capabilities
+- `teo-application-proxy-delete-params`: Adds `zone_id` and `proxy_id` as explicit input parameters for the `DeleteApplicationProxy` API in the `tencentcloud_teo_application_proxy` resource, following the coding guideline of using `d.Get()` over `d.Id()` for composite ID fields.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected file: `tencentcloud/services/teo/resource_tc_teo_application_proxy.go` (delete function)
+- Affected file: `tencentcloud/services/teo/resource_tc_teo_application_proxy_test.go` (unit tests)
+- Cloud API: `DeleteApplicationProxy` (parameters already exist in SDK, no vendor change needed)

--- a/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/specs/teo-application-proxy-delete-params/spec.md
+++ b/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/specs/teo-application-proxy-delete-params/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Delete function uses d.Get() for zone_id and proxy_id
+The `resourceTencentCloudTeoApplicationProxyDelete` function SHALL obtain `zone_id` and `proxy_id` from `d.Get("zone_id")` and `d.Get("proxy_id")` respectively, instead of parsing them from `d.Id()` by splitting on `FILED_SP`.
+
+#### Scenario: Successful deletion using d.Get() values
+- **WHEN** the delete function is called and `d.Get("zone_id")` returns a valid zone ID and `d.Get("proxy_id")` returns a valid proxy ID
+- **THEN** the function SHALL use these values as input parameters for the `DeleteApplicationProxy` API request
+
+#### Scenario: zone_id is empty from d.Get()
+- **WHEN** the delete function is called and `d.Get("zone_id")` returns an empty string
+- **THEN** the function SHALL return an error indicating zone_id is required for deletion
+
+#### Scenario: proxy_id is empty from d.Get()
+- **WHEN** the delete function is called and `d.Get("proxy_id")` returns an empty string
+- **THEN** the function SHALL return an error indicating proxy_id is required for deletion
+
+### Requirement: Delete function calls DeleteApplicationProxy API directly
+The `resourceTencentCloudTeoApplicationProxyDelete` function SHALL construct a `DeleteApplicationProxyRequest` with `ZoneId` and `ProxyId` fields and call the `DeleteApplicationProxy` API directly with retry logic using `tccommon.WriteRetryTimeout`, instead of delegating to `service.DeleteTeoApplicationProxyById()`.
+
+#### Scenario: Successful API call with retry
+- **WHEN** the `DeleteApplicationProxy` API is called with valid `ZoneId` and `ProxyId`
+- **THEN** the request SHALL include `ZoneId` and `ProxyId` as parameters and use `resource.Retry` with `tccommon.WriteRetryTimeout`
+
+#### Scenario: API call fails with retryable error
+- **WHEN** the `DeleteApplicationProxy` API returns a retryable error
+- **THEN** the function SHALL retry the request using `tccommon.RetryError()` to wrap the error
+
+### Requirement: Delete function preserves offline-before-delete flow
+The `resourceTencentCloudTeoApplicationProxyDelete` function SHALL preserve the existing two-step deletion flow: first setting the proxy status to `offline` via `ModifyApplicationProxyStatus`, then calling `DeleteApplicationProxy`.
+
+#### Scenario: Proxy is online before deletion
+- **WHEN** the proxy status is `online`
+- **THEN** the function SHALL first call `ModifyApplicationProxyStatus` to set status to `offline`, wait for the status change, then call `DeleteApplicationProxy`
+
+#### Scenario: Proxy is already offline
+- **WHEN** the proxy status is `offline`
+- **THEN** the function SHALL skip the offline step and directly call `DeleteApplicationProxy`
+
+### Requirement: Unit tests for delete function
+The `resource_tc_teo_application_proxy_test.go` file SHALL include unit tests that verify the delete function correctly uses `d.Get()` for `zone_id` and `proxy_id` and properly constructs the `DeleteApplicationProxyRequest`.
+
+#### Scenario: Unit test verifies d.Get() usage in delete
+- **WHEN** unit tests are run for the delete function
+- **THEN** tests SHALL verify that `zone_id` and `proxy_id` are obtained from `d.Get()` and passed as `ZoneId` and `ProxyId` in the API request

--- a/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/tasks.md
+++ b/openspec/changes/archive/2026-04-27-add-teo-application-proxy-delete-params/tasks.md
@@ -1,0 +1,14 @@
+## 1. 修改 Delete 函数实现
+
+- [x] 1.1 修改 `resourceTencentCloudTeoApplicationProxyDelete` 函数，将 `zone_id` 和 `proxy_id` 的获取方式从 `d.Id()` 解析改为 `d.Get("zone_id")` 和 `d.Get("proxy_id")`
+- [x] 1.2 在 delete 函数中，将 `service.DeleteTeoApplicationProxyById()` 调用替换为直接构造 `DeleteApplicationProxyRequest`，设置 `ZoneId` 和 `ProxyId` 字段，并使用 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 调用 `DeleteApplicationProxy` API
+- [x] 1.3 保留现有的先 offline 再 delete 的两步删除流程，确保 `ModifyApplicationProxyStatus` 调用仍然使用 `d.Get()` 获取的 `zone_id` 和 `proxy_id`
+
+## 2. 更新单元测试
+
+- [x] 2.1 在 `resource_tc_teo_application_proxy_test.go` 中添加或更新 delete 函数的单元测试，验证 `zone_id` 和 `proxy_id` 从 `d.Get()` 获取并正确传递给 `DeleteApplicationProxyRequest`
+- [x] 2.2 使用 go test（带 `-gcflags=all=-l` 参数）运行单元测试，验证测试通过
+
+## 3. 更新资源示例文档
+
+- [x] 3.1 更新 `resource_tc_teo_application_proxy.md` 示例文件（如有必要）

--- a/openspec/specs/teo-application-proxy-delete-params/spec.md
+++ b/openspec/specs/teo-application-proxy-delete-params/spec.md
@@ -1,0 +1,43 @@
+### Requirement: Delete function uses d.Get() for zone_id and proxy_id
+The `resourceTencentCloudTeoApplicationProxyDelete` function SHALL obtain `zone_id` and `proxy_id` from `d.Get("zone_id")` and `d.Get("proxy_id")` respectively, instead of parsing them from `d.Id()` by splitting on `FILED_SP`.
+
+#### Scenario: Successful deletion using d.Get() values
+- **WHEN** the delete function is called and `d.Get("zone_id")` returns a valid zone ID and `d.Get("proxy_id")` returns a valid proxy ID
+- **THEN** the function SHALL use these values as input parameters for the `DeleteApplicationProxy` API request
+
+#### Scenario: zone_id is empty from d.Get()
+- **WHEN** the delete function is called and `d.Get("zone_id")` returns an empty string
+- **THEN** the function SHALL return an error indicating zone_id is required for deletion
+
+#### Scenario: proxy_id is empty from d.Get()
+- **WHEN** the delete function is called and `d.Get("proxy_id")` returns an empty string
+- **THEN** the function SHALL return an error indicating proxy_id is required for deletion
+
+### Requirement: Delete function calls DeleteApplicationProxy API directly
+The `resourceTencentCloudTeoApplicationProxyDelete` function SHALL construct a `DeleteApplicationProxyRequest` with `ZoneId` and `ProxyId` fields and call the `DeleteApplicationProxy` API directly with retry logic using `tccommon.WriteRetryTimeout`, instead of delegating to `service.DeleteTeoApplicationProxyById()`.
+
+#### Scenario: Successful API call with retry
+- **WHEN** the `DeleteApplicationProxy` API is called with valid `ZoneId` and `ProxyId`
+- **THEN** the request SHALL include `ZoneId` and `ProxyId` as parameters and use `resource.Retry` with `tccommon.WriteRetryTimeout`
+
+#### Scenario: API call fails with retryable error
+- **WHEN** the `DeleteApplicationProxy` API returns a retryable error
+- **THEN** the function SHALL retry the request using `tccommon.RetryError()` to wrap the error
+
+### Requirement: Delete function preserves offline-before-delete flow
+The `resourceTencentCloudTeoApplicationProxyDelete` function SHALL preserve the existing two-step deletion flow: first setting the proxy status to `offline` via `ModifyApplicationProxyStatus`, then calling `DeleteApplicationProxy`.
+
+#### Scenario: Proxy is online before deletion
+- **WHEN** the proxy status is `online`
+- **THEN** the function SHALL first call `ModifyApplicationProxyStatus` to set status to `offline`, wait for the status change, then call `DeleteApplicationProxy`
+
+#### Scenario: Proxy is already offline
+- **WHEN** the proxy status is `offline`
+- **THEN** the function SHALL skip the offline step and directly call `DeleteApplicationProxy`
+
+### Requirement: Unit tests for delete function
+The `resource_tc_teo_application_proxy_test.go` file SHALL include unit tests that verify the delete function correctly uses `d.Get()` for `zone_id` and `proxy_id` and properly constructs the `DeleteApplicationProxyRequest`.
+
+#### Scenario: Unit test verifies d.Get() usage in delete
+- **WHEN** unit tests are run for the delete function
+- **THEN** tests SHALL verify that `zone_id` and `proxy_id` are obtained from `d.Get()` and passed as `ZoneId` and `ProxyId` in the API request

--- a/tencentcloud/services/teo/resource_tc_teo_application_proxy.go
+++ b/tencentcloud/services/teo/resource_tc_teo_application_proxy.go
@@ -471,15 +471,16 @@ func resourceTencentCloudTeoApplicationProxyDelete(d *schema.ResourceData, meta 
 	defer tccommon.InconsistentCheck(d, meta)()
 
 	logId := tccommon.GetLogId(tccommon.ContextNil)
-	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
-	service := TeoService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
-	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
-	if len(idSplit) != 2 {
-		return fmt.Errorf("id is broken,%s", d.Id())
+	zoneId := d.Get("zone_id").(string)
+	proxyId := d.Get("proxy_id").(string)
+
+	if zoneId == "" {
+		return fmt.Errorf("zone_id is required for deletion")
 	}
-	zoneId := idSplit[0]
-	proxyId := idSplit[1]
+	if proxyId == "" {
+		return fmt.Errorf("proxy_id is required for deletion")
+	}
 
 	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
 		e := resourceTencentCloudTeoApplicationProxyRead(d, meta)
@@ -510,7 +511,22 @@ func resourceTencentCloudTeoApplicationProxyDelete(d *schema.ResourceData, meta 
 		return err
 	}
 
-	if err = service.DeleteTeoApplicationProxyById(ctx, zoneId, proxyId); err != nil {
+	request := teo.NewDeleteApplicationProxyRequest()
+	request.ZoneId = &zoneId
+	request.ProxyId = &proxyId
+
+	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoClient().DeleteApplicationProxy(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s delete teo applicationProxy failed, reason:%+v", logId, err)
 		return err
 	}
 

--- a/tencentcloud/services/teo/resource_tc_teo_application_proxy_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_application_proxy_test.go
@@ -6,14 +6,337 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 	svcteo "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
+
+// mockMeta implements tccommon.ProviderMeta
+type mockMetaApplicationProxy struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaApplicationProxy) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaApplicationProxy{}
+
+func newMockMetaApplicationProxy() *mockMetaApplicationProxy {
+	return &mockMetaApplicationProxy{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringApplicationProxy(s string) *string {
+	return &s
+}
+
+func ptrInt64ApplicationProxy(v int64) *int64 {
+	return &v
+}
+
+func ptrUint64ApplicationProxy(v uint64) *uint64 {
+	return &v
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestApplicationProxy_Delete" -v -count=1 -gcflags="all=-l"
+
+// TestApplicationProxy_Delete_Success_AlreadyOffline tests Delete when proxy is already offline
+func TestApplicationProxy_Delete_Success_AlreadyOffline(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaApplicationProxy().client, "UseTeoClient", teoClient)
+
+	// Mock DescribeApplicationProxies for the read function - return offline status
+	patches.ApplyMethodFunc(teoClient, "DescribeApplicationProxies", func(request *teov20220901.DescribeApplicationProxiesRequest) (*teov20220901.DescribeApplicationProxiesResponse, error) {
+		resp := teov20220901.NewDescribeApplicationProxiesResponse()
+		resp.Response = &teov20220901.DescribeApplicationProxiesResponseParams{
+			ApplicationProxies: []*teov20220901.ApplicationProxy{
+				{
+					ZoneId:             ptrStringApplicationProxy("zone-1234567890"),
+					ProxyId:            ptrStringApplicationProxy("proxy-abcdefghij"),
+					ProxyName:          ptrStringApplicationProxy("test-proxy"),
+					ProxyType:          ptrStringApplicationProxy("instance"),
+					PlatType:           ptrStringApplicationProxy("domain"),
+					SecurityType:       ptrInt64ApplicationProxy(1),
+					AccelerateType:     ptrInt64ApplicationProxy(1),
+					SessionPersistTime: ptrUint64ApplicationProxy(600),
+					Status:             ptrStringApplicationProxy("offline"),
+				},
+			},
+			RequestId: ptrStringApplicationProxy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DeleteApplicationProxy
+	patches.ApplyMethodFunc(teoClient, "DeleteApplicationProxy", func(request *teov20220901.DeleteApplicationProxyRequest) (*teov20220901.DeleteApplicationProxyResponse, error) {
+		resp := teov20220901.NewDeleteApplicationProxyResponse()
+		resp.Response = &teov20220901.DeleteApplicationProxyResponseParams{
+			RequestId: ptrStringApplicationProxy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaApplicationProxy()
+	res := svcteo.ResourceTencentCloudTeoApplicationProxy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":              "zone-1234567890",
+		"proxy_id":             "proxy-abcdefghij",
+		"proxy_name":           "test-proxy",
+		"proxy_type":           "instance",
+		"plat_type":            "domain",
+		"security_type":        1,
+		"accelerate_type":      1,
+		"session_persist_time": 600,
+	})
+	d.SetId("zone-1234567890#proxy-abcdefghij")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+}
+
+// TestApplicationProxy_Delete_Success_SetOffline tests Delete when proxy needs to be set offline first
+func TestApplicationProxy_Delete_Success_SetOffline(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaApplicationProxy().client, "UseTeoClient", teoClient)
+
+	callCount := 0
+	// Mock DescribeApplicationProxies - first call returns online, second returns offline
+	patches.ApplyMethodFunc(teoClient, "DescribeApplicationProxies", func(request *teov20220901.DescribeApplicationProxiesRequest) (*teov20220901.DescribeApplicationProxiesResponse, error) {
+		callCount++
+		resp := teov20220901.NewDescribeApplicationProxiesResponse()
+		status := "offline"
+		if callCount == 1 {
+			status = "online"
+		}
+		resp.Response = &teov20220901.DescribeApplicationProxiesResponseParams{
+			ApplicationProxies: []*teov20220901.ApplicationProxy{
+				{
+					ZoneId:             ptrStringApplicationProxy("zone-1234567890"),
+					ProxyId:            ptrStringApplicationProxy("proxy-abcdefghij"),
+					ProxyName:          ptrStringApplicationProxy("test-proxy"),
+					ProxyType:          ptrStringApplicationProxy("instance"),
+					PlatType:           ptrStringApplicationProxy("domain"),
+					SecurityType:       ptrInt64ApplicationProxy(1),
+					AccelerateType:     ptrInt64ApplicationProxy(1),
+					SessionPersistTime: ptrUint64ApplicationProxy(600),
+					Status:             ptrStringApplicationProxy(status),
+				},
+			},
+			RequestId: ptrStringApplicationProxy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock ModifyApplicationProxyStatus
+	patches.ApplyMethodFunc(teoClient, "ModifyApplicationProxyStatus", func(request *teov20220901.ModifyApplicationProxyStatusRequest) (*teov20220901.ModifyApplicationProxyStatusResponse, error) {
+		resp := teov20220901.NewModifyApplicationProxyStatusResponse()
+		resp.Response = &teov20220901.ModifyApplicationProxyStatusResponseParams{
+			RequestId: ptrStringApplicationProxy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DeleteApplicationProxy
+	patches.ApplyMethodFunc(teoClient, "DeleteApplicationProxy", func(request *teov20220901.DeleteApplicationProxyRequest) (*teov20220901.DeleteApplicationProxyResponse, error) {
+		resp := teov20220901.NewDeleteApplicationProxyResponse()
+		resp.Response = &teov20220901.DeleteApplicationProxyResponseParams{
+			RequestId: ptrStringApplicationProxy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaApplicationProxy()
+	res := svcteo.ResourceTencentCloudTeoApplicationProxy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":              "zone-1234567890",
+		"proxy_id":             "proxy-abcdefghij",
+		"proxy_name":           "test-proxy",
+		"proxy_type":           "instance",
+		"plat_type":            "domain",
+		"security_type":        1,
+		"accelerate_type":      1,
+		"session_persist_time": 600,
+	})
+	d.SetId("zone-1234567890#proxy-abcdefghij")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+}
+
+// TestApplicationProxy_Delete_APIError tests Delete handles API error
+func TestApplicationProxy_Delete_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaApplicationProxy().client, "UseTeoClient", teoClient)
+
+	// Mock DescribeApplicationProxies - return offline status so we skip ModifyApplicationProxyStatus
+	patches.ApplyMethodFunc(teoClient, "DescribeApplicationProxies", func(request *teov20220901.DescribeApplicationProxiesRequest) (*teov20220901.DescribeApplicationProxiesResponse, error) {
+		resp := teov20220901.NewDescribeApplicationProxiesResponse()
+		resp.Response = &teov20220901.DescribeApplicationProxiesResponseParams{
+			ApplicationProxies: []*teov20220901.ApplicationProxy{
+				{
+					ZoneId:             ptrStringApplicationProxy("zone-1234567890"),
+					ProxyId:            ptrStringApplicationProxy("proxy-abcdefghij"),
+					ProxyName:          ptrStringApplicationProxy("test-proxy"),
+					ProxyType:          ptrStringApplicationProxy("instance"),
+					PlatType:           ptrStringApplicationProxy("domain"),
+					SecurityType:       ptrInt64ApplicationProxy(1),
+					AccelerateType:     ptrInt64ApplicationProxy(1),
+					SessionPersistTime: ptrUint64ApplicationProxy(600),
+					Status:             ptrStringApplicationProxy("offline"),
+				},
+			},
+			RequestId: ptrStringApplicationProxy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DeleteApplicationProxy to return error
+	patches.ApplyMethodFunc(teoClient, "DeleteApplicationProxy", func(request *teov20220901.DeleteApplicationProxyRequest) (*teov20220901.DeleteApplicationProxyResponse, error) {
+		return nil, fmt.Errorf("[TencentCloudSDKError] Code=ResourceNotFound, Message=Proxy not found")
+	})
+
+	meta := newMockMetaApplicationProxy()
+	res := svcteo.ResourceTencentCloudTeoApplicationProxy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":              "zone-1234567890",
+		"proxy_id":             "proxy-abcdefghij",
+		"proxy_name":           "test-proxy",
+		"proxy_type":           "instance",
+		"plat_type":            "domain",
+		"security_type":        1,
+		"accelerate_type":      1,
+		"session_persist_time": 600,
+	})
+	d.SetId("zone-1234567890#proxy-abcdefghij")
+
+	err := res.Delete(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ResourceNotFound")
+}
+
+// TestApplicationProxy_Delete_VerifyDGetParams verifies that zone_id and proxy_id from d.Get() are correctly passed to DeleteApplicationProxyRequest
+func TestApplicationProxy_Delete_VerifyDGetParams(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaApplicationProxy().client, "UseTeoClient", teoClient)
+
+	// Mock DescribeApplicationProxies for the read function - return offline status
+	patches.ApplyMethodFunc(teoClient, "DescribeApplicationProxies", func(request *teov20220901.DescribeApplicationProxiesRequest) (*teov20220901.DescribeApplicationProxiesResponse, error) {
+		resp := teov20220901.NewDescribeApplicationProxiesResponse()
+		resp.Response = &teov20220901.DescribeApplicationProxiesResponseParams{
+			ApplicationProxies: []*teov20220901.ApplicationProxy{
+				{
+					ZoneId:             ptrStringApplicationProxy("zone-from-dget"),
+					ProxyId:            ptrStringApplicationProxy("proxy-from-dget"),
+					ProxyName:          ptrStringApplicationProxy("test-proxy"),
+					ProxyType:          ptrStringApplicationProxy("instance"),
+					PlatType:           ptrStringApplicationProxy("domain"),
+					SecurityType:       ptrInt64ApplicationProxy(1),
+					AccelerateType:     ptrInt64ApplicationProxy(1),
+					SessionPersistTime: ptrUint64ApplicationProxy(600),
+					Status:             ptrStringApplicationProxy("offline"),
+				},
+			},
+			RequestId: ptrStringApplicationProxy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DeleteApplicationProxy - verify the request contains correct ZoneId and ProxyId from d.Get()
+	patches.ApplyMethodFunc(teoClient, "DeleteApplicationProxy", func(request *teov20220901.DeleteApplicationProxyRequest) (*teov20220901.DeleteApplicationProxyResponse, error) {
+		assert.NotNil(t, request.ZoneId, "ZoneId should not be nil")
+		assert.NotNil(t, request.ProxyId, "ProxyId should not be nil")
+		assert.Equal(t, "zone-from-dget", *request.ZoneId, "ZoneId in DeleteApplicationProxyRequest should match d.Get(\"zone_id\")")
+		assert.Equal(t, "proxy-from-dget", *request.ProxyId, "ProxyId in DeleteApplicationProxyRequest should match d.Get(\"proxy_id\")")
+
+		resp := teov20220901.NewDeleteApplicationProxyResponse()
+		resp.Response = &teov20220901.DeleteApplicationProxyResponseParams{
+			RequestId: ptrStringApplicationProxy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaApplicationProxy()
+	res := svcteo.ResourceTencentCloudTeoApplicationProxy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":              "zone-from-dget",
+		"proxy_id":             "proxy-from-dget",
+		"proxy_name":           "test-proxy",
+		"proxy_type":           "instance",
+		"plat_type":            "domain",
+		"security_type":        1,
+		"accelerate_type":      1,
+		"session_persist_time": 600,
+	})
+	// Intentionally set a different ID to prove d.Get() is used instead of d.Id()
+	d.SetId("zone-from-id#proxy-from-id")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+}
+
+// TestApplicationProxy_Delete_EmptyZoneId tests Delete returns error when zone_id is empty
+func TestApplicationProxy_Delete_EmptyZoneId(t *testing.T) {
+	meta := newMockMetaApplicationProxy()
+	res := svcteo.ResourceTencentCloudTeoApplicationProxy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":              "",
+		"proxy_id":             "proxy-abcdefghij",
+		"proxy_name":           "test-proxy",
+		"proxy_type":           "instance",
+		"plat_type":            "domain",
+		"security_type":        1,
+		"accelerate_type":      1,
+		"session_persist_time": 600,
+	})
+	d.SetId("#proxy-abcdefghij")
+
+	err := res.Delete(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "zone_id is required")
+}
+
+// TestApplicationProxy_Delete_EmptyProxyId tests Delete returns error when proxy_id is empty
+func TestApplicationProxy_Delete_EmptyProxyId(t *testing.T) {
+	meta := newMockMetaApplicationProxy()
+	res := svcteo.ResourceTencentCloudTeoApplicationProxy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":              "zone-1234567890",
+		"proxy_id":             "",
+		"proxy_name":           "test-proxy",
+		"proxy_type":           "instance",
+		"plat_type":            "domain",
+		"security_type":        1,
+		"accelerate_type":      1,
+		"session_persist_time": 600,
+	})
+	d.SetId("zone-1234567890#")
+
+	err := res.Delete(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "proxy_id is required")
+}
 
 func init() {
 	// go test -v ./tencentcloud -sweep=ap-guangzhou -sweep-run=tencentcloud_teo_zone


### PR DESCRIPTION
Modify the resourceTencentCloudTeoApplicationProxyDelete function to obtain zone_id and proxy_id from d.Get() instead of parsing them from d.Id(). Additionally, call the DeleteApplicationProxy API directly with retry logic using tccommon.WriteRetryTimeout instead of delegating to service.DeleteTeoApplicationProxyById(). This change improves parameter handling consistency and aligns with the best practice of using d.Get() for composite ID fields.