### PR TITLE
feat(teo): add origin_acl_family parameter for tencentcloud_teo_origin_acl resource

### DIFF
--- a/.changelog/4087.txt
+++ b/.changelog/4087.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_origin_acl: add origin_acl_family parameter to support origin ACL control domain configuration
+```

--- a/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/.openspec.yaml
+++ b/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/design.md
+++ b/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The `tencentcloud_teo_origin_acl` resource manages TEO (TencentCloud EdgeOne) origin ACL protection for a zone. Currently, the resource only supports configuring L7 hosts and L4 proxy IDs but does not expose the `OriginACLFamily` parameter, which controls the geographic domain for origin ACL protection.
+
+The cloud API already supports `OriginACLFamily` in:
+- **EnableOriginACL** (Create): Sets the control domain when enabling origin ACL. Defaults to standard global (`gaz`) if not specified.
+- **ModifyOriginACL** (Update): Changes the control domain. If not specified, the domain remains unchanged.
+- **DescribeOriginACL** (Read): Returns the current `OriginACLFamily` value in the `OriginACLInfo` response struct.
+- **DisableOriginACL** (Delete): Does not include `OriginACLFamily` — deletion is zone-level and does not need this parameter.
+
+The parameter is of type `*string` with valid values: `gaz`, `mlc`, `emc`, `plat-gaz`, `plat-mlc`, `plat-emc`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `origin_acl_family` as an Optional + Computed string parameter to the `tencentcloud_teo_origin_acl` resource schema
+- Pass `OriginACLFamily` in Create (EnableOriginACL) and Update (ModifyOriginACL) API calls when the user specifies a value
+- Read `OriginACLFamily` from the DescribeOriginACL response in the Read handler
+- Add `origin_acl_family` to the data source `tencentcloud_teo_origin_acl` under the `origin_acl_info` block
+- Maintain full backward compatibility — existing configurations without `origin_acl_family` continue to work
+
+**Non-Goals:**
+- Adding validation for the `origin_acl_family` valid values (the API will reject invalid values)
+- Adding a separate data source for `DescribeAvailableOriginACLFamily`
+- Changing the resource ID format or any existing schema fields
+
+## Decisions
+
+### Decision 1: Schema field type — Optional + Computed
+**Choice**: `Optional: true, Computed: true` with `TypeString`
+**Rationale**: The API defaults to `gaz` when not specified on Enable, and preserves the current value when not specified on Modify. Using `Computed: true` ensures the Read handler populates the actual value from the API response, so the state reflects the real configuration even when the user didn't explicitly set it.
+
+### Decision 2: Update handler — separate ModifyOriginACL call for origin_acl_family
+**Choice**: When `origin_acl_family` changes, make a separate ModifyOriginACL call with only `ZoneId` and `OriginACLFamily` set (without `OriginACLEntities`).
+**Rationale**: The ModifyOriginACL API accepts both `OriginACLEntities` and `OriginACLFamily` in the same request. Since `origin_acl_family` is independent of the entity-level changes (l7_hosts/l4_proxy_ids), it can be sent in the same call or a separate one. Using a separate call keeps the logic clean and avoids mixing entity operations with family changes. However, the API allows both in one call, so we could also combine them — but separation is cleaner for error handling.
+
+Actually, on further review, it's simpler and more consistent to set `OriginACLFamily` in ALL ModifyOriginACL calls when `d.HasChange("origin_acl_family")` is true. This way, the family change is propagated with the first ModifyOriginACL batch call, reducing the number of API calls.
+
+**Final choice**: When `origin_acl_family` has changed, set the `OriginACLFamily` field on the first ModifyOriginACL request in the update handler. If there are no entity changes but only origin_acl_family change, make a standalone ModifyOriginACL call with just ZoneId and OriginACLFamily.
+
+### Decision 3: Data source field placement
+**Choice**: Add `origin_acl_family` as a Computed string field inside the `origin_acl_info` block of the data source.
+**Rationale**: The `OriginACLFamily` field is part of the `OriginACLInfo` struct in the API response, so it naturally belongs in the `origin_acl_info` block of the data source.
+
+## Risks / Trade-offs
+
+- **[Risk] API rejects invalid OriginACLFamily values** → The API returns an error for unsupported values. Users will see the API error message. This is acceptable and consistent with how other string parameters work in the provider.
+- **[Risk] Changing origin_acl_family might affect existing ACL rules** → The API documentation states this is a control domain setting. Changing it could alter which IP ranges are used. This is by design — users explicitly opt into this change.
+- **[Trade-off] Not adding ValidateFunc for valid values** → We could add validation, but the API already validates and the valid values might change over time. Relying on API validation is more maintainable.

--- a/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/proposal.md
+++ b/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The `tencentcloud_teo_origin_acl` resource currently lacks the `origin_acl_family` parameter, which controls the geographic domain for origin ACL protection (global, mainland China, or global excluding mainland China). Without this parameter, users cannot specify the control domain through Terraform and always get the default (standard global), limiting the ability to configure region-specific origin ACL policies.
+
+## What Changes
+
+- Add `origin_acl_family` parameter (Optional + Computed, TypeString) to the `tencentcloud_teo_origin_acl` resource schema
+- Set `OriginACLFamily` in the Create handler (EnableOriginACL API request)
+- Set `OriginACLFamily` in the Update handler (ModifyOriginACL API request)
+- Read `OriginACLFamily` from the DescribeOriginACL API response in the Read handler
+- Add `origin_acl_family` to the data source `tencentcloud_teo_origin_acl` schema and read handler
+
+## Capabilities
+
+### New Capabilities
+- `teo-origin-acl-family-param`: Adds the `origin_acl_family` parameter to the `tencentcloud_teo_origin_acl` resource and data source, allowing users to configure the geographic control domain for origin ACL protection.
+
+### Modified Capabilities
+
+## Impact
+
+- **Affected files**: `tencentcloud/services/teo/resource_tc_teo_origin_acl.go`, `tencentcloud/services/teo/data_source_tc_teo_origin_acl.go`, and their corresponding test files and documentation
+- **APIs**: EnableOriginACL, ModifyOriginACL, DescribeOriginACL (all already used by the resource)
+- **Backward compatibility**: Fully backward compatible — `origin_acl_family` is Optional + Computed, existing configurations without it will continue to work with the default value

--- a/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/specs/teo-origin-acl-family-param/spec.md
+++ b/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/specs/teo-origin-acl-family-param/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: origin_acl_family schema parameter for tencentcloud_teo_origin_acl resource
+The resource SHALL expose an `origin_acl_family` parameter of type string that is Optional and Computed, describing the origin ACL control domain for source protection.
+
+#### Scenario: Create resource with origin_acl_family specified
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource with `origin_acl_family` set to a valid value (e.g., "mlc")
+- **THEN** the system SHALL set `OriginACLFamily` on the EnableOriginACL API request
+- **AND** the resource state SHALL reflect the specified `origin_acl_family` value after read
+
+#### Scenario: Create resource without origin_acl_family specified
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource without specifying `origin_acl_family`
+- **THEN** the system SHALL NOT set `OriginACLFamily` on the EnableOriginACL API request
+- **AND** the API SHALL apply the default value (gaz)
+- **AND** the Read handler SHALL populate `origin_acl_family` from the API response
+
+#### Scenario: Update origin_acl_family value
+- **WHEN** user changes the `origin_acl_family` value in an existing resource configuration
+- **THEN** the system SHALL set `OriginACLFamily` on the ModifyOriginACL API request with the new value
+- **AND** the resource state SHALL reflect the updated `origin_acl_family` value after read
+
+#### Scenario: Read origin_acl_family from API response
+- **WHEN** the Read handler calls DescribeOriginACL
+- **AND** the response `OriginACLInfo.OriginACLFamily` is not nil
+- **THEN** the system SHALL set `origin_acl_family` in the resource state to the API response value
+
+#### Scenario: Read with nil OriginACLFamily
+- **WHEN** the Read handler calls DescribeOriginACL
+- **AND** the response `OriginACLInfo.OriginACLFamily` is nil
+- **THEN** the system SHALL NOT set `origin_acl_family` in the resource state
+
+### Requirement: origin_acl_family in Create handler
+The Create handler SHALL pass `OriginACLFamily` on the EnableOriginACL request when the user specifies `origin_acl_family` in the Terraform configuration.
+
+#### Scenario: OriginACLFamily set on Enable request
+- **WHEN** user provides `origin_acl_family` in the resource configuration
+- **THEN** the system SHALL set `request.OriginACLFamily` to the provided value before calling EnableOriginACL
+
+### Requirement: origin_acl_family in Update handler
+The Update handler SHALL pass `OriginACLFamily` on ModifyOriginACL requests when `origin_acl_family` has changed.
+
+#### Scenario: OriginACLFamily change with entity changes
+- **WHEN** `origin_acl_family` has changed AND there are l7_hosts or l4_proxy_ids changes
+- **THEN** the system SHALL set `OriginACLFamily` on the first ModifyOriginACL request that processes entity changes
+
+#### Scenario: OriginACLFamily change without entity changes
+- **WHEN** `origin_acl_family` has changed AND there are no l7_hosts or l4_proxy_ids changes
+- **THEN** the system SHALL make a ModifyOriginACL request with only `ZoneId` and `OriginACLFamily` set
+
+#### Scenario: OriginACLFamily also set in Create batch ModifyOriginACL calls
+- **WHEN** the Create handler makes batch ModifyOriginACL calls for overflow L7/L4 entities
+- **AND** `origin_acl_family` was specified by the user
+- **THEN** the system SHALL set `OriginACLFamily` on each batch ModifyOriginACL request
+
+### Requirement: origin_acl_family in data source
+The data source `tencentcloud_teo_origin_acl` SHALL expose `origin_acl_family` as a Computed string field inside the `origin_acl_info` block.
+
+#### Scenario: Read origin_acl_family from data source
+- **WHEN** user queries the `tencentcloud_teo_origin_acl` data source
+- **AND** the DescribeOriginACL response `OriginACLInfo.OriginACLFamily` is not nil
+- **THEN** the system SHALL include `origin_acl_family` in the `origin_acl_info` output with the API response value
+
+#### Scenario: OriginACLFamily is nil in data source
+- **WHEN** user queries the `tencentcloud_teo_origin_acl` data source
+- **AND** the DescribeOriginACL response `OriginACLInfo.OriginACLFamily` is nil
+- **THEN** the system SHALL NOT include `origin_acl_family` in the `origin_acl_info` output
+
+### Requirement: Backward compatibility
+The addition of `origin_acl_family` SHALL NOT break existing Terraform configurations or state files.
+
+#### Scenario: Existing configuration without origin_acl_family
+- **WHEN** a user applies an existing configuration that does not include `origin_acl_family`
+- **THEN** the Terraform plan SHALL show no changes to the resource
+- **AND** the `origin_acl_family` value in state SHALL be populated from the API response after the next refresh

--- a/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/tasks.md
+++ b/openspec/changes/archive/2025-07-11-add-teo-origin-acl-family-param/tasks.md
@@ -1,0 +1,27 @@
+## 1. Resource Schema and CRUD Changes
+
+- [x] 1.1 Add `origin_acl_family` field (Optional + Computed, TypeString) to the `tencentcloud_teo_origin_acl` resource schema in `resource_tc_teo_origin_acl.go`
+- [x] 1.2 Update `ResourceTencentCloudTeoOriginAclCreate` to set `OriginACLFamily` on the EnableOriginACL request when the user specifies `origin_acl_family`
+- [x] 1.3 Update `ResourceTencentCloudTeoOriginAclCreate` to set `OriginACLFamily` on batch ModifyOriginACL requests (for overflow L7/L4 entities) when `origin_acl_family` is specified
+- [x] 1.4 Update `ResourceTencentCloudTeoOriginAclRead` to read `OriginACLFamily` from the DescribeOriginACL response and set it in state (with nil check)
+- [x] 1.5 Update `ResourceTencentCloudTeoOriginAclUpdate` to set `OriginACLFamily` on ModifyOriginACL requests when `origin_acl_family` has changed
+- [x] 1.6 Handle the case where only `origin_acl_family` changes (no entity changes) by making a standalone ModifyOriginACL call
+
+## 2. Data Source Changes
+
+- [x] 2.1 Add `origin_acl_family` field (Computed, TypeString) to the `origin_acl_info` block in the `tencentcloud_teo_origin_acl` data source schema in `data_source_tc_teo_origin_acl.go`
+- [x] 2.2 Update `dataSourceTencentCloudTeoOriginAclRead` to read `OriginACLFamily` from the DescribeOriginACL response and include it in the `origin_acl_info` output (with nil check)
+
+## 3. Documentation
+
+- [x] 3.1 Update `resource_tc_teo_origin_acl.md` to add `origin_acl_family` parameter example and description
+- [x] 3.2 Update `data_source_tc_teo_origin_acl.md` to add `origin_acl_family` parameter in the `origin_acl_info` block
+
+## 4. Unit Tests
+
+- [x] 4.1 Add unit test for Create with `origin_acl_family` specified in `resource_tc_teo_origin_acl_test.go`
+- [x] 4.2 Add unit test for Create without `origin_acl_family` specified
+- [x] 4.3 Add unit test for Update with `origin_acl_family` change
+- [x] 4.4 Add unit test for Read with `OriginACLFamily` in response
+- [x] 4.5 Add unit test for data source Read with `OriginACLFamily` in response
+- [x] 4.6 Run unit tests with `go test -gcflags=all=-l` to verify all tests pass

--- a/openspec/specs/teo-origin-acl-family-param/spec.md
+++ b/openspec/specs/teo-origin-acl-family-param/spec.md
@@ -1,0 +1,74 @@
+## Requirements
+
+### Requirement: origin_acl_family schema parameter for tencentcloud_teo_origin_acl resource
+The resource SHALL expose an `origin_acl_family` parameter of type string that is Optional and Computed, describing the origin ACL control domain for source protection.
+
+#### Scenario: Create resource with origin_acl_family specified
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource with `origin_acl_family` set to a valid value (e.g., "mlc")
+- **THEN** the system SHALL set `OriginACLFamily` on the EnableOriginACL API request
+- **AND** the resource state SHALL reflect the specified `origin_acl_family` value after read
+
+#### Scenario: Create resource without origin_acl_family specified
+- **WHEN** user creates a `tencentcloud_teo_origin_acl` resource without specifying `origin_acl_family`
+- **THEN** the system SHALL NOT set `OriginACLFamily` on the EnableOriginACL API request
+- **AND** the API SHALL apply the default value (gaz)
+- **AND** the Read handler SHALL populate `origin_acl_family` from the API response
+
+#### Scenario: Update origin_acl_family value
+- **WHEN** user changes the `origin_acl_family` value in an existing resource configuration
+- **THEN** the system SHALL set `OriginACLFamily` on the ModifyOriginACL API request with the new value
+- **AND** the resource state SHALL reflect the updated `origin_acl_family` value after read
+
+#### Scenario: Read origin_acl_family from API response
+- **WHEN** the Read handler calls DescribeOriginACL
+- **AND** the response `OriginACLInfo.OriginACLFamily` is not nil
+- **THEN** the system SHALL set `origin_acl_family` in the resource state to the API response value
+
+#### Scenario: Read with nil OriginACLFamily
+- **WHEN** the Read handler calls DescribeOriginACL
+- **AND** the response `OriginACLInfo.OriginACLFamily` is nil
+- **THEN** the system SHALL NOT set `origin_acl_family` in the resource state
+
+### Requirement: origin_acl_family in Create handler
+The Create handler SHALL pass `OriginACLFamily` on the EnableOriginACL request when the user specifies `origin_acl_family` in the Terraform configuration.
+
+#### Scenario: OriginACLFamily set on Enable request
+- **WHEN** user provides `origin_acl_family` in the resource configuration
+- **THEN** the system SHALL set `request.OriginACLFamily` to the provided value before calling EnableOriginACL
+
+### Requirement: origin_acl_family in Update handler
+The Update handler SHALL pass `OriginACLFamily` on ModifyOriginACL requests when `origin_acl_family` has changed.
+
+#### Scenario: OriginACLFamily change with entity changes
+- **WHEN** `origin_acl_family` has changed AND there are l7_hosts or l4_proxy_ids changes
+- **THEN** the system SHALL set `OriginACLFamily` on the first ModifyOriginACL request that processes entity changes
+
+#### Scenario: OriginACLFamily change without entity changes
+- **WHEN** `origin_acl_family` has changed AND there are no l7_hosts or l4_proxy_ids changes
+- **THEN** the system SHALL make a ModifyOriginACL request with only `ZoneId` and `OriginACLFamily` set
+
+#### Scenario: OriginACLFamily also set in Create batch ModifyOriginACL calls
+- **WHEN** the Create handler makes batch ModifyOriginACL calls for overflow L7/L4 entities
+- **AND** `origin_acl_family` was specified by the user
+- **THEN** the system SHALL set `OriginACLFamily` on each batch ModifyOriginACL request
+
+### Requirement: origin_acl_family in data source
+The data source `tencentcloud_teo_origin_acl` SHALL expose `origin_acl_family` as a Computed string field inside the `origin_acl_info` block.
+
+#### Scenario: Read origin_acl_family from data source
+- **WHEN** user queries the `tencentcloud_teo_origin_acl` data source
+- **AND** the DescribeOriginACL response `OriginACLInfo.OriginACLFamily` is not nil
+- **THEN** the system SHALL include `origin_acl_family` in the `origin_acl_info` output with the API response value
+
+#### Scenario: OriginACLFamily is nil in data source
+- **WHEN** user queries the `tencentcloud_teo_origin_acl` data source
+- **AND** the DescribeOriginACL response `OriginACLInfo.OriginACLFamily` is nil
+- **THEN** the system SHALL NOT include `origin_acl_family` in the `origin_acl_info` output
+
+### Requirement: Backward compatibility
+The addition of `origin_acl_family` SHALL NOT break existing Terraform configurations or state files.
+
+#### Scenario: Existing configuration without origin_acl_family
+- **WHEN** a user applies an existing configuration that does not include `origin_acl_family`
+- **THEN** the Terraform plan SHALL show no changes to the resource
+- **AND** the `origin_acl_family` value in state SHALL be populated from the API response after the next refresh

--- a/tencentcloud/services/teo/data_source_tc_teo_origin_acl.go
+++ b/tencentcloud/services/teo/data_source_tc_teo_origin_acl.go
@@ -306,6 +306,11 @@ func DataSourceTencentCloudTeoOriginAcl() *schema.Resource {
 							Computed:    true,
 							Description: "Origin protection status. Vaild values:\n- online: in effect;\n- offline: disabled;\n- updating: configuration deployment in progress.",
 						},
+						"origin_acl_family": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Origin ACL control domain.",
+						},
 					},
 				},
 			},
@@ -468,6 +473,10 @@ func dataSourceTencentCloudTeoOriginAclRead(d *schema.ResourceData, meta interfa
 
 		if respData.OriginACLInfo.Status != nil {
 			originACLInfoMap["status"] = respData.OriginACLInfo.Status
+		}
+
+		if respData.OriginACLInfo.OriginACLFamily != nil {
+			originACLInfoMap["origin_acl_family"] = respData.OriginACLInfo.OriginACLFamily
 		}
 
 		_ = d.Set("origin_acl_info", []interface{}{originACLInfoMap})

--- a/tencentcloud/services/teo/data_source_tc_teo_origin_acl_test.go
+++ b/tencentcloud/services/teo/data_source_tc_teo_origin_acl_test.go
@@ -1,13 +1,135 @@
 package teo_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
 
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 )
 
+// mockMetaOriginAclDS implements tccommon.ProviderMeta
+type mockMetaOriginAclDS struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaOriginAclDS) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaOriginAclDS{}
+
+func newMockMetaOriginAclDS() *mockMetaOriginAclDS {
+	return &mockMetaOriginAclDS{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringOriginAclDS(s string) *string {
+	return &s
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestTeoOriginAclDS" -v -count=1 -gcflags="all=-l"
+
+// TestTeoOriginAclDS_ReadWithOriginACLFamily tests data source Read with OriginACLFamily in response
+func TestTeoOriginAclDS_ReadWithOriginACLFamily(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaOriginAclDS().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeOriginACLWithContext", func(_ context.Context, request *teov20220901.DescribeOriginACLRequest) (*teov20220901.DescribeOriginACLResponse, error) {
+		resp := teov20220901.NewDescribeOriginACLResponse()
+		resp.Response = &teov20220901.DescribeOriginACLResponseParams{
+			OriginACLInfo: &teov20220901.OriginACLInfo{
+				Status:          ptrStringOriginAclDS("online"),
+				L7Hosts:         []*string{ptrStringOriginAclDS("example1.com")},
+				L4ProxyIds:      []*string{ptrStringOriginAclDS("sid-abc123")},
+				OriginACLFamily: ptrStringOriginAclDS("mlc"),
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaOriginAclDS()
+	res := teo.DataSourceTencentCloudTeoOriginAcl()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "zone-12345678", d.Id())
+
+	originAclInfo := d.Get("origin_acl_info").([]interface{})
+	assert.Len(t, originAclInfo, 1)
+	infoMap := originAclInfo[0].(map[string]interface{})
+	assert.Equal(t, "mlc", infoMap["origin_acl_family"].(string))
+}
+
+// TestTeoOriginAclDS_ReadWithNilOriginACLFamily tests data source Read when OriginACLFamily is nil
+func TestTeoOriginAclDS_ReadWithNilOriginACLFamily(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaOriginAclDS().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeOriginACLWithContext", func(_ context.Context, request *teov20220901.DescribeOriginACLRequest) (*teov20220901.DescribeOriginACLResponse, error) {
+		resp := teov20220901.NewDescribeOriginACLResponse()
+		resp.Response = &teov20220901.DescribeOriginACLResponseParams{
+			OriginACLInfo: &teov20220901.OriginACLInfo{
+				Status:     ptrStringOriginAclDS("online"),
+				L7Hosts:    []*string{ptrStringOriginAclDS("example1.com")},
+				L4ProxyIds: []*string{ptrStringOriginAclDS("sid-abc123")},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaOriginAclDS()
+	res := teo.DataSourceTencentCloudTeoOriginAcl()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "zone-12345678", d.Id())
+
+	originAclInfo := d.Get("origin_acl_info").([]interface{})
+	assert.Len(t, originAclInfo, 1)
+	infoMap := originAclInfo[0].(map[string]interface{})
+	assert.Equal(t, "", infoMap["origin_acl_family"].(string))
+}
+
+// TestTeoOriginAclDS_Schema tests the data source schema definition
+func TestTeoOriginAclDS_Schema(t *testing.T) {
+	res := teo.DataSourceTencentCloudTeoOriginAcl()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "origin_acl_info")
+
+	originAclInfoSchema := res.Schema["origin_acl_info"]
+	assert.Equal(t, schema.TypeList, originAclInfoSchema.Type)
+
+	elemRes := originAclInfoSchema.Elem.(*schema.Resource)
+	assert.Contains(t, elemRes.Schema, "origin_acl_family")
+
+	originACLFamily := elemRes.Schema["origin_acl_family"]
+	assert.Equal(t, schema.TypeString, originACLFamily.Type)
+	assert.True(t, originACLFamily.Computed)
+}
+
+// TestAccTencentCloudTeoOriginAclDataSource_basic is the acceptance test
 func TestAccTencentCloudTeoOriginAclDataSource_basic(t *testing.T) {
 	t.Parallel()
 	resource.Test(t, resource.TestCase{

--- a/tencentcloud/services/teo/resource_tc_teo_origin_acl.go
+++ b/tencentcloud/services/teo/resource_tc_teo_origin_acl.go
@@ -51,6 +51,13 @@ func ResourceTencentCloudTeoOriginAcl() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "he list of L4 proxy Instances that require enabling origin ACLs. This list must be empty when the request parameter L4EnableMode is set to 'all'.",
 			},
+
+			"origin_acl_family": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Origin ACL control domain. Valid values: gaz, mlc, emc, plat-gaz, plat-mlc, plat-emc.",
+			},
 		},
 	}
 }
@@ -104,6 +111,10 @@ func ResourceTencentCloudTeoOriginAclCreate(d *schema.ResourceData, meta interfa
 		}
 	}
 
+	if v, ok := d.GetOk("origin_acl_family"); ok {
+		request.OriginACLFamily = helper.String(v.(string))
+	}
+
 	request.L7EnableMode = helper.String("specific")
 	request.L4EnableMode = helper.String("specific")
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
@@ -134,6 +145,11 @@ func ResourceTencentCloudTeoOriginAclCreate(d *schema.ResourceData, meta interfa
 
 	if len(tmpL7Hosts) > 0 || len(tmpL4ProxyIds) > 0 {
 		batchSize := 200
+		originACLFamily := ""
+		if v, ok := d.GetOk("origin_acl_family"); ok {
+			originACLFamily = v.(string)
+		}
+
 		for i := 0; i < len(tmpL7Hosts); i += batchSize {
 			end := i + batchSize
 			if end > len(tmpL7Hosts) {
@@ -143,6 +159,9 @@ func ResourceTencentCloudTeoOriginAclCreate(d *schema.ResourceData, meta interfa
 			batchHosts := tmpL7Hosts[i:end]
 			request := teov20220901.NewModifyOriginACLRequest()
 			request.ZoneId = &zoneId
+			if originACLFamily != "" {
+				request.OriginACLFamily = &originACLFamily
+			}
 			request.OriginACLEntities = append(request.OriginACLEntities, &teov20220901.OriginACLEntity{
 				Type:          helper.String("l7"),
 				Instances:     helper.InterfacesStringsPoint(batchHosts),
@@ -185,6 +204,9 @@ func ResourceTencentCloudTeoOriginAclCreate(d *schema.ResourceData, meta interfa
 			batchProxyIds := tmpL4ProxyIds[i:end]
 			request := teov20220901.NewModifyOriginACLRequest()
 			request.ZoneId = &zoneId
+			if originACLFamily != "" {
+				request.OriginACLFamily = &originACLFamily
+			}
 			request.OriginACLEntities = append(request.OriginACLEntities, &teov20220901.OriginACLEntity{
 				Type:          helper.String("l4"),
 				Instances:     helper.InterfacesStringsPoint(batchProxyIds),
@@ -265,6 +287,10 @@ func ResourceTencentCloudTeoOriginAclRead(d *schema.ResourceData, meta interface
 		_ = d.Set("l4_proxy_ids", tmpList)
 	}
 
+	if respData.OriginACLFamily != nil {
+		_ = d.Set("origin_acl_family", respData.OriginACLFamily)
+	}
+
 	return nil
 }
 
@@ -328,6 +354,8 @@ func ResourceTencentCloudTeoOriginAclUpdate(d *schema.ResourceData, meta interfa
 
 	if len(l7List) > 0 || len(l4List) > 0 {
 		batchSize := 200
+		originACLFamilyChanged := d.HasChange("origin_acl_family")
+		originACLFamilySet := false
 		for i := 0; i < len(l7List); i += batchSize {
 			end := i + batchSize
 			if end > len(l7List) {
@@ -337,6 +365,12 @@ func ResourceTencentCloudTeoOriginAclUpdate(d *schema.ResourceData, meta interfa
 			batchHosts := l7List[i:end]
 			request := teov20220901.NewModifyOriginACLRequest()
 			request.ZoneId = &zoneId
+			if originACLFamilyChanged && !originACLFamilySet {
+				if v, ok := d.GetOk("origin_acl_family"); ok {
+					request.OriginACLFamily = helper.String(v.(string))
+				}
+				originACLFamilySet = true
+			}
 			request.OriginACLEntities = append(request.OriginACLEntities, batchHosts...)
 			err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 				result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().ModifyOriginACLWithContext(ctx, request)
@@ -374,6 +408,12 @@ func ResourceTencentCloudTeoOriginAclUpdate(d *schema.ResourceData, meta interfa
 			batchProxyIds := l4List[i:end]
 			request := teov20220901.NewModifyOriginACLRequest()
 			request.ZoneId = &zoneId
+			if originACLFamilyChanged && !originACLFamilySet {
+				if v, ok := d.GetOk("origin_acl_family"); ok {
+					request.OriginACLFamily = helper.String(v.(string))
+				}
+				originACLFamilySet = true
+			}
 			request.OriginACLEntities = append(request.OriginACLEntities, batchProxyIds...)
 			err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 				result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().ModifyOriginACLWithContext(ctx, request)
@@ -400,6 +440,40 @@ func ResourceTencentCloudTeoOriginAclUpdate(d *schema.ResourceData, meta interfa
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	if d.HasChange("origin_acl_family") && len(l7List) == 0 && len(l4List) == 0 {
+		request := teov20220901.NewModifyOriginACLRequest()
+		request.ZoneId = &zoneId
+		if v, ok := d.GetOk("origin_acl_family"); ok {
+			request.OriginACLFamily = helper.String(v.(string))
+		}
+
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().ModifyOriginACLWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify teo origin acl failed, Response is nil."))
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s modify teo origin acl (origin_acl_family) failed, reason:%+v", logId, err)
+			return err
+		}
+
+		// wait
+		err = service.WaitTeoOriginACLById(ctx, d.Timeout(schema.TimeoutUpdate), zoneId, "online")
+		if err != nil {
+			return err
 		}
 	}
 

--- a/tencentcloud/services/teo/resource_tc_teo_origin_acl.md
+++ b/tencentcloud/services/teo/resource_tc_teo_origin_acl.md
@@ -7,6 +7,7 @@ Example Usage
 ```hcl
 resource "tencentcloud_teo_origin_acl" "example" {
   zone_id        = "zone-39quuimqg8r6"
+  origin_acl_family = "mlc"
   l7_hosts       = [
     "example1.com",
     "example2.com",

--- a/tencentcloud/services/teo/resource_tc_teo_origin_acl.md
+++ b/tencentcloud/services/teo/resource_tc_teo_origin_acl.md
@@ -6,15 +6,15 @@ Example Usage
 
 ```hcl
 resource "tencentcloud_teo_origin_acl" "example" {
-  zone_id        = "zone-39quuimqg8r6"
-  origin_acl_family = "mlc"
-  l7_hosts       = [
+  zone_id           = "zone-3fkff38fyw8s"
+  origin_acl_family = "gaz"
+  l7_hosts = [
     "example1.com",
     "example2.com",
     "example3.com",
   ]
 
-  l4_proxy_ids   = [
+  l4_proxy_ids = [
     "sid-3dwf5252ravl",
     "sid-3dwfxzt8ed3l",
     "sid-3dwfy5mpwnk4",
@@ -31,8 +31,9 @@ resource "tencentcloud_teo_origin_acl" "example" {
 
 Import
 
-TEO origin acl can be imported using the zone_id, e.g.
+TEO origin acl can be imported using the id, e.g.
 
 ````
-terraform import tencentcloud_teo_origin_acl.example zone-39quuimqg8r6
+terraform import tencentcloud_teo_origin_acl.example zone-3fkff38fyw8s
 ````
+

--- a/tencentcloud/services/teo/resource_tc_teo_origin_acl_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_origin_acl_test.go
@@ -1,13 +1,318 @@
 package teo_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
 )
 
+// mockMetaOriginAcl implements tccommon.ProviderMeta
+type mockMetaOriginAcl struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaOriginAcl) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaOriginAcl{}
+
+func newMockMetaOriginAcl() *mockMetaOriginAcl {
+	return &mockMetaOriginAcl{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringOriginAcl(s string) *string {
+	return &s
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestTeoOriginAcl" -v -count=1 -gcflags="all=-l"
+
+// TestTeoOriginAcl_CreateWithOriginACLFamily tests Create with origin_acl_family specified
+func TestTeoOriginAcl_CreateWithOriginACLFamily(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaOriginAcl().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "EnableOriginACLWithContext", func(_ context.Context, request *teov20220901.EnableOriginACLRequest) (*teov20220901.EnableOriginACLResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+		assert.NotNil(t, request.OriginACLFamily)
+		assert.Equal(t, "mlc", *request.OriginACLFamily)
+
+		resp := teov20220901.NewEnableOriginACLResponse()
+		resp.Response = &teov20220901.EnableOriginACLResponseParams{
+			RequestId: ptrStringOriginAcl("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeOriginACLWithContext", func(_ context.Context, request *teov20220901.DescribeOriginACLRequest) (*teov20220901.DescribeOriginACLResponse, error) {
+		resp := teov20220901.NewDescribeOriginACLResponse()
+		resp.Response = &teov20220901.DescribeOriginACLResponseParams{
+			OriginACLInfo: &teov20220901.OriginACLInfo{
+				Status:          ptrStringOriginAcl("online"),
+				L7Hosts:         []*string{ptrStringOriginAcl("example1.com")},
+				L4ProxyIds:      []*string{ptrStringOriginAcl("sid-abc123")},
+				OriginACLFamily: ptrStringOriginAcl("mlc"),
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaOriginAcl()
+	res := teo.ResourceTencentCloudTeoOriginAcl()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":           "zone-12345678",
+		"origin_acl_family": "mlc",
+		"l7_hosts":          []interface{}{"example1.com"},
+		"l4_proxy_ids":      []interface{}{"sid-abc123"},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "zone-12345678", d.Id())
+	assert.Equal(t, "mlc", d.Get("origin_acl_family"))
+}
+
+// TestTeoOriginAcl_CreateWithoutOriginACLFamily tests Create without origin_acl_family specified
+func TestTeoOriginAcl_CreateWithoutOriginACLFamily(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaOriginAcl().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "EnableOriginACLWithContext", func(_ context.Context, request *teov20220901.EnableOriginACLRequest) (*teov20220901.EnableOriginACLResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+		assert.Nil(t, request.OriginACLFamily)
+
+		resp := teov20220901.NewEnableOriginACLResponse()
+		resp.Response = &teov20220901.EnableOriginACLResponseParams{
+			RequestId: ptrStringOriginAcl("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeOriginACLWithContext", func(_ context.Context, request *teov20220901.DescribeOriginACLRequest) (*teov20220901.DescribeOriginACLResponse, error) {
+		resp := teov20220901.NewDescribeOriginACLResponse()
+		resp.Response = &teov20220901.DescribeOriginACLResponseParams{
+			OriginACLInfo: &teov20220901.OriginACLInfo{
+				Status:          ptrStringOriginAcl("online"),
+				L7Hosts:         []*string{ptrStringOriginAcl("example1.com")},
+				OriginACLFamily: ptrStringOriginAcl("gaz"),
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaOriginAcl()
+	res := teo.ResourceTencentCloudTeoOriginAcl()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":      "zone-12345678",
+		"l7_hosts":     []interface{}{"example1.com"},
+		"l4_proxy_ids": []interface{}{},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "zone-12345678", d.Id())
+	assert.Equal(t, "gaz", d.Get("origin_acl_family"))
+}
+
+// TestTeoOriginAcl_ReadWithOriginACLFamily tests Read with OriginACLFamily in response
+func TestTeoOriginAcl_ReadWithOriginACLFamily(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaOriginAcl().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeOriginACLWithContext", func(_ context.Context, request *teov20220901.DescribeOriginACLRequest) (*teov20220901.DescribeOriginACLResponse, error) {
+		resp := teov20220901.NewDescribeOriginACLResponse()
+		resp.Response = &teov20220901.DescribeOriginACLResponseParams{
+			OriginACLInfo: &teov20220901.OriginACLInfo{
+				Status:          ptrStringOriginAcl("online"),
+				L7Hosts:         []*string{ptrStringOriginAcl("example1.com")},
+				L4ProxyIds:      []*string{ptrStringOriginAcl("sid-abc123")},
+				OriginACLFamily: ptrStringOriginAcl("mlc"),
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaOriginAcl()
+	res := teo.ResourceTencentCloudTeoOriginAcl()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+	})
+	d.SetId("zone-12345678")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "mlc", d.Get("origin_acl_family"))
+}
+
+// TestTeoOriginAcl_ReadWithNilOriginACLFamily tests Read when OriginACLFamily is nil
+func TestTeoOriginAcl_ReadWithNilOriginACLFamily(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaOriginAcl().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeOriginACLWithContext", func(_ context.Context, request *teov20220901.DescribeOriginACLRequest) (*teov20220901.DescribeOriginACLResponse, error) {
+		resp := teov20220901.NewDescribeOriginACLResponse()
+		resp.Response = &teov20220901.DescribeOriginACLResponseParams{
+			OriginACLInfo: &teov20220901.OriginACLInfo{
+				Status:     ptrStringOriginAcl("online"),
+				L7Hosts:    []*string{ptrStringOriginAcl("example1.com")},
+				L4ProxyIds: []*string{ptrStringOriginAcl("sid-abc123")},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaOriginAcl()
+	res := teo.ResourceTencentCloudTeoOriginAcl()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+	})
+	d.SetId("zone-12345678")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Get("origin_acl_family"))
+}
+
+// TestTeoOriginAcl_UpdateOriginACLFamily tests Update with origin_acl_family change
+func TestTeoOriginAcl_UpdateOriginACLFamily(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaOriginAcl().client, "UseTeoV20220901Client", teoClient)
+
+	modifyCalled := false
+	patches.ApplyMethodFunc(teoClient, "ModifyOriginACLWithContext", func(_ context.Context, request *teov20220901.ModifyOriginACLRequest) (*teov20220901.ModifyOriginACLResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+		assert.NotNil(t, request.OriginACLFamily)
+		assert.Equal(t, "emc", *request.OriginACLFamily)
+		modifyCalled = true
+
+		resp := teov20220901.NewModifyOriginACLResponse()
+		resp.Response = &teov20220901.ModifyOriginACLResponseParams{
+			RequestId: ptrStringOriginAcl("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeOriginACLWithContext", func(_ context.Context, request *teov20220901.DescribeOriginACLRequest) (*teov20220901.DescribeOriginACLResponse, error) {
+		resp := teov20220901.NewDescribeOriginACLResponse()
+		resp.Response = &teov20220901.DescribeOriginACLResponseParams{
+			OriginACLInfo: &teov20220901.OriginACLInfo{
+				Status:          ptrStringOriginAcl("online"),
+				L7Hosts:         []*string{ptrStringOriginAcl("example1.com")},
+				OriginACLFamily: ptrStringOriginAcl("emc"),
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaOriginAcl()
+	res := teo.ResourceTencentCloudTeoOriginAcl()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":           "zone-12345678",
+		"origin_acl_family": "emc",
+		"l7_hosts":          []interface{}{"example1.com"},
+		"l4_proxy_ids":      []interface{}{},
+	})
+	d.SetId("zone-12345678")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.True(t, modifyCalled)
+	assert.Equal(t, "emc", d.Get("origin_acl_family"))
+}
+
+// TestTeoOriginAcl_UpdateOriginACLFamilyOnly tests Update when only origin_acl_family changes (no entity changes)
+func TestTeoOriginAcl_UpdateOriginACLFamilyOnly(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaOriginAcl().client, "UseTeoV20220901Client", teoClient)
+
+	modifyCalled := false
+	patches.ApplyMethodFunc(teoClient, "ModifyOriginACLWithContext", func(_ context.Context, request *teov20220901.ModifyOriginACLRequest) (*teov20220901.ModifyOriginACLResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+		assert.NotNil(t, request.OriginACLFamily)
+		assert.Equal(t, "mlc", *request.OriginACLFamily)
+		modifyCalled = true
+
+		resp := teov20220901.NewModifyOriginACLResponse()
+		resp.Response = &teov20220901.ModifyOriginACLResponseParams{
+			RequestId: ptrStringOriginAcl("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeOriginACLWithContext", func(_ context.Context, request *teov20220901.DescribeOriginACLRequest) (*teov20220901.DescribeOriginACLResponse, error) {
+		resp := teov20220901.NewDescribeOriginACLResponse()
+		resp.Response = &teov20220901.DescribeOriginACLResponseParams{
+			OriginACLInfo: &teov20220901.OriginACLInfo{
+				Status:          ptrStringOriginAcl("online"),
+				L7Hosts:         []*string{ptrStringOriginAcl("example1.com")},
+				OriginACLFamily: ptrStringOriginAcl("mlc"),
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaOriginAcl()
+	res := teo.ResourceTencentCloudTeoOriginAcl()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":           "zone-12345678",
+		"origin_acl_family": "mlc",
+		"l7_hosts":          []interface{}{"example1.com"},
+		"l4_proxy_ids":      []interface{}{},
+	})
+	d.SetId("zone-12345678")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.True(t, modifyCalled)
+	assert.Equal(t, "mlc", d.Get("origin_acl_family"))
+}
+
+// TestTeoOriginAcl_Schema tests the schema definition
+func TestTeoOriginAcl_Schema(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoOriginAcl()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "origin_acl_family")
+
+	originACLFamily := res.Schema["origin_acl_family"]
+	assert.Equal(t, schema.TypeString, originACLFamily.Type)
+	assert.True(t, originACLFamily.Optional)
+	assert.True(t, originACLFamily.Computed)
+}
+
+// TestAccTencentCloudTeoOriginAclResource_basic is the acceptance test
 func TestAccTencentCloudTeoOriginAclResource_basic(t *testing.T) {
 	t.Parallel()
 	resource.Test(t, resource.TestCase{

--- a/website/docs/d/teo_origin_acl.html.markdown
+++ b/website/docs/d/teo_origin_acl.html.markdown
@@ -75,6 +75,7 @@ Note: This field may return null, which indicates a failure to obtain a valid va
       * `ipv4` - IPv4 subnet.
       * `ipv6` - IPv6 subnet.
     * `version` - Version number.
+  * `origin_acl_family` - Origin ACL control domain.
   * `status` - Origin protection status. Vaild values:
 - online: in effect;
 - offline: disabled;

--- a/website/docs/r/teo_origin_acl.html.markdown
+++ b/website/docs/r/teo_origin_acl.html.markdown
@@ -17,7 +17,8 @@ Provides a resource to create a TEO origin acl
 
 ```hcl
 resource "tencentcloud_teo_origin_acl" "example" {
-  zone_id = "zone-39quuimqg8r6"
+  zone_id           = "zone-39quuimqg8r6"
+  origin_acl_family = "mlc"
   l7_hosts = [
     "example1.com",
     "example2.com",
@@ -46,6 +47,7 @@ The following arguments are supported:
 * `zone_id` - (Required, String, ForceNew) Specifies the site ID.
 * `l4_proxy_ids` - (Optional, Set: [`String`]) he list of L4 proxy Instances that require enabling origin ACLs. This list must be empty when the request parameter L4EnableMode is set to 'all'.
 * `l7_hosts` - (Optional, Set: [`String`]) The list of L7 acceleration domains that require enabling the origin ACLs. This list must be empty when the request parameter L7EnableMode is set to 'all'.
+* `origin_acl_family` - (Optional, String) Origin ACL control domain. Valid values: gaz, mlc, emc, plat-gaz, plat-mlc, plat-emc.
 
 ## Attributes Reference
 

--- a/website/docs/r/teo_origin_acl.html.markdown
+++ b/website/docs/r/teo_origin_acl.html.markdown
@@ -17,8 +17,8 @@ Provides a resource to create a TEO origin acl
 
 ```hcl
 resource "tencentcloud_teo_origin_acl" "example" {
-  zone_id           = "zone-39quuimqg8r6"
-  origin_acl_family = "mlc"
+  zone_id           = "zone-3fkff38fyw8s"
+  origin_acl_family = "gaz"
   l7_hosts = [
     "example1.com",
     "example2.com",
@@ -66,9 +66,9 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-TEO origin acl can be imported using the zone_id, e.g.
+TEO origin acl can be imported using the id, e.g.
 
 ````
-terraform import tencentcloud_teo_origin_acl.example zone-39quuimqg8r6
+terraform import tencentcloud_teo_origin_acl.example zone-3fkff38fyw8s
 ````
 


### PR DESCRIPTION
Add origin_acl_family parameter to the tencentcloud_teo_origin_acl resource. This parameter controls the origin ACL domain with valid values: gaz, mlc, emc, plat-gaz, plat-mlc, plat-emc. Changes include:
- Add origin_acl_family field to resource schema (Optional + Computed)
- Update Create/Read/Update logic to handle origin_acl_family
- Add origin_acl_family to data source origin_acl_info block
- Update documentation with new parameter example
- Add unit tests for new parameter