### PR TITLE
feat(teo): add trigger_type parameter to tencentcloud_teo_function_rule resource

### DIFF
--- a/.changelog/4084.txt
+++ b/.changelog/4084.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_function_rule: add trigger_type parameter to support function selection configuration type
+```

--- a/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/.openspec.yaml
+++ b/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/design.md
+++ b/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The `tencentcloud_teo_function_rule` resource manages EdgeOne function trigger rules. Currently, the resource only supports the `direct` trigger type where a single function is specified by `function_id`. The TencentCloud TEO API (`CreateFunctionRule`/`ModifyFunctionRule`) supports a `TriggerType` parameter that controls how functions are selected for execution:
+
+- `direct`: Directly specify a single function (current behavior, default)
+- `weight`: Select functions based on weight ratios
+- `region`: Select functions based on client IP country/region
+
+The `TriggerType` field is present in `CreateFunctionRuleRequest`, `ModifyFunctionRuleRequest`, and `FunctionRule` (read response) in the cloud SDK (`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `trigger_type` as an Optional string parameter to `tencentcloud_teo_function_rule` resource
+- Support `trigger_type` in Create, Read, and Update operations
+- Maintain full backward compatibility — existing TF configurations without `trigger_type` continue to work (API defaults to `direct` when not specified)
+
+**Non-Goals:**
+- Adding `RegionMappingSelections` and `WeightedSelections` parameters (these are complex nested objects that depend on `trigger_type` and will be added in a separate change)
+- Changing the composite ID format or existing schema fields
+- Modifying the Delete operation (it does not use `TriggerType`)
+
+## Decisions
+
+1. **Schema: `trigger_type` as Optional string without ForceNew**
+   - The `TriggerType` field is present in both Create and Modify API requests, so it is mutable (not ForceNew).
+   - Default value is `direct` per API behavior — we do NOT set `Default:` in the schema to avoid spurious diffs; instead we let the API default handle it.
+   - Validate values using `ValidateFunc` with `validation.StringInSlice([]string{"direct", "weight", "region"}, false)`.
+
+2. **CRUD handler modifications**
+   - **Create**: Read `trigger_type` from schema and set `request.TriggerType` if specified.
+   - **Read**: Read `respData.TriggerType` from `FunctionRule` response and set `trigger_type` in state (with nil check).
+   - **Update**: Add `"trigger_type"` to `mutableArgs` list, and set `request.TriggerType` if specified in the Modify request.
+
+3. **Extension file not needed**
+   - The change is simple enough to be made directly in the main resource file without creating an `_extension.go` file.
+
+## Risks / Trade-offs
+
+- **[Risk] `trigger_type` set to `weight` or `region` without corresponding selection configs** → The API may reject the request if `RegionMappingSelections` or `WeightedSelections` are required but not provided. However, since this change only adds `trigger_type` and not the selection configs, users who set `trigger_type` to `weight` or `region` may encounter API errors. This is acceptable since the selection configs will be added in a follow-up change. The parameter description should note this dependency.
+- **[Risk] API returns empty/null `TriggerType` for existing rules** → The Read handler checks for nil before setting the field, so existing state will not be affected.

--- a/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/proposal.md
+++ b/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The `tencentcloud_teo_function_rule` resource currently only supports the `direct` trigger type (where a single function is directly specified by `function_id`). The cloud API (`CreateFunctionRule`/`ModifyFunctionRule`) also supports `weight` (weight-based function selection) and `region` (region-based function selection) trigger types via the `TriggerType` parameter. Without this parameter, users cannot configure weight-based or region-based function routing in their Terraform configurations.
+
+## What Changes
+
+- Add `trigger_type` parameter (Optional, string) to the `tencentcloud_teo_function_rule` resource schema, supporting values `direct`, `weight`, and `region`. Defaults to `direct` when not specified.
+- Update the Create handler to pass `TriggerType` to the `CreateFunctionRule` API request.
+- Update the Update handler to include `trigger_type` in the mutable arguments list and pass it to the `ModifyFunctionRule` API request.
+- Update the Read handler to read `TriggerType` from the `DescribeFunctionRules` API response and set it in the Terraform state.
+- Update the resource documentation (`.md` file) to describe the new `trigger_type` parameter.
+
+## Capabilities
+
+### New Capabilities
+- `teo-function-rule-trigger-type`: Adds `trigger_type` parameter to the `tencentcloud_teo_function_rule` resource, enabling users to specify the function selection configuration type (direct, weight, or region).
+
+### Modified Capabilities
+
+## Impact
+
+- `tencentcloud/services/teo/resource_tc_teo_function_rule.go` - Schema definition and CRUD handlers
+- `tencentcloud/services/teo/resource_tc_teo_function_rule.md` - Resource documentation
+- `tencentcloud/services/teo/resource_tc_teo_function_rule_test.go` - Unit tests
+- Backward compatible: `trigger_type` is Optional with no ForceNew, existing configurations continue to work unchanged

--- a/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/specs/teo-function-rule-trigger-type/spec.md
+++ b/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/specs/teo-function-rule-trigger-type/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: trigger_type parameter in tencentcloud_teo_function_rule resource
+The `tencentcloud_teo_function_rule` resource SHALL include an optional `trigger_type` parameter of type string. Valid values SHALL be `direct`, `weight`, and `region`. When not specified, the API defaults to `direct`. The parameter SHALL NOT have ForceNew set, allowing it to be updated in-place.
+
+#### Scenario: Create function rule with trigger_type set to direct
+- **WHEN** a user creates a `tencentcloud_teo_function_rule` resource with `trigger_type = "direct"`
+- **THEN** the Create handler SHALL set `request.TriggerType` to `"direct"` in the `CreateFunctionRule` API call
+
+#### Scenario: Create function rule without trigger_type
+- **WHEN** a user creates a `tencentcloud_teo_function_rule` resource without specifying `trigger_type`
+- **THEN** the Create handler SHALL NOT set `request.TriggerType` in the API call, and the API SHALL default to `"direct"`
+
+#### Scenario: Read function rule with trigger_type
+- **WHEN** the Read handler calls `DescribeFunctionRules` and the response `FunctionRule.TriggerType` is not nil
+- **THEN** the handler SHALL set `trigger_type` in the Terraform state to the value of `respData.TriggerType`
+
+#### Scenario: Read function rule with nil TriggerType
+- **WHEN** the Read handler calls `DescribeFunctionRules` and the response `FunctionRule.TriggerType` is nil
+- **THEN** the handler SHALL NOT set `trigger_type` in the Terraform state
+
+#### Scenario: Update function rule trigger_type
+- **WHEN** a user updates the `trigger_type` parameter of an existing `tencentcloud_teo_function_rule` resource
+- **THEN** the Update handler SHALL detect the change via `d.HasChange("trigger_type")`, include `trigger_type` in the mutable arguments, and set `request.TriggerType` in the `ModifyFunctionRule` API call
+
+#### Scenario: trigger_type validation
+- **WHEN** a user provides an invalid value for `trigger_type` (e.g., "invalid")
+- **THEN** Terraform SHALL produce a validation error at plan time

--- a/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/tasks.md
+++ b/openspec/changes/archive/2025-07-14-add-teo-function-rule-trigger-type/tasks.md
@@ -1,0 +1,17 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `trigger_type` field to the `tencentcloud_teo_function_rule` resource schema in `tencentcloud/services/teo/resource_tc_teo_function_rule.go`: Type `schema.TypeString`, Optional, with `ValidateFunc: validation.StringInSlice([]string{"direct", "weight", "region"}, false)`, and Description documenting valid values and that it defaults to `direct`
+
+## 2. CRUD Handler Updates
+
+- [x] 2.1 Update `resourceTencentCloudTeoFunctionRuleCreate`: Read `trigger_type` from schema and set `request.TriggerType` if the value is specified
+- [x] 2.2 Update `resourceTencentCloudTeoFunctionRuleRead`: After calling `DescribeTeoFunctionRuleById`, check if `respData.TriggerType` is not nil and set `trigger_type` in state via `d.Set("trigger_type", respData.TriggerType)`
+- [x] 2.3 Update `resourceTencentCloudTeoFunctionRuleUpdate`: Add `"trigger_type"` to the `mutableArgs` list, and in the Modify request block, set `request.TriggerType` if the value is specified
+
+## 3. Documentation
+
+- [x] 3.1 Update `tencentcloud/services/teo/resource_tc_teo_function_rule.md` to add `trigger_type` parameter description and usage example
+
+## 4. Unit Tests
+
+- [x] 4.1 Add unit test cases in `tencentcloud/services/teo/resource_tc_teo_function_rule_test.go` to verify Create/Read/Update handlers correctly handle the `trigger_type` parameter, including: setting trigger_type in create request, reading trigger_type from response, and updating trigger_type in modify request

--- a/openspec/specs/teo-function-rule-trigger-type/spec.md
+++ b/openspec/specs/teo-function-rule-trigger-type/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: trigger_type parameter in tencentcloud_teo_function_rule resource
+The `tencentcloud_teo_function_rule` resource SHALL include an optional `trigger_type` parameter of type string. Valid values SHALL be `direct`, `weight`, and `region`. When not specified, the API defaults to `direct`. The parameter SHALL NOT have ForceNew set, allowing it to be updated in-place.
+
+#### Scenario: Create function rule with trigger_type set to direct
+- **WHEN** a user creates a `tencentcloud_teo_function_rule` resource with `trigger_type = "direct"`
+- **THEN** the Create handler SHALL set `request.TriggerType` to `"direct"` in the `CreateFunctionRule` API call
+
+#### Scenario: Create function rule without trigger_type
+- **WHEN** a user creates a `tencentcloud_teo_function_rule` resource without specifying `trigger_type`
+- **THEN** the Create handler SHALL NOT set `request.TriggerType` in the API call, and the API SHALL default to `"direct"`
+
+#### Scenario: Read function rule with trigger_type
+- **WHEN** the Read handler calls `DescribeFunctionRules` and the response `FunctionRule.TriggerType` is not nil
+- **THEN** the handler SHALL set `trigger_type` in the Terraform state to the value of `respData.TriggerType`
+
+#### Scenario: Read function rule with nil TriggerType
+- **WHEN** the Read handler calls `DescribeFunctionRules` and the response `FunctionRule.TriggerType` is nil
+- **THEN** the handler SHALL NOT set `trigger_type` in the Terraform state
+
+#### Scenario: Update function rule trigger_type
+- **WHEN** a user updates the `trigger_type` parameter of an existing `tencentcloud_teo_function_rule` resource
+- **THEN** the Update handler SHALL detect the change via `d.HasChange("trigger_type")`, include `trigger_type` in the mutable arguments, and set `request.TriggerType` in the `ModifyFunctionRule` API call
+
+#### Scenario: trigger_type validation
+- **WHEN** a user provides an invalid value for `trigger_type` (e.g., "invalid")
+- **THEN** Terraform SHALL produce a validation error at plan time

--- a/tencentcloud/services/teo/resource_tc_teo_function_rule.go
+++ b/tencentcloud/services/teo/resource_tc_teo_function_rule.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
 
@@ -50,6 +51,13 @@ func ResourceTencentCloudTeoFunctionRule() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Rule description, maximum support of 60 characters.",
+			},
+
+			"trigger_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"direct", "weight", "region"}, false),
+				Description:  "Function selection configuration type. Valid values: `direct`, `weight`, `region`. Defaults to `direct` when not specified.",
 			},
 
 			"function_name": {
@@ -181,6 +189,10 @@ func resourceTencentCloudTeoFunctionRuleCreate(d *schema.ResourceData, meta inte
 		request.Remark = helper.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("trigger_type"); ok {
+		request.TriggerType = helper.String(v.(string))
+	}
+
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().CreateFunctionRuleWithContext(ctx, request)
 		if e != nil {
@@ -257,6 +269,10 @@ func resourceTencentCloudTeoFunctionRuleRead(d *schema.ResourceData, meta interf
 		_ = d.Set("remark", respData.Remark)
 	}
 
+	if respData.TriggerType != nil {
+		_ = d.Set("trigger_type", respData.TriggerType)
+	}
+
 	if respData.Priority != nil {
 		_ = d.Set("priority", respData.Priority)
 	}
@@ -322,7 +338,7 @@ func resourceTencentCloudTeoFunctionRuleUpdate(d *schema.ResourceData, meta inte
 	ruleId := idSplit[2]
 
 	needChange := false
-	mutableArgs := []string{"function_rule_conditions", "remark"}
+	mutableArgs := []string{"function_rule_conditions", "remark", "trigger_type"}
 	for _, v := range mutableArgs {
 		if d.HasChange(v) {
 			needChange = true
@@ -375,6 +391,10 @@ func resourceTencentCloudTeoFunctionRuleUpdate(d *schema.ResourceData, meta inte
 
 		if v, ok := d.GetOk("remark"); ok {
 			request.Remark = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("trigger_type"); ok {
+			request.TriggerType = helper.String(v.(string))
 		}
 
 		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {

--- a/tencentcloud/services/teo/resource_tc_teo_function_rule.go
+++ b/tencentcloud/services/teo/resource_tc_teo_function_rule.go
@@ -56,6 +56,7 @@ func ResourceTencentCloudTeoFunctionRule() *schema.Resource {
 			"trigger_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"direct", "weight", "region"}, false),
 				Description:  "Function selection configuration type. Valid values: `direct`, `weight`, `region`. Defaults to `direct` when not specified.",
 			},

--- a/tencentcloud/services/teo/resource_tc_teo_function_rule.md
+++ b/tencentcloud/services/teo/resource_tc_teo_function_rule.md
@@ -3,49 +3,27 @@ Provides a resource to create a TEO function rule
 Example Usage
 
 ```hcl
-resource "tencentcloud_teo_function_rule" "teo_function_rule" {
-    function_id   = "ef-txx7fnua"
-    remark        = "aaa"
+resource "tencentcloud_teo_function_rule" "example" {
+    function_id   = "ef-m01xn26e"
+    remark        = "remark."
     trigger_type  = "direct"
-    zone_id       = "zone-2qtuhspy7cr6"
+    zone_id       = "zone-3fkff38fyw8s"
 
     function_rule_conditions {
         rule_conditions {
             ignore_case = false
-            name        = null
             operator    = "equal"
             target      = "host"
             values      = [
-                "aaa.makn.cn",
+                "test.makn.cn",
             ]
         }
         rule_conditions {
             ignore_case = false
-            name        = null
             operator    = "equal"
-            target      = "extension"
+            target      = "url"
             values      = [
-                ".txt",
-            ]
-        }
-    }
-    function_rule_conditions {
-        rule_conditions {
-            ignore_case = false
-            name        = null
-            operator    = "notequal"
-            target      = "host"
-            values      = [
-                "aaa.makn.cn",
-            ]
-        }
-        rule_conditions {
-            ignore_case = false
-            name        = null
-            operator    = "equal"
-            target      = "extension"
-            values      = [
-                ".png",
+                "/path",
             ]
         }
     }
@@ -54,8 +32,8 @@ resource "tencentcloud_teo_function_rule" "teo_function_rule" {
 
 Import
 
-teo teo_function_rule can be imported using the id, e.g.
+teo teo_function_rule can be imported using the zoneId#functionId#ruleId, e.g.
 
 ```
-terraform import tencentcloud_teo_function_rule.teo_function_rule zone_id#function_id#rule_id
+terraform import tencentcloud_teo_function_rule.example zone-3fkff38fyw8s#ef-m01xn26e#rule-yuvufj6h
 ```

--- a/tencentcloud/services/teo/resource_tc_teo_function_rule.md
+++ b/tencentcloud/services/teo/resource_tc_teo_function_rule.md
@@ -1,4 +1,4 @@
-Provides a resource to create a teo teo_function_rule
+Provides a resource to create a TEO function rule
 
 Example Usage
 
@@ -6,6 +6,7 @@ Example Usage
 resource "tencentcloud_teo_function_rule" "teo_function_rule" {
     function_id   = "ef-txx7fnua"
     remark        = "aaa"
+    trigger_type  = "direct"
     zone_id       = "zone-2qtuhspy7cr6"
 
     function_rule_conditions {

--- a/tencentcloud/services/teo/resource_tc_teo_function_rule_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_function_rule_test.go
@@ -1,11 +1,19 @@
 package teo_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	svcteo "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
 )
 
 func TestAccTencentCloudTeoFunctionRuleResource_basic(t *testing.T) {
@@ -188,3 +196,389 @@ resource "tencentcloud_teo_function_rule" "teo_function_rule" {
     }
 }
 `
+
+// ---- Unit Tests (gomonkey mock) ----
+
+// go test ./tencentcloud/services/teo/ -run "TestTeoFunctionRule_" -v -count=1 -gcflags="all=-l"
+
+// mockMetaFuncRule implements tccommon.ProviderMeta
+type mockMetaFuncRule struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaFuncRule) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaFuncRule{}
+
+func newMockMetaFuncRule() *mockMetaFuncRule {
+	return &mockMetaFuncRule{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringFuncRule(s string) *string {
+	return &s
+}
+
+func ptrInt64FuncRule(i int64) *int64 {
+	return &i
+}
+
+// TestTeoFunctionRule_Schema validates trigger_type schema definition
+func TestTeoFunctionRule_Schema(t *testing.T) {
+	res := svcteo.ResourceTencentCloudTeoFunctionRule()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "trigger_type")
+
+	triggerTypeField := res.Schema["trigger_type"]
+	assert.Equal(t, schema.TypeString, triggerTypeField.Type)
+	assert.True(t, triggerTypeField.Optional)
+	assert.False(t, triggerTypeField.Required)
+	assert.False(t, triggerTypeField.Computed)
+	assert.Nil(t, triggerTypeField.Default)
+	assert.NotNil(t, triggerTypeField.ValidateFunc)
+}
+
+// TestTeoFunctionRule_CreateWithTriggerType tests creating function rule with trigger_type set
+func TestTeoFunctionRule_CreateWithTriggerType(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaFuncRule().client, "UseTeoV20220901Client", teoClient)
+
+	// Mock CreateFunctionRuleWithContext to verify TriggerType is set in request
+	patches.ApplyMethodFunc(teoClient, "CreateFunctionRuleWithContext",
+		func(_ context.Context, request *teov20220901.CreateFunctionRuleRequest) (*teov20220901.CreateFunctionRuleResponse, error) {
+			// Verify TriggerType is set correctly
+			assert.NotNil(t, request.TriggerType)
+			assert.Equal(t, "direct", *request.TriggerType)
+
+			resp := teov20220901.NewCreateFunctionRuleResponse()
+			resp.Response = &teov20220901.CreateFunctionRuleResponseParams{
+				RuleId:    ptrStringFuncRule("rule-12345678"),
+				RequestId: ptrStringFuncRule("fake-request-id"),
+			}
+			return resp, nil
+		},
+	)
+
+	// Mock DescribeTeoFunctionRuleById for the Read call after Create
+	patches.ApplyMethodFunc(&svcteo.TeoService{}, "DescribeTeoFunctionRuleById",
+		func(_ context.Context, zoneId string, functionId string, ruleId string) (*teov20220901.FunctionRule, error) {
+			return &teov20220901.FunctionRule{
+				RuleId:       ptrStringFuncRule("rule-12345678"),
+				FunctionId:   ptrStringFuncRule("ef-testfunc1"),
+				FunctionName: ptrStringFuncRule("test-func"),
+				TriggerType:  ptrStringFuncRule("direct"),
+				Priority:     ptrInt64FuncRule(1),
+				Remark:       ptrStringFuncRule("test remark"),
+				FunctionRuleConditions: []*teov20220901.FunctionRuleCondition{
+					{
+						RuleConditions: []*teov20220901.RuleCondition{
+							{
+								Operator: ptrStringFuncRule("equal"),
+								Target:   ptrStringFuncRule("host"),
+								Values:   []*string{ptrStringFuncRule("example.com")},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	)
+
+	meta := newMockMetaFuncRule()
+	res := svcteo.ResourceTencentCloudTeoFunctionRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":      "zone-test1234",
+		"function_id":  "ef-testfunc1",
+		"remark":       "test remark",
+		"trigger_type": "direct",
+		"function_rule_conditions": []interface{}{
+			map[string]interface{}{
+				"rule_conditions": []interface{}{
+					map[string]interface{}{
+						"operator": "equal",
+						"target":   "host",
+						"values":   []interface{}{"example.com"},
+					},
+				},
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+
+	// Verify trigger_type is set in state
+	triggerType := d.Get("trigger_type").(string)
+	assert.Equal(t, "direct", triggerType)
+
+	// Verify composite ID
+	assert.Equal(t, "zone-test1234#ef-testfunc1#rule-12345678", d.Id())
+}
+
+// TestTeoFunctionRule_CreateWithoutTriggerType tests creating function rule without trigger_type
+func TestTeoFunctionRule_CreateWithoutTriggerType(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaFuncRule().client, "UseTeoV20220901Client", teoClient)
+
+	// Mock CreateFunctionRuleWithContext
+	patches.ApplyMethodFunc(teoClient, "CreateFunctionRuleWithContext",
+		func(_ context.Context, request *teov20220901.CreateFunctionRuleRequest) (*teov20220901.CreateFunctionRuleResponse, error) {
+			// When trigger_type is not set, TriggerType should be nil in request
+			assert.Nil(t, request.TriggerType)
+
+			resp := teov20220901.NewCreateFunctionRuleResponse()
+			resp.Response = &teov20220901.CreateFunctionRuleResponseParams{
+				RuleId:    ptrStringFuncRule("rule-87654321"),
+				RequestId: ptrStringFuncRule("fake-request-id"),
+			}
+			return resp, nil
+		},
+	)
+
+	// Mock DescribeTeoFunctionRuleById for the Read call
+	patches.ApplyMethodFunc(&svcteo.TeoService{}, "DescribeTeoFunctionRuleById",
+		func(_ context.Context, zoneId string, functionId string, ruleId string) (*teov20220901.FunctionRule, error) {
+			return &teov20220901.FunctionRule{
+				RuleId:       ptrStringFuncRule("rule-87654321"),
+				FunctionId:   ptrStringFuncRule("ef-testfunc2"),
+				FunctionName: ptrStringFuncRule("test-func-2"),
+				TriggerType:  ptrStringFuncRule("direct"),
+				Priority:     ptrInt64FuncRule(1),
+				FunctionRuleConditions: []*teov20220901.FunctionRuleCondition{
+					{
+						RuleConditions: []*teov20220901.RuleCondition{
+							{
+								Operator: ptrStringFuncRule("equal"),
+								Target:   ptrStringFuncRule("host"),
+								Values:   []*string{ptrStringFuncRule("example.com")},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	)
+
+	meta := newMockMetaFuncRule()
+	res := svcteo.ResourceTencentCloudTeoFunctionRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":     "zone-test1234",
+		"function_id": "ef-testfunc2",
+		"function_rule_conditions": []interface{}{
+			map[string]interface{}{
+				"rule_conditions": []interface{}{
+					map[string]interface{}{
+						"operator": "equal",
+						"target":   "host",
+						"values":   []interface{}{"example.com"},
+					},
+				},
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "zone-test1234#ef-testfunc2#rule-87654321", d.Id())
+}
+
+// TestTeoFunctionRule_ReadWithTriggerType tests reading trigger_type from API response
+func TestTeoFunctionRule_ReadWithTriggerType(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Mock DescribeTeoFunctionRuleById to return a rule with TriggerType
+	patches.ApplyMethodFunc(&svcteo.TeoService{}, "DescribeTeoFunctionRuleById",
+		func(_ context.Context, zoneId string, functionId string, ruleId string) (*teov20220901.FunctionRule, error) {
+			assert.Equal(t, "zone-test1234", zoneId)
+			assert.Equal(t, "ef-testfunc1", functionId)
+			assert.Equal(t, "rule-12345678", ruleId)
+			return &teov20220901.FunctionRule{
+				RuleId:       ptrStringFuncRule("rule-12345678"),
+				FunctionId:   ptrStringFuncRule("ef-testfunc1"),
+				FunctionName: ptrStringFuncRule("test-func"),
+				TriggerType:  ptrStringFuncRule("weight"),
+				Priority:     ptrInt64FuncRule(5),
+				Remark:       ptrStringFuncRule("test remark"),
+				FunctionRuleConditions: []*teov20220901.FunctionRuleCondition{
+					{
+						RuleConditions: []*teov20220901.RuleCondition{
+							{
+								Operator: ptrStringFuncRule("equal"),
+								Target:   ptrStringFuncRule("host"),
+								Values:   []*string{ptrStringFuncRule("example.com")},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	)
+
+	meta := newMockMetaFuncRule()
+	res := svcteo.ResourceTencentCloudTeoFunctionRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":     "zone-test1234",
+		"function_id": "ef-testfunc1",
+		"function_rule_conditions": []interface{}{
+			map[string]interface{}{
+				"rule_conditions": []interface{}{
+					map[string]interface{}{
+						"operator": "equal",
+						"target":   "host",
+						"values":   []interface{}{"example.com"},
+					},
+				},
+			},
+		},
+	})
+	d.SetId("zone-test1234#ef-testfunc1#rule-12345678")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// Verify trigger_type is read correctly
+	triggerType := d.Get("trigger_type").(string)
+	assert.Equal(t, "weight", triggerType)
+}
+
+// TestTeoFunctionRule_ReadTriggerTypeNil tests reading when API returns nil TriggerType
+func TestTeoFunctionRule_ReadTriggerTypeNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Mock DescribeTeoFunctionRuleById to return a rule without TriggerType
+	patches.ApplyMethodFunc(&svcteo.TeoService{}, "DescribeTeoFunctionRuleById",
+		func(_ context.Context, zoneId string, functionId string, ruleId string) (*teov20220901.FunctionRule, error) {
+			return &teov20220901.FunctionRule{
+				RuleId:       ptrStringFuncRule("rule-12345678"),
+				FunctionId:   ptrStringFuncRule("ef-testfunc1"),
+				FunctionName: ptrStringFuncRule("test-func"),
+				TriggerType:  nil,
+				Priority:     ptrInt64FuncRule(5),
+				FunctionRuleConditions: []*teov20220901.FunctionRuleCondition{
+					{
+						RuleConditions: []*teov20220901.RuleCondition{
+							{
+								Operator: ptrStringFuncRule("equal"),
+								Target:   ptrStringFuncRule("host"),
+								Values:   []*string{ptrStringFuncRule("example.com")},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	)
+
+	meta := newMockMetaFuncRule()
+	res := svcteo.ResourceTencentCloudTeoFunctionRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":     "zone-test1234",
+		"function_id": "ef-testfunc1",
+		"function_rule_conditions": []interface{}{
+			map[string]interface{}{
+				"rule_conditions": []interface{}{
+					map[string]interface{}{
+						"operator": "equal",
+						"target":   "host",
+						"values":   []interface{}{"example.com"},
+					},
+				},
+			},
+		},
+	})
+	d.SetId("zone-test1234#ef-testfunc1#rule-12345678")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// When TriggerType is nil in response, trigger_type should remain empty
+	triggerType := d.Get("trigger_type").(string)
+	assert.Equal(t, "", triggerType)
+}
+
+// TestTeoFunctionRule_UpdateTriggerType tests updating trigger_type
+func TestTeoFunctionRule_UpdateTriggerType(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaFuncRule().client, "UseTeoV20220901Client", teoClient)
+
+	// Mock ModifyFunctionRuleWithContext to verify TriggerType is set in request
+	patches.ApplyMethodFunc(teoClient, "ModifyFunctionRuleWithContext",
+		func(_ context.Context, request *teov20220901.ModifyFunctionRuleRequest) (*teov20220901.ModifyFunctionRuleResponse, error) {
+			// Verify TriggerType is set correctly
+			assert.NotNil(t, request.TriggerType)
+			assert.Equal(t, "region", *request.TriggerType)
+
+			resp := teov20220901.NewModifyFunctionRuleResponse()
+			resp.Response = &teov20220901.ModifyFunctionRuleResponseParams{
+				RequestId: ptrStringFuncRule("fake-request-id"),
+			}
+			return resp, nil
+		},
+	)
+
+	// Mock DescribeTeoFunctionRuleById for the Read call after Update
+	patches.ApplyMethodFunc(&svcteo.TeoService{}, "DescribeTeoFunctionRuleById",
+		func(_ context.Context, zoneId string, functionId string, ruleId string) (*teov20220901.FunctionRule, error) {
+			return &teov20220901.FunctionRule{
+				RuleId:       ptrStringFuncRule("rule-12345678"),
+				FunctionId:   ptrStringFuncRule("ef-testfunc1"),
+				FunctionName: ptrStringFuncRule("test-func"),
+				TriggerType:  ptrStringFuncRule("region"),
+				Priority:     ptrInt64FuncRule(5),
+				Remark:       ptrStringFuncRule("test remark"),
+				FunctionRuleConditions: []*teov20220901.FunctionRuleCondition{
+					{
+						RuleConditions: []*teov20220901.RuleCondition{
+							{
+								Operator: ptrStringFuncRule("equal"),
+								Target:   ptrStringFuncRule("host"),
+								Values:   []*string{ptrStringFuncRule("example.com")},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	)
+
+	meta := newMockMetaFuncRule()
+	res := svcteo.ResourceTencentCloudTeoFunctionRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":      "zone-test1234",
+		"function_id":  "ef-testfunc1",
+		"trigger_type": "region",
+		"remark":       "test remark",
+		"function_rule_conditions": []interface{}{
+			map[string]interface{}{
+				"rule_conditions": []interface{}{
+					map[string]interface{}{
+						"operator": "equal",
+						"target":   "host",
+						"values":   []interface{}{"example.com"},
+					},
+				},
+			},
+		},
+	})
+	d.SetId("zone-test1234#ef-testfunc1#rule-12345678")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	// Verify trigger_type is updated correctly
+	triggerType := d.Get("trigger_type").(string)
+	assert.Equal(t, "region", triggerType)
+}

--- a/website/docs/r/teo_function_rule.html.markdown
+++ b/website/docs/r/teo_function_rule.html.markdown
@@ -14,49 +14,27 @@ Provides a resource to create a TEO function rule
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_teo_function_rule" "teo_function_rule" {
-  function_id  = "ef-txx7fnua"
-  remark       = "aaa"
+resource "tencentcloud_teo_function_rule" "example" {
+  function_id  = "ef-m01xn26e"
+  remark       = "remark."
   trigger_type = "direct"
-  zone_id      = "zone-2qtuhspy7cr6"
+  zone_id      = "zone-3fkff38fyw8s"
 
   function_rule_conditions {
     rule_conditions {
       ignore_case = false
-      name        = null
       operator    = "equal"
       target      = "host"
       values = [
-        "aaa.makn.cn",
+        "test.makn.cn",
       ]
     }
     rule_conditions {
       ignore_case = false
-      name        = null
       operator    = "equal"
-      target      = "extension"
+      target      = "url"
       values = [
-        ".txt",
-      ]
-    }
-  }
-  function_rule_conditions {
-    rule_conditions {
-      ignore_case = false
-      name        = null
-      operator    = "notequal"
-      target      = "host"
-      values = [
-        "aaa.makn.cn",
-      ]
-    }
-    rule_conditions {
-      ignore_case = false
-      name        = null
-      operator    = "equal"
-      target      = "extension"
-      values = [
-        ".png",
+        "/path",
       ]
     }
   }
@@ -120,9 +98,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-teo teo_function_rule can be imported using the id, e.g.
+teo teo_function_rule can be imported using the zoneId#functionId#ruleId, e.g.
 
 ```
-terraform import tencentcloud_teo_function_rule.teo_function_rule zone_id#function_id#rule_id
+terraform import tencentcloud_teo_function_rule.example zone-3fkff38fyw8s#ef-m01xn26e#rule-yuvufj6h
 ```
 

--- a/website/docs/r/teo_function_rule.html.markdown
+++ b/website/docs/r/teo_function_rule.html.markdown
@@ -4,20 +4,21 @@ layout: "tencentcloud"
 page_title: "TencentCloud: tencentcloud_teo_function_rule"
 sidebar_current: "docs-tencentcloud-resource-teo_function_rule"
 description: |-
-  Provides a resource to create a teo teo_function_rule
+  Provides a resource to create a TEO function rule
 ---
 
 # tencentcloud_teo_function_rule
 
-Provides a resource to create a teo teo_function_rule
+Provides a resource to create a TEO function rule
 
 ## Example Usage
 
 ```hcl
 resource "tencentcloud_teo_function_rule" "teo_function_rule" {
-  function_id = "ef-txx7fnua"
-  remark      = "aaa"
-  zone_id     = "zone-2qtuhspy7cr6"
+  function_id  = "ef-txx7fnua"
+  remark       = "aaa"
+  trigger_type = "direct"
+  zone_id      = "zone-2qtuhspy7cr6"
 
   function_rule_conditions {
     rule_conditions {
@@ -70,6 +71,7 @@ The following arguments are supported:
 * `function_rule_conditions` - (Required, List) The list of rule conditions, where the conditions are connected by an "OR" relationship.
 * `zone_id` - (Required, String, ForceNew) ID of the site.
 * `remark` - (Optional, String) Rule description, maximum support of 60 characters.
+* `trigger_type` - (Optional, String) Function selection configuration type. Valid values: `direct`, `weight`, `region`. Defaults to `direct` when not specified.
 
 The `function_rule_conditions` object supports the following:
 


### PR DESCRIPTION
Add trigger_type parameter to tencentcloud_teo_function_rule resource. This parameter supports function selection configuration type with valid values: direct, weight, region. Defaults to direct when not specified.