### PR TITLE
feat(teo): add data source tencentcloud_teo_security_ip_group_content

### DIFF
--- a/.changelog/4086.txt
+++ b/.changelog/4086.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_teo_security_ip_group_content
+```

--- a/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/design.md
+++ b/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/design.md
@@ -1,0 +1,37 @@
+## Context
+
+当前 Terraform Provider for TencentCloud 中，TEO（EdgeOne）产品缺少查询安全 IP 组中 IP 列表的数据源。用户需要通过 `DescribeSecurityIPGroupContent` 接口分页查询 IP 组中的 IP 或网段列表及总数，以便在 Terraform 配置中引用这些数据。
+
+该接口为同步接口，支持分页查询，入参包括 `ZoneId`（站点 ID）和 `GroupId`（IP 组 ID），出参包括 `IPTotalCount`（IP 总数）和 `IPList`（IP 列表）。
+
+现有 TEO 数据源文件位于 `tencentcloud/services/teo/` 目录下，遵循 `data_source_tc_teo_<name>.go` 命名规范。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 新增 `tencentcloud_teo_security_ip_group_content` 数据源，封装 `DescribeSecurityIPGroupContent` API
+- 支持按 `zone_id` 和 `group_id` 查询指定 IP 组中的 IP 列表
+- 内部自动分页获取所有 IP 数据，不暴露 limit/offset 参数给用户
+- 在 provider 中注册该数据源
+- 提供单元测试（使用 gomonkey mock）和文档
+
+**Non-Goals:**
+- 不支持创建、更新或删除安全 IP 组（这些由其他资源/接口负责）
+- 不暴露分页参数 limit/offset 给 Terraform 用户
+- 不修改已有的安全 IP 组相关资源
+
+## Decisions
+
+1. **数据源文件命名**: `data_source_tc_teo_security_ip_group_content.go`，遵循现有命名规范
+2. **分页策略**: 接口 `DescribeSecurityIPGroupContent` 支持分页，Limit 最大值为 100000。数据源内部自动分页获取所有 IP 数据，不暴露 limit/offset 给用户。使用 Limit=100000（API 注释中的最大值）一次性获取所有数据，若数据量超过单次限制则自动翻页。
+3. **ID 生成**: 由于该数据源为查询类数据源，使用 `helper.BuildToken()` 生成数据源 ID，与同类数据源保持一致。
+4. **GroupId 类型**: 云 API 中 `GroupId` 为 `int64` 类型，在 Terraform Schema 中使用 `TypeInt` 对应。
+5. **IPList 类型**: 云 API 返回的 `IPList` 为 `[]*string` 类型，在 Terraform Schema 中使用 `TypeList` + `TypeString` 元素。
+6. **IPTotalCount 类型**: 云 API 返回的 `IPTotalCount` 为 `int64` 类型，在 Terraform Schema 中使用 `TypeInt`。
+7. **Retry 逻辑**: 使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包装 API 调用，失败时使用 `tccommon.RetryError()` 包装错误。
+8. **代码风格**: 参考 `tencentcloud_teo_default_certificate` 数据源的分页模式和 `tencentcloud_igtm_instance_list` 数据源的业务逻辑模式。
+
+## Risks / Trade-offs
+
+- [IP 组数据量可能很大] → 使用分页查询确保能获取所有数据，Limit 设为 API 支持的最大值 100000
+- [API 变更风险] → 仅使用已验证存在的 `DescribeSecurityIPGroupContent` 接口，参数映射已通过 vendor 目录验证

--- a/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+当前 Terraform Provider 中缺少查询 TEO 安全 IP 组中 IP 列表的数据源。用户需要通过 `DescribeSecurityIPGroupContent` 接口分页查询 IP 组中的 IP 或网段列表及总数，以便在 Terraform 配置中引用这些数据。
+
+## What Changes
+
+- 新增数据源 `tencentcloud_teo_security_ip_group_content`，封装 `DescribeSecurityIPGroupContent` API
+- 支持按 `zone_id` 和 `group_id` 查询指定 IP 组中的 IP 列表
+- 内部自动分页，获取所有 IP 数据
+- 在 `provider.go` 和 `provider.md` 中注册该数据源
+
+## Capabilities
+
+### New Capabilities
+- `teo-security-ip-group-content-datasource`: 提供查询 TEO 安全 IP 组内容的数据源能力，支持按站点 ID 和 IP 组 ID 查询 IP 列表及总数
+
+### Modified Capabilities
+<!-- 无需修改现有能力 -->
+
+## Impact
+
+- 新增文件: `tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.go`
+- 新增文件: `tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content_test.go`
+- 新增文件: `tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.md`
+- 修改文件: `tencentcloud/provider.go`（注册数据源）
+- 修改文件: `tencentcloud/provider.md`（添加数据源文档条目）
+- 依赖: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`

--- a/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/specs/teo-security-ip-group-content-datasource/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/specs/teo-security-ip-group-content-datasource/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Data source for querying TEO security IP group content
+The system SHALL provide a Terraform data source `tencentcloud_teo_security_ip_group_content` that queries the IP list within a specified security IP group using the `DescribeSecurityIPGroupContent` API.
+
+#### Scenario: Query security IP group content with required parameters
+- **WHEN** user provides `zone_id` and `group_id` as required parameters
+- **THEN** the data source SHALL call `DescribeSecurityIPGroupContent` with the provided parameters and return `ip_total_count` and `ip_list`
+
+#### Scenario: Automatic pagination for IP list
+- **WHEN** the IP group contains more IPs than can be returned in a single API call
+- **THEN** the data source SHALL automatically paginate through all results by incrementing the offset until all IPs are retrieved
+
+#### Scenario: Set computed fields from API response
+- **WHEN** the API returns a successful response
+- **THEN** the data source SHALL set `ip_total_count` (TypeInt) from `response.Response.IPTotalCount` and `ip_list` (TypeList of TypeString) from `response.Response.IPList`, only if the response fields are not nil
+
+#### Scenario: Generate data source ID
+- **WHEN** the data source read completes successfully
+- **THEN** the data source SHALL use `helper.BuildToken()` to generate the data source ID
+
+### Requirement: Data source schema definition
+The system SHALL define the following schema for `tencentcloud_teo_security_ip_group_content`:
+- `zone_id` (TypeString, Required): Zone ID for the TEO site
+- `group_id` (TypeInt, Required): IP group ID
+- `ip_total_count` (TypeInt, Computed): Total count of IPs in the group
+- `ip_list` (TypeList of TypeString, Computed): List of IPs or CIDR blocks in the group
+- `result_output_file` (TypeString, Optional): Used to save results
+
+#### Scenario: Schema fields match API parameters
+- **WHEN** the data source schema is defined
+- **THEN** `zone_id` SHALL map to API request parameter `ZoneId`, `group_id` SHALL map to API request parameter `GroupId`, `ip_total_count` SHALL map to API response field `IPTotalCount`, and `ip_list` SHALL map to API response field `IPList`
+
+### Requirement: Error handling and retry
+The system SHALL wrap the API call with `resource.Retry(tccommon.ReadRetryTimeout, ...)` and use `tccommon.RetryError()` for error handling.
+
+#### Scenario: API call fails with retryable error
+- **WHEN** the `DescribeSecurityIPGroupContent` API call fails
+- **THEN** the error SHALL be wrapped with `tccommon.RetryError()` and retried up to `tccommon.ReadRetryTimeout`
+
+### Requirement: Provider registration
+The system SHALL register the data source `tencentcloud_teo_security_ip_group_content` in `provider.go` and `provider.md`.
+
+#### Scenario: Data source is available in Terraform
+- **WHEN** the provider is initialized
+- **THEN** the data source `tencentcloud_teo_security_ip_group_content` SHALL be available for use in Terraform configurations
+
+### Requirement: Unit tests with gomonkey mock
+The system SHALL provide unit tests using gomonkey mock for the data source, testing the Read operation without calling real cloud APIs.
+
+#### Scenario: Unit test covers Read operation
+- **WHEN** unit tests are executed with `go test -gcflags=all=-l`
+- **THEN** the tests SHALL mock the `DescribeSecurityIPGroupContent` API call and verify the data source correctly processes the response

--- a/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-teo-security-ip-group-content-datasource/tasks.md
@@ -1,0 +1,18 @@
+## 1. 数据源代码实现
+
+- [x] 1.1 创建 `tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.go`，定义 `DataSourceTencentCloudTeoSecurityIPGroupContent` 数据源 Schema（zone_id Required TypeString, group_id Required TypeInt, ip_total_count Computed TypeInt, ip_list Computed TypeList of TypeString, result_output_file Optional TypeString）
+- [x] 1.2 实现 `dataSourceTencentCloudTeoSecurityIPGroupContentRead` 函数，调用 `DescribeSecurityIPGroupContent` API，内部自动分页获取所有 IP 数据，使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包装 API 调用，对 response 字段做 nil 判断后再 Set，使用 `helper.BuildToken()` 生成数据源 ID
+
+## 2. Provider 注册
+
+- [x] 2.1 在 `tencentcloud/provider.go` 中注册 `tencentcloud_teo_security_ip_group_content` 数据源
+- [x] 2.2 在 `tencentcloud/provider.md` 中添加 `tencentcloud_teo_security_ip_group_content` 数据源条目
+
+## 3. 数据源文档
+
+- [x] 3.1 创建 `tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.md`，包含一句话描述（Use this data source to query ...）、Example Usage 部分
+
+## 4. 单元测试
+
+- [x] 4.1 创建 `tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content_test.go`，使用 gomonkey mock `DescribeSecurityIPGroupContent` API 调用，测试 Read 操作的正常场景
+- [x] 4.2 使用 `go test -gcflags=all=-l` 运行单元测试并确保通过

--- a/openspec/specs/teo-security-ip-group-content-datasource/spec.md
+++ b/openspec/specs/teo-security-ip-group-content-datasource/spec.md
@@ -1,0 +1,53 @@
+## Requirements
+
+### Requirement: Data source for querying TEO security IP group content
+The system SHALL provide a Terraform data source `tencentcloud_teo_security_ip_group_content` that queries the IP list within a specified security IP group using the `DescribeSecurityIPGroupContent` API.
+
+#### Scenario: Query security IP group content with required parameters
+- **WHEN** user provides `zone_id` and `group_id` as required parameters
+- **THEN** the data source SHALL call `DescribeSecurityIPGroupContent` with the provided parameters and return `ip_total_count` and `ip_list`
+
+#### Scenario: Automatic pagination for IP list
+- **WHEN** the IP group contains more IPs than can be returned in a single API call
+- **THEN** the data source SHALL automatically paginate through all results by incrementing the offset until all IPs are retrieved
+
+#### Scenario: Set computed fields from API response
+- **WHEN** the API returns a successful response
+- **THEN** the data source SHALL set `ip_total_count` (TypeInt) from `response.Response.IPTotalCount` and `ip_list` (TypeList of TypeString) from `response.Response.IPList`, only if the response fields are not nil
+
+#### Scenario: Generate data source ID
+- **WHEN** the data source read completes successfully
+- **THEN** the data source SHALL use `helper.BuildToken()` to generate the data source ID
+
+### Requirement: Data source schema definition
+The system SHALL define the following schema for `tencentcloud_teo_security_ip_group_content`:
+- `zone_id` (TypeString, Required): Zone ID for the TEO site
+- `group_id` (TypeInt, Required): IP group ID
+- `ip_total_count` (TypeInt, Computed): Total count of IPs in the group
+- `ip_list` (TypeList of TypeString, Computed): List of IPs or CIDR blocks in the group
+- `result_output_file` (TypeString, Optional): Used to save results
+
+#### Scenario: Schema fields match API parameters
+- **WHEN** the data source schema is defined
+- **THEN** `zone_id` SHALL map to API request parameter `ZoneId`, `group_id` SHALL map to API request parameter `GroupId`, `ip_total_count` SHALL map to API response field `IPTotalCount`, and `ip_list` SHALL map to API response field `IPList`
+
+### Requirement: Error handling and retry
+The system SHALL wrap the API call with `resource.Retry(tccommon.ReadRetryTimeout, ...)` and use `tccommon.RetryError()` for error handling.
+
+#### Scenario: API call fails with retryable error
+- **WHEN** the `DescribeSecurityIPGroupContent` API call fails
+- **THEN** the error SHALL be wrapped with `tccommon.RetryError()` and retried up to `tccommon.ReadRetryTimeout`
+
+### Requirement: Provider registration
+The system SHALL register the data source `tencentcloud_teo_security_ip_group_content` in `provider.go` and `provider.md`.
+
+#### Scenario: Data source is available in Terraform
+- **WHEN** the provider is initialized
+- **THEN** the data source `tencentcloud_teo_security_ip_group_content` SHALL be available for use in Terraform configurations
+
+### Requirement: Unit tests with gomonkey mock
+The system SHALL provide unit tests using gomonkey mock for the data source, testing the Read operation without calling real cloud APIs.
+
+#### Scenario: Unit test covers Read operation
+- **WHEN** unit tests are executed with `go test -gcflags=all=-l`
+- **THEN** the tests SHALL mock the `DescribeSecurityIPGroupContent` API call and verify the data source correctly processes the response

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -958,6 +958,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_teo_deploy_config_version_history":                     teo.DataSourceTencentCloudTeoDeployConfigVersionHistory(),
 			"tencentcloud_teo_export_zone_config":                                teo.DataSourceTencentCloudTeoExportZoneConfig(),
 			"tencentcloud_teo_ip_region":                                         teo.DataSourceTencentCloudTeoIPRegion(),
+			"tencentcloud_teo_security_ip_group_content":                         teo.DataSourceTencentCloudTeoSecurityIPGroupContent(),
 			"tencentcloud_sts_caller_identity":                                   sts.DataSourceTencentCloudStsCallerIdentity(),
 			"tencentcloud_dcdb_instances":                                        dcdb.DataSourceTencentCloudDcdbInstances(),
 			"tencentcloud_dcdb_accounts":                                         dcdb.DataSourceTencentCloudDcdbAccounts(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1548,6 +1548,7 @@ tencentcloud_teo_config_group_version_detail
 tencentcloud_teo_deploy_config_version_history
 tencentcloud_teo_export_zone_config
 tencentcloud_teo_ip_region
+tencentcloud_teo_security_ip_group_content
 
 Resource
 tencentcloud_teo_zone

--- a/tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.go
+++ b/tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.go
@@ -1,0 +1,130 @@
+package teo
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	teo "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/ratelimit"
+)
+
+func DataSourceTencentCloudTeoSecurityIPGroupContent() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudTeoSecurityIPGroupContentRead,
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Site ID.",
+			},
+
+			"group_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "IP group ID.",
+			},
+
+			"ip_total_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Total count of IPs or CIDR blocks in the IP group.",
+			},
+
+			"ip_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of IPs or CIDR blocks in the IP group.",
+			},
+
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudTeoSecurityIPGroupContentRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_teo_security_ip_group_content.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+	client := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoClient()
+
+	request := teo.NewDescribeSecurityIPGroupContentRequest()
+
+	if v, ok := d.GetOk("zone_id"); ok {
+		request.ZoneId = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOkExists("group_id"); ok {
+		request.GroupId = helper.IntInt64(v.(int))
+	}
+
+	var ipList []*string
+	var ipTotalCount int64
+	var offset int64 = 0
+	var limit int64 = 100000
+
+	for {
+		request.Offset = &offset
+		request.Limit = &limit
+		ratelimit.Check(request.GetAction())
+
+		var response *teo.DescribeSecurityIPGroupContentResponse
+		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			resp, e := client.DescribeSecurityIPGroupContent(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			}
+			response = resp
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+		if response == nil || response.Response == nil {
+			break
+		}
+
+		if response.Response.IPTotalCount != nil {
+			ipTotalCount = *response.Response.IPTotalCount
+		}
+
+		if response.Response.IPList != nil {
+			ipList = append(ipList, response.Response.IPList...)
+		}
+
+		if len(response.Response.IPList) < int(limit) {
+			break
+		}
+		offset += limit
+	}
+
+	if ipTotalCount > 0 {
+		_ = d.Set("ip_total_count", ipTotalCount)
+	}
+
+	if ipList != nil {
+		_ = d.Set("ip_list", ipList)
+	}
+
+	d.SetId(helper.BuildToken())
+
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), d); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.md
+++ b/tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.md
@@ -4,7 +4,7 @@ Example Usage
 
 ```hcl
 data "tencentcloud_teo_security_ip_group_content" "example" {
-  zone_id  = "zone-2qtuhspy7cr6"
-  group_id = 123
+  zone_id  = "zone-3fkff38fyw8s"
+  group_id = 33711
 }
 ```

--- a/tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.md
+++ b/tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content.md
@@ -1,0 +1,10 @@
+Use this data source to query the IP list within a specified TEO security IP group.
+
+Example Usage
+
+```hcl
+data "tencentcloud_teo_security_ip_group_content" "example" {
+  zone_id  = "zone-2qtuhspy7cr6"
+  group_id = 123
+}
+```

--- a/tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content_test.go
+++ b/tencentcloud/services/teo/data_source_tc_teo_security_ip_group_content_test.go
@@ -1,0 +1,127 @@
+package teo_test
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+)
+
+// go test ./tencentcloud/services/teo/ -run "TestTeoSecurityIPGroupContentDataSource" -v -count=1 -gcflags="all=-l"
+
+// TestTeoSecurityIPGroupContentDataSource_ReadSuccess tests successful read with IP group content data
+func TestTeoSecurityIPGroupContentDataSource_ReadSuccess(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(&connectivity.TencentCloudClient{}, "UseTeoClient", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityIPGroupContent", func(request *teov20220901.DescribeSecurityIPGroupContentRequest) (*teov20220901.DescribeSecurityIPGroupContentResponse, error) {
+		resp := teov20220901.NewDescribeSecurityIPGroupContentResponse()
+		resp.Response = &teov20220901.DescribeSecurityIPGroupContentResponseParams{
+			IPTotalCount: ptrInt64(3),
+			IPList: []*string{
+				ptrString("1.2.3.4"),
+				ptrString("5.6.7.0/24"),
+				ptrString("10.0.0.1"),
+			},
+			RequestId: ptrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMeta()
+	res := teo.DataSourceTencentCloudTeoSecurityIPGroupContent()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-2qtuhspy7cr6",
+		"group_id": 123,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	ipTotalCount := d.Get("ip_total_count").(int)
+	assert.Equal(t, 3, ipTotalCount)
+
+	ipList := d.Get("ip_list").([]interface{})
+	assert.Len(t, ipList, 3)
+	assert.Equal(t, "1.2.3.4", ipList[0].(string))
+	assert.Equal(t, "5.6.7.0/24", ipList[1].(string))
+	assert.Equal(t, "10.0.0.1", ipList[2].(string))
+}
+
+// TestTeoSecurityIPGroupContentDataSource_ReadEmpty tests read with no IP data
+func TestTeoSecurityIPGroupContentDataSource_ReadEmpty(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(&connectivity.TencentCloudClient{}, "UseTeoClient", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityIPGroupContent", func(request *teov20220901.DescribeSecurityIPGroupContentRequest) (*teov20220901.DescribeSecurityIPGroupContentResponse, error) {
+		resp := teov20220901.NewDescribeSecurityIPGroupContentResponse()
+		resp.Response = &teov20220901.DescribeSecurityIPGroupContentResponseParams{
+			IPTotalCount: ptrInt64(0),
+			IPList:       []*string{},
+			RequestId:    ptrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMeta()
+	res := teo.DataSourceTencentCloudTeoSecurityIPGroupContent()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-empty",
+		"group_id": 456,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+}
+
+// TestTeoSecurityIPGroupContentDataSource_Schema validates schema definition
+func TestTeoSecurityIPGroupContentDataSource_Schema(t *testing.T) {
+	res := teo.DataSourceTencentCloudTeoSecurityIPGroupContent()
+
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Read)
+
+	assert.Contains(t, res.Schema, "zone_id")
+	assert.Contains(t, res.Schema, "group_id")
+	assert.Contains(t, res.Schema, "ip_total_count")
+	assert.Contains(t, res.Schema, "ip_list")
+	assert.Contains(t, res.Schema, "result_output_file")
+
+	// zone_id is Required TypeString
+	zoneId := res.Schema["zone_id"]
+	assert.Equal(t, schema.TypeString, zoneId.Type)
+	assert.True(t, zoneId.Required)
+
+	// group_id is Required TypeInt
+	groupId := res.Schema["group_id"]
+	assert.Equal(t, schema.TypeInt, groupId.Type)
+	assert.True(t, groupId.Required)
+
+	// ip_total_count is Computed TypeInt
+	ipTotalCount := res.Schema["ip_total_count"]
+	assert.Equal(t, schema.TypeInt, ipTotalCount.Type)
+	assert.True(t, ipTotalCount.Computed)
+
+	// ip_list is Computed TypeList of TypeString
+	ipList := res.Schema["ip_list"]
+	assert.Equal(t, schema.TypeList, ipList.Type)
+	assert.True(t, ipList.Computed)
+
+	// result_output_file is Optional TypeString
+	outputFile := res.Schema["result_output_file"]
+	assert.Equal(t, schema.TypeString, outputFile.Type)
+	assert.True(t, outputFile.Optional)
+}

--- a/website/docs/d/teo_security_ip_group_content.html.markdown
+++ b/website/docs/d/teo_security_ip_group_content.html.markdown
@@ -15,8 +15,8 @@ Use this data source to query the IP list within a specified TEO security IP gro
 
 ```hcl
 data "tencentcloud_teo_security_ip_group_content" "example" {
-  zone_id  = "zone-2qtuhspy7cr6"
-  group_id = 123
+  zone_id  = "zone-3fkff38fyw8s"
+  group_id = 33711
 }
 ```
 

--- a/website/docs/d/teo_security_ip_group_content.html.markdown
+++ b/website/docs/d/teo_security_ip_group_content.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "TencentCloud EdgeOne(TEO)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_teo_security_ip_group_content"
+sidebar_current: "docs-tencentcloud-datasource-teo_security_ip_group_content"
+description: |-
+  Use this data source to query the IP list within a specified TEO security IP group.
+---
+
+# tencentcloud_teo_security_ip_group_content
+
+Use this data source to query the IP list within a specified TEO security IP group.
+
+## Example Usage
+
+```hcl
+data "tencentcloud_teo_security_ip_group_content" "example" {
+  zone_id  = "zone-2qtuhspy7cr6"
+  group_id = 123
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_id` - (Required, Int) IP group ID.
+* `zone_id` - (Required, String) Site ID.
+* `result_output_file` - (Optional, String) Used to save results.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `ip_list` - List of IPs or CIDR blocks in the IP group.
+* `ip_total_count` - Total count of IPs or CIDR blocks in the IP group.
+
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -5845,6 +5845,9 @@
                                     <a href="/docs/providers/tencentcloud/d/teo_rule_engine_settings.html">tencentcloud_teo_rule_engine_settings</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/d/teo_security_ip_group_content.html">tencentcloud_teo_security_ip_group_content</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/d/teo_zone_available_plans.html">tencentcloud_teo_zone_available_plans</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add a new data source tencentcloud_teo_security_ip_group_content to query the IP list within a specified TEO security IP group. This data source calls the DescribeSecurityIPGroupContent API and supports pagination, returning ip_total_count and ip_list.