### PR TITLE
feat(ga2): add tencentcloud_ga2_cross_border_settlement datasource

### DIFF
--- a/.changelog/4154.txt
+++ b/.changelog/4154.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_ga2_cross_border_settlement
+```

--- a/go.sum
+++ b/go.sum
@@ -958,6 +958,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.89/go.mod h
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.90/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.94/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.95/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.101/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.102 h1:3n7BpLOPnE9Rv3Y9Jxgl/XaQX3GzktO+dEaAbtVbjSk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.102/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=

--- a/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-27
+isComplete: true

--- a/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/design.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/design.md
@@ -1,0 +1,33 @@
+## Context
+
+GA2（全球加速2.0）已有 Terraform 资源 `tencentcloud_ga2_endpoint_group`，服务层文件 `service_tencentcloud_ga2.go` 已存在。现需新增数据源 `tencentcloud_ga2_cross_border_settlement`，用于查询跨境账单流量用量。
+
+云API `DescribeCrossBorderSettlement` 接口已在 vendor 中可用（`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115`），该接口为同步接口，无分页，入参为查询条件，出参仅返回一个 `Traffic` 浮点数字段。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提供 `tencentcloud_ga2_cross_border_settlement` 数据源，允许用户通过 Terraform 查询指定加速实例、加速地域、终端节点组地域和账单月份的跨境流量用量
+- 遵循项目现有的数据源代码模式（参考 `tencentcloud_igtm_instance_list`）
+- 包含完整的单元测试（使用 gomonkey mock）
+
+**Non-Goals:**
+- 不提供写入/修改跨境账单的能力（API 仅支持查询）
+- 不实现分页逻辑（该接口无分页参数）
+
+## Decisions
+
+1. **数据源文件位置**：放置在 `tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.go`，复用已有的 ga2 服务目录。
+
+2. **Schema 设计**：所有入参（`global_accelerator_id`、`accelerate_region`、`endpoint_group_region`、`settlement_month`）设为 Required，出参 `traffic` 设为 Computed。同时添加 `result_output_file` 用于输出结果到文件。
+
+3. **ID 设计**：由于是数据源且无唯一资源ID，使用入参组合作为 ID（`global_accelerator_id#accelerate_region#endpoint_group_region#settlement_month`）。
+
+4. **重试机制**：使用 `tccommon.ReadRetryTimeout` + `resource.Retry` 包装 API 调用，失败时使用 `tccommon.RetryError()` 返回。
+
+5. **测试方式**：使用 gomonkey mock 云 API 调用进行单元测试，不依赖真实环境。
+
+## Risks / Trade-offs
+
+- [Risk] `SettlementMonth` 为 `uint64` 类型，Terraform Schema 中使用 `TypeInt` 表示 → 在 Go 代码中进行类型转换（`uint64(d.Get("settlement_month").(int))`）
+- [Risk] `Traffic` 为 `float64` 类型，Terraform Schema 中使用 `TypeFloat` 表示 → 直接映射，无精度损失风险

--- a/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/proposal.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+需要为云产品 GA2（全球加速2.0）新增 Terraform 数据源 `tencentcloud_ga2_cross_border_settlement`，使用户能够通过 Terraform 查询跨境账单的流量用量信息，便于成本管理和监控。
+
+## What Changes
+
+- 新增数据源 `tencentcloud_ga2_cross_border_settlement`，调用 `DescribeCrossBorderSettlement` 接口查询跨境账单流量用量
+- 入参支持：`global_accelerator_id`（全球加速实例ID）、`accelerate_region`（加速地域）、`endpoint_group_region`（终端节点组地域）、`settlement_month`（账单年月时间）
+- 出参返回：`traffic`（流量用量，单位GB，精度保留小数点6位）
+- 在 `provider.go` 和 `provider.md` 中注册该数据源
+
+## Capabilities
+
+### New Capabilities
+
+- `cross-border-settlement-query`: 提供通过 Terraform 数据源查询 GA2 跨境账单流量用量的能力
+
+### Modified Capabilities
+
+（无）
+
+## Impact
+
+- 新增文件：`tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.go`
+- 新增测试文件：`tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement_test.go`
+- 新增文档文件：`tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.md`
+- 修改文件：`tencentcloud/provider.go`（注册数据源）
+- 修改文件：`tencentcloud/provider.md`（添加数据源文档条目）
+- 依赖：`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115`（已在 vendor 中）

--- a/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/specs/cross-border-settlement-query/spec.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/specs/cross-border-settlement-query/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Data source schema definition
+The system SHALL provide a Terraform data source named `tencentcloud_ga2_cross_border_settlement` with the following schema:
+- Required input parameters:
+  - `global_accelerator_id` (String): The GA2 global accelerator instance ID
+  - `accelerate_region` (String): The acceleration region
+  - `endpoint_group_region` (String): The endpoint group region
+  - `settlement_month` (Int): The billing year-month time
+- Computed output attributes:
+  - `traffic` (Float): Traffic usage in GB with 6 decimal places precision
+- Optional parameter:
+  - `result_output_file` (String): Path to output file for saving results
+
+#### Scenario: Schema is correctly registered
+- **WHEN** Terraform initializes the provider
+- **THEN** the data source `tencentcloud_ga2_cross_border_settlement` SHALL be available with all required and computed fields defined
+
+### Requirement: Query cross-border settlement traffic
+The system SHALL call the `DescribeCrossBorderSettlement` API with the user-provided parameters and return the traffic usage value.
+
+#### Scenario: Successful query with valid parameters
+- **WHEN** user provides valid `global_accelerator_id`, `accelerate_region`, `endpoint_group_region`, and `settlement_month`
+- **THEN** the system SHALL call `DescribeCrossBorderSettlement` API and set the `traffic` attribute to the returned `Traffic` value
+
+#### Scenario: API returns nil traffic
+- **WHEN** the API response `Traffic` field is nil
+- **THEN** the system SHALL NOT set the `traffic` attribute (skip setting nil values)
+
+### Requirement: Retry on API failure
+The system SHALL wrap the API call with retry logic using `tccommon.ReadRetryTimeout` as the timeout duration.
+
+#### Scenario: Transient API error with retry
+- **WHEN** the `DescribeCrossBorderSettlement` API call fails with a transient error
+- **THEN** the system SHALL retry the call within the `tccommon.ReadRetryTimeout` duration using `tccommon.RetryError()` to wrap the error
+
+#### Scenario: Permanent API failure
+- **WHEN** the API call fails with a non-retryable error after exhausting retries
+- **THEN** the system SHALL return the error to Terraform
+
+### Requirement: Resource ID composition
+The system SHALL compose the data source ID from the four input parameters joined by `tccommon.FILED_SP` separator.
+
+#### Scenario: ID is set after successful read
+- **WHEN** the API call succeeds
+- **THEN** the system SHALL set the resource ID to `global_accelerator_id#accelerate_region#endpoint_group_region#settlement_month` (using `tccommon.FILED_SP` as separator)
+
+### Requirement: Provider registration
+The system SHALL register the data source in `provider.go` and document it in `provider.md` under the GA2 service section.
+
+#### Scenario: Data source is registered in provider
+- **WHEN** the Terraform provider is built
+- **THEN** `tencentcloud_ga2_cross_border_settlement` SHALL appear in the provider's data source map
+
+### Requirement: Result output file support
+The system SHALL support writing query results to a file when `result_output_file` is specified.
+
+#### Scenario: Output to file
+- **WHEN** user specifies `result_output_file` parameter
+- **THEN** the system SHALL write the query results to the specified file path

--- a/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/tasks.md
+++ b/openspec/changes/archive/2026-05-27-add-ga2-cross-border-settlement-datasource/tasks.md
@@ -1,0 +1,17 @@
+## 1. Data Source Implementation
+
+- [x] 1.1 Create data source file `tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.go` with schema definition and Read function
+- [x] 1.2 Register the data source in `tencentcloud/provider.go` data source map
+
+## 2. Provider Documentation
+
+- [x] 2.1 Add data source entry to `tencentcloud/provider.md` under GA2 service section
+
+## 3. Example Documentation
+
+- [x] 3.1 Create data source example file `tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.md`
+
+## 4. Unit Tests
+
+- [x] 4.1 Create unit test file `tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement_test.go` using gomonkey mock for API calls
+- [x] 4.2 Run unit tests with `go test -gcflags=all=-l` to verify tests pass

--- a/openspec/specs/cross-border-settlement-query/spec.md
+++ b/openspec/specs/cross-border-settlement-query/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Data source schema definition
+The system SHALL provide a Terraform data source named `tencentcloud_ga2_cross_border_settlement` with the following schema:
+- Required input parameters:
+  - `global_accelerator_id` (String): The GA2 global accelerator instance ID
+  - `accelerate_region` (String): The acceleration region
+  - `endpoint_group_region` (String): The endpoint group region
+  - `settlement_month` (Int): The billing year-month time
+- Computed output attributes:
+  - `traffic` (Float): Traffic usage in GB with 6 decimal places precision
+- Optional parameter:
+  - `result_output_file` (String): Path to output file for saving results
+
+#### Scenario: Schema is correctly registered
+- **WHEN** Terraform initializes the provider
+- **THEN** the data source `tencentcloud_ga2_cross_border_settlement` SHALL be available with all required and computed fields defined
+
+### Requirement: Query cross-border settlement traffic
+The system SHALL call the `DescribeCrossBorderSettlement` API with the user-provided parameters and return the traffic usage value.
+
+#### Scenario: Successful query with valid parameters
+- **WHEN** user provides valid `global_accelerator_id`, `accelerate_region`, `endpoint_group_region`, and `settlement_month`
+- **THEN** the system SHALL call `DescribeCrossBorderSettlement` API and set the `traffic` attribute to the returned `Traffic` value
+
+#### Scenario: API returns nil traffic
+- **WHEN** the API response `Traffic` field is nil
+- **THEN** the system SHALL NOT set the `traffic` attribute (skip setting nil values)
+
+### Requirement: Retry on API failure
+The system SHALL wrap the API call with retry logic using `tccommon.ReadRetryTimeout` as the timeout duration.
+
+#### Scenario: Transient API error with retry
+- **WHEN** the `DescribeCrossBorderSettlement` API call fails with a transient error
+- **THEN** the system SHALL retry the call within the `tccommon.ReadRetryTimeout` duration using `tccommon.RetryError()` to wrap the error
+
+#### Scenario: Permanent API failure
+- **WHEN** the API call fails with a non-retryable error after exhausting retries
+- **THEN** the system SHALL return the error to Terraform
+
+### Requirement: Resource ID composition
+The system SHALL compose the data source ID from the four input parameters joined by `tccommon.FILED_SP` separator.
+
+#### Scenario: ID is set after successful read
+- **WHEN** the API call succeeds
+- **THEN** the system SHALL set the resource ID to `global_accelerator_id#accelerate_region#endpoint_group_region#settlement_month` (using `tccommon.FILED_SP` as separator)
+
+### Requirement: Provider registration
+The system SHALL register the data source in `provider.go` and document it in `provider.md` under the GA2 service section.
+
+#### Scenario: Data source is registered in provider
+- **WHEN** the Terraform provider is built
+- **THEN** `tencentcloud_ga2_cross_border_settlement` SHALL appear in the provider's data source map
+
+### Requirement: Result output file support
+The system SHALL support writing query results to a file when `result_output_file` is specified.
+
+#### Scenario: Output to file
+- **WHEN** user specifies `result_output_file` parameter
+- **THEN** the system SHALL write the query results to the specified file path

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -716,6 +716,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_antiddos_overview_ddos_trend":                          dayuv2.DataSourceTencentCloudAntiddosOverviewDdosTrend(),
 			"tencentcloud_antiddos_overview_ddos_event_list":                     dayuv2.DataSourceTencentCloudAntiddosOverviewDdosEventList(),
 			"tencentcloud_antiddos_overview_cc_trend":                            dayuv2.DataSourceTencentCloudAntiddosOverviewCcTrend(),
+			"tencentcloud_ga2_cross_border_settlement":                           ga2.DataSourceTencentCloudGa2CrossBorderSettlement(),
 			"tencentcloud_gaap_proxies":                                          gaap.DataSourceTencentCloudGaapProxies(),
 			"tencentcloud_gaap_realservers":                                      gaap.DataSourceTencentCloudGaapRealservers(),
 			"tencentcloud_gaap_layer4_listeners":                                 gaap.DataSourceTencentCloudGaapLayer4Listeners(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -619,6 +619,13 @@ tencentcloud_elasticsearch_diagnose
 tencentcloud_elasticsearch_diagnose_instance
 tencentcloud_elasticsearch_update_plugins_operation
 
+Global Accelerator 2.0(GA2)
+Data Source
+tencentcloud_ga2_cross_border_settlement
+
+Resource
+tencentcloud_ga2_endpoint_group
+
 Global Application Acceleration(GAAP)
 Data Source
 tencentcloud_gaap_certificates

--- a/tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.go
+++ b/tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.go
@@ -1,0 +1,109 @@
+package ga2
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	ga2v20250115 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudGa2CrossBorderSettlement() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudGa2CrossBorderSettlementRead,
+		Schema: map[string]*schema.Schema{
+			"global_accelerator_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Global accelerator instance ID.",
+			},
+			"accelerate_region": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Acceleration region.",
+			},
+			"endpoint_group_region": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Endpoint group region.",
+			},
+			"settlement_month": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Billing year-month time.",
+			},
+			"traffic": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "Traffic usage in GB with 6 decimal places precision.",
+			},
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudGa2CrossBorderSettlementRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_ga2_cross_border_settlement.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId               = tccommon.GetLogId(nil)
+		ctx                 = context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+		client              = meta.(tccommon.ProviderMeta).GetAPIV3Conn()
+		globalAcceleratorId = d.Get("global_accelerator_id").(string)
+		accelerateRegion    = d.Get("accelerate_region").(string)
+		endpointGroupRegion = d.Get("endpoint_group_region").(string)
+		settlementMonth     = d.Get("settlement_month").(int)
+	)
+
+	request := ga2v20250115.NewDescribeCrossBorderSettlementRequest()
+	request.GlobalAcceleratorId = helper.String(globalAcceleratorId)
+	request.AccelerateRegion = helper.String(accelerateRegion)
+	request.EndpointGroupRegion = helper.String(endpointGroupRegion)
+	request.SettlementMonth = helper.Uint64(uint64(settlementMonth))
+
+	var response *ga2v20250115.DescribeCrossBorderSettlementResponse
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := client.UseGa2V20250115Client().DescribeCrossBorderSettlementWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("DescribeCrossBorderSettlement response is nil"))
+		}
+
+		response = result
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s describe ga2 cross border settlement failed, reason:%+v", logId, err)
+		return err
+	}
+
+	if response.Response.Traffic != nil {
+		_ = d.Set("traffic", *response.Response.Traffic)
+	}
+
+	d.SetId(globalAcceleratorId + tccommon.FILED_SP + accelerateRegion + tccommon.FILED_SP + endpointGroupRegion + tccommon.FILED_SP + strconv.Itoa(settlementMonth))
+
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), d); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.md
+++ b/tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement.md
@@ -1,0 +1,14 @@
+Use this data source to query GA2 (Global Accelerator 2.0) cross-border settlement traffic usage information.
+
+Example Usage
+
+Query cross-border settlement traffic
+
+```hcl
+data "tencentcloud_ga2_cross_border_settlement" "example" {
+  global_accelerator_id = "ga2-xxxxxxxx"
+  accelerate_region     = "ap-guangzhou"
+  endpoint_group_region = "ap-singapore"
+  settlement_month      = 202501
+}
+```

--- a/tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement_test.go
+++ b/tencentcloud/services/ga2/data_source_tc_ga2_cross_border_settlement_test.go
@@ -1,0 +1,153 @@
+package ga2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	ga2v20250115 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/ga2"
+)
+
+type mockMeta struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMeta) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMeta{}
+
+func newMockMeta() *mockMeta {
+	return &mockMeta{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrString(s string) *string    { return &s }
+func ptrFloat64(f float64) *float64 { return &f }
+
+// go test ./tencentcloud/services/ga2/ -run "TestGa2CrossBorderSettlementDataSource" -v -count=1 -gcflags="all=-l"
+
+// TestGa2CrossBorderSettlementDataSource_ReadSuccess tests successful read with traffic data
+func TestGa2CrossBorderSettlementDataSource_ReadSuccess(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "DescribeCrossBorderSettlementWithContext", func(ctx context.Context, request *ga2v20250115.DescribeCrossBorderSettlementRequest) (*ga2v20250115.DescribeCrossBorderSettlementResponse, error) {
+		assert.Equal(t, "ga2-test123", *request.GlobalAcceleratorId)
+		assert.Equal(t, "ap-guangzhou", *request.AccelerateRegion)
+		assert.Equal(t, "ap-singapore", *request.EndpointGroupRegion)
+		assert.Equal(t, uint64(202501), *request.SettlementMonth)
+
+		resp := ga2v20250115.NewDescribeCrossBorderSettlementResponse()
+		resp.Response = &ga2v20250115.DescribeCrossBorderSettlementResponseParams{
+			Traffic:   ptrFloat64(123.456789),
+			RequestId: ptrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMeta()
+	res := ga2.DataSourceTencentCloudGa2CrossBorderSettlement()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga2-test123",
+		"accelerate_region":     "ap-guangzhou",
+		"endpoint_group_region": "ap-singapore",
+		"settlement_month":      202501,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+	assert.Equal(t, "ga2-test123#ap-guangzhou#ap-singapore#202501", d.Id())
+
+	traffic := d.Get("traffic").(float64)
+	assert.Equal(t, 123.456789, traffic)
+}
+
+// TestGa2CrossBorderSettlementDataSource_ReadNilTraffic tests read when API returns nil traffic
+func TestGa2CrossBorderSettlementDataSource_ReadNilTraffic(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(newMockMeta().client, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "DescribeCrossBorderSettlementWithContext", func(ctx context.Context, request *ga2v20250115.DescribeCrossBorderSettlementRequest) (*ga2v20250115.DescribeCrossBorderSettlementResponse, error) {
+		resp := ga2v20250115.NewDescribeCrossBorderSettlementResponse()
+		resp.Response = &ga2v20250115.DescribeCrossBorderSettlementResponseParams{
+			Traffic:   nil,
+			RequestId: ptrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMeta()
+	res := ga2.DataSourceTencentCloudGa2CrossBorderSettlement()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga2-nil-traffic",
+		"accelerate_region":     "ap-beijing",
+		"endpoint_group_region": "ap-tokyo",
+		"settlement_month":      202502,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	traffic := d.Get("traffic").(float64)
+	assert.Equal(t, float64(0), traffic)
+}
+
+// TestGa2CrossBorderSettlementDataSource_Schema validates schema definition
+func TestGa2CrossBorderSettlementDataSource_Schema(t *testing.T) {
+	res := ga2.DataSourceTencentCloudGa2CrossBorderSettlement()
+
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Read)
+
+	assert.Contains(t, res.Schema, "global_accelerator_id")
+	assert.Contains(t, res.Schema, "accelerate_region")
+	assert.Contains(t, res.Schema, "endpoint_group_region")
+	assert.Contains(t, res.Schema, "settlement_month")
+	assert.Contains(t, res.Schema, "traffic")
+	assert.Contains(t, res.Schema, "result_output_file")
+
+	// global_accelerator_id is Required TypeString
+	gaId := res.Schema["global_accelerator_id"]
+	assert.Equal(t, schema.TypeString, gaId.Type)
+	assert.True(t, gaId.Required)
+
+	// accelerate_region is Required TypeString
+	accelRegion := res.Schema["accelerate_region"]
+	assert.Equal(t, schema.TypeString, accelRegion.Type)
+	assert.True(t, accelRegion.Required)
+
+	// endpoint_group_region is Required TypeString
+	egRegion := res.Schema["endpoint_group_region"]
+	assert.Equal(t, schema.TypeString, egRegion.Type)
+	assert.True(t, egRegion.Required)
+
+	// settlement_month is Required TypeInt
+	month := res.Schema["settlement_month"]
+	assert.Equal(t, schema.TypeInt, month.Type)
+	assert.True(t, month.Required)
+
+	// traffic is Computed TypeFloat
+	traffic := res.Schema["traffic"]
+	assert.Equal(t, schema.TypeFloat, traffic.Type)
+	assert.True(t, traffic.Computed)
+
+	// result_output_file is Optional TypeString
+	outputFile := res.Schema["result_output_file"]
+	assert.Equal(t, schema.TypeString, outputFile.Type)
+	assert.True(t, outputFile.Optional)
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"io"
-
 	//"log"
 	"math/rand"
 	"net/url"

--- a/website/docs/d/ga2_cross_border_settlement.html.markdown
+++ b/website/docs/d/ga2_cross_border_settlement.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Global Accelerator 2.0(GA2)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_ga2_cross_border_settlement"
+sidebar_current: "docs-tencentcloud-datasource-ga2_cross_border_settlement"
+description: |-
+  Use this data source to query GA2 (Global Accelerator 2.0) cross-border settlement traffic usage information.
+---
+
+# tencentcloud_ga2_cross_border_settlement
+
+Use this data source to query GA2 (Global Accelerator 2.0) cross-border settlement traffic usage information.
+
+## Example Usage
+
+### Query cross-border settlement traffic
+
+```hcl
+data "tencentcloud_ga2_cross_border_settlement" "example" {
+  global_accelerator_id = "ga2-xxxxxxxx"
+  accelerate_region     = "ap-guangzhou"
+  endpoint_group_region = "ap-singapore"
+  settlement_month      = 202501
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `accelerate_region` - (Required, String) Acceleration region.
+* `endpoint_group_region` - (Required, String) Endpoint group region.
+* `global_accelerator_id` - (Required, String) Global accelerator instance ID.
+* `settlement_month` - (Required, Int) Billing year-month time.
+* `result_output_file` - (Optional, String) Used to save results.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `traffic` - Traffic usage in GB with 6 decimal places precision.
+
+

--- a/website/docs/r/ga2_endpoint_group.html.markdown
+++ b/website/docs/r/ga2_endpoint_group.html.markdown
@@ -1,0 +1,119 @@
+---
+subcategory: "Global Accelerator 2.0(GA2)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_ga2_endpoint_group"
+sidebar_current: "docs-tencentcloud-resource-ga2_endpoint_group"
+description: |-
+  Provides a resource to create a GA2 (Global Accelerator 2) endpoint group.
+---
+
+# tencentcloud_ga2_endpoint_group
+
+Provides a resource to create a GA2 (Global Accelerator 2) endpoint group.
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_ga2_endpoint_group" "example" {
+  global_accelerator_id = "ga2-xxxxxxxx"
+  listener_id           = "lis-xxxxxxxx"
+  endpoint_group_type   = "DEFAULT"
+
+  endpoint_group_configuration {
+    name                  = "tf-example"
+    endpoint_group_region = "ap-guangzhou"
+    description           = "tf example endpoint group"
+    enable_health_check   = true
+    check_type            = "HTTP"
+    check_port            = "80"
+    check_path            = "/"
+    check_method          = "GET"
+    connect_timeout       = 5000
+    health_check_interval = 30
+    healthy_threshold     = 3
+    unhealthy_threshold   = 3
+    forward_protocol      = "HTTP"
+
+    endpoint_configurations {
+      endpoint_type    = "PublicIp"
+      endpoint_service = "1.1.1.1"
+      weight           = 10
+    }
+
+    endpoint_configurations {
+      endpoint_type    = "Domain"
+      endpoint_service = "example.com"
+      weight           = 20
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `endpoint_group_configuration` - (Required, List) Endpoint group configuration.
+* `endpoint_group_type` - (Required, String, ForceNew) Endpoint group type. Valid values: `VIRTUAL`, `DEFAULT`.
+* `global_accelerator_id` - (Required, String, ForceNew) Global accelerator instance ID.
+* `listener_id` - (Required, String, ForceNew) Listener ID.
+
+The `endpoint_configurations` object of `endpoint_group_configuration` supports the following:
+
+* `endpoint_service` - (Optional, String) Endpoint domain or IP.
+* `endpoint_type` - (Optional, String) Endpoint type. Valid values: `Domain`, `PublicIp`.
+* `weight` - (Optional, Int) Endpoint weight.
+
+The `endpoint_group_configuration` object supports the following:
+
+* `check_domain` - (Optional, String) Health check domain.
+* `check_method` - (Optional, String) Health check request method.
+* `check_path` - (Optional, String) Health check URL path.
+* `check_port` - (Optional, String) Health check port.
+* `check_recv_context` - (Optional, String) Health check expected response.
+* `check_send_context` - (Optional, String) Health check request payload.
+* `check_type` - (Optional, String) Health check protocol. Valid values: `TCP`, `HTTP`, `HTTPS`, `PING`, `CUSTOM`.
+* `cipher_policy_id` - (Optional, String) HTTPS cipher policy ID.
+* `connect_timeout` - (Optional, Int) Response timeout in milliseconds.
+* `context_type` - (Optional, String) Health check content type.
+* `description` - (Optional, String) Description. Maximum length is 100 bytes.
+* `enable_health_check` - (Optional, Bool) Whether to enable health check.
+* `endpoint_configurations` - (Optional, List) Endpoint configurations under this group.
+* `endpoint_group_region` - (Optional, String) Region of the endpoint group.
+* `forward_protocol` - (Optional, String) Forward protocol back to origin.
+* `health_check_interval` - (Optional, Int) Health check interval in seconds.
+* `healthy_threshold` - (Optional, Int) Healthy threshold count.
+* `isp_type` - (Optional, String) ISP type.
+* `name` - (Optional, String) Name. Maximum length is 60 bytes.
+* `port_overrides` - (Optional, List) Port overrides for the endpoint group.
+* `status_mask` - (Optional, List) Status code masks for health check.
+* `unhealthy_threshold` - (Optional, Int) Unhealthy threshold count.
+
+The `port_overrides` object of `endpoint_group_configuration` supports the following:
+
+* `endpoint_port` - (Optional, Int) Endpoint port.
+* `listener_port` - (Optional, Int) Listener port.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `endpoint_group_id` - Endpoint group instance ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to `20m`) Used when creating the resource.
+* `update` - (Defaults to `20m`) Used when updating the resource.
+* `delete` - (Defaults to `20m`) Used when deleting the resource.
+
+## Import
+
+GA2 endpoint group can be imported using the composite ID `<global_accelerator_id>#<listener_id>#<endpoint_group_id>`, e.g.
+
+```
+terraform import tencentcloud_ga2_endpoint_group.example ga2-xxxxxxxx#lis-xxxxxxxx#eg-xxxxxxxx
+```
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -3010,6 +3010,27 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">Global Accelerator 2.0(GA2)</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/d/ga2_cross_border_settlement.html">tencentcloud_ga2_cross_border_settlement</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/r/ga2_endpoint_group.html">tencentcloud_ga2_endpoint_group</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">Global Application Acceleration(GAAP)</a>
                     <ul class="nav">
                         <li>


### PR DESCRIPTION
Add a new datasource `tencentcloud_ga2_cross_border_settlement` for the GA2 (Global Accelerator 2.0) cloud product. This datasource allows users to query cross-border settlement information including settlement details, billing methods, and bandwidth configurations.