### PR TITLE
docs(teo): [134771911]update entity field description in teo_bind_security_template

### DIFF
--- a/.changelog/4167.txt
+++ b/.changelog/4167.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_bind_security_template: update entity field description
+```

--- a/tencentcloud/services/teo/resource_tc_teo_bind_security_template.go
+++ b/tencentcloud/services/teo/resource_tc_teo_bind_security_template.go
@@ -37,7 +37,7 @@ func ResourceTencentCloudTeoBindSecurityTemplate() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "List of domain names to bind to/unbind from a policy template.",
+				Description: "The domain to be bound to or unbound from the policy template.",
 			},
 
 			"template_id": {

--- a/website/docs/r/teo_bind_security_template.html.markdown
+++ b/website/docs/r/teo_bind_security_template.html.markdown
@@ -29,7 +29,7 @@ resource "tencentcloud_teo_bind_security_template" "teo_bind_security_template" 
 
 The following arguments are supported:
 
-* `entity` - (Required, String, ForceNew) List of domain names to bind to/unbind from a policy template.
+* `entity` - (Required, String, ForceNew) The domain to be bound to or unbound from the policy template.
 * `template_id` - (Required, String, ForceNew) Specifies the ID of the policy template or the site global policy to be bound or unbound.
 <li>To bind to a policy template, or unbind from it, specify the policy template ID.</li>.
 <li>To bind to the site's global policy, or unbind from it, use the @ZoneLevel@domain parameter value.</li>.


### PR DESCRIPTION
Update the description of the entity field in tencentcloud_teo_bind_security_template resource to more accurately reflect that it represents a single domain rather than a list of domain names.