### PR TITLE
feat(teo): add l4proxy_rule_ids parameter to tencentcloud_teo_l4_proxy_rule resource

### DIFF
--- a/.changelog/4073.txt
+++ b/.changelog/4073.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_l4_proxy_rule: add l4proxy_rule_ids computed parameter
+```

--- a/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/.openspec.yaml
+++ b/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/design.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/design.md
@@ -1,0 +1,38 @@
+## Context
+
+The `tencentcloud_teo_l4_proxy_rule` resource manages Layer 4 proxy rules for TencentCloud EdgeOne (TEO). When creating L4 proxy rules via the `CreateL4ProxyRules` API, the response includes `L4ProxyRuleIds` — a list of IDs assigned to the newly created rules. Currently, the resource extracts the first rule ID to compose the composite resource ID (`zoneId#proxyId#ruleId`), but the full list of rule IDs is not persisted in the Terraform state.
+
+The resource uses a composite ID format: `zoneId#proxyId#ruleId`, where `ruleId` is the first element of `L4ProxyRuleIds` from the create response.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `l4proxy_rule_ids` as a computed attribute (TypeList of TypeString) to the resource schema
+- Persist the `L4ProxyRuleIds` values from the `CreateL4ProxyRules` API response into the Terraform state
+- Ensure the `l4proxy_rule_ids` is populated in the read function for state consistency
+- Maintain full backward compatibility with existing configurations
+
+**Non-Goals:**
+- Changing the existing composite ID format or the `l4_proxy_rules` nested block structure
+- Adding any other new parameters beyond `l4proxy_rule_ids`
+- Modifying the update or delete logic
+
+## Decisions
+
+1. **Schema type: TypeList of TypeString (Computed)**
+   - The `L4ProxyRuleIds` from the API is `[]*string`, so TypeList of TypeString maps directly
+   - Computed only — users cannot set this value; it is populated from the API response
+   - Alternative considered: TypeSet — rejected because rule IDs are ordered and duplicates are not expected
+
+2. **Populate in create and read functions**
+   - In create: set `l4proxy_rule_ids` from `response.Response.L4ProxyRuleIds` after the API call succeeds
+   - In read: reconstruct `l4proxy_rule_ids` from the rule ID in the composite ID (since the DescribeL4ProxyRules API returns individual rule details, not the full list of IDs from batch creation)
+   - Actually, since the resource creates one rule at a time (takes `l4_proxy_rules` with MaxItems:1), the list will contain exactly one rule ID, which is the same as the third component of the composite ID
+
+3. **No changes to update/delete**
+   - `l4proxy_rule_ids` is computed and read-only, so it does not participate in update or delete operations
+
+## Risks / Trade-offs
+
+- **State consistency**: Since the resource only supports one rule (MaxItems:1 for `l4_proxy_rules`), `l4proxy_rule_ids` will always be a single-element list. This is consistent with the current behavior where only the first rule ID from the response is used.
+- **Read reconstruction**: On read, the rule ID is reconstructed from the composite ID rather than from a separate API call, which is reliable since the ID was originally set from the create response.

--- a/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/proposal.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The `tencentcloud_teo_l4_proxy_rule` resource currently does not expose the `l4proxy_rule_ids` field from the `CreateL4ProxyRules` API response. The API returns `L4ProxyRuleIds` upon successful creation, but this value is not persisted in the Terraform state, making it unavailable for downstream references or debugging. Adding this computed parameter will allow users to reference the created rule IDs in other resources or outputs.
+
+## What Changes
+
+- Add a new computed parameter `l4proxy_rule_ids` (TypeList of TypeString) to the `tencentcloud_teo_l4_proxy_rule` resource schema
+- Populate `l4proxy_rule_ids` from `response.Response.L4ProxyRuleIds` in the create function
+- Persist `l4proxy_rule_ids` in the read function by reading from the resource ID (the rule ID is already part of the composite ID)
+
+## Capabilities
+
+### New Capabilities
+- `teo-l4proxy-rule-ids`: Adds the `l4proxy_rule_ids` computed attribute to the `tencentcloud_teo_l4_proxy_rule` resource, exposing the rule IDs returned by the `CreateL4ProxyRules` API
+
+### Modified Capabilities
+
+## Impact
+
+- **Affected code**: `tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule.go` (schema definition, create and read functions)
+- **API**: Uses existing `CreateL4ProxyRules` API response field `L4ProxyRuleIds`, no new API calls needed
+- **Backward compatibility**: Fully backward compatible — adding a computed attribute does not break existing configurations

--- a/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/specs/teo-l4proxy-rule-ids/spec.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/specs/teo-l4proxy-rule-ids/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: l4proxy_rule_ids computed attribute
+The `tencentcloud_teo_l4_proxy_rule` resource SHALL include a computed attribute `l4proxy_rule_ids` of type `TypeList` with element type `TypeString`. This attribute SHALL be populated from the `L4ProxyRuleIds` field in the `CreateL4ProxyRules` API response during resource creation and persisted in the Terraform state during read operations.
+
+#### Scenario: l4proxy_rule_ids populated after resource creation
+- **WHEN** a `tencentcloud_teo_l4_proxy_rule` resource is created successfully via the `CreateL4ProxyRules` API
+- **THEN** the `l4proxy_rule_ids` attribute SHALL be set to the list of rule IDs returned in `response.Response.L4ProxyRuleIds`
+
+#### Scenario: l4proxy_rule_ids populated during resource read
+- **WHEN** the `tencentcloud_teo_l4_proxy_rule` resource is read (refresh state)
+- **THEN** the `l4proxy_rule_ids` attribute SHALL be set to a list containing the rule ID extracted from the composite resource ID
+
+#### Scenario: l4proxy_rule_ids is computed and read-only
+- **WHEN** a user attempts to set `l4proxy_rule_ids` in their Terraform configuration
+- **THEN** the provider SHALL reject the configuration since the attribute is computed-only and not user-configurable

--- a/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/tasks.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-l4proxy-rule-ids/tasks.md
@@ -1,0 +1,13 @@
+## 1. Schema & CRUD 代码修改
+
+- [x] 1.1 在 `tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule.go` 的 Schema 中添加 `l4proxy_rule_ids` 计算属性（TypeList of TypeString, Computed: true）
+- [x] 1.2 在 `resourceTencentCloudTeoL4ProxyRuleCreate` 函数中，API 调用成功后将 `response.Response.L4ProxyRuleIds` 设置到 `l4proxy_rule_ids` 属性
+- [x] 1.3 在 `resourceTencentCloudTeoL4ProxyRuleRead` 函数中，从复合 ID 中提取 ruleId 并设置到 `l4proxy_rule_ids` 属性
+
+## 2. 单元测试
+
+- [x] 2.1 在 `tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule_test.go` 中补充 `l4proxy_rule_ids` 字段的单元测试用例
+
+## 3. 文档更新
+
+- [x] 3.1 更新 `tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule.md` 示例文件，添加 `l4proxy_rule_ids` 属性说明

--- a/openspec/specs/teo-l4proxy-rule-ids/spec.md
+++ b/openspec/specs/teo-l4proxy-rule-ids/spec.md
@@ -1,0 +1,19 @@
+# teo-l4proxy-rule-ids Specification
+
+## Purpose
+TBD - created by archiving change add-teo-l4proxy-rule-ids. Update Purpose after archive.
+## Requirements
+### Requirement: l4proxy_rule_ids computed attribute
+The `tencentcloud_teo_l4_proxy_rule` resource SHALL include a computed attribute `l4proxy_rule_ids` of type `TypeList` with element type `TypeString`. This attribute SHALL be populated from the `L4ProxyRuleIds` field in the `CreateL4ProxyRules` API response during resource creation and persisted in the Terraform state during read operations.
+
+#### Scenario: l4proxy_rule_ids populated after resource creation
+- **WHEN** a `tencentcloud_teo_l4_proxy_rule` resource is created successfully via the `CreateL4ProxyRules` API
+- **THEN** the `l4proxy_rule_ids` attribute SHALL be set to the list of rule IDs returned in `response.Response.L4ProxyRuleIds`
+
+#### Scenario: l4proxy_rule_ids populated during resource read
+- **WHEN** the `tencentcloud_teo_l4_proxy_rule` resource is read (refresh state)
+- **THEN** the `l4proxy_rule_ids` attribute SHALL be set to a list containing the rule ID extracted from the composite resource ID
+
+#### Scenario: l4proxy_rule_ids is computed and read-only
+- **WHEN** a user attempts to set `l4proxy_rule_ids` in their Terraform configuration
+- **THEN** the provider SHALL reject the configuration since the attribute is computed-only and not user-configurable

--- a/tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule.go
+++ b/tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule.go
@@ -110,6 +110,15 @@ func ResourceTencentCloudTeoL4ProxyRule() *schema.Resource {
 					},
 				},
 			},
+
+			"l4proxy_rule_ids": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of L4 proxy rule IDs returned by the CreateL4ProxyRules API.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -207,6 +216,14 @@ func resourceTencentCloudTeoL4ProxyRuleCreate(d *schema.ResourceData, meta inter
 	}
 	ruleId := *response.Response.L4ProxyRuleIds[0]
 
+	l4proxyRuleIds := make([]string, 0, len(response.Response.L4ProxyRuleIds))
+	for _, id := range response.Response.L4ProxyRuleIds {
+		if id != nil {
+			l4proxyRuleIds = append(l4proxyRuleIds, *id)
+		}
+	}
+	_ = d.Set("l4proxy_rule_ids", l4proxyRuleIds)
+
 	if err := resourceTencentCloudTeoL4ProxyRuleCreatePostHandleResponse0(ctx, response); err != nil {
 		return err
 	}
@@ -300,6 +317,8 @@ func resourceTencentCloudTeoL4ProxyRuleRead(d *schema.ResourceData, meta interfa
 
 		_ = d.Set("l4_proxy_rules", l4ProxyRuleList)
 	}
+
+	_ = d.Set("l4proxy_rule_ids", []string{ruleId})
 
 	return nil
 }

--- a/tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule.md
+++ b/tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule.md
@@ -1,4 +1,4 @@
-Provides a resource to create a teo teo_l4_proxy_rule
+Provides a resource to create a TEO (EdgeOne) L4 proxy rule
 
 Example Usage
 

--- a/tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_l4_proxy_rule_test.go
@@ -1,12 +1,45 @@
 package teo_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
+
+// mockMetaL4ProxyRule implements tccommon.ProviderMeta
+type mockMetaL4ProxyRule struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaL4ProxyRule) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaL4ProxyRule{}
+
+func newMockMetaL4ProxyRule() *mockMetaL4ProxyRule {
+	return &mockMetaL4ProxyRule{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringL4ProxyRule(s string) *string {
+	return &s
+}
+
+func ptrUint64L4ProxyRule(v uint64) *uint64 {
+	return &v
+}
 
 // go test -test.run TestAccTencentCloudTeoL4ProxyRuleResource_basic -v -timeout=0
 func TestAccTencentCloudTeoL4ProxyRuleResource_basic(t *testing.T) {
@@ -109,3 +142,180 @@ resource "tencentcloud_teo_l4_proxy_rule" "teo_l4_proxy_rule" {
     }
 }
 `
+
+// go test ./tencentcloud/services/teo/ -run "TestL4ProxyRuleL4proxyRuleIds" -v -count=1 -gcflags="all=-l"
+
+// TestL4ProxyRuleL4proxyRuleIds_Schema validates l4proxy_rule_ids schema definition
+func TestL4ProxyRuleL4proxyRuleIds_Schema(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoL4ProxyRule()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "l4proxy_rule_ids")
+
+	l4proxyRuleIdsSchema := res.Schema["l4proxy_rule_ids"]
+	assert.Equal(t, schema.TypeList, l4proxyRuleIdsSchema.Type)
+	assert.True(t, l4proxyRuleIdsSchema.Computed)
+	assert.False(t, l4proxyRuleIdsSchema.Required)
+	assert.False(t, l4proxyRuleIdsSchema.Optional)
+	assert.NotNil(t, l4proxyRuleIdsSchema.Elem)
+}
+
+// TestL4ProxyRuleL4proxyRuleIds_Read tests that l4proxy_rule_ids is populated in read from composite ID
+func TestL4ProxyRuleL4proxyRuleIds_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaL4ProxyRule().client, "UseTeoV20220901Client", teoClient)
+	patches.ApplyMethodReturn(newMockMetaL4ProxyRule().client, "UseTeoClient", teoClient)
+
+	// Patch DescribeL4ProxyRules for the read function's service call
+	patches.ApplyMethodFunc(teoClient, "DescribeL4ProxyRules", func(request *teov20220901.DescribeL4ProxyRulesRequest) (*teov20220901.DescribeL4ProxyRulesResponse, error) {
+		resp := teov20220901.NewDescribeL4ProxyRulesResponse()
+		resp.Response = &teov20220901.DescribeL4ProxyRulesResponseParams{
+			L4ProxyRules: []*teov20220901.L4ProxyRule{
+				{
+					RuleId:                  ptrStringL4ProxyRule("rule-xyz789"),
+					Protocol:                ptrStringL4ProxyRule("TCP"),
+					PortRange:               []*string{ptrStringL4ProxyRule("80")},
+					OriginType:              ptrStringL4ProxyRule("IP_DOMAIN"),
+					OriginValue:             []*string{ptrStringL4ProxyRule("8.8.8.8")},
+					OriginPortRange:         ptrStringL4ProxyRule("80"),
+					ClientIPPassThroughMode: ptrStringL4ProxyRule("OFF"),
+					SessionPersist:          ptrStringL4ProxyRule("off"),
+					SessionPersistTime:      ptrUint64L4ProxyRule(3600),
+					Status:                  ptrStringL4ProxyRule("online"),
+				},
+			},
+			RequestId: ptrStringL4ProxyRule("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaL4ProxyRule()
+	res := teo.ResourceTencentCloudTeoL4ProxyRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-12345678",
+		"proxy_id": "sid-abcdef",
+		"l4_proxy_rules": []interface{}{
+			map[string]interface{}{
+				"protocol":          "TCP",
+				"port_range":        []interface{}{"80"},
+				"origin_type":       "IP_DOMAIN",
+				"origin_value":      []interface{}{"8.8.8.8"},
+				"origin_port_range": "80",
+			},
+		},
+	})
+	d.SetId("zone-12345678#sid-abcdef#rule-xyz789")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// Verify l4proxy_rule_ids is set from composite ID
+	l4proxyRuleIds := d.Get("l4proxy_rule_ids").([]interface{})
+	assert.Equal(t, 1, len(l4proxyRuleIds))
+	assert.Equal(t, "rule-xyz789", l4proxyRuleIds[0].(string))
+}
+
+// TestL4ProxyRuleL4proxyRuleIds_Create tests that l4proxy_rule_ids is set after create
+func TestL4ProxyRuleL4proxyRuleIds_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaL4ProxyRule().client, "UseTeoV20220901Client", teoClient)
+	patches.ApplyMethodReturn(newMockMetaL4ProxyRule().client, "UseTeoClient", teoClient)
+
+	// Patch CreateL4ProxyRulesWithContext to return L4ProxyRuleIds
+	patches.ApplyMethodFunc(teoClient, "CreateL4ProxyRulesWithContext", func(ctx context.Context, request *teov20220901.CreateL4ProxyRulesRequest) (*teov20220901.CreateL4ProxyRulesResponse, error) {
+		resp := teov20220901.NewCreateL4ProxyRulesResponse()
+		resp.Response = &teov20220901.CreateL4ProxyRulesResponseParams{
+			L4ProxyRuleIds: []*string{
+				ptrStringL4ProxyRule("rule-abc123"),
+			},
+			RequestId: ptrStringL4ProxyRule("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Patch DescribeL4ProxyRules for the state refresh and read function
+	patches.ApplyMethodFunc(teoClient, "DescribeL4ProxyRules", func(request *teov20220901.DescribeL4ProxyRulesRequest) (*teov20220901.DescribeL4ProxyRulesResponse, error) {
+		resp := teov20220901.NewDescribeL4ProxyRulesResponse()
+		resp.Response = &teov20220901.DescribeL4ProxyRulesResponseParams{
+			L4ProxyRules: []*teov20220901.L4ProxyRule{
+				{
+					RuleId:                  ptrStringL4ProxyRule("rule-abc123"),
+					Protocol:                ptrStringL4ProxyRule("TCP"),
+					PortRange:               []*string{ptrStringL4ProxyRule("1212")},
+					OriginType:              ptrStringL4ProxyRule("IP_DOMAIN"),
+					OriginValue:             []*string{ptrStringL4ProxyRule("8.8.8.8")},
+					OriginPortRange:         ptrStringL4ProxyRule("1212"),
+					ClientIPPassThroughMode: ptrStringL4ProxyRule("OFF"),
+					SessionPersist:          ptrStringL4ProxyRule("off"),
+					SessionPersistTime:      ptrUint64L4ProxyRule(3600),
+					Status:                  ptrStringL4ProxyRule("online"),
+				},
+			},
+			RequestId: ptrStringL4ProxyRule("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaL4ProxyRule()
+	res := teo.ResourceTencentCloudTeoL4ProxyRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-12345678",
+		"proxy_id": "sid-abcdef",
+		"l4_proxy_rules": []interface{}{
+			map[string]interface{}{
+				"protocol":          "TCP",
+				"port_range":        []interface{}{"1212"},
+				"origin_type":       "IP_DOMAIN",
+				"origin_value":      []interface{}{"8.8.8.8"},
+				"origin_port_range": "1212",
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+
+	// Verify l4proxy_rule_ids is set after create
+	l4proxyRuleIds := d.Get("l4proxy_rule_ids").([]interface{})
+	assert.Equal(t, 1, len(l4proxyRuleIds))
+	assert.Equal(t, "rule-abc123", l4proxyRuleIds[0].(string))
+}
+
+// TestL4ProxyRuleL4proxyRuleIds_APIError tests create handles API error
+func TestL4ProxyRuleL4proxyRuleIds_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaL4ProxyRule().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "CreateL4ProxyRulesWithContext", func(ctx context.Context, request *teov20220901.CreateL4ProxyRulesRequest) (*teov20220901.CreateL4ProxyRulesResponse, error) {
+		return nil, fmt.Errorf("[TencentCloudSDKError] Code=ResourceNotFound, Message=Zone not found")
+	})
+
+	meta := newMockMetaL4ProxyRule()
+	res := teo.ResourceTencentCloudTeoL4ProxyRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-invalid",
+		"proxy_id": "sid-invalid",
+		"l4_proxy_rules": []interface{}{
+			map[string]interface{}{
+				"protocol":          "TCP",
+				"port_range":        []interface{}{"80"},
+				"origin_type":       "IP_DOMAIN",
+				"origin_value":      []interface{}{"8.8.8.8"},
+				"origin_port_range": "80",
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ResourceNotFound")
+}

--- a/website/docs/r/teo_l4_proxy_rule.html.markdown
+++ b/website/docs/r/teo_l4_proxy_rule.html.markdown
@@ -4,12 +4,12 @@ layout: "tencentcloud"
 page_title: "TencentCloud: tencentcloud_teo_l4_proxy_rule"
 sidebar_current: "docs-tencentcloud-resource-teo_l4_proxy_rule"
 description: |-
-  Provides a resource to create a teo teo_l4_proxy_rule
+  Provides a resource to create a TEO (EdgeOne) L4 proxy rule
 ---
 
 # tencentcloud_teo_l4_proxy_rule
 
-Provides a resource to create a teo teo_l4_proxy_rule
+Provides a resource to create a TEO (EdgeOne) L4 proxy rule
 
 ## Example Usage
 
@@ -92,7 +92,7 @@ Note: This parameter is optional when L4ProxyRule is used as an input parameter 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-
+* `l4proxy_rule_ids` - List of L4 proxy rule IDs returned by the CreateL4ProxyRules API.
 
 
 ## Import


### PR DESCRIPTION
Add l4proxy_rule_ids computed parameter to the tencentcloud_teo_l4_proxy_rule resource. This parameter returns the list of L4 proxy rule IDs from the CreateL4ProxyRules API response, and is also populated during read operations.