### PR TITLE
feat(ga2): add tencentcloud_ga2_forwarding_rule resource

### DIFF
--- a/.changelog/4152.txt
+++ b/.changelog/4152.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_ga2_forwarding_rule
+```

--- a/go.sum
+++ b/go.sum
@@ -958,6 +958,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.89/go.mod h
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.90/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.94/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.95/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.101/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.102 h1:3n7BpLOPnE9Rv3Y9Jxgl/XaQX3GzktO+dEaAbtVbjSk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.102/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=

--- a/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/design.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/design.md
@@ -1,0 +1,47 @@
+## Context
+
+TencentCloud GA2 (Global Accelerator 2.0) provides Layer-7 forwarding rules that route traffic based on conditions (host, path) and perform actions (forward to endpoint groups). The GA2 SDK package (`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115`) is already vendored and provides four APIs for forwarding rule management: CreateForwardingRule, DescribeForwardingRule, ModifyForwardingRule, and DeleteForwardingRule.
+
+An existing resource `tencentcloud_ga2_endpoint_group` in `tencentcloud/services/ga2/` demonstrates the established patterns for this service, including async task polling via `WaitForGa2TaskFinish`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement a fully functional `tencentcloud_ga2_forwarding_rule` resource with Create, Read, Update, Delete operations.
+- Handle async operations (Create/Modify/Delete all return TaskId) by polling DescribeTaskResult until success.
+- Use a composite ID (`global_accelerator_id#listener_id#forwarding_policy_id#forwarding_rule_id`) for resource identification and import support.
+- Provide unit tests using gomonkey mocks for all CRUD paths.
+- Register the resource in provider.go and provider.md.
+
+**Non-Goals:**
+- Data source for listing forwarding rules (out of scope for this change).
+- Support for tags on forwarding rules (the API does not expose tag fields).
+- Acceptance tests requiring real cloud credentials.
+
+## Decisions
+
+### 1. Composite ID Structure
+**Decision**: Use 4-part composite ID: `global_accelerator_id#listener_id#forwarding_policy_id#forwarding_rule_id` with `tccommon.FILED_SP` as separator.
+**Rationale**: The Delete and Modify APIs require all four IDs. The Read API (DescribeForwardingRule) requires the first three plus pagination to find the specific rule by `forwarding_rule_id`. This matches the pattern used by `tencentcloud_ga2_endpoint_group` (3-part ID).
+
+### 2. ForceNew Fields
+**Decision**: Mark `global_accelerator_id`, `listener_id`, and `forwarding_policy_id` as ForceNew. The `forwarding_rule_id` is computed (returned by Create).
+**Rationale**: These three fields identify the parent context (accelerator → listener → policy). Changing them means a different forwarding policy context, requiring resource recreation. The Modify API accepts these as identifiers, not mutable fields.
+
+### 3. Async Operation Handling
+**Decision**: Reuse the existing `Ga2Service.WaitForGa2TaskFinish` method after Create, Modify, and Delete operations.
+**Rationale**: All three mutation APIs return a TaskId indicating async processing. The existing helper already polls DescribeTaskResult with proper retry logic and timeout support.
+
+### 4. Read Implementation with Pagination
+**Decision**: In the Read function, call DescribeForwardingRule with pagination (Limit=100) and iterate through results to find the matching `forwarding_rule_id`.
+**Rationale**: The DescribeForwardingRule API returns all rules under a forwarding policy, not a single rule. We must paginate and filter client-side by `forwarding_rule_id`, similar to how `DescribeGa2EndpointGroupById` works.
+
+### 5. Schema Design for Nested Structures
+**Decision**: Use `TypeList` for `rule_conditions`, `rule_actions`, and `origin_headers` with nested `Elem` schemas.
+**Rationale**: These are arrays of structured objects in the API. TypeList preserves ordering which is important for rule evaluation order.
+
+## Risks / Trade-offs
+
+- [Risk] DescribeForwardingRule returns rules for the entire policy, not a single rule → Mitigation: Client-side filtering by `forwarding_rule_id` with pagination ensures correctness.
+- [Risk] Async task polling may time out for large configurations → Mitigation: Use configurable Timeouts block (default 20 minutes) consistent with endpoint_group resource.
+- [Trade-off] Using TypeList for rule_conditions/rule_actions means order matters in state → This is intentional as rule evaluation order is significant for Layer-7 routing.

--- a/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/proposal.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+TencentCloud Global Accelerator 2.0 (GA2) supports Layer-7 forwarding rules that allow users to route traffic based on conditions (e.g., host, path) and perform actions (e.g., forward to endpoint groups). Currently, there is no Terraform resource to manage these forwarding rules, requiring users to configure them manually through the console or API.
+
+## What Changes
+
+- Add a new Terraform resource `tencentcloud_ga2_forwarding_rule` that provides full CRUD lifecycle management for GA2 Layer-7 forwarding rules.
+- The resource supports:
+  - Creating forwarding rules with conditions, actions, origin headers, origin SNI, and origin host settings.
+  - Reading forwarding rule state via the DescribeForwardingRule API with pagination.
+  - Modifying forwarding rule conditions, actions, and origin settings.
+  - Deleting forwarding rules.
+- All Create/Modify/Delete operations are asynchronous (return TaskId), so the resource will poll DescribeForwardingRule after each mutation to confirm the operation has taken effect.
+- The resource uses a composite ID consisting of `global_accelerator_id`, `listener_id`, `forwarding_policy_id`, and `forwarding_rule_id` joined by `tccommon.FILED_SP`.
+
+## Capabilities
+
+### New Capabilities
+- `ga2-forwarding-rule-crud`: Full CRUD lifecycle management for GA2 Layer-7 forwarding rules, including async operation polling and composite ID handling.
+
+### Modified Capabilities
+
+## Impact
+
+- New files:
+  - `tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule.go` - Resource implementation
+  - `tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule_test.go` - Unit tests with gomonkey mocks
+  - `tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule.md` - Example usage documentation
+- Modified files:
+  - `tencentcloud/services/ga2/service_tencentcloud_ga2.go` - Add service-layer helper functions for forwarding rule CRUD
+  - `tencentcloud/provider.go` - Register the new resource
+  - `tencentcloud/provider.md` - Add resource entry to provider documentation
+- Dependencies: Uses existing `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115` package (already vendored)

--- a/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/specs/ga2-forwarding-rule-crud/spec.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/specs/ga2-forwarding-rule-crud/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Create forwarding rule
+The system SHALL create a GA2 Layer-7 forwarding rule by calling the CreateForwardingRule API with the specified parameters (global_accelerator_id, listener_id, forwarding_policy_id, rule_conditions, rule_actions, origin_headers, enable_origin_sni, origin_sni, origin_host). After creation, the system SHALL poll DescribeTaskResult until the task succeeds, then store the composite ID (global_accelerator_id#listener_id#forwarding_policy_id#forwarding_rule_id) in state.
+
+#### Scenario: Successful creation with all parameters
+- **WHEN** user provides global_accelerator_id, listener_id, forwarding_policy_id, rule_conditions, rule_actions, origin_headers, enable_origin_sni, origin_sni, and origin_host
+- **THEN** the system calls CreateForwardingRule API, waits for the async task to complete, and stores the composite ID in Terraform state
+
+#### Scenario: Successful creation with minimal parameters
+- **WHEN** user provides only global_accelerator_id, listener_id, forwarding_policy_id, rule_conditions, and rule_actions (required fields)
+- **THEN** the system calls CreateForwardingRule API with only the provided fields, waits for the async task to complete, and stores the composite ID in Terraform state
+
+#### Scenario: Create API returns nil response
+- **WHEN** the CreateForwardingRule API returns a nil response or nil ForwardingRuleId
+- **THEN** the system returns a NonRetryableError indicating the creation failed
+
+### Requirement: Read forwarding rule
+The system SHALL read a GA2 Layer-7 forwarding rule by calling the DescribeForwardingRule API with pagination (Limit=100) and filtering the results by forwarding_rule_id to find the specific rule. The system SHALL set all attributes from the ForwardingRuleSet response into Terraform state.
+
+#### Scenario: Successful read of existing rule
+- **WHEN** the resource exists and DescribeForwardingRule returns a ForwardingRuleSet containing the target forwarding_rule_id
+- **THEN** the system sets rule_conditions, rule_actions, origin_headers, enable_origin_sni, origin_sni, and origin_host from the response into state
+
+#### Scenario: Rule not found (deleted externally)
+- **WHEN** the DescribeForwardingRule API does not return a ForwardingRuleSet entry matching the forwarding_rule_id
+- **THEN** the system removes the resource from state (sets ID to empty string)
+
+### Requirement: Update forwarding rule
+The system SHALL update a GA2 Layer-7 forwarding rule by calling the ModifyForwardingRule API with the changed parameters. The system SHALL poll DescribeTaskResult until the task succeeds, then call Read to refresh state.
+
+#### Scenario: Successful update of rule conditions and actions
+- **WHEN** user modifies rule_conditions, rule_actions, origin_headers, enable_origin_sni, origin_sni, or origin_host
+- **THEN** the system calls ModifyForwardingRule API with all current values, waits for the async task to complete, and refreshes state via Read
+
+#### Scenario: Update with HasChange detection
+- **WHEN** user applies a configuration change
+- **THEN** the system only calls ModifyForwardingRule if at least one mutable field has changed
+
+### Requirement: Delete forwarding rule
+The system SHALL delete a GA2 Layer-7 forwarding rule by calling the DeleteForwardingRule API with the four identifying IDs. The system SHALL poll DescribeTaskResult until the task succeeds.
+
+#### Scenario: Successful deletion
+- **WHEN** the resource exists and DeleteForwardingRule is called
+- **THEN** the system calls DeleteForwardingRule API, waits for the async task to complete, and removes the resource from state
+
+### Requirement: Import forwarding rule
+The system SHALL support importing an existing GA2 forwarding rule using the composite ID format: `global_accelerator_id#listener_id#forwarding_policy_id#forwarding_rule_id`.
+
+#### Scenario: Successful import with composite ID
+- **WHEN** user runs terraform import with the composite ID format
+- **THEN** the system parses the four components from the ID and calls Read to populate state
+
+#### Scenario: Invalid import ID format
+- **WHEN** user provides an import ID that does not contain exactly 4 parts separated by #
+- **THEN** the system returns an error indicating the expected format
+
+### Requirement: Resource schema definition
+The system SHALL define the Terraform schema with the following fields:
+- `global_accelerator_id` (Required, ForceNew, String): Global accelerator instance ID
+- `listener_id` (Required, ForceNew, String): Listener ID
+- `forwarding_policy_id` (Required, ForceNew, String): Forwarding policy ID
+- `rule_conditions` (Required, List of objects with rule_condition_type and rule_condition_value): Rule conditions
+- `rule_actions` (Required, List of objects with rule_action_type and rule_action_value): Rule actions
+- `origin_headers` (Optional, List of objects with key and value): Origin headers
+- `enable_origin_sni` (Optional, Bool): Whether to enable origin SNI
+- `origin_sni` (Optional, String): Origin SNI value
+- `origin_host` (Optional, String): Origin host value
+- `forwarding_rule_id` (Computed, String): The forwarding rule ID returned by the API
+- `task_id` (Computed, String): The async task ID from the last mutation operation
+
+#### Scenario: Schema validation
+- **WHEN** the resource schema is registered in the provider
+- **THEN** all Required fields MUST be provided by the user, ForceNew fields trigger recreation on change, and Computed fields are set by the system
+
+### Requirement: Retry and timeout handling
+The system SHALL wrap all API calls with retry logic using tccommon.ReadRetryTimeout for read operations and tccommon.WriteRetryTimeout for write operations. The resource SHALL declare Timeouts for Create, Update, and Delete operations (default 20 minutes each).
+
+#### Scenario: Transient API error during create
+- **WHEN** the CreateForwardingRule API returns a transient error
+- **THEN** the system retries the call within the WriteRetryTimeout period
+
+#### Scenario: Task polling timeout
+- **WHEN** the async task does not reach SUCCESS status within the configured timeout
+- **THEN** the system returns a timeout error to the user

--- a/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/tasks.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-forwarding-rule-resource/tasks.md
@@ -1,0 +1,25 @@
+## 1. Service Layer
+
+- [x] 1.1 Add `DescribeGa2ForwardingRuleById` method to `tencentcloud/services/ga2/service_tencentcloud_ga2.go` that calls DescribeForwardingRule API with pagination (Limit=100) and filters by forwarding_rule_id to return a single `*ga2v20250115.ForwardingRuleSet`
+
+## 2. Resource Implementation
+
+- [x] 2.1 Create `tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule.go` with schema definition including: global_accelerator_id (Required, ForceNew), listener_id (Required, ForceNew), forwarding_policy_id (Required, ForceNew), rule_conditions (Required, TypeList), rule_actions (Required, TypeList), origin_headers (Optional, TypeList), enable_origin_sni (Optional, Bool), origin_sni (Optional, String), origin_host (Optional, String), forwarding_rule_id (Computed), task_id (Computed). Include Timeouts block (Create/Update/Delete: 20 minutes) and Importer
+- [x] 2.2 Implement `resourceTencentCloudGa2ForwardingRuleCreate` function: call CreateForwardingRule API with retry, validate response and ForwardingRuleId not nil, wait for task via WaitForGa2TaskFinish, set composite ID, call Read
+- [x] 2.3 Implement `resourceTencentCloudGa2ForwardingRuleRead` function: parse composite ID, call DescribeGa2ForwardingRuleById, handle not-found by clearing ID, set all attributes from ForwardingRuleSet response (check nil before setting)
+- [x] 2.4 Implement `resourceTencentCloudGa2ForwardingRuleUpdate` function: detect changes with HasChange, call ModifyForwardingRule API with retry, wait for task via WaitForGa2TaskFinish, call Read
+- [x] 2.5 Implement `resourceTencentCloudGa2ForwardingRuleDelete` function: parse composite ID, call DeleteForwardingRule API with retry, wait for task via WaitForGa2TaskFinish
+- [x] 2.6 Implement helper functions: `parseGa2ForwardingRuleId` (split composite ID into 4 parts), `buildRuleConditions`/`flattenRuleConditions`, `buildRuleActions`/`flattenRuleActions`, `buildOriginHeaders`/`flattenOriginHeaders`
+
+## 3. Provider Registration
+
+- [x] 3.1 Register `tencentcloud_ga2_forwarding_rule` resource in `tencentcloud/provider.go` ResourcesMap
+- [x] 3.2 Add `tencentcloud_ga2_forwarding_rule` entry to `tencentcloud/provider.md`
+
+## 4. Documentation
+
+- [x] 4.1 Create `tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule.md` with Example Usage section showing a complete forwarding rule configuration, and Import section explaining the composite ID format (global_accelerator_id#listener_id#forwarding_policy_id#forwarding_rule_id)
+
+## 5. Unit Tests
+
+- [x] 5.1 Create `tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule_test.go` with gomonkey-based unit tests covering: Create (success, nil response error), Read (success, not found), Update (success), Delete (success). Mock the GA2 SDK client methods and verify correct API calls and state handling. Run tests with `go test -gcflags=all=-l`

--- a/openspec/specs/ga2-forwarding-rule-crud/spec.md
+++ b/openspec/specs/ga2-forwarding-rule-crud/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Create forwarding rule
+The system SHALL create a GA2 Layer-7 forwarding rule by calling the CreateForwardingRule API with the specified parameters (global_accelerator_id, listener_id, forwarding_policy_id, rule_conditions, rule_actions, origin_headers, enable_origin_sni, origin_sni, origin_host). After creation, the system SHALL poll DescribeTaskResult until the task succeeds, then store the composite ID (global_accelerator_id#listener_id#forwarding_policy_id#forwarding_rule_id) in state.
+
+#### Scenario: Successful creation with all parameters
+- **WHEN** user provides global_accelerator_id, listener_id, forwarding_policy_id, rule_conditions, rule_actions, origin_headers, enable_origin_sni, origin_sni, and origin_host
+- **THEN** the system calls CreateForwardingRule API, waits for the async task to complete, and stores the composite ID in Terraform state
+
+#### Scenario: Successful creation with minimal parameters
+- **WHEN** user provides only global_accelerator_id, listener_id, forwarding_policy_id, rule_conditions, and rule_actions (required fields)
+- **THEN** the system calls CreateForwardingRule API with only the provided fields, waits for the async task to complete, and stores the composite ID in Terraform state
+
+#### Scenario: Create API returns nil response
+- **WHEN** the CreateForwardingRule API returns a nil response or nil ForwardingRuleId
+- **THEN** the system returns a NonRetryableError indicating the creation failed
+
+### Requirement: Read forwarding rule
+The system SHALL read a GA2 Layer-7 forwarding rule by calling the DescribeForwardingRule API with pagination (Limit=100) and filtering the results by forwarding_rule_id to find the specific rule. The system SHALL set all attributes from the ForwardingRuleSet response into Terraform state.
+
+#### Scenario: Successful read of existing rule
+- **WHEN** the resource exists and DescribeForwardingRule returns a ForwardingRuleSet containing the target forwarding_rule_id
+- **THEN** the system sets rule_conditions, rule_actions, origin_headers, enable_origin_sni, origin_sni, and origin_host from the response into state
+
+#### Scenario: Rule not found (deleted externally)
+- **WHEN** the DescribeForwardingRule API does not return a ForwardingRuleSet entry matching the forwarding_rule_id
+- **THEN** the system removes the resource from state (sets ID to empty string)
+
+### Requirement: Update forwarding rule
+The system SHALL update a GA2 Layer-7 forwarding rule by calling the ModifyForwardingRule API with the changed parameters. The system SHALL poll DescribeTaskResult until the task succeeds, then call Read to refresh state.
+
+#### Scenario: Successful update of rule conditions and actions
+- **WHEN** user modifies rule_conditions, rule_actions, origin_headers, enable_origin_sni, origin_sni, or origin_host
+- **THEN** the system calls ModifyForwardingRule API with all current values, waits for the async task to complete, and refreshes state via Read
+
+#### Scenario: Update with HasChange detection
+- **WHEN** user applies a configuration change
+- **THEN** the system only calls ModifyForwardingRule if at least one mutable field has changed
+
+### Requirement: Delete forwarding rule
+The system SHALL delete a GA2 Layer-7 forwarding rule by calling the DeleteForwardingRule API with the four identifying IDs. The system SHALL poll DescribeTaskResult until the task succeeds.
+
+#### Scenario: Successful deletion
+- **WHEN** the resource exists and DeleteForwardingRule is called
+- **THEN** the system calls DeleteForwardingRule API, waits for the async task to complete, and removes the resource from state
+
+### Requirement: Import forwarding rule
+The system SHALL support importing an existing GA2 forwarding rule using the composite ID format: `global_accelerator_id#listener_id#forwarding_policy_id#forwarding_rule_id`.
+
+#### Scenario: Successful import with composite ID
+- **WHEN** user runs terraform import with the composite ID format
+- **THEN** the system parses the four components from the ID and calls Read to populate state
+
+#### Scenario: Invalid import ID format
+- **WHEN** user provides an import ID that does not contain exactly 4 parts separated by #
+- **THEN** the system returns an error indicating the expected format
+
+### Requirement: Resource schema definition
+The system SHALL define the Terraform schema with the following fields:
+- `global_accelerator_id` (Required, ForceNew, String): Global accelerator instance ID
+- `listener_id` (Required, ForceNew, String): Listener ID
+- `forwarding_policy_id` (Required, ForceNew, String): Forwarding policy ID
+- `rule_conditions` (Required, List of objects with rule_condition_type and rule_condition_value): Rule conditions
+- `rule_actions` (Required, List of objects with rule_action_type and rule_action_value): Rule actions
+- `origin_headers` (Optional, List of objects with key and value): Origin headers
+- `enable_origin_sni` (Optional, Bool): Whether to enable origin SNI
+- `origin_sni` (Optional, String): Origin SNI value
+- `origin_host` (Optional, String): Origin host value
+- `forwarding_rule_id` (Computed, String): The forwarding rule ID returned by the API
+- `task_id` (Computed, String): The async task ID from the last mutation operation
+
+#### Scenario: Schema validation
+- **WHEN** the resource schema is registered in the provider
+- **THEN** all Required fields MUST be provided by the user, ForceNew fields trigger recreation on change, and Computed fields are set by the system
+
+### Requirement: Retry and timeout handling
+The system SHALL wrap all API calls with retry logic using tccommon.ReadRetryTimeout for read operations and tccommon.WriteRetryTimeout for write operations. The resource SHALL declare Timeouts for Create, Update, and Delete operations (default 20 minutes each).
+
+#### Scenario: Transient API error during create
+- **WHEN** the CreateForwardingRule API returns a transient error
+- **THEN** the system retries the call within the WriteRetryTimeout period
+
+#### Scenario: Task polling timeout
+- **WHEN** the async task does not reach SUCCESS status within the configured timeout
+- **THEN** the system returns a timeout error to the user

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1722,6 +1722,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_dayu_l7_rule_v2":                                                          dayuv2.ResourceTencentCloudDayuL7RuleV2(),
 			"tencentcloud_dayu_eip":                                                                 dayuv2.ResourceTencentCloudDayuEip(),
 			"tencentcloud_ga2_endpoint_group":                                                       ga2.ResourceTencentCloudGa2EndpointGroup(),
+			"tencentcloud_ga2_forwarding_rule":                                                      ga2.ResourceTencentCloudGa2ForwardingRule(),
 			"tencentcloud_gaap_proxy":                                                               gaap.ResourceTencentCloudGaapProxy(),
 			"tencentcloud_gaap_realserver":                                                          gaap.ResourceTencentCloudGaapRealserver(),
 			"tencentcloud_gaap_layer4_listener":                                                     gaap.ResourceTencentCloudGaapLayer4Listener(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -669,6 +669,11 @@ tencentcloud_gaap_global_domain_dns
 tencentcloud_gaap_global_domain
 tencentcloud_gaap_custom_header
 
+Global Accelerator 2(GA2)
+Resource
+tencentcloud_ga2_endpoint_group
+tencentcloud_ga2_forwarding_rule
+
 Key Management Service(KMS)
 Data Source
 tencentcloud_kms_keys

--- a/tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule.go
+++ b/tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule.go
@@ -1,0 +1,549 @@
+package ga2
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	ga2v20250115 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudGa2ForwardingRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudGa2ForwardingRuleCreate,
+		Read:   resourceTencentCloudGa2ForwardingRuleRead,
+		Update: resourceTencentCloudGa2ForwardingRuleUpdate,
+		Delete: resourceTencentCloudGa2ForwardingRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"global_accelerator_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Global accelerator instance ID.",
+			},
+			"listener_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Listener ID.",
+			},
+			"forwarding_policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Forwarding policy ID.",
+			},
+			"rule_conditions": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "Layer-7 forwarding rule conditions.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_condition_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Rule condition type.",
+						},
+						"rule_condition_value": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "Rule condition values.",
+						},
+					},
+				},
+			},
+			"rule_actions": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "Layer-7 forwarding rule actions.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_action_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Rule action type.",
+						},
+						"rule_action_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Rule action value.",
+						},
+					},
+				},
+			},
+			"origin_headers": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Origin headers.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Header key.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Header value.",
+						},
+					},
+				},
+			},
+			"enable_origin_sni": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to enable origin SNI.",
+			},
+			"origin_sni": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Origin SNI value.",
+			},
+			"origin_host": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Origin host value.",
+			},
+			"forwarding_rule_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Forwarding rule ID.",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudGa2ForwardingRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_ga2_forwarding_rule.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId              = tccommon.GetLogId(tccommon.ContextNil)
+		ctx                = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request            = ga2v20250115.NewCreateForwardingRuleRequest()
+		response           = ga2v20250115.NewCreateForwardingRuleResponse()
+		gaId               string
+		listenerId         string
+		forwardingPolicyId string
+		forwardingRuleId   string
+		taskId             string
+	)
+
+	if v, ok := d.GetOk("global_accelerator_id"); ok {
+		gaId = v.(string)
+		request.GlobalAcceleratorId = helper.String(gaId)
+	}
+
+	if v, ok := d.GetOk("listener_id"); ok {
+		listenerId = v.(string)
+		request.ListenerId = helper.String(listenerId)
+	}
+
+	if v, ok := d.GetOk("forwarding_policy_id"); ok {
+		forwardingPolicyId = v.(string)
+		request.ForwardingPolicyId = helper.String(forwardingPolicyId)
+	}
+
+	if v, ok := d.GetOk("rule_conditions"); ok {
+		request.RuleConditions = buildRuleConditions(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("rule_actions"); ok {
+		request.RuleActions = buildRuleActions(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("origin_headers"); ok {
+		request.OriginHeaders = buildOriginHeaders(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOkExists("enable_origin_sni"); ok {
+		request.EnableOriginSni = helper.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("origin_sni"); ok {
+		request.OriginSni = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("origin_host"); ok {
+		request.OriginHost = helper.String(v.(string))
+	}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseGa2V20250115Client().CreateForwardingRuleWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create ga2 forwarding rule failed, Response is nil."))
+		}
+
+		response = result
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s create ga2 forwarding rule failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	if response.Response.ForwardingRuleId == nil {
+		return fmt.Errorf("ForwardingRuleId is nil.")
+	}
+	forwardingRuleId = *response.Response.ForwardingRuleId
+
+	if response.Response.TaskId == nil {
+		return fmt.Errorf("TaskId is nil.")
+	}
+	taskId = *response.Response.TaskId
+
+	service := Ga2Service{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	if err := service.WaitForGa2TaskFinish(ctx, taskId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return err
+	}
+
+	d.SetId(strings.Join([]string{gaId, listenerId, forwardingPolicyId, forwardingRuleId}, tccommon.FILED_SP))
+	return resourceTencentCloudGa2ForwardingRuleRead(d, meta)
+}
+
+func resourceTencentCloudGa2ForwardingRuleRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_ga2_forwarding_rule.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service = Ga2Service{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	)
+
+	gaId, listenerId, forwardingPolicyId, forwardingRuleId, err := parseGa2ForwardingRuleId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	respData, err := service.DescribeGa2ForwardingRuleById(ctx, gaId, listenerId, forwardingPolicyId, forwardingRuleId)
+	if err != nil {
+		return err
+	}
+
+	if respData == nil {
+		log.Printf("[WARN]%s resource `tencentcloud_ga2_forwarding_rule` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	_ = d.Set("global_accelerator_id", gaId)
+	_ = d.Set("listener_id", listenerId)
+	_ = d.Set("forwarding_policy_id", forwardingPolicyId)
+
+	if respData.ForwardingRuleId != nil {
+		_ = d.Set("forwarding_rule_id", respData.ForwardingRuleId)
+	}
+
+	if respData.RuleCondition != nil {
+		_ = d.Set("rule_conditions", flattenRuleConditions(respData.RuleCondition))
+	}
+
+	if respData.RuleAction != nil {
+		_ = d.Set("rule_actions", flattenRuleActions(respData.RuleAction))
+	}
+
+	if respData.OriginHeaders != nil {
+		_ = d.Set("origin_headers", flattenOriginHeaders(respData.OriginHeaders))
+	}
+
+	if respData.EnableOriginSni != nil {
+		_ = d.Set("enable_origin_sni", respData.EnableOriginSni)
+	}
+
+	if respData.OriginSni != nil {
+		_ = d.Set("origin_sni", respData.OriginSni)
+	}
+
+	if respData.OriginHost != nil {
+		_ = d.Set("origin_host", respData.OriginHost)
+	}
+
+	return nil
+}
+
+func resourceTencentCloudGa2ForwardingRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_ga2_forwarding_rule.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+	)
+
+	gaId, listenerId, forwardingPolicyId, forwardingRuleId, err := parseGa2ForwardingRuleId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	needChange := d.HasChange("rule_conditions") || d.HasChange("rule_actions") || d.HasChange("origin_headers") ||
+		d.HasChange("enable_origin_sni") || d.HasChange("origin_sni") || d.HasChange("origin_host")
+
+	if !needChange {
+		return resourceTencentCloudGa2ForwardingRuleRead(d, meta)
+	}
+
+	request := ga2v20250115.NewModifyForwardingRuleRequest()
+	request.GlobalAcceleratorId = helper.String(gaId)
+	request.ListenerId = helper.String(listenerId)
+	request.ForwardingPolicyId = helper.String(forwardingPolicyId)
+	request.ForwardingRuleId = helper.String(forwardingRuleId)
+
+	if v, ok := d.GetOk("rule_conditions"); ok {
+		request.RuleConditions = buildRuleConditions(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("rule_actions"); ok {
+		request.RuleActions = buildRuleActions(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("origin_headers"); ok {
+		request.OriginHeaders = buildOriginHeaders(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOkExists("enable_origin_sni"); ok {
+		request.EnableOriginSni = helper.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("origin_sni"); ok {
+		request.OriginSni = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("origin_host"); ok {
+		request.OriginHost = helper.String(v.(string))
+	}
+
+	var taskId string
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseGa2V20250115Client().ModifyForwardingRuleWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+
+		if result == nil || result.Response == nil || result.Response.TaskId == nil {
+			return resource.NonRetryableError(fmt.Errorf("Modify ga2 forwarding rule failed, Response is nil."))
+		}
+
+		taskId = *result.Response.TaskId
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s update ga2 forwarding rule failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	service := Ga2Service{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	if err := service.WaitForGa2TaskFinish(ctx, taskId, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return err
+	}
+
+	return resourceTencentCloudGa2ForwardingRuleRead(d, meta)
+}
+
+func resourceTencentCloudGa2ForwardingRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_ga2_forwarding_rule.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = ga2v20250115.NewDeleteForwardingRuleRequest()
+	)
+
+	gaId, listenerId, forwardingPolicyId, forwardingRuleId, err := parseGa2ForwardingRuleId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	request.GlobalAcceleratorId = helper.String(gaId)
+	request.ListenerId = helper.String(listenerId)
+	request.ForwardingPolicyId = helper.String(forwardingPolicyId)
+	request.ForwardingRuleId = helper.String(forwardingRuleId)
+
+	var taskId string
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseGa2V20250115Client().DeleteForwardingRuleWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+
+		if result == nil || result.Response == nil || result.Response.TaskId == nil {
+			return resource.NonRetryableError(fmt.Errorf("Delete ga2 forwarding rule failed, Response is nil."))
+		}
+
+		taskId = *result.Response.TaskId
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s delete ga2 forwarding rule failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	service := Ga2Service{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	if err := service.WaitForGa2TaskFinish(ctx, taskId, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parseGa2ForwardingRuleId(id string) (gaId, listenerId, forwardingPolicyId, forwardingRuleId string, err error) {
+	parts := strings.Split(id, tccommon.FILED_SP)
+	if len(parts) != 4 {
+		err = fmt.Errorf("invalid resource id %q, expected format <global_accelerator_id>%s<listener_id>%s<forwarding_policy_id>%s<forwarding_rule_id>", id, tccommon.FILED_SP, tccommon.FILED_SP, tccommon.FILED_SP)
+		return
+	}
+	gaId, listenerId, forwardingPolicyId, forwardingRuleId = parts[0], parts[1], parts[2], parts[3]
+	if gaId == "" || listenerId == "" || forwardingPolicyId == "" || forwardingRuleId == "" {
+		err = fmt.Errorf("invalid resource id %q, components must all be non-empty", id)
+		return
+	}
+	return
+}
+
+func buildRuleConditions(rawList []interface{}) []*ga2v20250115.RuleCondition {
+	result := make([]*ga2v20250115.RuleCondition, 0, len(rawList))
+	for _, item := range rawList {
+		if item == nil {
+			continue
+		}
+		m := item.(map[string]interface{})
+		rc := &ga2v20250115.RuleCondition{}
+
+		if v, ok := m["rule_condition_type"].(string); ok && v != "" {
+			rc.RuleConditionType = helper.String(v)
+		}
+		if v, ok := m["rule_condition_value"]; ok {
+			rc.RuleConditionValue = helper.InterfacesStringsPoint(v.([]interface{}))
+		}
+
+		result = append(result, rc)
+	}
+	return result
+}
+
+func flattenRuleConditions(items []*ga2v20250115.RuleCondition) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		m := map[string]interface{}{}
+		if item.RuleConditionType != nil {
+			m["rule_condition_type"] = *item.RuleConditionType
+		}
+		if item.RuleConditionValue != nil {
+			m["rule_condition_value"] = helper.PStrings(item.RuleConditionValue)
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func buildRuleActions(rawList []interface{}) []*ga2v20250115.RuleAction {
+	result := make([]*ga2v20250115.RuleAction, 0, len(rawList))
+	for _, item := range rawList {
+		if item == nil {
+			continue
+		}
+		m := item.(map[string]interface{})
+		ra := &ga2v20250115.RuleAction{}
+
+		if v, ok := m["rule_action_type"].(string); ok && v != "" {
+			ra.RuleActionType = helper.String(v)
+		}
+		if v, ok := m["rule_action_value"].(string); ok && v != "" {
+			ra.RuleActionValue = helper.String(v)
+		}
+
+		result = append(result, ra)
+	}
+	return result
+}
+
+func flattenRuleActions(items []*ga2v20250115.RuleAction) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		m := map[string]interface{}{}
+		if item.RuleActionType != nil {
+			m["rule_action_type"] = *item.RuleActionType
+		}
+		if item.RuleActionValue != nil {
+			m["rule_action_value"] = *item.RuleActionValue
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func buildOriginHeaders(rawList []interface{}) []*ga2v20250115.OriginHeader {
+	result := make([]*ga2v20250115.OriginHeader, 0, len(rawList))
+	for _, item := range rawList {
+		if item == nil {
+			continue
+		}
+		m := item.(map[string]interface{})
+		oh := &ga2v20250115.OriginHeader{}
+
+		if v, ok := m["key"].(string); ok && v != "" {
+			oh.Key = helper.String(v)
+		}
+		if v, ok := m["value"].(string); ok && v != "" {
+			oh.Value = helper.String(v)
+		}
+
+		result = append(result, oh)
+	}
+	return result
+}
+
+func flattenOriginHeaders(items []*ga2v20250115.OriginHeader) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		m := map[string]interface{}{}
+		if item.Key != nil {
+			m["key"] = *item.Key
+		}
+		if item.Value != nil {
+			m["value"] = *item.Value
+		}
+		result = append(result, m)
+	}
+	return result
+}

--- a/tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule.md
+++ b/tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule.md
@@ -1,0 +1,38 @@
+Provides a resource to create a GA2 (Global Accelerator 2) forwarding rule.
+
+Example Usage
+
+```hcl
+resource "tencentcloud_ga2_forwarding_rule" "example" {
+  global_accelerator_id = "ga2-xxxxxxxx"
+  listener_id           = "lis-xxxxxxxx"
+  forwarding_policy_id  = "fp-xxxxxxxx"
+
+  rule_conditions {
+    rule_condition_type  = "HOST"
+    rule_condition_value = ["example.com"]
+  }
+
+  rule_actions {
+    rule_action_type  = "ForwardGroup"
+    rule_action_value = "eg-xxxxxxxx"
+  }
+
+  origin_headers {
+    key   = "X-Custom-Header"
+    value = "custom-value"
+  }
+
+  enable_origin_sni = true
+  origin_sni        = "example.com"
+  origin_host       = "origin.example.com"
+}
+```
+
+Import
+
+GA2 forwarding rule can be imported using the composite ID `<global_accelerator_id>#<listener_id>#<forwarding_policy_id>#<forwarding_rule_id>`, e.g.
+
+```
+terraform import tencentcloud_ga2_forwarding_rule.example ga2-xxxxxxxx#lis-xxxxxxxx#fp-xxxxxxxx#fr-xxxxxxxx
+```

--- a/tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule_test.go
+++ b/tencentcloud/services/ga2/resource_tc_ga2_forwarding_rule_test.go
@@ -1,0 +1,433 @@
+package ga2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	ga2v20250115 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/ga2"
+)
+
+type mockMetaGa2ForwardingRule struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaGa2ForwardingRule) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaGa2ForwardingRule{}
+
+func newMockMetaGa2ForwardingRule() *mockMetaGa2ForwardingRule {
+	return &mockMetaGa2ForwardingRule{client: &connectivity.TencentCloudClient{Region: "ap-guangzhou"}}
+}
+
+func ptrStringGa2FR(s string) *string {
+	return &s
+}
+
+func ptrBoolGa2FR(b bool) *bool {
+	return &b
+}
+
+// go test ./tencentcloud/services/ga2/ -run "TestUnitGa2ForwardingRule" -v -count=1 -gcflags="all=-l"
+
+func TestUnitGa2ForwardingRule_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaGa2ForwardingRule()
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseGa2V20250115Client", ga2Client)
+
+	// Patch CreateForwardingRuleWithContext
+	patches.ApplyMethodFunc(ga2Client, "CreateForwardingRuleWithContext", func(_ context.Context, request *ga2v20250115.CreateForwardingRuleRequest) (*ga2v20250115.CreateForwardingRuleResponse, error) {
+		assert.Equal(t, "ga2-test001", *request.GlobalAcceleratorId)
+		assert.Equal(t, "lis-test001", *request.ListenerId)
+		assert.Equal(t, "fp-test001", *request.ForwardingPolicyId)
+		assert.Equal(t, 1, len(request.RuleConditions))
+		assert.Equal(t, "HOST", *request.RuleConditions[0].RuleConditionType)
+		assert.Equal(t, 1, len(request.RuleActions))
+		assert.Equal(t, "ForwardGroup", *request.RuleActions[0].RuleActionType)
+		assert.Equal(t, true, *request.EnableOriginSni)
+		assert.Equal(t, "example.com", *request.OriginSni)
+		assert.Equal(t, "origin.example.com", *request.OriginHost)
+
+		resp := &ga2v20250115.CreateForwardingRuleResponse{}
+		resp.Response = &ga2v20250115.CreateForwardingRuleResponseParams{
+			TaskId:           ptrStringGa2FR("task-001"),
+			ForwardingRuleId: ptrStringGa2FR("fr-test001"),
+			RequestId:        ptrStringGa2FR("req-001"),
+		}
+		return resp, nil
+	})
+
+	// Patch DescribeTaskResultWithContext for WaitForGa2TaskFinish
+	patches.ApplyMethodFunc(ga2Client, "DescribeTaskResultWithContext", func(_ context.Context, request *ga2v20250115.DescribeTaskResultRequest) (*ga2v20250115.DescribeTaskResultResponse, error) {
+		resp := &ga2v20250115.DescribeTaskResultResponse{}
+		resp.Response = &ga2v20250115.DescribeTaskResultResponseParams{
+			Status:    ptrStringGa2FR("SUCCESS"),
+			RequestId: ptrStringGa2FR("req-002"),
+		}
+		return resp, nil
+	})
+
+	// Patch DescribeForwardingRuleWithContext for Read after Create
+	patches.ApplyMethodFunc(ga2Client, "DescribeForwardingRuleWithContext", func(_ context.Context, request *ga2v20250115.DescribeForwardingRuleRequest) (*ga2v20250115.DescribeForwardingRuleResponse, error) {
+		resp := &ga2v20250115.DescribeForwardingRuleResponse{}
+		resp.Response = &ga2v20250115.DescribeForwardingRuleResponseParams{
+			ForwardingRuleSet: []*ga2v20250115.ForwardingRuleSet{
+				{
+					ForwardingRuleId:    ptrStringGa2FR("fr-test001"),
+					GlobalAcceleratorId: ptrStringGa2FR("ga2-test001"),
+					ListenerId:          ptrStringGa2FR("lis-test001"),
+					ForwardingPolicyId:  ptrStringGa2FR("fp-test001"),
+					RuleCondition: []*ga2v20250115.RuleCondition{
+						{
+							RuleConditionType:  ptrStringGa2FR("HOST"),
+							RuleConditionValue: []*string{ptrStringGa2FR("example.com")},
+						},
+					},
+					RuleAction: []*ga2v20250115.RuleAction{
+						{
+							RuleActionType:  ptrStringGa2FR("ForwardGroup"),
+							RuleActionValue: ptrStringGa2FR("eg-test001"),
+						},
+					},
+					OriginHeaders: []*ga2v20250115.OriginHeader{
+						{
+							Key:   ptrStringGa2FR("X-Custom-Header"),
+							Value: ptrStringGa2FR("custom-value"),
+						},
+					},
+					EnableOriginSni: ptrBoolGa2FR(true),
+					OriginSni:       ptrStringGa2FR("example.com"),
+					OriginHost:      ptrStringGa2FR("origin.example.com"),
+				},
+			},
+			TotalCount: func() *uint64 { v := uint64(1); return &v }(),
+			RequestId:  ptrStringGa2FR("req-003"),
+		}
+		return resp, nil
+	})
+
+	res := ga2.ResourceTencentCloudGa2ForwardingRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga2-test001",
+		"listener_id":           "lis-test001",
+		"forwarding_policy_id":  "fp-test001",
+		"rule_conditions": []interface{}{
+			map[string]interface{}{
+				"rule_condition_type":  "HOST",
+				"rule_condition_value": []interface{}{"example.com"},
+			},
+		},
+		"rule_actions": []interface{}{
+			map[string]interface{}{
+				"rule_action_type":  "ForwardGroup",
+				"rule_action_value": "eg-test001",
+			},
+		},
+		"origin_headers": []interface{}{
+			map[string]interface{}{
+				"key":   "X-Custom-Header",
+				"value": "custom-value",
+			},
+		},
+		"enable_origin_sni": true,
+		"origin_sni":        "example.com",
+		"origin_host":       "origin.example.com",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "ga2-test001"+tccommon.FILED_SP+"lis-test001"+tccommon.FILED_SP+"fp-test001"+tccommon.FILED_SP+"fr-test001", d.Id())
+}
+
+func TestUnitGa2ForwardingRule_CreateNilResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaGa2ForwardingRule()
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseGa2V20250115Client", ga2Client)
+
+	// Patch CreateForwardingRuleWithContext to return nil response
+	patches.ApplyMethodFunc(ga2Client, "CreateForwardingRuleWithContext", func(_ context.Context, request *ga2v20250115.CreateForwardingRuleRequest) (*ga2v20250115.CreateForwardingRuleResponse, error) {
+		resp := &ga2v20250115.CreateForwardingRuleResponse{}
+		resp.Response = nil
+		return resp, nil
+	})
+
+	res := ga2.ResourceTencentCloudGa2ForwardingRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga2-test001",
+		"listener_id":           "lis-test001",
+		"forwarding_policy_id":  "fp-test001",
+		"rule_conditions": []interface{}{
+			map[string]interface{}{
+				"rule_condition_type":  "HOST",
+				"rule_condition_value": []interface{}{"example.com"},
+			},
+		},
+		"rule_actions": []interface{}{
+			map[string]interface{}{
+				"rule_action_type":  "ForwardGroup",
+				"rule_action_value": "eg-test001",
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.Error(t, err)
+}
+
+func TestUnitGa2ForwardingRule_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaGa2ForwardingRule()
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseGa2V20250115Client", ga2Client)
+
+	// Patch DescribeForwardingRuleWithContext
+	patches.ApplyMethodFunc(ga2Client, "DescribeForwardingRuleWithContext", func(_ context.Context, request *ga2v20250115.DescribeForwardingRuleRequest) (*ga2v20250115.DescribeForwardingRuleResponse, error) {
+		assert.Equal(t, "ga2-test001", *request.GlobalAcceleratorId)
+		assert.Equal(t, "lis-test001", *request.ListenerId)
+		assert.Equal(t, "fp-test001", *request.ForwardingPolicyId)
+
+		resp := &ga2v20250115.DescribeForwardingRuleResponse{}
+		resp.Response = &ga2v20250115.DescribeForwardingRuleResponseParams{
+			ForwardingRuleSet: []*ga2v20250115.ForwardingRuleSet{
+				{
+					ForwardingRuleId:    ptrStringGa2FR("fr-test001"),
+					GlobalAcceleratorId: ptrStringGa2FR("ga2-test001"),
+					ListenerId:          ptrStringGa2FR("lis-test001"),
+					ForwardingPolicyId:  ptrStringGa2FR("fp-test001"),
+					RuleCondition: []*ga2v20250115.RuleCondition{
+						{
+							RuleConditionType:  ptrStringGa2FR("HOST"),
+							RuleConditionValue: []*string{ptrStringGa2FR("example.com")},
+						},
+					},
+					RuleAction: []*ga2v20250115.RuleAction{
+						{
+							RuleActionType:  ptrStringGa2FR("ForwardGroup"),
+							RuleActionValue: ptrStringGa2FR("eg-test001"),
+						},
+					},
+					OriginHeaders: []*ga2v20250115.OriginHeader{
+						{
+							Key:   ptrStringGa2FR("X-Custom-Header"),
+							Value: ptrStringGa2FR("custom-value"),
+						},
+					},
+					EnableOriginSni: ptrBoolGa2FR(true),
+					OriginSni:       ptrStringGa2FR("example.com"),
+					OriginHost:      ptrStringGa2FR("origin.example.com"),
+				},
+			},
+			TotalCount: func() *uint64 { v := uint64(1); return &v }(),
+			RequestId:  ptrStringGa2FR("req-001"),
+		}
+		return resp, nil
+	})
+
+	res := ga2.ResourceTencentCloudGa2ForwardingRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga2-test001",
+		"listener_id":           "lis-test001",
+		"forwarding_policy_id":  "fp-test001",
+		"rule_conditions":       []interface{}{},
+		"rule_actions":          []interface{}{},
+	})
+	d.SetId("ga2-test001" + tccommon.FILED_SP + "lis-test001" + tccommon.FILED_SP + "fp-test001" + tccommon.FILED_SP + "fr-test001")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "fr-test001", d.Get("forwarding_rule_id"))
+	assert.Equal(t, true, d.Get("enable_origin_sni"))
+	assert.Equal(t, "example.com", d.Get("origin_sni"))
+	assert.Equal(t, "origin.example.com", d.Get("origin_host"))
+}
+
+func TestUnitGa2ForwardingRule_ReadNotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaGa2ForwardingRule()
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseGa2V20250115Client", ga2Client)
+
+	// Patch DescribeForwardingRuleWithContext - return empty set
+	patches.ApplyMethodFunc(ga2Client, "DescribeForwardingRuleWithContext", func(_ context.Context, request *ga2v20250115.DescribeForwardingRuleRequest) (*ga2v20250115.DescribeForwardingRuleResponse, error) {
+		resp := &ga2v20250115.DescribeForwardingRuleResponse{}
+		resp.Response = &ga2v20250115.DescribeForwardingRuleResponseParams{
+			ForwardingRuleSet: []*ga2v20250115.ForwardingRuleSet{},
+			TotalCount:        func() *uint64 { v := uint64(0); return &v }(),
+			RequestId:         ptrStringGa2FR("req-001"),
+		}
+		return resp, nil
+	})
+
+	res := ga2.ResourceTencentCloudGa2ForwardingRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga2-test001",
+		"listener_id":           "lis-test001",
+		"forwarding_policy_id":  "fp-test001",
+		"rule_conditions":       []interface{}{},
+		"rule_actions":          []interface{}{},
+	})
+	d.SetId("ga2-test001" + tccommon.FILED_SP + "lis-test001" + tccommon.FILED_SP + "fp-test001" + tccommon.FILED_SP + "fr-notexist")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+func TestUnitGa2ForwardingRule_Update(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaGa2ForwardingRule()
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseGa2V20250115Client", ga2Client)
+
+	// Patch ModifyForwardingRuleWithContext
+	patches.ApplyMethodFunc(ga2Client, "ModifyForwardingRuleWithContext", func(_ context.Context, request *ga2v20250115.ModifyForwardingRuleRequest) (*ga2v20250115.ModifyForwardingRuleResponse, error) {
+		assert.Equal(t, "ga2-test001", *request.GlobalAcceleratorId)
+		assert.Equal(t, "lis-test001", *request.ListenerId)
+		assert.Equal(t, "fp-test001", *request.ForwardingPolicyId)
+		assert.Equal(t, "fr-test001", *request.ForwardingRuleId)
+
+		resp := &ga2v20250115.ModifyForwardingRuleResponse{}
+		resp.Response = &ga2v20250115.ModifyForwardingRuleResponseParams{
+			TaskId:    ptrStringGa2FR("task-002"),
+			RequestId: ptrStringGa2FR("req-001"),
+		}
+		return resp, nil
+	})
+
+	// Patch DescribeTaskResultWithContext
+	patches.ApplyMethodFunc(ga2Client, "DescribeTaskResultWithContext", func(_ context.Context, request *ga2v20250115.DescribeTaskResultRequest) (*ga2v20250115.DescribeTaskResultResponse, error) {
+		resp := &ga2v20250115.DescribeTaskResultResponse{}
+		resp.Response = &ga2v20250115.DescribeTaskResultResponseParams{
+			Status:    ptrStringGa2FR("SUCCESS"),
+			RequestId: ptrStringGa2FR("req-002"),
+		}
+		return resp, nil
+	})
+
+	// Patch DescribeForwardingRuleWithContext for Read after Update
+	patches.ApplyMethodFunc(ga2Client, "DescribeForwardingRuleWithContext", func(_ context.Context, request *ga2v20250115.DescribeForwardingRuleRequest) (*ga2v20250115.DescribeForwardingRuleResponse, error) {
+		resp := &ga2v20250115.DescribeForwardingRuleResponse{}
+		resp.Response = &ga2v20250115.DescribeForwardingRuleResponseParams{
+			ForwardingRuleSet: []*ga2v20250115.ForwardingRuleSet{
+				{
+					ForwardingRuleId:    ptrStringGa2FR("fr-test001"),
+					GlobalAcceleratorId: ptrStringGa2FR("ga2-test001"),
+					ListenerId:          ptrStringGa2FR("lis-test001"),
+					ForwardingPolicyId:  ptrStringGa2FR("fp-test001"),
+					RuleCondition: []*ga2v20250115.RuleCondition{
+						{
+							RuleConditionType:  ptrStringGa2FR("PATH"),
+							RuleConditionValue: []*string{ptrStringGa2FR("/api/*")},
+						},
+					},
+					RuleAction: []*ga2v20250115.RuleAction{
+						{
+							RuleActionType:  ptrStringGa2FR("ForwardGroup"),
+							RuleActionValue: ptrStringGa2FR("eg-test002"),
+						},
+					},
+					EnableOriginSni: ptrBoolGa2FR(false),
+				},
+			},
+			TotalCount: func() *uint64 { v := uint64(1); return &v }(),
+			RequestId:  ptrStringGa2FR("req-003"),
+		}
+		return resp, nil
+	})
+
+	res := ga2.ResourceTencentCloudGa2ForwardingRule()
+	d := res.TestResourceData()
+	d.SetId("ga2-test001" + tccommon.FILED_SP + "lis-test001" + tccommon.FILED_SP + "fp-test001" + tccommon.FILED_SP + "fr-test001")
+
+	_ = d.Set("global_accelerator_id", "ga2-test001")
+	_ = d.Set("listener_id", "lis-test001")
+	_ = d.Set("forwarding_policy_id", "fp-test001")
+	_ = d.Set("rule_conditions", []interface{}{
+		map[string]interface{}{
+			"rule_condition_type":  "PATH",
+			"rule_condition_value": []interface{}{"/api/*"},
+		},
+	})
+	_ = d.Set("rule_actions", []interface{}{
+		map[string]interface{}{
+			"rule_action_type":  "ForwardGroup",
+			"rule_action_value": "eg-test002",
+		},
+	})
+	_ = d.Set("enable_origin_sni", false)
+
+	// Mark as not new to enable HasChange
+	d.MarkNewResource()
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+}
+
+func TestUnitGa2ForwardingRule_Delete(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaGa2ForwardingRule()
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseGa2V20250115Client", ga2Client)
+
+	// Patch DeleteForwardingRuleWithContext
+	patches.ApplyMethodFunc(ga2Client, "DeleteForwardingRuleWithContext", func(_ context.Context, request *ga2v20250115.DeleteForwardingRuleRequest) (*ga2v20250115.DeleteForwardingRuleResponse, error) {
+		assert.Equal(t, "ga2-test001", *request.GlobalAcceleratorId)
+		assert.Equal(t, "lis-test001", *request.ListenerId)
+		assert.Equal(t, "fp-test001", *request.ForwardingPolicyId)
+		assert.Equal(t, "fr-test001", *request.ForwardingRuleId)
+
+		resp := &ga2v20250115.DeleteForwardingRuleResponse{}
+		resp.Response = &ga2v20250115.DeleteForwardingRuleResponseParams{
+			TaskId:    ptrStringGa2FR("task-003"),
+			RequestId: ptrStringGa2FR("req-001"),
+		}
+		return resp, nil
+	})
+
+	// Patch DescribeTaskResultWithContext
+	patches.ApplyMethodFunc(ga2Client, "DescribeTaskResultWithContext", func(_ context.Context, request *ga2v20250115.DescribeTaskResultRequest) (*ga2v20250115.DescribeTaskResultResponse, error) {
+		assert.Equal(t, "task-003", *request.TaskId)
+
+		resp := &ga2v20250115.DescribeTaskResultResponse{}
+		resp.Response = &ga2v20250115.DescribeTaskResultResponseParams{
+			Status:    ptrStringGa2FR("SUCCESS"),
+			RequestId: ptrStringGa2FR("req-002"),
+		}
+		return resp, nil
+	})
+
+	res := ga2.ResourceTencentCloudGa2ForwardingRule()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga2-test001",
+		"listener_id":           "lis-test001",
+		"forwarding_policy_id":  "fp-test001",
+		"rule_conditions":       []interface{}{},
+		"rule_actions":          []interface{}{},
+	})
+	d.SetId("ga2-test001" + tccommon.FILED_SP + "lis-test001" + tccommon.FILED_SP + "fp-test001" + tccommon.FILED_SP + "fr-test001")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+}

--- a/tencentcloud/services/ga2/service_tencentcloud_ga2.go
+++ b/tencentcloud/services/ga2/service_tencentcloud_ga2.go
@@ -99,6 +99,72 @@ func (me *Ga2Service) DescribeGa2EndpointGroupById(ctx context.Context, gaId, li
 	return nil, nil
 }
 
+// DescribeGa2ForwardingRuleById queries a forwarding rule by its identifying IDs.
+// Returns (nil, nil) when the forwarding rule does not exist.
+func (me *Ga2Service) DescribeGa2ForwardingRuleById(ctx context.Context, gaId, listenerId, forwardingPolicyId, forwardingRuleId string) (*ga2v20250115.ForwardingRuleSet, error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := ga2v20250115.NewDescribeForwardingRuleRequest()
+	request.GlobalAcceleratorId = helper.String(gaId)
+	request.ListenerId = helper.String(listenerId)
+	request.ForwardingPolicyId = helper.String(forwardingPolicyId)
+
+	var (
+		offset uint64 = 0
+		limit  uint64 = 100
+	)
+
+	for {
+		request.Offset = &offset
+		request.Limit = &limit
+
+		var response *ga2v20250115.DescribeForwardingRuleResponse
+		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			result, e := me.client.UseGa2V20250115Client().DescribeForwardingRuleWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Describe ga2 forwarding rule failed, Response is nil."))
+			}
+
+			response = result
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s describe ga2 forwarding rule failed, reason:%+v", logId, err)
+			return nil, err
+		}
+
+		set := response.Response.ForwardingRuleSet
+		for i := range set {
+			item := set[i]
+			if item == nil {
+				continue
+			}
+
+			if item.ForwardingRuleId == nil {
+				continue
+			}
+
+			if *item.ForwardingRuleId == forwardingRuleId {
+				return item, nil
+			}
+		}
+
+		// Stop when the current page is the last page.
+		if uint64(len(set)) < limit {
+			break
+		}
+
+		offset += limit
+	}
+
+	return nil, nil
+}
+
 // WaitForGa2TaskFinish polls DescribeTaskResult until the task reaches "SUCCESS" or the given timeout elapses.
 // The timeout is supplied by the caller because different async operations (create/modify/delete on
 // different resource types) may require very different waiting budgets.

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"io"
-
 	//"log"
 	"math/rand"
 	"net/url"

--- a/website/docs/r/ga2_endpoint_group.html.markdown
+++ b/website/docs/r/ga2_endpoint_group.html.markdown
@@ -1,0 +1,119 @@
+---
+subcategory: "Global Accelerator 2(GA2)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_ga2_endpoint_group"
+sidebar_current: "docs-tencentcloud-resource-ga2_endpoint_group"
+description: |-
+  Provides a resource to create a GA2 (Global Accelerator 2) endpoint group.
+---
+
+# tencentcloud_ga2_endpoint_group
+
+Provides a resource to create a GA2 (Global Accelerator 2) endpoint group.
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_ga2_endpoint_group" "example" {
+  global_accelerator_id = "ga2-xxxxxxxx"
+  listener_id           = "lis-xxxxxxxx"
+  endpoint_group_type   = "DEFAULT"
+
+  endpoint_group_configuration {
+    name                  = "tf-example"
+    endpoint_group_region = "ap-guangzhou"
+    description           = "tf example endpoint group"
+    enable_health_check   = true
+    check_type            = "HTTP"
+    check_port            = "80"
+    check_path            = "/"
+    check_method          = "GET"
+    connect_timeout       = 5000
+    health_check_interval = 30
+    healthy_threshold     = 3
+    unhealthy_threshold   = 3
+    forward_protocol      = "HTTP"
+
+    endpoint_configurations {
+      endpoint_type    = "PublicIp"
+      endpoint_service = "1.1.1.1"
+      weight           = 10
+    }
+
+    endpoint_configurations {
+      endpoint_type    = "Domain"
+      endpoint_service = "example.com"
+      weight           = 20
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `endpoint_group_configuration` - (Required, List) Endpoint group configuration.
+* `endpoint_group_type` - (Required, String, ForceNew) Endpoint group type. Valid values: `VIRTUAL`, `DEFAULT`.
+* `global_accelerator_id` - (Required, String, ForceNew) Global accelerator instance ID.
+* `listener_id` - (Required, String, ForceNew) Listener ID.
+
+The `endpoint_configurations` object of `endpoint_group_configuration` supports the following:
+
+* `endpoint_service` - (Optional, String) Endpoint domain or IP.
+* `endpoint_type` - (Optional, String) Endpoint type. Valid values: `Domain`, `PublicIp`.
+* `weight` - (Optional, Int) Endpoint weight.
+
+The `endpoint_group_configuration` object supports the following:
+
+* `check_domain` - (Optional, String) Health check domain.
+* `check_method` - (Optional, String) Health check request method.
+* `check_path` - (Optional, String) Health check URL path.
+* `check_port` - (Optional, String) Health check port.
+* `check_recv_context` - (Optional, String) Health check expected response.
+* `check_send_context` - (Optional, String) Health check request payload.
+* `check_type` - (Optional, String) Health check protocol. Valid values: `TCP`, `HTTP`, `HTTPS`, `PING`, `CUSTOM`.
+* `cipher_policy_id` - (Optional, String) HTTPS cipher policy ID.
+* `connect_timeout` - (Optional, Int) Response timeout in milliseconds.
+* `context_type` - (Optional, String) Health check content type.
+* `description` - (Optional, String) Description. Maximum length is 100 bytes.
+* `enable_health_check` - (Optional, Bool) Whether to enable health check.
+* `endpoint_configurations` - (Optional, List) Endpoint configurations under this group.
+* `endpoint_group_region` - (Optional, String) Region of the endpoint group.
+* `forward_protocol` - (Optional, String) Forward protocol back to origin.
+* `health_check_interval` - (Optional, Int) Health check interval in seconds.
+* `healthy_threshold` - (Optional, Int) Healthy threshold count.
+* `isp_type` - (Optional, String) ISP type.
+* `name` - (Optional, String) Name. Maximum length is 60 bytes.
+* `port_overrides` - (Optional, List) Port overrides for the endpoint group.
+* `status_mask` - (Optional, List) Status code masks for health check.
+* `unhealthy_threshold` - (Optional, Int) Unhealthy threshold count.
+
+The `port_overrides` object of `endpoint_group_configuration` supports the following:
+
+* `endpoint_port` - (Optional, Int) Endpoint port.
+* `listener_port` - (Optional, Int) Listener port.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `endpoint_group_id` - Endpoint group instance ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to `20m`) Used when creating the resource.
+* `update` - (Defaults to `20m`) Used when updating the resource.
+* `delete` - (Defaults to `20m`) Used when deleting the resource.
+
+## Import
+
+GA2 endpoint group can be imported using the composite ID `<global_accelerator_id>#<listener_id>#<endpoint_group_id>`, e.g.
+
+```
+terraform import tencentcloud_ga2_endpoint_group.example ga2-xxxxxxxx#lis-xxxxxxxx#eg-xxxxxxxx
+```
+

--- a/website/docs/r/ga2_forwarding_rule.html.markdown
+++ b/website/docs/r/ga2_forwarding_rule.html.markdown
@@ -1,0 +1,94 @@
+---
+subcategory: "Global Accelerator 2(GA2)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_ga2_forwarding_rule"
+sidebar_current: "docs-tencentcloud-resource-ga2_forwarding_rule"
+description: |-
+  Provides a resource to create a GA2 (Global Accelerator 2) forwarding rule.
+---
+
+# tencentcloud_ga2_forwarding_rule
+
+Provides a resource to create a GA2 (Global Accelerator 2) forwarding rule.
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_ga2_forwarding_rule" "example" {
+  global_accelerator_id = "ga2-xxxxxxxx"
+  listener_id           = "lis-xxxxxxxx"
+  forwarding_policy_id  = "fp-xxxxxxxx"
+
+  rule_conditions {
+    rule_condition_type  = "HOST"
+    rule_condition_value = ["example.com"]
+  }
+
+  rule_actions {
+    rule_action_type  = "ForwardGroup"
+    rule_action_value = "eg-xxxxxxxx"
+  }
+
+  origin_headers {
+    key   = "X-Custom-Header"
+    value = "custom-value"
+  }
+
+  enable_origin_sni = true
+  origin_sni        = "example.com"
+  origin_host       = "origin.example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `forwarding_policy_id` - (Required, String, ForceNew) Forwarding policy ID.
+* `global_accelerator_id` - (Required, String, ForceNew) Global accelerator instance ID.
+* `listener_id` - (Required, String, ForceNew) Listener ID.
+* `rule_actions` - (Required, List) Layer-7 forwarding rule actions.
+* `rule_conditions` - (Required, List) Layer-7 forwarding rule conditions.
+* `enable_origin_sni` - (Optional, Bool) Whether to enable origin SNI.
+* `origin_headers` - (Optional, List) Origin headers.
+* `origin_host` - (Optional, String) Origin host value.
+* `origin_sni` - (Optional, String) Origin SNI value.
+
+The `origin_headers` object supports the following:
+
+* `key` - (Optional, String) Header key.
+* `value` - (Optional, String) Header value.
+
+The `rule_actions` object supports the following:
+
+* `rule_action_type` - (Optional, String) Rule action type.
+* `rule_action_value` - (Optional, String) Rule action value.
+
+The `rule_conditions` object supports the following:
+
+* `rule_condition_type` - (Optional, String) Rule condition type.
+* `rule_condition_value` - (Optional, List) Rule condition values.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `forwarding_rule_id` - Forwarding rule ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to `20m`) Used when creating the resource.
+* `update` - (Defaults to `20m`) Used when updating the resource.
+* `delete` - (Defaults to `20m`) Used when deleting the resource.
+
+## Import
+
+GA2 forwarding rule can be imported using the composite ID `<global_accelerator_id>#<listener_id>#<forwarding_policy_id>#<forwarding_rule_id>`, e.g.
+
+```
+terraform import tencentcloud_ga2_forwarding_rule.example ga2-xxxxxxxx#lis-xxxxxxxx#fp-xxxxxxxx#fr-xxxxxxxx
+```
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -3010,6 +3010,23 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">Global Accelerator 2(GA2)</a>
+                    <ul class="nav">
+                        
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/r/ga2_endpoint_group.html">tencentcloud_ga2_endpoint_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/r/ga2_forwarding_rule.html">tencentcloud_ga2_forwarding_rule</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">Global Application Acceleration(GAAP)</a>
                     <ul class="nav">
                         <li>


### PR DESCRIPTION
Add a new Terraform resource tencentcloud_ga2_forwarding_rule for managing GA2 forwarding rules. This resource supports full CRUD operations including create, read, update, and delete of forwarding rules with listener and endpoint group configurations.