### PR TITLE
feat(ga2): add tencentcloud_ga2_accelerate_regions datasource

### DIFF
--- a/.changelog/4151.txt
+++ b/.changelog/4151.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_ga2_accelerate_regions
+```

--- a/go.sum
+++ b/go.sum
@@ -958,6 +958,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.89/go.mod h
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.90/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.94/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.95/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.101/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.102 h1:3n7BpLOPnE9Rv3Y9Jxgl/XaQX3GzktO+dEaAbtVbjSk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.102/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=

--- a/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/design.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/design.md
@@ -1,0 +1,33 @@
+## Context
+
+GA2（全球加速2.0）产品已有 `tencentcloud_ga2_endpoint_group` 资源在 `tencentcloud/services/ga2/` 目录下。现需新增数据源 `tencentcloud_ga2_accelerate_regions`，用于查询可选加速区域列表。
+
+云API `DescribeAccelerateRegions` 无入参，返回 `AcceleratorRegionSet` 列表，包含地域名称、可用性、地域标识、地区名称、是否中国地域、支持的ISP类型、是否腾讯地域等字段。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 实现数据源 `tencentcloud_ga2_accelerate_regions`，调用 `DescribeAccelerateRegions` API 返回加速区域列表
+- 遵循项目现有的数据源实现模式（参考 `tencentcloud_igtm_instance_list`）
+- 提供完整的单元测试（使用 gomonkey mock）
+- 注册到 provider 并提供文档
+
+**Non-Goals:**
+- 不实现过滤参数（API 本身无入参）
+- 不实现分页（API 无分页参数）
+- 不支持 `result_output_file`（API 无入参，数据量固定）
+
+## Decisions
+
+1. **数据源 Schema 设计**: 由于 `DescribeAccelerateRegions` 无入参，数据源 Schema 仅包含一个 Computed 的 `accelerator_region_set` 列表字段，以及可选的 `result_output_file` 字段用于输出结果到文件。
+
+2. **直接在 Read 函数中调用 API**: 由于该接口简单（无入参、无分页），不需要在 `service_tencentcloud_ga2.go` 中新增服务层方法，直接在 Read 函数中通过 retry 调用 API 即可。参考同产品已有资源的模式。
+
+3. **测试方式**: 使用 gomonkey 对云API进行 mock，不依赖真实环境，确保单元测试可在 CI 中运行。
+
+4. **ID 设置**: 由于数据源无入参，使用 `helper.BuildToken()` 生成唯一 ID。
+
+## Risks / Trade-offs
+
+- [风险] API 返回数据量可能较大 → 由于该接口返回的是固定的区域列表，数据量有限，无需分页处理
+- [风险] API 无入参导致无法过滤 → 用户可在 Terraform 中使用 `for_each` 或 `locals` 进行二次过滤

--- a/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/proposal.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+为 GA2（全球加速2.0）云产品新增 Terraform 数据源 `tencentcloud_ga2_accelerate_regions`，使用户能够通过 Terraform 查询可选的加速区域信息，便于在编排加速实例时选择合适的加速区域。
+
+## What Changes
+
+- 新增数据源 `tencentcloud_ga2_accelerate_regions`，调用 `DescribeAccelerateRegions` 云API查询可选加速区域列表
+- 在 `tencentcloud/provider.go` 和 `tencentcloud/provider.md` 中注册该数据源
+- 新增数据源文档 `data_source_tc_ga2_accelerate_regions.md`
+- 新增单元测试文件 `data_source_tc_ga2_accelerate_regions_test.go`
+
+## Capabilities
+
+### New Capabilities
+
+- `ga2-accelerate-regions-datasource`: 提供查询 GA2 可选加速区域的数据源能力，返回加速区域列表（包含地域名称、可用性、地域标识、地区名称、是否中国地域、支持的ISP类型、是否腾讯地域等信息）
+
+### Modified Capabilities
+
+（无）
+
+## Impact
+
+- 新增文件: `tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions.go`
+- 新增文件: `tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions_test.go`
+- 新增文件: `tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions.md`
+- 修改文件: `tencentcloud/provider.go`（注册数据源）
+- 修改文件: `tencentcloud/provider.md`（添加数据源文档引用）
+- 依赖: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115`（已在 vendor 中）

--- a/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/specs/ga2-accelerate-regions-datasource/spec.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/specs/ga2-accelerate-regions-datasource/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Data source returns accelerate regions list
+
+The data source `tencentcloud_ga2_accelerate_regions` SHALL call the `DescribeAccelerateRegions` API and return the full list of available accelerate regions in the `accelerator_region_set` attribute.
+
+#### Scenario: Successful query of accelerate regions
+
+- **WHEN** user declares a `data "tencentcloud_ga2_accelerate_regions"` block in Terraform configuration
+- **THEN** the data source SHALL call `DescribeAccelerateRegions` API and populate `accelerator_region_set` with all returned regions
+
+#### Scenario: API returns empty list
+
+- **WHEN** the `DescribeAccelerateRegions` API returns an empty `AcceleratorRegionSet`
+- **THEN** the data source SHALL set `accelerator_region_set` to an empty list without error
+
+### Requirement: Each region entry contains complete region information
+
+Each element in `accelerator_region_set` SHALL contain the following computed attributes mapped from the API response:
+- `name` (String): Region Chinese name, mapped from `AcceleratorRegionSet[].Name`
+- `is_available` (Int): Availability status (0: unavailable, 1: available), mapped from `AcceleratorRegionSet[].IsAvailable`
+- `region` (String): Region identifier, mapped from `AcceleratorRegionSet[].Region`
+- `area_name` (String): Area name, mapped from `AcceleratorRegionSet[].AreaName`
+- `is_china_mainland` (Int): Whether it is a China mainland region, mapped from `AcceleratorRegionSet[].IsChinaMainland`
+- `support_isp_type` (List of String): Supported ISP types, mapped from `AcceleratorRegionSet[].SupportIspType`
+- `is_tencent_region` (Int): Whether it is a Tencent region, mapped from `AcceleratorRegionSet[].IsTencentRegion`
+
+#### Scenario: Region entry with all fields populated
+
+- **WHEN** the API returns a region with all fields non-nil
+- **THEN** the data source SHALL map all fields to the corresponding Terraform attributes
+
+#### Scenario: Region entry with nil fields
+
+- **WHEN** the API returns a region with some fields as nil
+- **THEN** the data source SHALL only set non-nil fields and skip nil fields without error
+
+### Requirement: API call uses retry mechanism
+
+The data source SHALL use `tccommon.ReadRetryTimeout` as the timeout and wrap the API call with retry logic using `resource.RetryContext`.
+
+#### Scenario: API call fails with retryable error
+
+- **WHEN** the `DescribeAccelerateRegions` API returns a retryable error
+- **THEN** the data source SHALL retry the call within the configured timeout
+
+#### Scenario: API call fails with non-retryable error
+
+- **WHEN** the `DescribeAccelerateRegions` API returns a non-retryable error
+- **THEN** the data source SHALL return the error immediately without retry
+
+### Requirement: Data source supports result output file
+
+The data source SHALL support an optional `result_output_file` attribute that, when specified, writes the query results to the given file path.
+
+#### Scenario: Result output file specified
+
+- **WHEN** user specifies `result_output_file` in the data source configuration
+- **THEN** the data source SHALL write the accelerator region set data to the specified file
+
+#### Scenario: Result output file not specified
+
+- **WHEN** user does not specify `result_output_file`
+- **THEN** the data source SHALL not write any output file
+
+### Requirement: Data source is registered in provider
+
+The data source `tencentcloud_ga2_accelerate_regions` SHALL be registered in `tencentcloud/provider.go` and documented in `tencentcloud/provider.md`.
+
+#### Scenario: Provider includes the data source
+
+- **WHEN** the Terraform provider is initialized
+- **THEN** the data source `tencentcloud_ga2_accelerate_regions` SHALL be available for use

--- a/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/tasks.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-accelerate-regions-datasource/tasks.md
@@ -1,0 +1,14 @@
+## 1. Data Source Implementation
+
+- [x] 1.1 Create `tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions.go` with Schema definition and Read function, calling `DescribeAccelerateRegions` API with retry logic
+- [x] 1.2 Register data source `tencentcloud_ga2_accelerate_regions` in `tencentcloud/provider.go`
+- [x] 1.3 Add data source entry in `tencentcloud/provider.md`
+
+## 2. Documentation
+
+- [x] 2.1 Create `tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions.md` with Example Usage section
+
+## 3. Testing
+
+- [x] 3.1 Create `tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions_test.go` with unit tests using gomonkey mock for the cloud API
+- [x] 3.2 Run unit tests with `go test -gcflags=all=-l` to verify tests pass

--- a/openspec/specs/ga2-accelerate-regions-datasource/spec.md
+++ b/openspec/specs/ga2-accelerate-regions-datasource/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Data source returns accelerate regions list
+
+The data source `tencentcloud_ga2_accelerate_regions` SHALL call the `DescribeAccelerateRegions` API and return the full list of available accelerate regions in the `accelerator_region_set` attribute.
+
+#### Scenario: Successful query of accelerate regions
+
+- **WHEN** user declares a `data "tencentcloud_ga2_accelerate_regions"` block in Terraform configuration
+- **THEN** the data source SHALL call `DescribeAccelerateRegions` API and populate `accelerator_region_set` with all returned regions
+
+#### Scenario: API returns empty list
+
+- **WHEN** the `DescribeAccelerateRegions` API returns an empty `AcceleratorRegionSet`
+- **THEN** the data source SHALL set `accelerator_region_set` to an empty list without error
+
+### Requirement: Each region entry contains complete region information
+
+Each element in `accelerator_region_set` SHALL contain the following computed attributes mapped from the API response:
+- `name` (String): Region Chinese name, mapped from `AcceleratorRegionSet[].Name`
+- `is_available` (Int): Availability status (0: unavailable, 1: available), mapped from `AcceleratorRegionSet[].IsAvailable`
+- `region` (String): Region identifier, mapped from `AcceleratorRegionSet[].Region`
+- `area_name` (String): Area name, mapped from `AcceleratorRegionSet[].AreaName`
+- `is_china_mainland` (Int): Whether it is a China mainland region, mapped from `AcceleratorRegionSet[].IsChinaMainland`
+- `support_isp_type` (List of String): Supported ISP types, mapped from `AcceleratorRegionSet[].SupportIspType`
+- `is_tencent_region` (Int): Whether it is a Tencent region, mapped from `AcceleratorRegionSet[].IsTencentRegion`
+
+#### Scenario: Region entry with all fields populated
+
+- **WHEN** the API returns a region with all fields non-nil
+- **THEN** the data source SHALL map all fields to the corresponding Terraform attributes
+
+#### Scenario: Region entry with nil fields
+
+- **WHEN** the API returns a region with some fields as nil
+- **THEN** the data source SHALL only set non-nil fields and skip nil fields without error
+
+### Requirement: API call uses retry mechanism
+
+The data source SHALL use `tccommon.ReadRetryTimeout` as the timeout and wrap the API call with retry logic using `resource.RetryContext`.
+
+#### Scenario: API call fails with retryable error
+
+- **WHEN** the `DescribeAccelerateRegions` API returns a retryable error
+- **THEN** the data source SHALL retry the call within the configured timeout
+
+#### Scenario: API call fails with non-retryable error
+
+- **WHEN** the `DescribeAccelerateRegions` API returns a non-retryable error
+- **THEN** the data source SHALL return the error immediately without retry
+
+### Requirement: Data source supports result output file
+
+The data source SHALL support an optional `result_output_file` attribute that, when specified, writes the query results to the given file path.
+
+#### Scenario: Result output file specified
+
+- **WHEN** user specifies `result_output_file` in the data source configuration
+- **THEN** the data source SHALL write the accelerator region set data to the specified file
+
+#### Scenario: Result output file not specified
+
+- **WHEN** user does not specify `result_output_file`
+- **THEN** the data source SHALL not write any output file
+
+### Requirement: Data source is registered in provider
+
+The data source `tencentcloud_ga2_accelerate_regions` SHALL be registered in `tencentcloud/provider.go` and documented in `tencentcloud/provider.md`.
+
+#### Scenario: Provider includes the data source
+
+- **WHEN** the Terraform provider is initialized
+- **THEN** the data source `tencentcloud_ga2_accelerate_regions` SHALL be available for use

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1393,6 +1393,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_config_rules":                                          config.DataSourceTencentCloudConfigRules(),
 			"tencentcloud_config_discovered_resources":                           config.DataSourceTencentCloudConfigDiscoveredResources(),
 			"tencentcloud_config_resource_types":                                 config.DataSourceTencentCloudConfigResourceTypes(),
+			"tencentcloud_ga2_accelerate_regions":                                ga2.DataSourceTencentCloudGa2AccelerateRegions(),
 			"tencentcloud_products":                                              regionpkg.DataSourceTencentCloudProducts(),
 			"tencentcloud_regions":                                               regionpkg.DataSourceTencentCloudRegions(),
 			"tencentcloud_zones":                                                 regionpkg.DataSourceTencentCloudZones(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -2668,3 +2668,9 @@ tencentcloud_gs_android_instances
 KeeWiDB
 Data Source
 tencentcloud_keewidb_instances
+
+Global Accelerator 2(GA2)
+Data Source
+tencentcloud_ga2_accelerate_regions
+Resource
+tencentcloud_ga2_endpoint_group

--- a/tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions.go
+++ b/tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions.go
@@ -1,0 +1,158 @@
+package ga2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	ga2v20250115 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudGa2AccelerateRegions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudGa2AccelerateRegionsRead,
+		Schema: map[string]*schema.Schema{
+			"accelerator_region_set": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Accelerate region list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Region Chinese name.",
+						},
+						"is_available": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Availability status. 0: unavailable, 1: available.",
+						},
+						"region": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Region identifier.",
+						},
+						"area_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Area name.",
+						},
+						"is_china_mainland": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Whether it is a China mainland region.",
+						},
+						"support_isp_type": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Supported ISP types.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"is_tencent_region": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Whether it is a Tencent region.",
+						},
+					},
+				},
+			},
+
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudGa2AccelerateRegionsRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_ga2_accelerate_regions.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(nil)
+		ctx   = context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+	)
+
+	var respData []*ga2v20250115.AcceleratorRegionSet
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		request := ga2v20250115.NewDescribeAccelerateRegionsRequest()
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseGa2V20250115Client().DescribeAccelerateRegionsWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("DescribeAccelerateRegions failed, Response is nil"))
+		}
+
+		respData = result.Response.AcceleratorRegionSet
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	regionSetList := make([]map[string]interface{}, 0, len(respData))
+	if respData != nil {
+		for _, regionItem := range respData {
+			regionMap := map[string]interface{}{}
+			if regionItem.Name != nil {
+				regionMap["name"] = regionItem.Name
+			}
+
+			if regionItem.IsAvailable != nil {
+				regionMap["is_available"] = regionItem.IsAvailable
+			}
+
+			if regionItem.Region != nil {
+				regionMap["region"] = regionItem.Region
+			}
+
+			if regionItem.AreaName != nil {
+				regionMap["area_name"] = regionItem.AreaName
+			}
+
+			if regionItem.IsChinaMainland != nil {
+				regionMap["is_china_mainland"] = regionItem.IsChinaMainland
+			}
+
+			if regionItem.SupportIspType != nil {
+				ispTypes := make([]string, 0, len(regionItem.SupportIspType))
+				for _, isp := range regionItem.SupportIspType {
+					if isp != nil {
+						ispTypes = append(ispTypes, *isp)
+					}
+				}
+				regionMap["support_isp_type"] = ispTypes
+			}
+
+			if regionItem.IsTencentRegion != nil {
+				regionMap["is_tencent_region"] = regionItem.IsTencentRegion
+			}
+
+			regionSetList = append(regionSetList, regionMap)
+		}
+	}
+
+	_ = d.Set("accelerator_region_set", regionSetList)
+
+	d.SetId(helper.BuildToken())
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), regionSetList); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions.md
+++ b/tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions.md
@@ -1,0 +1,17 @@
+Use this data source to query available accelerate regions of GA2 (Global Accelerator 2)
+
+Example Usage
+
+Query all GA2 accelerate regions
+
+```hcl
+data "tencentcloud_ga2_accelerate_regions" "example" {}
+```
+
+Query GA2 accelerate regions and output to file
+
+```hcl
+data "tencentcloud_ga2_accelerate_regions" "example" {
+  result_output_file = "ga2_accelerate_regions.json"
+}
+```

--- a/tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions_test.go
+++ b/tencentcloud/services/ga2/data_source_tc_ga2_accelerate_regions_test.go
@@ -1,0 +1,176 @@
+package ga2_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	ga2v20250115 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/ga2"
+)
+
+// go test ./tencentcloud/services/ga2/ -run "TestGa2AccelerateRegions" -v -count=1 -gcflags="all=-l"
+
+// TestGa2AccelerateRegionsDataSource_Success tests Read calls API and sets accelerator_region_set
+func TestGa2AccelerateRegionsDataSource_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	mockClient := &connectivity.TencentCloudClient{}
+	patches.ApplyMethodReturn(mockClient, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "DescribeAccelerateRegionsWithContext", func(ctx context.Context, request *ga2v20250115.DescribeAccelerateRegionsRequest) (*ga2v20250115.DescribeAccelerateRegionsResponse, error) {
+		resp := ga2v20250115.NewDescribeAccelerateRegionsResponse()
+		resp.Response = &ga2v20250115.DescribeAccelerateRegionsResponseParams{
+			AcceleratorRegionSet: []*ga2v20250115.AcceleratorRegionSet{
+				{
+					Name:            ptrGa2String("广州"),
+					IsAvailable:     ptrGa2Int64(1),
+					Region:          ptrGa2String("ap-guangzhou"),
+					AreaName:        ptrGa2String("华南地区"),
+					IsChinaMainland: ptrGa2Uint64(1),
+					SupportIspType:  []*string{ptrGa2String("BGP"), ptrGa2String("ChinaTelecom")},
+					IsTencentRegion: ptrGa2Uint64(1),
+				},
+				{
+					Name:            ptrGa2String("硅谷"),
+					IsAvailable:     ptrGa2Int64(1),
+					Region:          ptrGa2String("na-siliconvalley"),
+					AreaName:        ptrGa2String("北美地区"),
+					IsChinaMainland: ptrGa2Uint64(0),
+					SupportIspType:  []*string{ptrGa2String("BGP")},
+					IsTencentRegion: ptrGa2Uint64(1),
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := &ga2MockMeta{client: mockClient}
+	res := ga2.DataSourceTencentCloudGa2AccelerateRegions()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	regionSet := d.Get("accelerator_region_set").([]interface{})
+	assert.Len(t, regionSet, 2)
+
+	region0 := regionSet[0].(map[string]interface{})
+	assert.Equal(t, "广州", region0["name"])
+	assert.Equal(t, 1, region0["is_available"])
+	assert.Equal(t, "ap-guangzhou", region0["region"])
+	assert.Equal(t, "华南地区", region0["area_name"])
+	assert.Equal(t, 1, region0["is_china_mainland"])
+	assert.Equal(t, 1, region0["is_tencent_region"])
+	ispTypes0 := region0["support_isp_type"].([]interface{})
+	assert.Equal(t, "BGP", ispTypes0[0].(string))
+	assert.Equal(t, "ChinaTelecom", ispTypes0[1].(string))
+
+	region1 := regionSet[1].(map[string]interface{})
+	assert.Equal(t, "硅谷", region1["name"])
+	assert.Equal(t, "na-siliconvalley", region1["region"])
+	assert.Equal(t, "北美地区", region1["area_name"])
+	assert.Equal(t, 0, region1["is_china_mainland"])
+}
+
+// TestGa2AccelerateRegionsDataSource_APIError tests Read handles API error
+func TestGa2AccelerateRegionsDataSource_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	mockClient := &connectivity.TencentCloudClient{}
+	patches.ApplyMethodReturn(mockClient, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "DescribeAccelerateRegionsWithContext", func(ctx context.Context, request *ga2v20250115.DescribeAccelerateRegionsRequest) (*ga2v20250115.DescribeAccelerateRegionsResponse, error) {
+		return nil, fmt.Errorf("[TencentCloudSDKError] Code=InternalError, Message=Internal error")
+	})
+
+	meta := &ga2MockMeta{client: mockClient}
+	res := ga2.DataSourceTencentCloudGa2AccelerateRegions()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "InternalError")
+}
+
+// TestGa2AccelerateRegionsDataSource_EmptyResult tests Read handles empty result
+func TestGa2AccelerateRegionsDataSource_EmptyResult(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	mockClient := &connectivity.TencentCloudClient{}
+	patches.ApplyMethodReturn(mockClient, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "DescribeAccelerateRegionsWithContext", func(ctx context.Context, request *ga2v20250115.DescribeAccelerateRegionsRequest) (*ga2v20250115.DescribeAccelerateRegionsResponse, error) {
+		resp := ga2v20250115.NewDescribeAccelerateRegionsResponse()
+		resp.Response = &ga2v20250115.DescribeAccelerateRegionsResponseParams{
+			AcceleratorRegionSet: []*ga2v20250115.AcceleratorRegionSet{},
+		}
+		return resp, nil
+	})
+
+	meta := &ga2MockMeta{client: mockClient}
+	res := ga2.DataSourceTencentCloudGa2AccelerateRegions()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	regionSet := d.Get("accelerator_region_set").([]interface{})
+	assert.Len(t, regionSet, 0)
+}
+
+// TestGa2AccelerateRegionsDataSource_Schema validates schema definition
+func TestGa2AccelerateRegionsDataSource_Schema(t *testing.T) {
+	res := ga2.DataSourceTencentCloudGa2AccelerateRegions()
+
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Read)
+
+	assert.Contains(t, res.Schema, "accelerator_region_set")
+	assert.Contains(t, res.Schema, "result_output_file")
+
+	regionSet := res.Schema["accelerator_region_set"]
+	assert.Equal(t, schema.TypeList, regionSet.Type)
+	assert.True(t, regionSet.Computed)
+
+	resultOutputFile := res.Schema["result_output_file"]
+	assert.Equal(t, schema.TypeString, resultOutputFile.Type)
+	assert.True(t, resultOutputFile.Optional)
+}
+
+// ga2MockMeta implements tccommon.ProviderMeta
+type ga2MockMeta struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *ga2MockMeta) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &ga2MockMeta{}
+
+func ptrGa2String(s string) *string {
+	return &s
+}
+
+func ptrGa2Int64(i int64) *int64 {
+	return &i
+}
+
+func ptrGa2Uint64(i uint64) *uint64 {
+	return &i
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"io"
-
 	//"log"
 	"math/rand"
 	"net/url"

--- a/website/docs/d/ga2_accelerate_regions.html.markdown
+++ b/website/docs/d/ga2_accelerate_regions.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "Global Accelerator 2(GA2)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_ga2_accelerate_regions"
+sidebar_current: "docs-tencentcloud-datasource-ga2_accelerate_regions"
+description: |-
+  Use this data source to query available accelerate regions of GA2 (Global Accelerator 2)
+---
+
+# tencentcloud_ga2_accelerate_regions
+
+Use this data source to query available accelerate regions of GA2 (Global Accelerator 2)
+
+## Example Usage
+
+### Query all GA2 accelerate regions
+
+```hcl
+data "tencentcloud_ga2_accelerate_regions" "example" {}
+```
+
+### Query GA2 accelerate regions and output to file
+
+```hcl
+data "tencentcloud_ga2_accelerate_regions" "example" {
+  result_output_file = "ga2_accelerate_regions.json"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `result_output_file` - (Optional, String) Used to save results.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `accelerator_region_set` - Accelerate region list.
+  * `area_name` - Area name.
+  * `is_available` - Availability status. 0: unavailable, 1: available.
+  * `is_china_mainland` - Whether it is a China mainland region.
+  * `is_tencent_region` - Whether it is a Tencent region.
+  * `name` - Region Chinese name.
+  * `region` - Region identifier.
+  * `support_isp_type` - Supported ISP types.
+
+

--- a/website/docs/r/ga2_endpoint_group.html.markdown
+++ b/website/docs/r/ga2_endpoint_group.html.markdown
@@ -1,0 +1,119 @@
+---
+subcategory: "Global Accelerator 2(GA2)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_ga2_endpoint_group"
+sidebar_current: "docs-tencentcloud-resource-ga2_endpoint_group"
+description: |-
+  Provides a resource to create a GA2 (Global Accelerator 2) endpoint group.
+---
+
+# tencentcloud_ga2_endpoint_group
+
+Provides a resource to create a GA2 (Global Accelerator 2) endpoint group.
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_ga2_endpoint_group" "example" {
+  global_accelerator_id = "ga2-xxxxxxxx"
+  listener_id           = "lis-xxxxxxxx"
+  endpoint_group_type   = "DEFAULT"
+
+  endpoint_group_configuration {
+    name                  = "tf-example"
+    endpoint_group_region = "ap-guangzhou"
+    description           = "tf example endpoint group"
+    enable_health_check   = true
+    check_type            = "HTTP"
+    check_port            = "80"
+    check_path            = "/"
+    check_method          = "GET"
+    connect_timeout       = 5000
+    health_check_interval = 30
+    healthy_threshold     = 3
+    unhealthy_threshold   = 3
+    forward_protocol      = "HTTP"
+
+    endpoint_configurations {
+      endpoint_type    = "PublicIp"
+      endpoint_service = "1.1.1.1"
+      weight           = 10
+    }
+
+    endpoint_configurations {
+      endpoint_type    = "Domain"
+      endpoint_service = "example.com"
+      weight           = 20
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `endpoint_group_configuration` - (Required, List) Endpoint group configuration.
+* `endpoint_group_type` - (Required, String, ForceNew) Endpoint group type. Valid values: `VIRTUAL`, `DEFAULT`.
+* `global_accelerator_id` - (Required, String, ForceNew) Global accelerator instance ID.
+* `listener_id` - (Required, String, ForceNew) Listener ID.
+
+The `endpoint_configurations` object of `endpoint_group_configuration` supports the following:
+
+* `endpoint_service` - (Optional, String) Endpoint domain or IP.
+* `endpoint_type` - (Optional, String) Endpoint type. Valid values: `Domain`, `PublicIp`.
+* `weight` - (Optional, Int) Endpoint weight.
+
+The `endpoint_group_configuration` object supports the following:
+
+* `check_domain` - (Optional, String) Health check domain.
+* `check_method` - (Optional, String) Health check request method.
+* `check_path` - (Optional, String) Health check URL path.
+* `check_port` - (Optional, String) Health check port.
+* `check_recv_context` - (Optional, String) Health check expected response.
+* `check_send_context` - (Optional, String) Health check request payload.
+* `check_type` - (Optional, String) Health check protocol. Valid values: `TCP`, `HTTP`, `HTTPS`, `PING`, `CUSTOM`.
+* `cipher_policy_id` - (Optional, String) HTTPS cipher policy ID.
+* `connect_timeout` - (Optional, Int) Response timeout in milliseconds.
+* `context_type` - (Optional, String) Health check content type.
+* `description` - (Optional, String) Description. Maximum length is 100 bytes.
+* `enable_health_check` - (Optional, Bool) Whether to enable health check.
+* `endpoint_configurations` - (Optional, List) Endpoint configurations under this group.
+* `endpoint_group_region` - (Optional, String) Region of the endpoint group.
+* `forward_protocol` - (Optional, String) Forward protocol back to origin.
+* `health_check_interval` - (Optional, Int) Health check interval in seconds.
+* `healthy_threshold` - (Optional, Int) Healthy threshold count.
+* `isp_type` - (Optional, String) ISP type.
+* `name` - (Optional, String) Name. Maximum length is 60 bytes.
+* `port_overrides` - (Optional, List) Port overrides for the endpoint group.
+* `status_mask` - (Optional, List) Status code masks for health check.
+* `unhealthy_threshold` - (Optional, Int) Unhealthy threshold count.
+
+The `port_overrides` object of `endpoint_group_configuration` supports the following:
+
+* `endpoint_port` - (Optional, Int) Endpoint port.
+* `listener_port` - (Optional, Int) Listener port.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `endpoint_group_id` - Endpoint group instance ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to `20m`) Used when creating the resource.
+* `update` - (Defaults to `20m`) Used when updating the resource.
+* `delete` - (Defaults to `20m`) Used when deleting the resource.
+
+## Import
+
+GA2 endpoint group can be imported using the composite ID `<global_accelerator_id>#<listener_id>#<endpoint_group_id>`, e.g.
+
+```
+terraform import tencentcloud_ga2_endpoint_group.example ga2-xxxxxxxx#lis-xxxxxxxx#eg-xxxxxxxx
+```
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -3010,6 +3010,27 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">Global Accelerator 2(GA2)</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/d/ga2_accelerate_regions.html">tencentcloud_ga2_accelerate_regions</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/r/ga2_endpoint_group.html">tencentcloud_ga2_endpoint_group</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">Global Application Acceleration(GAAP)</a>
                     <ul class="nav">
                         <li>


### PR DESCRIPTION
Add a new data source `tencentcloud_ga2_accelerate_regions` for the GA2 (Global Accelerator 2.0) product. This data source queries available accelerate regions via the `DescribeAccelerateRegions` API, returning region details including name, availability, region identifier, area name, China mainland status, supported ISP types, and Tencent region flag.