### PR TITLE
docs(teo): update zone type description with detailed access modes

### DIFF
--- a/.changelog/4089.txt
+++ b/.changelog/4089.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_zone: update type parameter description with detailed access modes
+```

--- a/tencentcloud/services/teo/resource_tc_teo_zone.go
+++ b/tencentcloud/services/teo/resource_tc_teo_zone.go
@@ -41,7 +41,7 @@ func ResourceTencentCloudTeoZone() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Site access type. The value of this parameter is as follows, and the default is partial if not filled in:partial: CNAME access; full: NS access; noDomainAccess: No domain access.",
+				Description: "Site Access Type. The possible values for this parameter are as follows; if left unspecified, the default value is `partial`:\n\n- `partial`: CNAME Access;\n- `full`: NS Access;\n- `noDomainAccess`: No-Domain Access;\n- `dnsPodAccess`: DNSPod Managed Access (this mode requires your domain to already be hosted on DNSPod);\n- `ai`: Edge Inference Access.",
 			},
 
 			"alias_zone_name": {

--- a/website/docs/r/teo_zone.html.markdown
+++ b/website/docs/r/teo_zone.html.markdown
@@ -64,7 +64,13 @@ The following arguments are supported:
   - mainland: Chinese mainland availability zone.
   - overseas: Global availability zone (excluding Chinese mainland).
 * `plan_id` - (Required, String, ForceNew) The target Plan ID to be bound. When you have an existing Plan in your account, you can fill in this parameter to directly bind the site to the Plan. If you do not have a Plan that can be bound at the moment, please go to the console to purchase a Plan to complete the site creation.
-* `type` - (Required, String) Site access type. The value of this parameter is as follows, and the default is partial if not filled in:partial: CNAME access; full: NS access; noDomainAccess: No domain access.
+* `type` - (Required, String) Site Access Type. The possible values for this parameter are as follows; if left unspecified, the default value is `partial`:
+
+- `partial`: CNAME Access;
+- `full`: NS Access;
+- `noDomainAccess`: No-Domain Access;
+- `dnsPodAccess`: DNSPod Managed Access (this mode requires your domain to already be hosted on DNSPod);
+- `ai`: Edge Inference Access.
 * `zone_name` - (Required, String, ForceNew) Site name. When accessing CNAME/NS, please pass the second-level domain (example.com) as the site name; when accessing without a domain name, please leave this value empty.
 * `alias_zone_name` - (Optional, String) Alias site identifier. Limit the input to a combination of numbers, English, - and _, within 20 characters. For details, refer to the alias site identifier. If there is no such usage scenario, leave this field empty.
 * `paused` - (Optional, Bool) Indicates whether the site is disabled.


### PR DESCRIPTION
Update the description of the `type` parameter in `tencentcloud_teo_zone` resource to provide detailed access mode information. The description now includes all possible values (partial, full, noDomainAccess, dnsPodAccess, ai) with their meanings.