### PR TITLE
feat(teo): [132968456] add rule_ids computed attribute to tencentcloud_teo_l7_acc_rule_v2

### DIFF
--- a/.changelog/4075.txt
+++ b/.changelog/4075.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_l7_acc_rule_v2: add `rule_ids` computed attribute
+```

--- a/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/.openspec.yaml
+++ b/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/design.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The `tencentcloud_teo_l7_acc_rule_v2` resource manages TEO (TencentCloud EdgeOne) L7 acceleration rules. Currently, the resource schema exposes a `rule_id` computed field that stores only the first rule ID from the `CreateL7AccRules` API response. However, the API's response (`response.Response.RuleIds`) returns a list of all rule IDs created, which is not fully exposed to Terraform users.
+
+The existing resource already handles:
+- `zone_id` (required, ForceNew) - the site ID
+- `status`, `rule_name`, `description`, `branches` - rule configuration fields
+- `rule_id` (computed) - single rule ID
+- `rule_priority` (computed) - rule priority
+
+The `CreateL7AccRules` API response contains `RuleIds []*string` which represents all rule IDs created in the batch. This needs to be exposed as a new `rule_ids` computed schema field.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a `rule_ids` computed attribute (TypeList of TypeString) to the `tencentcloud_teo_l7_acc_rule_v2` resource schema
+- Populate `rule_ids` from the `CreateL7AccRules` API response in the Create function
+- Populate `rule_ids` in the Read function using data from the `DescribeL7AccRules` API response
+- Update the resource documentation (.md file)
+- Add unit tests for the new `rule_ids` field
+
+**Non-Goals:**
+- Modifying the existing `rule_id` computed field behavior
+- Changing the resource's composite ID format (zone_id + FILED_SP + rule_id)
+- Adding new input parameters beyond `rule_ids`
+- Modifying the CreateL7AccRules request structure
+
+## Decisions
+
+1. **`rule_ids` as TypeList of TypeString**: The API returns `RuleIds []*string`, so `rule_ids` SHALL be defined as `schema.TypeList` with `Elem: &schema.Schema{Type: schema.TypeString}` and `Computed: true`. This aligns with the API's list-based response.
+
+2. **Populating `rule_ids` in Create**: After the `CreateL7AccRules` API call succeeds, extract all values from `result.Response.RuleIds` and flatten them for `d.Set("rule_ids", ...)`. The existing logic already reads `result.Response.RuleIds[0]` for the composite ID.
+
+3. **Populating `rule_ids` in Read**: In the Read function, after calling `DescribeTeoL7AccRuleById`, iterate over `respData.Rules` and collect the `RuleId` from each `RuleEngineItem` to build the `rule_ids` list. Since the current query filters by a single rule-id, the list will contain one element matching the current rule, consistent with the Create response.
+
+4. **No change to Update/Delete functions**: The `rule_ids` field is computed-only and does not need to be handled in the Update or Delete functions.
+
+## Risks / Trade-offs
+
+- [Risk] The `DescribeL7AccRules` API returns rules filtered by rule-id, so `rule_ids` in Read will only contain the current rule's ID, not necessarily matching the full Create response if the API ever returns multiple IDs → Mitigation: This is acceptable since the current implementation only creates one rule per resource, and the behavior is consistent with the existing `rule_id` field.

--- a/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/proposal.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The `tencentcloud_teo_l7_acc_rule_v2` resource currently lacks a `rule_ids` computed output parameter to expose all rule IDs returned by the `CreateL7AccRules` API response. While the existing code internally reads `response.Response.RuleIds[0]` to set the composite resource ID, the full list of rule IDs is not available to Terraform users as a schema field. Adding `rule_ids` as a computed attribute will allow users to reference all created rule IDs in their Terraform configurations.
+
+## What Changes
+
+- Add a new computed schema field `rule_ids` (TypeList of TypeString) to the `tencentcloud_teo_l7_acc_rule_v2` resource
+- Populate `rule_ids` from `response.Response.RuleIds` in the Create function
+- Populate `rule_ids` from the DescribeL7AccRules response in the Read function
+
+## Capabilities
+
+### New Capabilities
+- `teo-l7-acc-rule-v2-rule-ids`: Expose the `rule_ids` computed attribute in the `tencentcloud_teo_l7_acc_rule_v2` resource, allowing Terraform users to access all rule IDs returned by the CreateL7AccRules API
+
+### Modified Capabilities
+<!-- No existing capability requirements are changing -->
+
+## Impact
+
+- Affected code: `tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2.go`
+- Affected tests: `tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2_test.go`
+- Affected docs: `tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2.md`
+- API dependency: `CreateL7AccRules` response (`RuleIds` field) and `DescribeL7AccRules` response
+- Backward compatible: Only adding a new computed field, no breaking changes

--- a/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/specs/teo-l7-acc-rule-v2-rule-ids/spec.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/specs/teo-l7-acc-rule-v2-rule-ids/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: rule_ids computed attribute
+The `tencentcloud_teo_l7_acc_rule_v2` resource SHALL expose a `rule_ids` computed attribute of type list of strings, populated from the `CreateL7AccRules` API response field `RuleIds`.
+
+#### Scenario: rule_ids populated after resource creation
+- **WHEN** the `tencentcloud_teo_l7_acc_rule_v2` resource is created successfully via the `CreateL7AccRules` API
+- **THEN** the `rule_ids` attribute SHALL contain all rule IDs returned in `response.Response.RuleIds`
+
+#### Scenario: rule_ids populated during resource read
+- **WHEN** the `tencentcloud_teo_l7_acc_rule_v2` resource is read via the `DescribeL7AccRules` API
+- **THEN** the `rule_ids` attribute SHALL be populated from the `RuleId` field of each `RuleEngineItem` in the response
+
+#### Scenario: rule_ids is computed only
+- **WHEN** a user writes a Terraform configuration for `tencentcloud_teo_l7_acc_rule_v2`
+- **THEN** the `rule_ids` attribute SHALL NOT be settable by the user (Computed: true, not Optional or Required)
+
+### Requirement: rule_ids schema definition
+The `rule_ids` field SHALL be defined in the resource schema as a TypeList with TypeString elements, marked as Computed.
+
+#### Scenario: schema definition correctness
+- **WHEN** the resource schema is defined
+- **THEN** `rule_ids` SHALL have `Type: schema.TypeList`, `Computed: true`, and `Elem: &schema.Schema{Type: schema.TypeString}`

--- a/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/tasks.md
+++ b/openspec/changes/archive/2025-07-18-add-teo-l7-acc-rule-v2-params/tasks.md
@@ -1,0 +1,16 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2.go` 的 Schema 中添加 `rule_ids` 字段，定义为 `TypeList`、`Computed: true`、`Elem: &schema.Schema{Type: schema.TypeString}`，描述为 "Rule ID list."
+
+## 2. CRUD 函数修改
+
+- [x] 2.1 在 `ResourceTencentCloudTeoL7AccRuleV2Create` 函数中，CreateL7AccRules API 调用成功后，将 `result.Response.RuleIds` 扁平化并设置到 `d.Set("rule_ids", ...)` 中
+- [x] 2.2 在 `ResourceTencentCloudTeoL7AccRuleV2Read` 函数中，从 `respData.Rules` 中收集所有 `RuleId` 并设置到 `d.Set("rule_ids", ...)` 中
+
+## 3. 单元测试
+
+- [x] 3.1 在 `tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2_test.go` 中补充 `rule_ids` 字段的单元测试用例，使用 gomonkey mock 云 API
+
+## 4. 文档更新
+
+- [x] 4.1 更新 `tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2.md` 文件，添加 `rule_ids` 属性的文档说明

--- a/openspec/specs/teo-l7-acc-rule-v2-rule-ids/spec.md
+++ b/openspec/specs/teo-l7-acc-rule-v2-rule-ids/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: rule_ids computed attribute
+The `tencentcloud_teo_l7_acc_rule_v2` resource SHALL expose a `rule_ids` computed attribute of type list of strings, populated from the `CreateL7AccRules` API response field `RuleIds`.
+
+#### Scenario: rule_ids populated after resource creation
+- **WHEN** the `tencentcloud_teo_l7_acc_rule_v2` resource is created successfully via the `CreateL7AccRules` API
+- **THEN** the `rule_ids` attribute SHALL contain all rule IDs returned in `response.Response.RuleIds`
+
+#### Scenario: rule_ids populated during resource read
+- **WHEN** the `tencentcloud_teo_l7_acc_rule_v2` resource is read via the `DescribeL7AccRules` API
+- **THEN** the `rule_ids` attribute SHALL be populated from the `RuleId` field of each `RuleEngineItem` in the response
+
+#### Scenario: rule_ids is computed only
+- **WHEN** a user writes a Terraform configuration for `tencentcloud_teo_l7_acc_rule_v2`
+- **THEN** the `rule_ids` attribute SHALL NOT be settable by the user (Computed: true, not Optional or Required)
+
+### Requirement: rule_ids schema definition
+The `rule_ids` field SHALL be defined in the resource schema as a TypeList with TypeString elements, marked as Computed.
+
+#### Scenario: schema definition correctness
+- **WHEN** the resource schema is defined
+- **THEN** `rule_ids` SHALL have `Type: schema.TypeList`, `Computed: true`, and `Elem: &schema.Schema{Type: schema.TypeString}`

--- a/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2.go
+++ b/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2.go
@@ -60,6 +60,14 @@ func ResourceTencentCloudTeoL7AccRuleV2() *schema.Resource {
 				Computed:    true,
 				Description: "Rule ID. Unique identifier of the rule.",
 			},
+			"rule_ids": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Rule ID list.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"rule_priority": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -77,6 +85,8 @@ func ResourceTencentCloudTeoL7AccRuleV2Create(d *schema.ResourceData, meta inter
 	var (
 		zoneId string
 		ruleId string
+		result *teov20220901.CreateL7AccRulesResponse
+		e      error
 	)
 	zoneId = d.Get("zone_id").(string)
 	request := teov20220901.NewCreateL7AccRulesRequest()
@@ -103,7 +113,7 @@ func ResourceTencentCloudTeoL7AccRuleV2Create(d *schema.ResourceData, meta inter
 
 	request.Rules = []*teov20220901.RuleEngineItem{rule}
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().CreateL7AccRules(request)
+		result, e = meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().CreateL7AccRules(request)
 		if e != nil {
 			return tccommon.RetryError(e)
 		} else {
@@ -119,6 +129,14 @@ func ResourceTencentCloudTeoL7AccRuleV2Create(d *schema.ResourceData, meta inter
 	}
 
 	d.SetId(zoneId + tccommon.FILED_SP + ruleId)
+
+	ruleIds := make([]string, 0, len(result.Response.RuleIds))
+	for _, v := range result.Response.RuleIds {
+		if v != nil {
+			ruleIds = append(ruleIds, *v)
+		}
+	}
+	_ = d.Set("rule_ids", ruleIds)
 
 	return ResourceTencentCloudTeoL7AccRuleV2Read(d, meta)
 }
@@ -160,6 +178,14 @@ func ResourceTencentCloudTeoL7AccRuleV2Read(d *schema.ResourceData, meta interfa
 		_ = d.Set("description", rule.Description)
 		_ = d.Set("rule_priority", rule.RulePriority)
 		_ = d.Set("branches", resourceTencentCloudTeoL7AccRuleSetBranchs(rule.Branches))
+
+		ruleIds := make([]string, 0, len(respData.Rules))
+		for _, r := range respData.Rules {
+			if r.RuleId != nil {
+				ruleIds = append(ruleIds, *r.RuleId)
+			}
+		}
+		_ = d.Set("rule_ids", ruleIds)
 	}
 
 	return nil

--- a/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2_test.go
@@ -1,11 +1,44 @@
 package teo_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 )
+
+// mockMetaForL7AccRuleV2 implements tccommon.ProviderMeta
+type mockMetaForL7AccRuleV2 struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForL7AccRuleV2) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForL7AccRuleV2{}
+
+func newMockMetaForL7AccRuleV2() *mockMetaForL7AccRuleV2 {
+	return &mockMetaForL7AccRuleV2{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrL7AccRuleV2(s string) *string {
+	return &s
+}
+
+func ptrInt64L7AccRuleV2(n int64) *int64 {
+	return &n
+}
 
 func TestAccTencentCloudTeoL7AccRuleV2Resource_basic(t *testing.T) {
 	t.Parallel()
@@ -185,3 +218,138 @@ resource "tencentcloud_teo_l7_acc_rule_v2" "teo_l7_acc_rule_v2" {
   }
 }
 `
+
+// go test ./tencentcloud/services/teo/ -run "TestL7AccRuleV2RuleIds" -v -count=1 -gcflags="all=-l"
+
+// TestL7AccRuleV2RuleIds_Read_Success tests Read populates rule_ids computed attribute
+func TestL7AccRuleV2RuleIds_Read_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForL7AccRuleV2().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeL7AccRules", func(request *teov20220901.DescribeL7AccRulesRequest) (*teov20220901.DescribeL7AccRulesResponse, error) {
+		resp := teov20220901.NewDescribeL7AccRulesResponse()
+		resp.Response = &teov20220901.DescribeL7AccRulesResponseParams{
+			Rules: []*teov20220901.RuleEngineItem{
+				{
+					RuleId:       ptrStrL7AccRuleV2("rule-001"),
+					RuleName:     ptrStrL7AccRuleV2("test-rule"),
+					Status:       ptrStrL7AccRuleV2("enable"),
+					RulePriority: ptrInt64L7AccRuleV2(10),
+				},
+			},
+			RequestId: ptrStrL7AccRuleV2("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForL7AccRuleV2()
+	res := teo.ResourceTencentCloudTeoL7AccRuleV2()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-test123",
+	})
+	d.SetId("zone-test123#rule-001")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "rule-001", d.Get("rule_id"))
+
+	// Verify rule_ids computed attribute
+	ruleIds := d.Get("rule_ids").([]interface{})
+	assert.Equal(t, 1, len(ruleIds))
+	assert.Equal(t, "rule-001", ruleIds[0])
+}
+
+// TestL7AccRuleV2RuleIds_Read_MultipleRules tests Read populates rule_ids with multiple rule IDs
+func TestL7AccRuleV2RuleIds_Read_MultipleRules(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForL7AccRuleV2().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeL7AccRules", func(request *teov20220901.DescribeL7AccRulesRequest) (*teov20220901.DescribeL7AccRulesResponse, error) {
+		resp := teov20220901.NewDescribeL7AccRulesResponse()
+		resp.Response = &teov20220901.DescribeL7AccRulesResponseParams{
+			Rules: []*teov20220901.RuleEngineItem{
+				{
+					RuleId:       ptrStrL7AccRuleV2("rule-001"),
+					RuleName:     ptrStrL7AccRuleV2("test-rule-1"),
+					Status:       ptrStrL7AccRuleV2("enable"),
+					RulePriority: ptrInt64L7AccRuleV2(10),
+				},
+				{
+					RuleId:       ptrStrL7AccRuleV2("rule-002"),
+					RuleName:     ptrStrL7AccRuleV2("test-rule-2"),
+					Status:       ptrStrL7AccRuleV2("disable"),
+					RulePriority: ptrInt64L7AccRuleV2(5),
+				},
+			},
+			RequestId: ptrStrL7AccRuleV2("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForL7AccRuleV2()
+	res := teo.ResourceTencentCloudTeoL7AccRuleV2()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-test123",
+	})
+	d.SetId("zone-test123#rule-001")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// Verify rule_ids contains all rule IDs from response
+	ruleIds := d.Get("rule_ids").([]interface{})
+	assert.Equal(t, 2, len(ruleIds))
+	assert.Equal(t, "rule-001", ruleIds[0])
+	assert.Equal(t, "rule-002", ruleIds[1])
+}
+
+// TestL7AccRuleV2RuleIds_Read_NotFound tests Read handles resource not found (nil response)
+func TestL7AccRuleV2RuleIds_Read_NotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForL7AccRuleV2().client, "UseTeoV20220901Client", teoClient)
+
+	// Mock DescribeL7AccRules to return an error simulating resource not found
+	patches.ApplyMethodFunc(teoClient, "DescribeL7AccRules", func(request *teov20220901.DescribeL7AccRulesRequest) (*teov20220901.DescribeL7AccRulesResponse, error) {
+		return nil, fmt.Errorf("ResourceNotFound")
+	})
+
+	meta := newMockMetaForL7AccRuleV2()
+	res := teo.ResourceTencentCloudTeoL7AccRuleV2()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-test123",
+	})
+	d.SetId("zone-test123#rule-nonexistent")
+
+	err := res.Read(d, meta)
+	// When API returns error, Read should return error
+	assert.Error(t, err)
+}
+
+// TestL7AccRuleV2RuleIds_Schema tests the rule_ids schema definition
+func TestL7AccRuleV2RuleIds_Schema(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoL7AccRuleV2()
+
+	assert.NotNil(t, res)
+
+	// Check rule_ids field
+	assert.Contains(t, res.Schema, "rule_ids")
+	ruleIdsSchema := res.Schema["rule_ids"]
+	assert.Equal(t, schema.TypeList, ruleIdsSchema.Type)
+	assert.True(t, ruleIdsSchema.Computed)
+	assert.False(t, ruleIdsSchema.Optional)
+	assert.False(t, ruleIdsSchema.Required)
+
+	// Verify rule_ids is TypeList of TypeString
+	ruleIdsElem, ok := ruleIdsSchema.Elem.(*schema.Schema)
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeString, ruleIdsElem.Type)
+}

--- a/website/docs/r/teo_l7_acc_rule_v2.html.markdown
+++ b/website/docs/r/teo_l7_acc_rule_v2.html.markdown
@@ -503,6 +503,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
 * `rule_id` - Rule ID. Unique identifier of the rule.
+* `rule_ids` - Rule ID list.
 * `rule_priority` - Rule priority. only used as an output parameter.
 
 


### PR DESCRIPTION
Add rule_ids computed attribute to the tencentcloud_teo_l7_acc_rule_v2 resource. The rule_ids attribute exposes a list of rule IDs returned by the CreateL7AccRules API response and populated during resource read from DescribeL7AccRules API response.