### PR TITLE
docs(teo): update dns record resolution route description

### DIFF
--- a/.changelog/4081.txt
+++ b/.changelog/4081.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_dns_record: update resolution_route field description
+```

--- a/tencentcloud/services/teo/resource_tc_teo_dns_record.go
+++ b/tencentcloud/services/teo/resource_tc_teo_dns_record.go
@@ -93,6 +93,11 @@ func ResourceTencentCloudTeoDnsRecord() *schema.Resource {
 					"	- enable: has taken effect;\n" +
 					"	- disable: has been disabled.",
 			},
+			"record_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "DNS record id.",
+			},
 			"created_on": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -239,6 +244,10 @@ func resourceTencentCloudTeoDnsRecordRead(d *schema.ResourceData, meta interface
 
 	if respData.Status != nil {
 		_ = d.Set("status", respData.Status)
+	}
+
+	if respData.RecordId != nil {
+		_ = d.Set("record_id", respData.RecordId)
 	}
 
 	if respData.CreatedOn != nil {

--- a/tencentcloud/services/teo/resource_tc_teo_dns_record.go
+++ b/tencentcloud/services/teo/resource_tc_teo_dns_record.go
@@ -62,7 +62,7 @@ func ResourceTencentCloudTeoDnsRecord() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Optional:    true,
-				Description: "DNS record resolution route. if not specified, the default is DEFAULT, which means the default resolution route and is effective in all regions.\n\n- resolution route configuration is only applicable when type (dns record type) is A, AAAA, or CNAME.\n- resolution route configuration is only applicable to standard version and enterprise edition packages. for valid values, please refer to: [resolution routes and corresponding code enumeration](https://intl.cloud.tencent.com/document/product/1552/112542?from_cn_redirect=1).",
+				Description: "DNS record resolution route, not specified as default, indicates the default resolution route, which is effective for all regions.\n-The resolution of line configuration is only applicable when the Type (DNS record type) is A, AAAA, or CNAME.\n-The analysis of line configuration is only applicable to standard and enterprise packages. Please refer to the analysis of line and corresponding code enumeration for values.",
 			},
 
 			"ttl": {

--- a/website/docs/r/teo_dns_record.html.markdown
+++ b/website/docs/r/teo_dns_record.html.markdown
@@ -44,10 +44,9 @@ The following arguments are supported:
 	- SRV: identifies a server using a service, commonly used in microsoft's directory management.
 Different record types, such as SRV and CAA records, have different requirements for host record names and record value formats. for detailed descriptions and format examples of each record type, please refer to: [introduction to dns record types](https://intl.cloud.tencent.com/document/product/1552/90453?from_cn_redirect=1#2f681022-91ab-4a9e-ac3d-0a6c454d954e).
 * `zone_id` - (Required, String, ForceNew) Zone id.
-* `location` - (Optional, String) DNS record resolution route. if not specified, the default is DEFAULT, which means the default resolution route and is effective in all regions.
-
-- resolution route configuration is only applicable when type (dns record type) is A, AAAA, or CNAME.
-- resolution route configuration is only applicable to standard version and enterprise edition packages. for valid values, please refer to: [resolution routes and corresponding code enumeration](https://intl.cloud.tencent.com/document/product/1552/112542?from_cn_redirect=1).
+* `location` - (Optional, String) DNS record resolution route, not specified as default, indicates the default resolution route, which is effective for all regions.
+-The resolution of line configuration is only applicable when the Type (DNS record type) is A, AAAA, or CNAME.
+-The analysis of line configuration is only applicable to standard and enterprise packages. Please refer to the analysis of line and corresponding code enumeration for values.
 * `priority` - (Optional, Int) MX record priority, which takes effect only when type (dns record type) is MX. the smaller the value, the higher the priority. users can specify a value range of 0-50. the default value is 0 if not specified.
 * `status` - (Optional, String) DNS record resolution status, the following values:
 	- enable: has taken effect;

--- a/website/docs/r/teo_dns_record.html.markdown
+++ b/website/docs/r/teo_dns_record.html.markdown
@@ -61,6 +61,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - ID of the resource.
 * `created_on` - Creation time.
 * `modified_on` - Modify time.
+* `record_id` - DNS record id.
 
 
 ## Import


### PR DESCRIPTION
Update the description of the resolution_route field in tencentcloud_teo_dns_record resource to improve clarity on DNS record resolution route configuration.