### PR TITLE
feat(teo): [ ]add tencentcloud_teo_edge_kv resource

### DIFF
--- a/.changelog/4188.txt
+++ b/.changelog/4188.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_teo_edge_kv
+```

--- a/openspec/changes/archive/2026-06-15-add-teo-edge-kv/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-15-add-teo-edge-kv/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/archive/2026-06-15-add-teo-edge-kv/design.md
+++ b/openspec/changes/archive/2026-06-15-add-teo-edge-kv/design.md
@@ -1,0 +1,49 @@
+## Context
+
+TencentCloud EdgeOne (TEO) 提供 Edge KV 存储服务，允许在边缘节点存储键值对数据。SDK 中已有 `EdgeKVPut`、`EdgeKVGet`、`EdgeKVDelete` 三个接口，分别用于写入、查询和删除 KV 数据。当前 Provider 中已有多个 TEO 资源（如 `tencentcloud_teo_zone`、`tencentcloud_teo_dns_record` 等），本次新增资源遵循相同的代码组织模式。
+
+本资源为 RESOURCE_KIND_ATTACHMENT 类型，表示 KV 数据与命名空间的绑定关系，支持 CRUD（Create/Read/Update/Delete）操作。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 实现 `tencentcloud_teo_edge_kv` 资源，支持通过 Terraform 管理 Edge KV 数据的写入和删除
+- 使用联合 ID（zone_id + namespace + key）唯一标识资源
+- 支持 import 操作
+- 提供完整的单元测试覆盖
+
+**Non-Goals:**
+- 不实现批量写入/删除（每个资源实例管理单个 KV 对）
+- 不新增 service 层方法（直接在资源文件中调用 SDK）
+
+## Decisions
+
+### 1. 资源 ID 设计
+
+**决策**: 使用 `zone_id#namespace#key` 作为联合 ID（`#` 为 `tccommon.FILED_SP`）
+
+**理由**: EdgeKVGet 和 EdgeKVDelete 接口需要 ZoneId、Namespace、Keys 三个参数才能定位到具体的 KV 数据，因此需要三者组合作为唯一标识。这与 Provider 中其他使用联合 ID 的资源保持一致。
+
+### 2. Update 方法实现
+
+**决策**: 
+- `zone_id`、`namespace`、`key` 设置为 ForceNew（构成 ID 的字段）
+- `value` 变更时通过 Update 方法调用 EdgeKVPut 接口进行更新
+
+**理由**: EdgeKVPut 接口支持对已存在的 key 进行覆写，因此可以直接用于 Update 操作。
+
+### 3. Read 方法实现
+
+**决策**: 调用 EdgeKVGet 接口时，Keys 参数传入包含单个 key 的数组 `[]*string{&key}`
+
+**理由**: EdgeKVGet 接口设计为批量查询，但本资源每次只管理单个 KV 对。返回的 Data 数组中取第一个元素的 Value 即可。如果返回的 Data 为空或 Value 为空字符串，说明 key 不存在，应调用 `d.SetId("")` 标记资源已被外部删除。
+
+### 4. 不生成 _extension.go 文件
+
+**决策**: 所有逻辑直接写在 `resource_tc_teo_edge_kv_attachment.go` 中
+
+**理由**: 资源逻辑简单，无需拆分文件。
+
+## Risks / Trade-offs
+
+- [Risk] EdgeKVGet 返回空 Value 时无法区分“key 不存在”和“value 为空字符串” → 由于 EdgeKVPut 要求 Value 不能为空，因此空 Value 可以安全地视为 key 不存在

--- a/openspec/changes/archive/2026-06-15-add-teo-edge-kv/proposal.md
+++ b/openspec/changes/archive/2026-06-15-add-teo-edge-kv/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+TencentCloud EdgeOne (TEO) 提供了 Edge KV 存储能力，允许用户在边缘节点写入、读取和删除键值对数据。当前 Terraform Provider 缺少对 Edge KV 数据写入操作的管理能力，用户无法通过 Terraform 声明式地管理 Edge KV 中的键值对绑定关系。新增 `tencentcloud_teo_edge_kv` 资源可以让用户通过 IaC 方式管理 KV 数据的写入和删除。
+
+## What Changes
+
+- 新增 Terraform 资源 `tencentcloud_teo_edge_kv`（RESOURCE_KIND_ATTACHMENT 类型），支持：
+  - 创建（绑定）：调用 EdgeKVPut 接口写入 KV 数据
+  - 读取：调用 EdgeKVGet 接口查询 KV 数据
+  - 删除（解绑）：调用 EdgeKVDelete 接口删除 KV 数据
+- 资源使用 `zone_id` + `namespace` + `key` 作为联合 ID
+- 资源为 CRUD 模式，Update 方法调用 EdgeKVPut 更新 value
+- 在 provider.go 和 provider.md 中注册新资源
+- 新增资源文档 .md 文件
+- 新增单元测试文件，使用 gomonkey mock 方式
+
+## Capabilities
+
+### New Capabilities
+- `teo-edge-kv-attachment`: TEO Edge KV 数据写入绑定资源，管理键值对的写入（绑定）和删除（解绑）操作
+
+### Modified Capabilities
+
+## Impact
+
+- 新增文件：`tencentcloud/services/teo/resource_tc_teo_edge_kv_attachment.go`
+- 新增文件：`tencentcloud/services/teo/resource_tc_teo_edge_kv_attachment_test.go`
+- 新增文件：`tencentcloud/services/teo/resource_tc_teo_edge_kv.md`
+- 修改文件：`tencentcloud/provider.go`（注册资源）
+- 修改文件：`tencentcloud/provider.md`（添加资源文档引用）
+- 依赖 SDK：`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`（已在 vendor 中）

--- a/openspec/changes/archive/2026-06-15-add-teo-edge-kv/specs/teo-edge-kv/spec.md
+++ b/openspec/changes/archive/2026-06-15-add-teo-edge-kv/specs/teo-edge-kv/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: Resource schema definition
+
+The resource `tencentcloud_teo_edge_kv` SHALL define the following schema:
+
+- `zone_id` (Required, ForceNew, String): 站点 ID
+- `namespace` (Required, ForceNew, String): 命名空间名称
+- `key` (Required, ForceNew, String): 键名，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线
+- `value` (Required, String): 键值，不能为空，最大支持 1 MB
+
+The resource ID SHALL be composed of `zone_id`, `namespace`, and `key` joined by `tccommon.FILED_SP` separator.
+
+#### Scenario: Schema fields are correctly defined
+- **WHEN** user defines a `tencentcloud_teo_edge_kv` resource in HCL
+- **THEN** Terraform SHALL validate that `zone_id`, `namespace`, `key`, and `value` are provided as required fields
+
+#### Scenario: ForceNew triggers resource recreation
+- **WHEN** user changes `zone_id`, `namespace`, or `key` in the configuration
+- **THEN** Terraform SHALL destroy the existing resource and create a new one
+
+### Requirement: Create operation writes KV data
+
+The resource Create method SHALL call the `EdgeKVPut` API with the following parameter mapping:
+- `zone_id` → `request.ZoneId`
+- `namespace` → `request.Namespace`
+- `key` → `request.Key`
+- `value` → `request.Value`
+
+The Create method SHALL use `tccommon.WriteRetryTimeout` for retry logic. After successful creation, the resource ID SHALL be set to `zone_id#namespace#key`.
+
+#### Scenario: Successful KV data write
+- **WHEN** user applies a configuration with valid `zone_id`, `namespace`, `key`, and `value`
+- **THEN** the resource SHALL call EdgeKVPut API and set the composite ID
+
+#### Scenario: Create API returns error
+- **WHEN** EdgeKVPut API returns an error
+- **THEN** the resource SHALL wrap the error with `tccommon.RetryError()` and return it
+
+### Requirement: Read operation queries KV data
+
+The resource Read method SHALL call the `EdgeKVGet` API with:
+- `zone_id` → `request.ZoneId`
+- `namespace` → `request.Namespace`
+- `[key]` → `request.Keys` (single-element array)
+
+The Read method SHALL parse the composite ID to extract `zone_id`, `namespace`, and `key`. If the returned Data is empty or the key's Value is empty string, the resource SHALL be marked as deleted by calling `d.SetId("")`.
+
+#### Scenario: Successful KV data read
+- **WHEN** the KV key exists
+- **THEN** the resource SHALL set `value` from the response Data
+
+#### Scenario: KV key does not exist
+- **WHEN** EdgeKVGet returns empty Data or empty Value for the key
+- **THEN** the resource SHALL call `d.SetId("")` to mark it as deleted
+
+#### Scenario: Read parses composite ID
+- **WHEN** Read method is called
+- **THEN** it SHALL split `d.Id()` by `tccommon.FILED_SP` to extract `zone_id`, `namespace`, and `key`
+
+### Requirement: Delete operation removes KV data
+
+The resource Delete method SHALL call the `EdgeKVDelete` API with:
+- `zone_id` → `request.ZoneId`
+- `namespace` → `request.Namespace`
+- `[key]` → `request.Keys` (single-element array)
+
+The Delete method SHALL use `tccommon.ReadRetryTimeout` for retry logic.
+
+#### Scenario: Successful KV data deletion
+- **WHEN** user destroys the resource
+- **THEN** the resource SHALL call EdgeKVDelete API to remove the KV data
+
+#### Scenario: Delete API returns error
+- **WHEN** EdgeKVDelete API returns an error
+- **THEN** the resource SHALL wrap the error with `tccommon.RetryError()` and return it
+
+### Requirement: Update operation modifies KV data
+
+The resource Update method SHALL call the `EdgeKVPut` API with the current `zone_id`, `namespace`, `key`, and the new `value` to update the key-value pair in place.
+
+#### Scenario: Successful value update
+- **WHEN** user changes `value` without changing ForceNew fields
+- **THEN** the resource SHALL call EdgeKVPut API with the new value and refresh state via Read
+
+### Requirement: Import support
+
+The resource SHALL support import using the composite ID format `zone_id#namespace#key`.
+
+#### Scenario: Import existing KV data
+- **WHEN** user runs `terraform import tencentcloud_teo_edge_kv.example zone_id#namespace#key`
+- **THEN** the resource SHALL read the KV data and populate the state
+
+### Requirement: Provider registration
+
+The resource SHALL be registered in `tencentcloud/provider.go` and documented in `tencentcloud/provider.md`.
+
+#### Scenario: Resource is available in provider
+- **WHEN** user references `tencentcloud_teo_edge_kv` in their configuration
+- **THEN** Terraform SHALL recognize it as a valid resource type
+
+### Requirement: Unit tests with gomonkey mock
+
+The resource SHALL have unit tests in `resource_tc_teo_edge_kv_test.go` that use gomonkey to mock the cloud API calls. Tests SHALL cover Create, Read, Update, and Delete operations.
+
+#### Scenario: Unit test for Create
+- **WHEN** unit test for Create is executed
+- **THEN** it SHALL mock EdgeKVPut API and verify the resource is created correctly
+
+#### Scenario: Unit test for Read
+- **WHEN** unit test for Read is executed
+- **THEN** it SHALL mock EdgeKVGet API and verify state is populated correctly
+
+#### Scenario: Unit test for Delete
+- **WHEN** unit test for Delete is executed
+- **THEN** it SHALL mock EdgeKVDelete API and verify the resource is deleted correctly

--- a/openspec/changes/archive/2026-06-15-add-teo-edge-kv/tasks.md
+++ b/openspec/changes/archive/2026-06-15-add-teo-edge-kv/tasks.md
@@ -1,0 +1,18 @@
+## 1. Resource Implementation
+
+- [x] 1.1 Create resource file `tencentcloud/services/teo/resource_tc_teo_edge_kv.go` with schema definition (zone_id, namespace, key, value) and CRUD functions (Create calls EdgeKVPut, Read calls EdgeKVGet, Update calls EdgeKVPut, Delete calls EdgeKVDelete)
+- [x] 1.2 Implement composite ID using `tccommon.FILED_SP` separator (zone_id#namespace#key), with ID parsing in Read and Delete methods
+
+## 2. Provider Registration
+
+- [x] 2.1 Register `tencentcloud_teo_edge_kv` resource in `tencentcloud/provider.go`
+- [x] 2.2 Add `tencentcloud_teo_edge_kv` entry in `tencentcloud/provider.md`
+
+## 3. Documentation
+
+- [x] 3.1 Create resource documentation file `tencentcloud/services/teo/resource_tc_teo_edge_kv.md` with Example Usage and Import sections
+
+## 4. Unit Tests
+
+- [x] 4.1 Create unit test file `tencentcloud/services/teo/resource_tc_teo_edge_kv_test.go` with gomonkey mock tests covering Create, Read, Update, and Delete operations
+- [x] 4.2 Run unit tests with `go test -gcflags=all=-l` to verify they pass

--- a/openspec/specs/teo-edge-kv/spec.md
+++ b/openspec/specs/teo-edge-kv/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: Resource schema definition
+
+The resource `tencentcloud_teo_edge_kv` SHALL define the following schema:
+
+- `zone_id` (Required, ForceNew, String): 站点 ID
+- `namespace` (Required, ForceNew, String): 命名空间名称
+- `key` (Required, ForceNew, String): 键名，长度为 1-512 个字符，允许的字符为字母、数字、中划线和下划线
+- `value` (Required, String): 键值，不能为空，最大支持 1 MB
+- `expiration` (Optional, Int): 键值对的过期时间，绝对时间，Unix 时间戳，取值必须大于等于当前时间 + 60
+- `expiration_ttl` (Optional, Int): 键值对的存活时长，相对时间，单位为秒，取值范围大于等于 60
+
+The resource ID SHALL be composed of `zone_id`, `namespace`, and `key` joined by `tccommon.FILED_SP` separator.
+
+#### Scenario: Schema fields are correctly defined
+- **WHEN** user defines a `tencentcloud_teo_edge_kv` resource in HCL
+- **THEN** Terraform SHALL validate that `zone_id`, `namespace`, `key`, and `value` are provided as required fields
+
+#### Scenario: ForceNew triggers resource recreation
+- **WHEN** user changes `zone_id`, `namespace`, or `key` in the configuration
+- **THEN** Terraform SHALL destroy the existing resource and create a new one
+
+### Requirement: Create operation writes KV data
+
+The resource Create method SHALL call the `EdgeKVPut` API with the following parameter mapping:
+- `zone_id` → `request.ZoneId`
+- `namespace` → `request.Namespace`
+- `key` → `request.Key`
+- `value` → `request.Value`
+- `expiration` → `request.Expiration` (if set)
+- `expiration_ttl` → `request.ExpirationTTL` (if set)
+
+The Create method SHALL use `tccommon.ReadRetryTimeout` for retry logic. After successful creation, the resource ID SHALL be set to `zone_id#namespace#key`.
+
+#### Scenario: Successful KV data write
+- **WHEN** user applies a configuration with valid `zone_id`, `namespace`, `key`, and `value`
+- **THEN** the resource SHALL call EdgeKVPut API and set the composite ID
+
+#### Scenario: Create with expiration parameters
+- **WHEN** user specifies `expiration` or `expiration_ttl`
+- **THEN** the resource SHALL pass these values to the EdgeKVPut API
+
+#### Scenario: Create API returns error
+- **WHEN** EdgeKVPut API returns an error
+- **THEN** the resource SHALL wrap the error with `tccommon.RetryError()` and return it
+
+### Requirement: Read operation queries KV data
+
+The resource Read method SHALL call the `EdgeKVGet` API with:
+- `zone_id` → `request.ZoneId`
+- `namespace` → `request.Namespace`
+- `[key]` → `request.Keys` (single-element array)
+
+The Read method SHALL parse the composite ID to extract `zone_id`, `namespace`, and `key`. If the returned Data is empty or the key's Value is empty string, the resource SHALL be marked as deleted by calling `d.SetId("")`.
+
+#### Scenario: Successful KV data read
+- **WHEN** the KV key exists
+- **THEN** the resource SHALL set `value` from the response Data
+
+#### Scenario: KV key does not exist
+- **WHEN** EdgeKVGet returns empty Data or empty Value for the key
+- **THEN** the resource SHALL call `d.SetId("")` to mark it as deleted
+
+#### Scenario: Read parses composite ID
+- **WHEN** Read method is called
+- **THEN** it SHALL split `d.Id()` by `tccommon.FILED_SP` to extract `zone_id`, `namespace`, and `key`
+
+### Requirement: Delete operation removes KV data
+
+The resource Delete method SHALL call the `EdgeKVDelete` API with:
+- `zone_id` → `request.ZoneId`
+- `namespace` → `request.Namespace`
+- `[key]` → `request.Keys` (single-element array)
+
+The Delete method SHALL use `tccommon.ReadRetryTimeout` for retry logic.
+
+#### Scenario: Successful KV data deletion
+- **WHEN** user destroys the resource
+- **THEN** the resource SHALL call EdgeKVDelete API to remove the KV data
+
+#### Scenario: Delete API returns error
+- **WHEN** EdgeKVDelete API returns an error
+- **THEN** the resource SHALL wrap the error with `tccommon.RetryError()` and return it
+
+### Requirement: Update method enforces immutability
+
+The resource Update method SHALL check if any of `value`, `expiration`, `expiration_ttl` have changed. If any of these fields are in the change set, the Update method SHALL return an error indicating that the field cannot be modified in-place.
+
+#### Scenario: Attempt to modify immutable field
+- **WHEN** user changes `value`, `expiration`, or `expiration_ttl` without changing ForceNew fields
+- **THEN** the resource SHALL return an error stating the field is immutable
+
+### Requirement: Import support
+
+The resource SHALL support import using the composite ID format `zone_id#namespace#key`.
+
+#### Scenario: Import existing KV data
+- **WHEN** user runs `terraform import tencentcloud_teo_edge_kv.example zone_id#namespace#key`
+- **THEN** the resource SHALL read the KV data and populate the state
+
+### Requirement: Provider registration
+
+The resource SHALL be registered in `tencentcloud/provider.go` and documented in `tencentcloud/provider.md`.
+
+#### Scenario: Resource is available in provider
+- **WHEN** user references `tencentcloud_teo_edge_kv` in their configuration
+- **THEN** Terraform SHALL recognize it as a valid resource type
+
+### Requirement: Unit tests with gomonkey mock
+
+The resource SHALL have unit tests in `resource_tc_teo_edge_kv_test.go` that use gomonkey to mock the cloud API calls. Tests SHALL cover Create, Read, and Delete operations.
+
+#### Scenario: Unit test for Create
+- **WHEN** unit test for Create is executed
+- **THEN** it SHALL mock EdgeKVPut API and verify the resource is created correctly
+
+#### Scenario: Unit test for Read
+- **WHEN** unit test for Read is executed
+- **THEN** it SHALL mock EdgeKVGet API and verify state is populated correctly
+
+#### Scenario: Unit test for Delete
+- **WHEN** unit test for Delete is executed
+- **THEN** it SHALL mock EdgeKVDelete API and verify the resource is deleted correctly

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -2145,6 +2145,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_teo_purge_task":                                                           teo.ResourceTencentCloudTeoPurgeTaskOperation(),
 			"tencentcloud_teo_shared_cname":                                                         teo.ResourceTencentCloudTeoSharedCname(),
 			"tencentcloud_teo_domain_shared_cname_attachment":                                       teo.ResourceTencentCloudTeoDomainSharedCnameAttachment(),
+			"tencentcloud_teo_edge_kv":                                                              teo.ResourceTencentCloudTeoEdgeKV(),
 			"tencentcloud_tcm_mesh":                                                                 tcm.ResourceTencentCloudTcmMesh(),
 			"tencentcloud_tcm_cluster_attachment":                                                   tcm.ResourceTencentCloudTcmClusterAttachment(),
 			"tencentcloud_tcm_prometheus_attachment":                                                tcm.ResourceTencentCloudTcmPrometheusAttachment(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1628,6 +1628,7 @@ tencentcloud_teo_prefetch_origin_limit
 tencentcloud_teo_purge_task
 tencentcloud_teo_shared_cname
 tencentcloud_teo_domain_shared_cname_attachment
+tencentcloud_teo_edge_kv
 
 TencentCloud ServiceMesh(TCM)
 Data Source

--- a/tencentcloud/services/teo/resource_tc_teo_edge_kv.go
+++ b/tencentcloud/services/teo/resource_tc_teo_edge_kv.go
@@ -1,0 +1,262 @@
+package teo
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudTeoEdgeKV() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudTeoEdgeKVCreate,
+		Read:   resourceTencentCloudTeoEdgeKVRead,
+		Update: resourceTencentCloudTeoEdgeKVUpdate,
+		Delete: resourceTencentCloudTeoEdgeKVDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Site ID.",
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Namespace name.",
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Key name, 1-512 characters, allowed characters are letters, numbers, hyphens and underscores.",
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Key value. Cannot be empty, maximum 1 MB.",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudTeoEdgeKVCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_edge_kv.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = teov20220901.NewEdgeKVPutRequest()
+		zoneId  string
+		ns      string
+		key     string
+	)
+
+	if v, ok := d.GetOk("zone_id"); ok {
+		request.ZoneId = helper.String(v.(string))
+		zoneId = v.(string)
+	}
+
+	if v, ok := d.GetOk("namespace"); ok {
+		request.Namespace = helper.String(v.(string))
+		ns = v.(string)
+	}
+
+	if v, ok := d.GetOk("key"); ok {
+		request.Key = helper.String(v.(string))
+		key = v.(string)
+	}
+
+	if v, ok := d.GetOk("value"); ok {
+		request.Value = helper.String(v.(string))
+	}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().EdgeKVPutWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create tencentcloud_teo_edge_kv failed, Response is nil."))
+		}
+
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s create tencentcloud_teo_edge_kv failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	d.SetId(strings.Join([]string{zoneId, ns, key}, tccommon.FILED_SP))
+	return resourceTencentCloudTeoEdgeKVRead(d, meta)
+}
+
+func resourceTencentCloudTeoEdgeKVRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_edge_kv.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = teov20220901.NewEdgeKVGetRequest()
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	zoneId := idSplit[0]
+	ns := idSplit[1]
+	key := idSplit[2]
+
+	request.ZoneId = helper.String(zoneId)
+	request.Namespace = helper.String(ns)
+	request.Keys = []*string{helper.String(key)}
+
+	var response *teov20220901.EdgeKVGetResponse
+	reqErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().EdgeKVGetWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		response = result
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s read tencentcloud_teo_edge_kv failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	if response == nil || response.Response == nil || len(response.Response.Data) == 0 {
+		log.Printf("[WARN]%s resource `tencentcloud_teo_edge_kv` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	kvPair := response.Response.Data[0]
+	if kvPair.Value == nil || *kvPair.Value == "" {
+		log.Printf("[WARN]%s resource `tencentcloud_teo_edge_kv` [%s] value is empty, marking as deleted.\n", logId, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	_ = d.Set("zone_id", zoneId)
+	_ = d.Set("namespace", ns)
+	_ = d.Set("key", key)
+	_ = d.Set("value", kvPair.Value)
+
+	return nil
+}
+
+func resourceTencentCloudTeoEdgeKVUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_edge_kv.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = teov20220901.NewEdgeKVPutRequest()
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	request.ZoneId = helper.String(idSplit[0])
+	request.Namespace = helper.String(idSplit[1])
+	request.Key = helper.String(idSplit[2])
+
+	if v, ok := d.GetOk("value"); ok {
+		request.Value = helper.String(v.(string))
+	}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().EdgeKVPutWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Update tencentcloud_teo_edge_kv failed, Response is nil."))
+		}
+
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s update tencentcloud_teo_edge_kv failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	return resourceTencentCloudTeoEdgeKVRead(d, meta)
+}
+
+func resourceTencentCloudTeoEdgeKVDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_teo_edge_kv.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = teov20220901.NewEdgeKVDeleteRequest()
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	zoneId := idSplit[0]
+	ns := idSplit[1]
+	key := idSplit[2]
+
+	request.ZoneId = helper.String(zoneId)
+	request.Namespace = helper.String(ns)
+	request.Keys = []*string{helper.String(key)}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().EdgeKVDeleteWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Delete tencentcloud_teo_edge_kv failed, Response is nil."))
+		}
+
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s delete tencentcloud_teo_edge_kv failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	return nil
+}

--- a/tencentcloud/services/teo/resource_tc_teo_edge_kv.md
+++ b/tencentcloud/services/teo/resource_tc_teo_edge_kv.md
@@ -1,0 +1,20 @@
+Provides a resource to create a TEO Edge KV key-value pair
+
+Example Usage
+
+```hcl
+resource "tencentcloud_teo_edge_kv" "example" {
+  zone_id   = "zone-2o3h21ed2t68"
+  namespace = "example-namespace"
+  key       = "example-key"
+  value     = "example-value"
+}
+```
+
+Import
+
+TEO Edge KV can be imported using the zoneId#namespace#key, e.g.
+
+```
+terraform import tencentcloud_teo_edge_kv.example zone-2o3h21ed2t68#example-namespace#example-key
+```

--- a/tencentcloud/services/teo/resource_tc_teo_edge_kv_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_edge_kv_test.go
@@ -1,0 +1,265 @@
+package teo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+)
+
+// mockMetaEdgeKV implements tccommon.ProviderMeta
+type mockMetaEdgeKV struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaEdgeKV) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaEdgeKV{}
+
+func newMockMetaEdgeKV() *mockMetaEdgeKV {
+	return &mockMetaEdgeKV{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringEdgeKV(s string) *string {
+	return &s
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestTeoEdgeKV" -v -count=1 -gcflags="all=-l"
+
+// TestTeoEdgeKV_Create tests Create operation
+func TestTeoEdgeKV_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaEdgeKV().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "EdgeKVPutWithContext", func(_ context.Context, request *teov20220901.EdgeKVPutRequest) (*teov20220901.EdgeKVPutResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+		assert.NotNil(t, request.Namespace)
+		assert.Equal(t, "test-namespace", *request.Namespace)
+		assert.NotNil(t, request.Key)
+		assert.Equal(t, "test-key", *request.Key)
+		assert.NotNil(t, request.Value)
+		assert.Equal(t, "test-value", *request.Value)
+
+		resp := teov20220901.NewEdgeKVPutResponse()
+		resp.Response = &teov20220901.EdgeKVPutResponseParams{
+			RequestId: ptrStringEdgeKV("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "EdgeKVGetWithContext", func(_ context.Context, request *teov20220901.EdgeKVGetRequest) (*teov20220901.EdgeKVGetResponse, error) {
+		resp := teov20220901.NewEdgeKVGetResponse()
+		resp.Response = &teov20220901.EdgeKVGetResponseParams{
+			Data: []*teov20220901.KeyValuePair{
+				{
+					Key:   ptrStringEdgeKV("test-key"),
+					Value: ptrStringEdgeKV("test-value"),
+				},
+			},
+			RequestId: ptrStringEdgeKV("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaEdgeKV()
+	res := teo.ResourceTencentCloudTeoEdgeKV()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":   "zone-12345678",
+		"namespace": "test-namespace",
+		"key":       "test-key",
+		"value":     "test-value",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "zone-12345678"+tccommon.FILED_SP+"test-namespace"+tccommon.FILED_SP+"test-key", d.Id())
+}
+
+// TestTeoEdgeKV_Update tests Update operation
+func TestTeoEdgeKV_Update(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaEdgeKV().client, "UseTeoV20220901Client", teoClient)
+
+	updateCalled := false
+	patches.ApplyMethodFunc(teoClient, "EdgeKVPutWithContext", func(_ context.Context, request *teov20220901.EdgeKVPutRequest) (*teov20220901.EdgeKVPutResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+		assert.NotNil(t, request.Namespace)
+		assert.Equal(t, "test-namespace", *request.Namespace)
+		assert.NotNil(t, request.Key)
+		assert.Equal(t, "test-key", *request.Key)
+		assert.NotNil(t, request.Value)
+		assert.Equal(t, "updated-value", *request.Value)
+		updateCalled = true
+
+		resp := teov20220901.NewEdgeKVPutResponse()
+		resp.Response = &teov20220901.EdgeKVPutResponseParams{
+			RequestId: ptrStringEdgeKV("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "EdgeKVGetWithContext", func(_ context.Context, request *teov20220901.EdgeKVGetRequest) (*teov20220901.EdgeKVGetResponse, error) {
+		resp := teov20220901.NewEdgeKVGetResponse()
+		resp.Response = &teov20220901.EdgeKVGetResponseParams{
+			Data: []*teov20220901.KeyValuePair{
+				{
+					Key:   ptrStringEdgeKV("test-key"),
+					Value: ptrStringEdgeKV("updated-value"),
+				},
+			},
+			RequestId: ptrStringEdgeKV("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaEdgeKV()
+	res := teo.ResourceTencentCloudTeoEdgeKV()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":   "zone-12345678",
+		"namespace": "test-namespace",
+		"key":       "test-key",
+		"value":     "updated-value",
+	})
+	d.SetId("zone-12345678" + tccommon.FILED_SP + "test-namespace" + tccommon.FILED_SP + "test-key")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.True(t, updateCalled)
+	assert.Equal(t, "updated-value", d.Get("value"))
+}
+
+// TestTeoEdgeKV_Read tests Read operation
+func TestTeoEdgeKV_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaEdgeKV().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "EdgeKVGetWithContext", func(_ context.Context, request *teov20220901.EdgeKVGetRequest) (*teov20220901.EdgeKVGetResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+		assert.NotNil(t, request.Namespace)
+		assert.Equal(t, "test-namespace", *request.Namespace)
+		assert.Equal(t, 1, len(request.Keys))
+		assert.Equal(t, "test-key", *request.Keys[0])
+
+		resp := teov20220901.NewEdgeKVGetResponse()
+		resp.Response = &teov20220901.EdgeKVGetResponseParams{
+			Data: []*teov20220901.KeyValuePair{
+				{
+					Key:   ptrStringEdgeKV("test-key"),
+					Value: ptrStringEdgeKV("test-value-read"),
+				},
+			},
+			RequestId: ptrStringEdgeKV("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaEdgeKV()
+	res := teo.ResourceTencentCloudTeoEdgeKV()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":   "zone-12345678",
+		"namespace": "test-namespace",
+		"key":       "test-key",
+		"value":     "test-value",
+	})
+	d.SetId("zone-12345678" + tccommon.FILED_SP + "test-namespace" + tccommon.FILED_SP + "test-key")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-value-read", d.Get("value"))
+	assert.Equal(t, "zone-12345678", d.Get("zone_id"))
+	assert.Equal(t, "test-namespace", d.Get("namespace"))
+	assert.Equal(t, "test-key", d.Get("key"))
+}
+
+// TestTeoEdgeKV_ReadNotFound tests Read when key does not exist
+func TestTeoEdgeKV_ReadNotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaEdgeKV().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "EdgeKVGetWithContext", func(_ context.Context, request *teov20220901.EdgeKVGetRequest) (*teov20220901.EdgeKVGetResponse, error) {
+		resp := teov20220901.NewEdgeKVGetResponse()
+		resp.Response = &teov20220901.EdgeKVGetResponseParams{
+			Data:      []*teov20220901.KeyValuePair{},
+			RequestId: ptrStringEdgeKV("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaEdgeKV()
+	res := teo.ResourceTencentCloudTeoEdgeKV()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":   "zone-12345678",
+		"namespace": "test-namespace",
+		"key":       "test-key",
+		"value":     "test-value",
+	})
+	d.SetId("zone-12345678" + tccommon.FILED_SP + "test-namespace" + tccommon.FILED_SP + "test-key")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestTeoEdgeKV_Delete tests Delete operation
+func TestTeoEdgeKV_Delete(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaEdgeKV().client, "UseTeoV20220901Client", teoClient)
+
+	deleteCalled := false
+	patches.ApplyMethodFunc(teoClient, "EdgeKVDeleteWithContext", func(_ context.Context, request *teov20220901.EdgeKVDeleteRequest) (*teov20220901.EdgeKVDeleteResponse, error) {
+		assert.NotNil(t, request.ZoneId)
+		assert.Equal(t, "zone-12345678", *request.ZoneId)
+		assert.NotNil(t, request.Namespace)
+		assert.Equal(t, "test-namespace", *request.Namespace)
+		assert.Equal(t, 1, len(request.Keys))
+		assert.Equal(t, "test-key", *request.Keys[0])
+		deleteCalled = true
+
+		resp := teov20220901.NewEdgeKVDeleteResponse()
+		resp.Response = &teov20220901.EdgeKVDeleteResponseParams{
+			RequestId: ptrStringEdgeKV("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaEdgeKV()
+	res := teo.ResourceTencentCloudTeoEdgeKV()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":   "zone-12345678",
+		"namespace": "test-namespace",
+		"key":       "test-key",
+		"value":     "test-value",
+	})
+	d.SetId("zone-12345678" + tccommon.FILED_SP + "test-namespace" + tccommon.FILED_SP + "test-key")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+	assert.True(t, deleteCalled)
+}

--- a/website/docs/r/teo_edge_kv.html.markdown
+++ b/website/docs/r/teo_edge_kv.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "TencentCloud EdgeOne(TEO)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_teo_edge_kv"
+sidebar_current: "docs-tencentcloud-resource-teo_edge_kv"
+description: |-
+  Provides a resource to create a TEO Edge KV key-value pair
+---
+
+# tencentcloud_teo_edge_kv
+
+Provides a resource to create a TEO Edge KV key-value pair
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_teo_edge_kv" "example" {
+  zone_id   = "zone-2o3h21ed2t68"
+  namespace = "example-namespace"
+  key       = "example-key"
+  value     = "example-value"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `key` - (Required, String, ForceNew) Key name, 1-512 characters, allowed characters are letters, numbers, hyphens and underscores.
+* `namespace` - (Required, String, ForceNew) Namespace name.
+* `value` - (Required, String) Key value. Cannot be empty, maximum 1 MB.
+* `zone_id` - (Required, String, ForceNew) Site ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+
+
+
+## Import
+
+TEO Edge KV can be imported using the zoneId#namespace#key, e.g.
+
+```
+terraform import tencentcloud_teo_edge_kv.example zone-2o3h21ed2t68#example-namespace#example-key
+```
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -5953,6 +5953,9 @@
                                     <a href="/docs/providers/tencentcloud/r/teo_domain_shared_cname_attachment.html">tencentcloud_teo_domain_shared_cname_attachment</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/r/teo_edge_kv.html">tencentcloud_teo_edge_kv</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/r/teo_function.html">tencentcloud_teo_function</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add a new resource tencentcloud_teo_edge_k_v_put for TEO Edge KV put operations. This resource allows users to create and manage key-value pairs in TEO Edge KV namespaces.