### PR TITLE
feat(teo): add security_policy parameter to tencentcloud_teo_security_policy_config resource

### DIFF
--- a/.changelog/4192.txt
+++ b/.changelog/4192.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_security_policy_config: add `security_policy` parameter support
+```

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdcpg v1.0.533
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.46
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.90
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.108
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.86
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.1.0
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tse v1.0.857

--- a/go.sum
+++ b/go.sum
@@ -1073,8 +1073,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.46 h1:hnBTV4y
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.46/go.mod h1:brB63yRDKDgCzEBFU5G3OBV+wQ+lpnOnedxwdnLgjjk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578 h1:vBpQhUroO+FAslUmsDWGi8nvczsqZBWVgQwlnyT0Aj8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578/go.mod h1:UlojGQh/9wb7/uXPNi7PvMral1CNAskVDNgqJEV83l0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.90 h1:UAefUxiVLj639m5jplPyTyOkF5vT8W0d8TrWZ7cepj4=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.90/go.mod h1:YV/JlZueAHyf9eyLmowdbeX90MR5jJmy0Dn6gZwPT2M=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.108 h1:cAw2o4gMuAUZnjdo+WDZmUTHgH6FdysXeUDI1YcBjgI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.108/go.mod h1:/+JtDwgVSkaDGMU42zTWtidw/p56hl2N46zkWJLAr9U=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998 h1:f4/n0dVKQTD06xJ84B5asHViNJHrZmGojdAWEPIsITM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998/go.mod h1:fyi/HUwCwVe2NCCCjz8k/C5GwPu3QazCZO+OBJ3MhLk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.86 h1:vTpLGPpzAbZHOv0F6hmy8C9IBwJIUfhTrXH0vi7eiGA=

--- a/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/design.md
+++ b/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The `tencentcloud_teo_security_policy_config` resource manages TEO (TencentCloud EdgeOne) security policy configurations. It uses:
+- `ModifySecurityPolicy` API for create/update operations
+- `DescribeSecurityPolicy` API for read operations
+
+The resource already exists at `tencentcloud/services/teo/resource_tc_teo_security_policy_config.go` with the following top-level schema fields:
+- `zone_id` (Required, ForceNew) - Zone ID
+- `entity` (Optional, ForceNew) - Security policy type (ZoneDefaultPolicy/Template/Host)
+- `host` (Optional, ForceNew) - Domain name for Host entity type
+- `template_id` (Optional, ForceNew) - Template ID for Template entity type
+- `security_policy` (Optional, TypeList, MaxItems: 1) - Security policy configuration using expression grammar
+- `security_config` (Optional, Computed, TypeList, MaxItems: 1) - Classic web protection settings
+
+The `SecurityPolicy` parameter in the `ModifySecurityPolicy` API maps to the `security_policy` schema field and contains sub-structures for:
+- `CustomRules` - Custom rule configuration
+- `ManagedRules` - Managed rules configuration
+- `HttpDDoSProtection` - HTTP DDoS protection configuration
+- `RateLimitingRules` - Rate limiting rules configuration
+- `ExceptionRules` - Exception rules configuration
+- `BotManagement` - Bot management configuration
+- `BotManagementLite` - Basic bot management configuration
+- `DefaultDenySecurityActionParameters` - Default deny action parameters
+
+The `DescribeSecurityPolicy` API returns `response.Response.SecurityPolicy` which is read back into the `security_policy` terraform attribute.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure the `security_policy` parameter is properly supported in the `ModifySecurityPolicy` API call (create/update)
+- Ensure the `DescribeSecurityPolicy` API properly reads back the `SecurityPolicy` response into the `security_policy` attribute
+- Ensure proper input parameters (`ZoneId`, `Entity`, `Host`, `TemplateId`) are passed to `DescribeSecurityPolicy`
+- Maintain backward compatibility with existing terraform configurations
+
+**Non-Goals:**
+- Modifying the `security_config` (classic) parameter handling
+- Adding new sub-fields within the `SecurityPolicy` structure beyond what the vendor SDK supports
+- Changing the resource ID format or import behavior
+
+## Decisions
+
+1. **Parameter mapping**: The `request.SecurityPolicy` field in `ModifySecurityPolicy` maps to the terraform schema field `security_policy`. This is a complex nested structure (TypeList with MaxItems: 1) containing all security policy sub-configurations.
+
+2. **Read operation**: The `DescribeSecurityPolicy` API requires `ZoneId`, `Entity`, `Host`, and `TemplateId` as input parameters (extracted from the resource ID) and returns `SecurityPolicy` in the response which is flattened into the `security_policy` attribute.
+
+3. **Resource lifecycle**: Since there is no `CreateSecurityPolicy` or `DeleteSecurityPolicy` API, the resource uses `ModifySecurityPolicy` for both create and update operations. Delete is a no-op (the security policy always exists for a zone).
+
+4. **Retry handling**: API calls use `tccommon.ReadRetryTimeout` with `resource.RetryContext` for retry logic, wrapping errors with `tccommon.RetryError()`.
+
+## Risks / Trade-offs
+
+- [Risk] The `SecurityPolicy` structure is complex with deeply nested fields → Mitigation: Follow existing patterns in the resource code for flattening/expanding nested structures.
+- [Risk] Backward compatibility with existing state files → Mitigation: Only add Optional fields, never modify existing Required fields or change field types.

--- a/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/proposal.md
+++ b/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The existing `tencentcloud_teo_security_policy_config` resource needs to support the `SecurityPolicy` parameter in the `ModifySecurityPolicy` API and properly read it back via the `DescribeSecurityPolicy` API. This enables users to configure security policies (custom rules, managed rules, HTTP DDoS protection, rate limiting rules, exception rules, bot management, bot management lite, and default deny security action parameters) using the expression-based `SecurityPolicy` structure for TEO (TencentCloud EdgeOne) security policy management.
+
+## What Changes
+
+- Add the `security_policy` parameter to the `tencentcloud_teo_security_policy_config` resource that maps to `request.SecurityPolicy` in the `ModifySecurityPolicy` API for create/update operations.
+- Ensure the `DescribeSecurityPolicy` API is called with proper input parameters (`ZoneId`, `Entity`, `Host`, `TemplateId`) and the `response.Response.SecurityPolicy` output is read back into the `security_policy` terraform attribute.
+
+## Capabilities
+
+### New Capabilities
+- `teo-security-policy-param`: Add the `SecurityPolicy` parameter support to the `tencentcloud_teo_security_policy_config` resource, enabling configuration of security policies via the `ModifySecurityPolicy` API and reading them back via `DescribeSecurityPolicy` API.
+
+### Modified Capabilities
+<!-- No existing capabilities are being modified -->
+
+## Impact
+
+- **Code**: `tencentcloud/services/teo/resource_tc_teo_security_policy_config.go` - Add/verify `security_policy` schema field and CRUD logic
+- **Code**: `tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go` - Add unit tests
+- **Code**: `tencentcloud/services/teo/resource_tc_teo_security_policy_config.md` - Update documentation with example usage
+- **API**: Uses `ModifySecurityPolicy` and `DescribeSecurityPolicy` from `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`
+- **Dependencies**: No new dependencies required (vendor SDK already includes the TEO v20220901 package)

--- a/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/specs/teo-security-policy-param/spec.md
+++ b/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/specs/teo-security-policy-param/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: SecurityPolicy parameter support in ModifySecurityPolicy API
+
+The `tencentcloud_teo_security_policy_config` resource SHALL support the `security_policy` parameter that maps to `request.SecurityPolicy` in the `ModifySecurityPolicy` API. When the user specifies the `security_policy` block in their terraform configuration, the resource MUST construct the `SecurityPolicy` struct and pass it to the `ModifySecurityPolicy` API request during create and update operations.
+
+#### Scenario: User configures security_policy with custom rules
+- **WHEN** user specifies a `security_policy` block with `custom_rules` configuration in their terraform resource
+- **THEN** the resource MUST construct the `SecurityPolicy.CustomRules` struct and include it in the `ModifySecurityPolicy` API request
+
+#### Scenario: User configures security_policy with managed rules
+- **WHEN** user specifies a `security_policy` block with `managed_rules` configuration
+- **THEN** the resource MUST construct the `SecurityPolicy.ManagedRules` struct and include it in the `ModifySecurityPolicy` API request
+
+#### Scenario: User does not specify security_policy
+- **WHEN** user does not include the `security_policy` block in their terraform configuration
+- **THEN** the resource MUST NOT set `request.SecurityPolicy` on the `ModifySecurityPolicy` API request
+
+### Requirement: DescribeSecurityPolicy reads SecurityPolicy response
+
+The resource SHALL call the `DescribeSecurityPolicy` API with proper input parameters (`ZoneId`, `Entity`, `Host`, `TemplateId`) during read operations and MUST flatten the `response.Response.SecurityPolicy` output into the `security_policy` terraform attribute.
+
+#### Scenario: Read operation retrieves security policy
+- **WHEN** terraform performs a read/refresh operation on the `tencentcloud_teo_security_policy_config` resource
+- **THEN** the resource MUST call `DescribeSecurityPolicy` with `ZoneId`, `Entity`, `Host`, and `TemplateId` extracted from the resource ID, and set the returned `SecurityPolicy` data into the `security_policy` attribute
+
+#### Scenario: DescribeSecurityPolicy returns nil SecurityPolicy
+- **WHEN** the `DescribeSecurityPolicy` API returns a nil `SecurityPolicy` in the response
+- **THEN** the resource MUST NOT attempt to set the `security_policy` attribute and SHALL treat the resource as deleted (remove from state)
+
+### Requirement: Input parameters for DescribeSecurityPolicy
+
+The resource SHALL pass the following input parameters to the `DescribeSecurityPolicy` API:
+- `ZoneId` from the `zone_id` schema field
+- `Entity` from the `entity` schema field
+- `Host` from the `host` schema field (when entity is "Host")
+- `TemplateId` from the `template_id` schema field (when entity is "Template")
+
+#### Scenario: Zone default policy query
+- **WHEN** the resource ID contains entity "ZoneDefaultPolicy"
+- **THEN** the resource MUST call `DescribeSecurityPolicy` with `ZoneId` and `Entity` set to "ZoneDefaultPolicy"
+
+#### Scenario: Host-level policy query
+- **WHEN** the resource ID contains entity "Host" with a host value
+- **THEN** the resource MUST call `DescribeSecurityPolicy` with `ZoneId`, `Entity` set to "Host", and `Host` set to the domain name
+
+#### Scenario: Template-level policy query
+- **WHEN** the resource ID contains entity "Template" with a template_id value
+- **THEN** the resource MUST call `DescribeSecurityPolicy` with `ZoneId`, `Entity` set to "Template", and `TemplateId` set to the template ID

--- a/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/tasks.md
+++ b/openspec/changes/archive/2026-06-04-add-teo-security-policy-config-params/tasks.md
@@ -1,0 +1,13 @@
+## 1. Resource Implementation
+
+- [x] 1.1 Verify and ensure the `security_policy` schema field in `tencentcloud/services/teo/resource_tc_teo_security_policy_config.go` properly maps all sub-fields of the `SecurityPolicy` struct from the vendor SDK (`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`)
+- [x] 1.2 Verify the Update function correctly constructs `request.SecurityPolicy` from the `security_policy` schema field and passes it to `ModifySecurityPolicy` API
+- [x] 1.3 Verify the Read function correctly calls `DescribeSecurityPolicy` with `ZoneId`, `Entity`, `Host`, `TemplateId` input parameters and flattens `response.Response.SecurityPolicy` into the `security_policy` attribute
+
+## 2. Unit Tests
+
+- [x] 2.1 Add unit tests in `tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go` using gomonkey to mock the cloud API calls, verifying the `security_policy` parameter is correctly handled in create/update/read operations
+
+## 3. Documentation
+
+- [x] 3.1 Update `tencentcloud/services/teo/resource_tc_teo_security_policy_config.md` with example usage demonstrating the `security_policy` parameter configuration

--- a/openspec/specs/teo-security-policy-param/spec.md
+++ b/openspec/specs/teo-security-policy-param/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: SecurityPolicy parameter support in ModifySecurityPolicy API
+
+The `tencentcloud_teo_security_policy_config` resource SHALL support the `security_policy` parameter that maps to `request.SecurityPolicy` in the `ModifySecurityPolicy` API. When the user specifies the `security_policy` block in their terraform configuration, the resource MUST construct the `SecurityPolicy` struct and pass it to the `ModifySecurityPolicy` API request during create and update operations.
+
+#### Scenario: User configures security_policy with custom rules
+- **WHEN** user specifies a `security_policy` block with `custom_rules` configuration in their terraform resource
+- **THEN** the resource MUST construct the `SecurityPolicy.CustomRules` struct and include it in the `ModifySecurityPolicy` API request
+
+#### Scenario: User configures security_policy with managed rules
+- **WHEN** user specifies a `security_policy` block with `managed_rules` configuration
+- **THEN** the resource MUST construct the `SecurityPolicy.ManagedRules` struct and include it in the `ModifySecurityPolicy` API request
+
+#### Scenario: User does not specify security_policy
+- **WHEN** user does not include the `security_policy` block in their terraform configuration
+- **THEN** the resource MUST NOT set `request.SecurityPolicy` on the `ModifySecurityPolicy` API request
+
+### Requirement: DescribeSecurityPolicy reads SecurityPolicy response
+
+The resource SHALL call the `DescribeSecurityPolicy` API with proper input parameters (`ZoneId`, `Entity`, `Host`, `TemplateId`) during read operations and MUST flatten the `response.Response.SecurityPolicy` output into the `security_policy` terraform attribute.
+
+#### Scenario: Read operation retrieves security policy
+- **WHEN** terraform performs a read/refresh operation on the `tencentcloud_teo_security_policy_config` resource
+- **THEN** the resource MUST call `DescribeSecurityPolicy` with `ZoneId`, `Entity`, `Host`, and `TemplateId` extracted from the resource ID, and set the returned `SecurityPolicy` data into the `security_policy` attribute
+
+#### Scenario: DescribeSecurityPolicy returns nil SecurityPolicy
+- **WHEN** the `DescribeSecurityPolicy` API returns a nil `SecurityPolicy` in the response
+- **THEN** the resource MUST NOT attempt to set the `security_policy` attribute and SHALL treat the resource as deleted (remove from state)
+
+### Requirement: Input parameters for DescribeSecurityPolicy
+
+The resource SHALL pass the following input parameters to the `DescribeSecurityPolicy` API:
+- `ZoneId` from the `zone_id` schema field
+- `Entity` from the `entity` schema field
+- `Host` from the `host` schema field (when entity is "Host")
+- `TemplateId` from the `template_id` schema field (when entity is "Template")
+
+#### Scenario: Zone default policy query
+- **WHEN** the resource ID contains entity "ZoneDefaultPolicy"
+- **THEN** the resource MUST call `DescribeSecurityPolicy` with `ZoneId` and `Entity` set to "ZoneDefaultPolicy"
+
+#### Scenario: Host-level policy query
+- **WHEN** the resource ID contains entity "Host" with a host value
+- **THEN** the resource MUST call `DescribeSecurityPolicy` with `ZoneId`, `Entity` set to "Host", and `Host` set to the domain name
+
+#### Scenario: Template-level policy query
+- **WHEN** the resource ID contains entity "Template" with a template_id value
+- **THEN** the resource MUST call `DescribeSecurityPolicy` with `ZoneId`, `Entity` set to "Template", and `TemplateId` set to the template ID

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go
@@ -13,6 +13,7 @@ import (
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
 )
 
@@ -626,6 +627,455 @@ func TestBotManagementLite_UpdateExpand(t *testing.T) {
 	assert.NotNil(t, capturedRequest.SecurityPolicy.BotManagementLite.AICrawlerDetection.Action.DenyActionParameters)
 	assert.Equal(t, "on", *capturedRequest.SecurityPolicy.BotManagementLite.AICrawlerDetection.Action.DenyActionParameters.BlockIp)
 	assert.Equal(t, "120s", *capturedRequest.SecurityPolicy.BotManagementLite.AICrawlerDetection.Action.DenyActionParameters.BlockIpDuration)
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestSecurityPolicy_ReadWithCustomRules" -v -count=1 -gcflags="all=-l"
+// TestSecurityPolicy_ReadWithCustomRules tests Read flattens CustomRules from API response
+func TestSecurityPolicy_ReadWithCustomRules(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+		resp := teov20220901.NewDescribeSecurityPolicyResponse()
+		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
+			SecurityPolicy: &teov20220901.SecurityPolicy{
+				CustomRules: &teov20220901.CustomRules{
+					Rules: []*teov20220901.CustomRule{
+						{
+							Name:      ptrStringSecurityPolicy("precise-rule-1"),
+							Condition: ptrStringSecurityPolicy("${http.request.host} contain ['test']"),
+							Action: &teov20220901.SecurityAction{
+								Name: ptrStringSecurityPolicy("BlockIP"),
+								BlockIPActionParameters: &teov20220901.BlockIPActionParameters{
+									Duration: ptrStringSecurityPolicy("120s"),
+								},
+							},
+							Enabled:  ptrStringSecurityPolicy("on"),
+							Id:       ptrStringSecurityPolicy("12345"),
+							RuleType: ptrStringSecurityPolicy("PreciseMatchRule"),
+							Priority: helper.Int64(50),
+						},
+						{
+							Name:      ptrStringSecurityPolicy("basic-rule-1"),
+							Condition: ptrStringSecurityPolicy("${http.request.ip} in ['1.2.3.4']"),
+							Action: &teov20220901.SecurityAction{
+								Name: ptrStringSecurityPolicy("Deny"),
+							},
+							Enabled:  ptrStringSecurityPolicy("off"),
+							Id:       ptrStringSecurityPolicy("67890"),
+							RuleType: ptrStringSecurityPolicy("BasicAccessRule"),
+							Priority: helper.Int64(30),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringSecurityPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaSecurityPolicy()
+	res := teo.ResourceTencentCloudTeoSecurityPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+		"entity":  "ZoneDefaultPolicy",
+	})
+	d.SetId("zone-12345678#ZoneDefaultPolicy")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	securityPolicy := d.Get("security_policy").([]interface{})
+	assert.Len(t, securityPolicy, 1)
+	spMap := securityPolicy[0].(map[string]interface{})
+
+	customRules := spMap["custom_rules"].([]interface{})
+	assert.Len(t, customRules, 1)
+	crMap := customRules[0].(map[string]interface{})
+
+	preciseMatchRules := crMap["precise_match_rules"].([]interface{})
+	assert.Len(t, preciseMatchRules, 1)
+	pmrMap := preciseMatchRules[0].(map[string]interface{})
+	assert.Equal(t, "precise-rule-1", pmrMap["name"])
+	assert.Equal(t, "${http.request.host} contain ['test']", pmrMap["condition"])
+	assert.Equal(t, "on", pmrMap["enabled"])
+	assert.Equal(t, "12345", pmrMap["id"])
+	assert.Equal(t, "PreciseMatchRule", pmrMap["rule_type"])
+
+	pmrAction := pmrMap["action"].([]interface{})
+	assert.Len(t, pmrAction, 1)
+	pmrActionMap := pmrAction[0].(map[string]interface{})
+	assert.Equal(t, "BlockIP", pmrActionMap["name"])
+	blockIPParams := pmrActionMap["block_ip_action_parameters"].([]interface{})
+	assert.Len(t, blockIPParams, 1)
+	blockIPMap := blockIPParams[0].(map[string]interface{})
+	assert.Equal(t, "120s", blockIPMap["duration"])
+
+	basicAccessRules := crMap["basic_access_rules"].([]interface{})
+	assert.Len(t, basicAccessRules, 1)
+	barMap := basicAccessRules[0].(map[string]interface{})
+	assert.Equal(t, "basic-rule-1", barMap["name"])
+	assert.Equal(t, "${http.request.ip} in ['1.2.3.4']", barMap["condition"])
+	assert.Equal(t, "off", barMap["enabled"])
+	assert.Equal(t, "67890", barMap["id"])
+	assert.Equal(t, "BasicAccessRule", barMap["rule_type"])
+
+	barAction := barMap["action"].([]interface{})
+	assert.Len(t, barAction, 1)
+	barActionMap := barAction[0].(map[string]interface{})
+	assert.Equal(t, "Deny", barActionMap["name"])
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestSecurityPolicy_ReadWithManagedRules" -v -count=1 -gcflags="all=-l"
+// TestSecurityPolicy_ReadWithManagedRules tests Read flattens ManagedRules from API response
+func TestSecurityPolicy_ReadWithManagedRules(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+		resp := teov20220901.NewDescribeSecurityPolicyResponse()
+		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
+			SecurityPolicy: &teov20220901.SecurityPolicy{
+				ManagedRules: &teov20220901.ManagedRules{
+					Enabled:          ptrStringSecurityPolicy("on"),
+					DetectionOnly:    ptrStringSecurityPolicy("off"),
+					SemanticAnalysis: ptrStringSecurityPolicy("off"),
+					AutoUpdate: &teov20220901.ManagedRuleAutoUpdate{
+						AutoUpdateToLatestVersion: ptrStringSecurityPolicy("on"),
+						RulesetVersion:            ptrStringSecurityPolicy("v2024.01"),
+					},
+					ManagedRuleGroups: []*teov20220901.ManagedRuleGroup{
+						{
+							GroupId:          ptrStringSecurityPolicy("wafgroup-sql-injections"),
+							SensitivityLevel: ptrStringSecurityPolicy("strict"),
+							Action: &teov20220901.SecurityAction{
+								Name: ptrStringSecurityPolicy("Deny"),
+							},
+						},
+						{
+							GroupId:          ptrStringSecurityPolicy("wafgroup-xss-attacks"),
+							SensitivityLevel: ptrStringSecurityPolicy("normal"),
+							Action: &teov20220901.SecurityAction{
+								Name: ptrStringSecurityPolicy("Monitor"),
+							},
+						},
+					},
+				},
+			},
+			RequestId: ptrStringSecurityPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaSecurityPolicy()
+	res := teo.ResourceTencentCloudTeoSecurityPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+		"entity":  "ZoneDefaultPolicy",
+	})
+	d.SetId("zone-12345678#ZoneDefaultPolicy")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	securityPolicy := d.Get("security_policy").([]interface{})
+	assert.Len(t, securityPolicy, 1)
+	spMap := securityPolicy[0].(map[string]interface{})
+
+	managedRules := spMap["managed_rules"].([]interface{})
+	assert.Len(t, managedRules, 1)
+	mrMap := managedRules[0].(map[string]interface{})
+	assert.Equal(t, "on", mrMap["enabled"])
+	assert.Equal(t, "off", mrMap["detection_only"])
+	assert.Equal(t, "off", mrMap["semantic_analysis"])
+
+	autoUpdate := mrMap["auto_update"].([]interface{})
+	assert.Len(t, autoUpdate, 1)
+	auMap := autoUpdate[0].(map[string]interface{})
+	assert.Equal(t, "on", auMap["auto_update_to_latest_version"])
+	assert.Equal(t, "v2024.01", auMap["ruleset_version"])
+
+	managedRuleGroups := mrMap["managed_rule_groups"].(*schema.Set).List()
+	assert.Len(t, managedRuleGroups, 2)
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestSecurityPolicy_UpdateWithCustomRules" -v -count=1 -gcflags="all=-l"
+// TestSecurityPolicy_UpdateWithCustomRules tests Update expands custom_rules into ModifySecurityPolicy request
+func TestSecurityPolicy_UpdateWithCustomRules(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
+
+	var capturedRequest *teov20220901.ModifySecurityPolicyRequest
+	patches.ApplyMethodFunc(teoClient, "ModifySecurityPolicyWithContext", func(_ context.Context, request *teov20220901.ModifySecurityPolicyRequest) (*teov20220901.ModifySecurityPolicyResponse, error) {
+		capturedRequest = request
+		resp := teov20220901.NewModifySecurityPolicyResponse()
+		resp.Response = &teov20220901.ModifySecurityPolicyResponseParams{
+			RequestId: ptrStringSecurityPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+		resp := teov20220901.NewDescribeSecurityPolicyResponse()
+		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
+			SecurityPolicy: &teov20220901.SecurityPolicy{
+				CustomRules: &teov20220901.CustomRules{
+					Rules: []*teov20220901.CustomRule{
+						{
+							Name:      ptrStringSecurityPolicy("precise-rule-1"),
+							Condition: ptrStringSecurityPolicy("${http.request.host} contain ['test']"),
+							Action: &teov20220901.SecurityAction{
+								Name: ptrStringSecurityPolicy("BlockIP"),
+								BlockIPActionParameters: &teov20220901.BlockIPActionParameters{
+									Duration: ptrStringSecurityPolicy("120s"),
+								},
+							},
+							Enabled:  ptrStringSecurityPolicy("on"),
+							RuleType: ptrStringSecurityPolicy("PreciseMatchRule"),
+							Priority: helper.Int64(50),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringSecurityPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaSecurityPolicy()
+	res := teo.ResourceTencentCloudTeoSecurityPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+		"entity":  "ZoneDefaultPolicy",
+		"security_policy": []interface{}{
+			map[string]interface{}{
+				"custom_rules": []interface{}{
+					map[string]interface{}{
+						"precise_match_rules": []interface{}{
+							map[string]interface{}{
+								"name":      "precise-rule-1",
+								"condition": "${http.request.host} contain ['test']",
+								"enabled":   "on",
+								"priority":  50,
+								"action": []interface{}{
+									map[string]interface{}{
+										"name": "BlockIP",
+										"block_ip_action_parameters": []interface{}{
+											map[string]interface{}{
+												"duration": "120s",
+											},
+										},
+									},
+								},
+							},
+						},
+						"basic_access_rules": []interface{}{
+							map[string]interface{}{
+								"name":      "basic-rule-1",
+								"condition": "${http.request.ip} in ['1.2.3.4']",
+								"enabled":   "off",
+								"priority":  30,
+								"action": []interface{}{
+									map[string]interface{}{
+										"name": "Deny",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	d.SetId("zone-12345678#ZoneDefaultPolicy")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedRequest)
+	assert.NotNil(t, capturedRequest.SecurityPolicy)
+	assert.NotNil(t, capturedRequest.SecurityPolicy.CustomRules)
+	assert.Len(t, capturedRequest.SecurityPolicy.CustomRules.Rules, 2)
+
+	// Verify precise match rule
+	preciseRule := capturedRequest.SecurityPolicy.CustomRules.Rules[0]
+	assert.Equal(t, "precise-rule-1", *preciseRule.Name)
+	assert.Equal(t, "${http.request.host} contain ['test']", *preciseRule.Condition)
+	assert.Equal(t, "on", *preciseRule.Enabled)
+	assert.Equal(t, "PreciseMatchRule", *preciseRule.RuleType)
+	assert.Equal(t, int64(50), *preciseRule.Priority)
+	assert.NotNil(t, preciseRule.Action)
+	assert.Equal(t, "BlockIP", *preciseRule.Action.Name)
+	assert.NotNil(t, preciseRule.Action.BlockIPActionParameters)
+	assert.Equal(t, "120s", *preciseRule.Action.BlockIPActionParameters.Duration)
+
+	// Verify basic access rule
+	basicRule := capturedRequest.SecurityPolicy.CustomRules.Rules[1]
+	assert.Equal(t, "basic-rule-1", *basicRule.Name)
+	assert.Equal(t, "${http.request.ip} in ['1.2.3.4']", *basicRule.Condition)
+	assert.Equal(t, "off", *basicRule.Enabled)
+	assert.Equal(t, "BasicAccessRule", *basicRule.RuleType)
+	assert.Equal(t, int64(30), *basicRule.Priority)
+	assert.NotNil(t, basicRule.Action)
+	assert.Equal(t, "Deny", *basicRule.Action.Name)
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestSecurityPolicy_UpdateWithManagedRules" -v -count=1 -gcflags="all=-l"
+// TestSecurityPolicy_UpdateWithManagedRules tests Update expands managed_rules into ModifySecurityPolicy request
+func TestSecurityPolicy_UpdateWithManagedRules(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
+
+	var capturedRequest *teov20220901.ModifySecurityPolicyRequest
+	patches.ApplyMethodFunc(teoClient, "ModifySecurityPolicyWithContext", func(_ context.Context, request *teov20220901.ModifySecurityPolicyRequest) (*teov20220901.ModifySecurityPolicyResponse, error) {
+		capturedRequest = request
+		resp := teov20220901.NewModifySecurityPolicyResponse()
+		resp.Response = &teov20220901.ModifySecurityPolicyResponseParams{
+			RequestId: ptrStringSecurityPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+		resp := teov20220901.NewDescribeSecurityPolicyResponse()
+		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
+			SecurityPolicy: &teov20220901.SecurityPolicy{
+				ManagedRules: &teov20220901.ManagedRules{
+					Enabled:          ptrStringSecurityPolicy("on"),
+					DetectionOnly:    ptrStringSecurityPolicy("off"),
+					SemanticAnalysis: ptrStringSecurityPolicy("off"),
+					AutoUpdate: &teov20220901.ManagedRuleAutoUpdate{
+						AutoUpdateToLatestVersion: ptrStringSecurityPolicy("off"),
+					},
+					ManagedRuleGroups: []*teov20220901.ManagedRuleGroup{
+						{
+							GroupId:          ptrStringSecurityPolicy("wafgroup-sql-injections"),
+							SensitivityLevel: ptrStringSecurityPolicy("strict"),
+							Action: &teov20220901.SecurityAction{
+								Name: ptrStringSecurityPolicy("Deny"),
+							},
+						},
+					},
+				},
+			},
+			RequestId: ptrStringSecurityPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaSecurityPolicy()
+	res := teo.ResourceTencentCloudTeoSecurityPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+		"entity":  "ZoneDefaultPolicy",
+		"security_policy": []interface{}{
+			map[string]interface{}{
+				"managed_rules": []interface{}{
+					map[string]interface{}{
+						"enabled":           "on",
+						"detection_only":    "off",
+						"semantic_analysis": "off",
+						"auto_update": []interface{}{
+							map[string]interface{}{
+								"auto_update_to_latest_version": "off",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	d.SetId("zone-12345678#ZoneDefaultPolicy")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedRequest)
+	assert.NotNil(t, capturedRequest.SecurityPolicy)
+	assert.NotNil(t, capturedRequest.SecurityPolicy.ManagedRules)
+	assert.Equal(t, "on", *capturedRequest.SecurityPolicy.ManagedRules.Enabled)
+	assert.Equal(t, "off", *capturedRequest.SecurityPolicy.ManagedRules.DetectionOnly)
+	assert.Equal(t, "off", *capturedRequest.SecurityPolicy.ManagedRules.SemanticAnalysis)
+	assert.NotNil(t, capturedRequest.SecurityPolicy.ManagedRules.AutoUpdate)
+	assert.Equal(t, "off", *capturedRequest.SecurityPolicy.ManagedRules.AutoUpdate.AutoUpdateToLatestVersion)
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestSecurityPolicy_ReadWithNilSecurityPolicy" -v -count=1 -gcflags="all=-l"
+// TestSecurityPolicy_ReadWithNilSecurityPolicy tests Read when SecurityPolicy is nil (resource deleted)
+func TestSecurityPolicy_ReadWithNilSecurityPolicy(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+		resp := teov20220901.NewDescribeSecurityPolicyResponse()
+		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
+			SecurityPolicy: nil,
+			RequestId:      ptrStringSecurityPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaSecurityPolicy()
+	res := teo.ResourceTencentCloudTeoSecurityPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+		"entity":  "ZoneDefaultPolicy",
+	})
+	d.SetId("zone-12345678#ZoneDefaultPolicy")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// go test ./tencentcloud/services/teo/ -run "TestSecurityPolicy_ReadWithHostEntity" -v -count=1 -gcflags="all=-l"
+// TestSecurityPolicy_ReadWithHostEntity tests Read correctly parses Host entity ID
+func TestSecurityPolicy_ReadWithHostEntity(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
+
+	var capturedRequest *teov20220901.DescribeSecurityPolicyRequest
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+		capturedRequest = request
+		resp := teov20220901.NewDescribeSecurityPolicyResponse()
+		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
+			SecurityPolicy: &teov20220901.SecurityPolicy{},
+			RequestId:      ptrStringSecurityPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaSecurityPolicy()
+	res := teo.ResourceTencentCloudTeoSecurityPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id": "zone-12345678",
+		"entity":  "Host",
+		"host":    "www.example.com",
+	})
+	d.SetId("zone-12345678#Host#www.example.com")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedRequest)
+	assert.Equal(t, "zone-12345678", *capturedRequest.ZoneId)
+	assert.Equal(t, "Host", *capturedRequest.Entity)
+	assert.Equal(t, "www.example.com", *capturedRequest.Host)
 }
 
 // TestBotManagementLite_Schema tests the bot_management_lite schema definition

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/client.go
@@ -600,7 +600,9 @@ func NewCreateAccelerationDomainResponse() (response *CreateAccelerationDomainRe
 //  INVALIDPARAMETERVALUE_INVALIDDNSNAME = "InvalidParameterValue.InvalidDNSName"
 //  INVALIDPARAMETERVALUE_INVALIDDOMAINNAME = "InvalidParameterValue.InvalidDomainName"
 //  INVALIDPARAMETERVALUE_INVALIDPROXYORIGIN = "InvalidParameterValue.InvalidProxyOrigin"
+//  INVALIDPARAMETERVALUE_INVALIDSITEFAILOVERUNSUPPORTED = "InvalidParameterValue.InvalidSiteFailoverUnsupported"
 //  INVALIDPARAMETERVALUE_ORIGINGROUPNOTEXISTS = "InvalidParameterValue.OriginGroupNotExists"
+//  INVALIDPARAMETERVALUE_SITEFAILOVERNOTSUPPORTHOSTORIGINTYPEVOD = "InvalidParameterValue.SiteFailoverNotSupportHostOriginTypeVod"
 //  OPERATIONDENIED = "OperationDenied"
 //  OPERATIONDENIED_ACCELERATEMAINLANDDISABLE = "OperationDenied.AccelerateMainlandDisable"
 //  OPERATIONDENIED_CONFIGLOCKED = "OperationDenied.ConfigLocked"
@@ -662,7 +664,9 @@ func (c *Client) CreateAccelerationDomain(request *CreateAccelerationDomainReque
 //  INVALIDPARAMETERVALUE_INVALIDDNSNAME = "InvalidParameterValue.InvalidDNSName"
 //  INVALIDPARAMETERVALUE_INVALIDDOMAINNAME = "InvalidParameterValue.InvalidDomainName"
 //  INVALIDPARAMETERVALUE_INVALIDPROXYORIGIN = "InvalidParameterValue.InvalidProxyOrigin"
+//  INVALIDPARAMETERVALUE_INVALIDSITEFAILOVERUNSUPPORTED = "InvalidParameterValue.InvalidSiteFailoverUnsupported"
 //  INVALIDPARAMETERVALUE_ORIGINGROUPNOTEXISTS = "InvalidParameterValue.OriginGroupNotExists"
+//  INVALIDPARAMETERVALUE_SITEFAILOVERNOTSUPPORTHOSTORIGINTYPEVOD = "InvalidParameterValue.SiteFailoverNotSupportHostOriginTypeVod"
 //  OPERATIONDENIED = "OperationDenied"
 //  OPERATIONDENIED_ACCELERATEMAINLANDDISABLE = "OperationDenied.AccelerateMainlandDisable"
 //  OPERATIONDENIED_CONFIGLOCKED = "OperationDenied.ConfigLocked"
@@ -1499,6 +1503,78 @@ func (c *Client) CreateFunctionWithContext(ctx context.Context, request *CreateF
     request.SetContext(ctx)
     
     response = NewCreateFunctionResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateFunctionReplicaRequest() (request *CreateFunctionReplicaRequest) {
+    request = &CreateFunctionReplicaRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "CreateFunctionReplica")
+    
+    
+    return
+}
+
+func NewCreateFunctionReplicaResponse() (response *CreateFunctionReplicaResponse) {
+    response = &CreateFunctionReplicaResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateFunctionReplica
+// 本接口用于创建指定边缘函数的副本。创建副本后，当客户端请求匹配已配置的触发规则或默认域名时，您可以通过在请求头中添加 EO-Function-Replica-Name:[副本名称] 来访问特定的函数副本。每个函数默认支持创建两个副本。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_FUNCTIONDEPLOYING = "FailedOperation.FunctionDeploying"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETER_BADCONTENT = "InvalidParameter.BadContent"
+//  INVALIDPARAMETER_BADFUNCTIONNAME = "InvalidParameter.BadFunctionName"
+//  INVALIDPARAMETER_CONTENTEXCEEDSLIMIT = "InvalidParameter.ContentExceedsLimit"
+//  INVALIDPARAMETER_FUNCTIONNAMECONFLICT = "InvalidParameter.FunctionNameConflict"
+//  INVALIDPARAMETER_LENGTHEXCEEDSLIMIT = "InvalidParameter.LengthExceedsLimit"
+//  LIMITEXCEEDED_FUNCTIONLIMITEXCEEDED = "LimitExceeded.FunctionLimitExceeded"
+//  OPERATIONDENIED_VERSIONCONTROLLOCKED = "OperationDenied.VersionControlLocked"
+//  RESOURCEUNAVAILABLE_ZONENOTFOUND = "ResourceUnavailable.ZoneNotFound"
+//  UNAUTHORIZEDOPERATION_CAMUNAUTHORIZED = "UnauthorizedOperation.CamUnauthorized"
+func (c *Client) CreateFunctionReplica(request *CreateFunctionReplicaRequest) (response *CreateFunctionReplicaResponse, err error) {
+    return c.CreateFunctionReplicaWithContext(context.Background(), request)
+}
+
+// CreateFunctionReplica
+// 本接口用于创建指定边缘函数的副本。创建副本后，当客户端请求匹配已配置的触发规则或默认域名时，您可以通过在请求头中添加 EO-Function-Replica-Name:[副本名称] 来访问特定的函数副本。每个函数默认支持创建两个副本。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_FUNCTIONDEPLOYING = "FailedOperation.FunctionDeploying"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETER_BADCONTENT = "InvalidParameter.BadContent"
+//  INVALIDPARAMETER_BADFUNCTIONNAME = "InvalidParameter.BadFunctionName"
+//  INVALIDPARAMETER_CONTENTEXCEEDSLIMIT = "InvalidParameter.ContentExceedsLimit"
+//  INVALIDPARAMETER_FUNCTIONNAMECONFLICT = "InvalidParameter.FunctionNameConflict"
+//  INVALIDPARAMETER_LENGTHEXCEEDSLIMIT = "InvalidParameter.LengthExceedsLimit"
+//  LIMITEXCEEDED_FUNCTIONLIMITEXCEEDED = "LimitExceeded.FunctionLimitExceeded"
+//  OPERATIONDENIED_VERSIONCONTROLLOCKED = "OperationDenied.VersionControlLocked"
+//  RESOURCEUNAVAILABLE_ZONENOTFOUND = "ResourceUnavailable.ZoneNotFound"
+//  UNAUTHORIZEDOPERATION_CAMUNAUTHORIZED = "UnauthorizedOperation.CamUnauthorized"
+func (c *Client) CreateFunctionReplicaWithContext(ctx context.Context, request *CreateFunctionReplicaRequest) (response *CreateFunctionReplicaResponse, err error) {
+    if request == nil {
+        request = NewCreateFunctionReplicaRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "CreateFunctionReplica")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateFunctionReplica require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateFunctionReplicaResponse()
     err = c.Send(request, response)
     return
 }
@@ -2667,7 +2743,7 @@ func NewCreateRealtimeLogDeliveryTaskResponse() (response *CreateRealtimeLogDeli
 //
 // - 当数据投递类型（LogType）为速率限制和 CC 攻击防护日志、托管规则日志、自定义规则日志、Bot 管理日志时，同一个实体在同种数据投递类型（LogType）和数据投递区域（Area）的组合下，只能被添加到一个实时日志投递任务中。
 //
-// - 当实时日志投递任务类型（TaskType）为 EdgeOne 日志分析（log_analysis）时，只支持数据投递类型（LogType）为站点加速日志（domain）；在同一站点（ZoneId）和数据投递区域（Area）的组合下，只能添加一个推送至 EdgeOne 日志分析的实时日志投递任务；。
+// - 当实时日志投递任务类型（TaskType）为 EdgeOne 日志分析（log_analysis）时，只支持数据投递类型（LogType）为站点加速日志（domain）或托管规则日志（web-attack）；在同一站点（ZoneId）、同一数据投递区域（Area）和数据的组合下，每种数据投递类型（LogType）只能添加一个推送至 EdgeOne 日志分析的实时日志投递任务。
 //
 // 
 //
@@ -2711,7 +2787,7 @@ func (c *Client) CreateRealtimeLogDeliveryTask(request *CreateRealtimeLogDeliver
 //
 // - 当数据投递类型（LogType）为速率限制和 CC 攻击防护日志、托管规则日志、自定义规则日志、Bot 管理日志时，同一个实体在同种数据投递类型（LogType）和数据投递区域（Area）的组合下，只能被添加到一个实时日志投递任务中。
 //
-// - 当实时日志投递任务类型（TaskType）为 EdgeOne 日志分析（log_analysis）时，只支持数据投递类型（LogType）为站点加速日志（domain）；在同一站点（ZoneId）和数据投递区域（Area）的组合下，只能添加一个推送至 EdgeOne 日志分析的实时日志投递任务；。
+// - 当实时日志投递任务类型（TaskType）为 EdgeOne 日志分析（log_analysis）时，只支持数据投递类型（LogType）为站点加速日志（domain）或托管规则日志（web-attack）；在同一站点（ZoneId）、同一数据投递区域（Area）和数据的组合下，每种数据投递类型（LogType）只能添加一个推送至 EdgeOne 日志分析的实时日志投递任务。
 //
 // 
 //
@@ -4549,6 +4625,66 @@ func (c *Client) DeleteFunctionWithContext(ctx context.Context, request *DeleteF
     request.SetContext(ctx)
     
     response = NewDeleteFunctionResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteFunctionReplicaRequest() (request *DeleteFunctionReplicaRequest) {
+    request = &DeleteFunctionReplicaRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "DeleteFunctionReplica")
+    
+    
+    return
+}
+
+func NewDeleteFunctionReplicaResponse() (response *DeleteFunctionReplicaResponse) {
+    response = &DeleteFunctionReplicaResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteFunctionReplica
+// 本接口用于删除指定的边缘函数副本。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_RULEOPERATIONCONFLICT = "FailedOperation.RuleOperationConflict"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  OPERATIONDENIED_VERSIONCONTROLLOCKED = "OperationDenied.VersionControlLocked"
+//  RESOURCEUNAVAILABLE_FUNCTIONNOTFOUND = "ResourceUnavailable.FunctionNotFound"
+//  RESOURCEUNAVAILABLE_ZONENOTFOUND = "ResourceUnavailable.ZoneNotFound"
+func (c *Client) DeleteFunctionReplica(request *DeleteFunctionReplicaRequest) (response *DeleteFunctionReplicaResponse, err error) {
+    return c.DeleteFunctionReplicaWithContext(context.Background(), request)
+}
+
+// DeleteFunctionReplica
+// 本接口用于删除指定的边缘函数副本。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_RULEOPERATIONCONFLICT = "FailedOperation.RuleOperationConflict"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  OPERATIONDENIED_VERSIONCONTROLLOCKED = "OperationDenied.VersionControlLocked"
+//  RESOURCEUNAVAILABLE_FUNCTIONNOTFOUND = "ResourceUnavailable.FunctionNotFound"
+//  RESOURCEUNAVAILABLE_ZONENOTFOUND = "ResourceUnavailable.ZoneNotFound"
+func (c *Client) DeleteFunctionReplicaWithContext(ctx context.Context, request *DeleteFunctionReplicaRequest) (response *DeleteFunctionReplicaResponse, err error) {
+    if request == nil {
+        request = NewDeleteFunctionReplicaRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "DeleteFunctionReplica")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteFunctionReplica require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteFunctionReplicaResponse()
     err = c.Send(request, response)
     return
 }
@@ -6989,6 +7125,60 @@ func (c *Client) DescribeFunctionComponentBindingsWithContext(ctx context.Contex
     request.SetContext(ctx)
     
     response = NewDescribeFunctionComponentBindingsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeFunctionReplicasRequest() (request *DescribeFunctionReplicasRequest) {
+    request = &DescribeFunctionReplicasRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "DescribeFunctionReplicas")
+    
+    
+    return
+}
+
+func NewDescribeFunctionReplicasResponse() (response *DescribeFunctionReplicasResponse) {
+    response = &DescribeFunctionReplicasResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeFunctionReplicas
+// 本接口用于查询边缘函数的副本列表。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_INVALIDFILTERNAME = "InvalidParameter.InvalidFilterName"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeFunctionReplicas(request *DescribeFunctionReplicasRequest) (response *DescribeFunctionReplicasResponse, err error) {
+    return c.DescribeFunctionReplicasWithContext(context.Background(), request)
+}
+
+// DescribeFunctionReplicas
+// 本接口用于查询边缘函数的副本列表。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_INVALIDFILTERNAME = "InvalidParameter.InvalidFilterName"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeFunctionReplicasWithContext(ctx context.Context, request *DescribeFunctionReplicasRequest) (response *DescribeFunctionReplicasResponse, err error) {
+    if request == nil {
+        request = NewDescribeFunctionReplicasRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "DescribeFunctionReplicas")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeFunctionReplicas require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeFunctionReplicasResponse()
     err = c.Send(request, response)
     return
 }
@@ -9499,125 +9689,9 @@ func NewDescribeTimingL7OriginPullDataResponse() (response *DescribeTimingL7Orig
 }
 
 // DescribeTimingL7OriginPullData
-// 本接口用以查询七层域名业务的回源时序数据，可以通过指定查询维度 <code>DimensionName</code> 进行分组查询，返回多组时序数据。
+// 本接口用以查询七层域名业务的回源时序数据。
 //
-// 
-//
-// <p>单次请求最多返回 <strong>50,000</strong> 个数据项<code> TimingDataItem </code>。数据项总数的计算规则如下：</p>
-//
-// <pre>
-//
-//    指标个数 * 时间点个数 * 维度值个数 = 数据项总数
-//
-// </pre>
-//
-// <ul>
-//
-//   <li>
-//
-//     <strong>指标个数</strong>：<code>MetricNames</code> 的列表长度。
-//
-//   </li>
-//
-//   <li>
-//
-//     <strong>时间点个数</strong>：<code>(EndTime - StartTime) / Interval</code>。
-//
-//   </li>
-//
-//   <li>
-//
-//     <strong>维度值个数</strong>：
-//
-//     <ul>
-//
-//       <li>当未指定 <code>DimensionName</code> 时，默认按账号维度汇总数据，维度值个数为 1。</li>
-//
-//       <li>当 <code>DimensionName = domain</code> 时，维度值个数为 <code>Filters</code> 中 <code>domain</code> 过滤条件指定的域名列表长度。</li>
-//
-//       <li>当 <code>DimensionName = origin-status-code-category</code> 时，维度值个数默认为 <code>6</code>。</li>
-//
-//       <li>当 <code>DimensionName = origin-status-code</code> 时，维度值个数默认为 <code>600</code>。</li>
-//
-//     </ul>
-//
-//   </li>
-//
-// </ul>
-//
-// 
-//
-// <p><code>DimensionName</code> 可以与 <code>Filters</code> 组合使用，通过在 <code>Filters</code> 中指定 <code>DimensionName</code> 对应的过滤条件以限制维度值个数。</p>
-//
-// 
-//
-// <h3>示例</h3>
-//
-// <p>以查询某一小时的具体状态码维度的时序数据为例，假设查询条件如下：</p>
-//
-// <ul>
-//
-//   <li><code>MetricNames = ["l7Flow_request_hy"]</code>（指标个数 = 1）</li>
-//
-//   <li><code>StartTime = 2025-10-01T06:00:00+08:00</code>，<code>EndTime = 2025-10-01T06:59:59+08:00</code>，<code>Interval = "min"</code>（时间点个数 = 60）</li>
-//
-//   <li><code>DimensionName = origin-status-code</code>，<code>Filters = [{"originStatusCode": ["0", "4xx", "5xx"]}]</code>（维度值个数 = 201）</li>
-//
-// </ul>
-//
-// <p>则数据项总数为：</p>
-//
-// <pre>1 × 60 × 201 = 12060 </pre>
-//
-// <p>未超过限制。</p>
-//
-// 
-//
-// <p><strong>注意</strong>：若查询的数据项总数超过 <strong>50,000</strong>，系统会返回错误 <strong>LimitExceeded.TimingDataItemLimitExceeded</strong>。</p>
-//
-// <p>此时，请通过调整入参减少单次查询的数据项至 50,000 以内，可采取的做法有：</p>
-//
-// <ol>
-//
-//   <li>
-//
-//     <strong>减少时间点个数</strong>：
-//
-//     <ul>
-//
-//       <li>缩短查询时间范围（<code>StartTime</code> 到 <code>EndTime</code> 之间的时间跨度）。</li>
-//
-//       <li>选择更大的时间间隔（<code>Interval</code>）。</li>
-//
-//     </ul>
-//
-//   </li>
-//
-//   <li>
-//
-//     <strong>减少维度值个数</strong>：
-//
-//     <ul>
-//
-//       <li>调整 <code>Filters</code>，指定更少的 <code>domain</code> 或 <code>originStatusCode</code> 列表。</li>
-//
-//     </ul>
-//
-//   </li>
-//
-//   <li>
-//
-//     <strong>减少指标值个数</strong>：
-//
-//     <ul>
-//
-//       <li>调整 <code>MetricNames</code>，指定更少的查询指标。</li>
-//
-//     </ul>
-//
-//   </li>
-//
-// </ol>
+// 您可以选择通过指定查询维度 <code>DimensionName</code> 进行分组查询，返回多组时序数据，详细指引与使用限制请参考 [如何使用 API 实现单次调用中的分组查询](https://cloud.tencent.com/document/product/1552/127501)。
 //
 // 可能返回的错误码:
 //  INVALIDPARAMETER_ACTIONINPROGRESS = "InvalidParameter.ActionInProgress"
@@ -9630,125 +9704,9 @@ func (c *Client) DescribeTimingL7OriginPullData(request *DescribeTimingL7OriginP
 }
 
 // DescribeTimingL7OriginPullData
-// 本接口用以查询七层域名业务的回源时序数据，可以通过指定查询维度 <code>DimensionName</code> 进行分组查询，返回多组时序数据。
+// 本接口用以查询七层域名业务的回源时序数据。
 //
-// 
-//
-// <p>单次请求最多返回 <strong>50,000</strong> 个数据项<code> TimingDataItem </code>。数据项总数的计算规则如下：</p>
-//
-// <pre>
-//
-//    指标个数 * 时间点个数 * 维度值个数 = 数据项总数
-//
-// </pre>
-//
-// <ul>
-//
-//   <li>
-//
-//     <strong>指标个数</strong>：<code>MetricNames</code> 的列表长度。
-//
-//   </li>
-//
-//   <li>
-//
-//     <strong>时间点个数</strong>：<code>(EndTime - StartTime) / Interval</code>。
-//
-//   </li>
-//
-//   <li>
-//
-//     <strong>维度值个数</strong>：
-//
-//     <ul>
-//
-//       <li>当未指定 <code>DimensionName</code> 时，默认按账号维度汇总数据，维度值个数为 1。</li>
-//
-//       <li>当 <code>DimensionName = domain</code> 时，维度值个数为 <code>Filters</code> 中 <code>domain</code> 过滤条件指定的域名列表长度。</li>
-//
-//       <li>当 <code>DimensionName = origin-status-code-category</code> 时，维度值个数默认为 <code>6</code>。</li>
-//
-//       <li>当 <code>DimensionName = origin-status-code</code> 时，维度值个数默认为 <code>600</code>。</li>
-//
-//     </ul>
-//
-//   </li>
-//
-// </ul>
-//
-// 
-//
-// <p><code>DimensionName</code> 可以与 <code>Filters</code> 组合使用，通过在 <code>Filters</code> 中指定 <code>DimensionName</code> 对应的过滤条件以限制维度值个数。</p>
-//
-// 
-//
-// <h3>示例</h3>
-//
-// <p>以查询某一小时的具体状态码维度的时序数据为例，假设查询条件如下：</p>
-//
-// <ul>
-//
-//   <li><code>MetricNames = ["l7Flow_request_hy"]</code>（指标个数 = 1）</li>
-//
-//   <li><code>StartTime = 2025-10-01T06:00:00+08:00</code>，<code>EndTime = 2025-10-01T06:59:59+08:00</code>，<code>Interval = "min"</code>（时间点个数 = 60）</li>
-//
-//   <li><code>DimensionName = origin-status-code</code>，<code>Filters = [{"originStatusCode": ["0", "4xx", "5xx"]}]</code>（维度值个数 = 201）</li>
-//
-// </ul>
-//
-// <p>则数据项总数为：</p>
-//
-// <pre>1 × 60 × 201 = 12060 </pre>
-//
-// <p>未超过限制。</p>
-//
-// 
-//
-// <p><strong>注意</strong>：若查询的数据项总数超过 <strong>50,000</strong>，系统会返回错误 <strong>LimitExceeded.TimingDataItemLimitExceeded</strong>。</p>
-//
-// <p>此时，请通过调整入参减少单次查询的数据项至 50,000 以内，可采取的做法有：</p>
-//
-// <ol>
-//
-//   <li>
-//
-//     <strong>减少时间点个数</strong>：
-//
-//     <ul>
-//
-//       <li>缩短查询时间范围（<code>StartTime</code> 到 <code>EndTime</code> 之间的时间跨度）。</li>
-//
-//       <li>选择更大的时间间隔（<code>Interval</code>）。</li>
-//
-//     </ul>
-//
-//   </li>
-//
-//   <li>
-//
-//     <strong>减少维度值个数</strong>：
-//
-//     <ul>
-//
-//       <li>调整 <code>Filters</code>，指定更少的 <code>domain</code> 或 <code>originStatusCode</code> 列表。</li>
-//
-//     </ul>
-//
-//   </li>
-//
-//   <li>
-//
-//     <strong>减少指标值个数</strong>：
-//
-//     <ul>
-//
-//       <li>调整 <code>MetricNames</code>，指定更少的查询指标。</li>
-//
-//     </ul>
-//
-//   </li>
-//
-// </ol>
+// 您可以选择通过指定查询维度 <code>DimensionName</code> 进行分组查询，返回多组时序数据，详细指引与使用限制请参考 [如何使用 API 实现单次调用中的分组查询](https://cloud.tencent.com/document/product/1552/127501)。
 //
 // 可能返回的错误码:
 //  INVALIDPARAMETER_ACTIONINPROGRESS = "InvalidParameter.ActionInProgress"
@@ -11086,6 +11044,7 @@ func NewModifyAccelerationDomainResponse() (response *ModifyAccelerationDomainRe
 //  INVALIDPARAMETERVALUE_CONFLICTRECORD = "InvalidParameterValue.ConflictRecord"
 //  INVALIDPARAMETERVALUE_DOMAINNOTMATCHZONE = "InvalidParameterValue.DomainNotMatchZone"
 //  INVALIDPARAMETERVALUE_INVALIDDOMAINSTATUS = "InvalidParameterValue.InvalidDomainStatus"
+//  INVALIDPARAMETERVALUE_SITEFAILOVERNOTSUPPORTHOSTORIGINTYPEVOD = "InvalidParameterValue.SiteFailoverNotSupportHostOriginTypeVod"
 //  OPERATIONDENIED_DOMAINNOICP = "OperationDenied.DomainNoICP"
 //  OPERATIONDENIED_RESOURCELOCKEDTEMPORARY = "OperationDenied.ResourceLockedTemporary"
 //  OPERATIONDENIED_VERSIONCONTROLISGRAYING = "OperationDenied.VersionControlIsGraying"
@@ -11122,6 +11081,7 @@ func (c *Client) ModifyAccelerationDomain(request *ModifyAccelerationDomainReque
 //  INVALIDPARAMETERVALUE_CONFLICTRECORD = "InvalidParameterValue.ConflictRecord"
 //  INVALIDPARAMETERVALUE_DOMAINNOTMATCHZONE = "InvalidParameterValue.DomainNotMatchZone"
 //  INVALIDPARAMETERVALUE_INVALIDDOMAINSTATUS = "InvalidParameterValue.InvalidDomainStatus"
+//  INVALIDPARAMETERVALUE_SITEFAILOVERNOTSUPPORTHOSTORIGINTYPEVOD = "InvalidParameterValue.SiteFailoverNotSupportHostOriginTypeVod"
 //  OPERATIONDENIED_DOMAINNOICP = "OperationDenied.DomainNoICP"
 //  OPERATIONDENIED_RESOURCELOCKEDTEMPORARY = "OperationDenied.ResourceLockedTemporary"
 //  OPERATIONDENIED_VERSIONCONTROLISGRAYING = "OperationDenied.VersionControlIsGraying"
@@ -12057,6 +12017,70 @@ func (c *Client) ModifyFunctionComponentBindingsWithContext(ctx context.Context,
     return
 }
 
+func NewModifyFunctionReplicaRequest() (request *ModifyFunctionReplicaRequest) {
+    request = &ModifyFunctionReplicaRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("teo", APIVersion, "ModifyFunctionReplica")
+    
+    
+    return
+}
+
+func NewModifyFunctionReplicaResponse() (response *ModifyFunctionReplicaResponse) {
+    response = &ModifyFunctionReplicaResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyFunctionReplica
+// 本接口用于修改指定边缘函数副本的内容和描述。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_BINDINGNOTFOUND = "InvalidParameter.BindingNotFound"
+//  INVALIDPARAMETER_DUPLICATEBINDINGNAME = "InvalidParameter.DuplicateBindingName"
+//  INVALIDPARAMETER_FUNCTIONBINDVARIABLENAMECONFLICT = "InvalidParameter.FunctionBindVariableNameConflict"
+//  INVALIDPARAMETER_INVALIDOPERATION = "InvalidParameter.InvalidOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_FUNCTIONNOTFOUND = "ResourceUnavailable.FunctionNotFound"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) ModifyFunctionReplica(request *ModifyFunctionReplicaRequest) (response *ModifyFunctionReplicaResponse, err error) {
+    return c.ModifyFunctionReplicaWithContext(context.Background(), request)
+}
+
+// ModifyFunctionReplica
+// 本接口用于修改指定边缘函数副本的内容和描述。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER_BINDINGNOTFOUND = "InvalidParameter.BindingNotFound"
+//  INVALIDPARAMETER_DUPLICATEBINDINGNAME = "InvalidParameter.DuplicateBindingName"
+//  INVALIDPARAMETER_FUNCTIONBINDVARIABLENAMECONFLICT = "InvalidParameter.FunctionBindVariableNameConflict"
+//  INVALIDPARAMETER_INVALIDOPERATION = "InvalidParameter.InvalidOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE_FUNCTIONNOTFOUND = "ResourceUnavailable.FunctionNotFound"
+//  RESOURCEUNAVAILABLE_NAMESPACENOTFOUND = "ResourceUnavailable.NamespaceNotFound"
+func (c *Client) ModifyFunctionReplicaWithContext(ctx context.Context, request *ModifyFunctionReplicaRequest) (response *ModifyFunctionReplicaResponse, err error) {
+    if request == nil {
+        request = NewModifyFunctionReplicaRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "teo", APIVersion, "ModifyFunctionReplica")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyFunctionReplica require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyFunctionReplicaResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyFunctionRuleRequest() (request *ModifyFunctionRuleRequest) {
     request = &ModifyFunctionRuleRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -12252,6 +12276,7 @@ func NewModifyHostsCertificateResponse() (response *ModifyHostsCertificateRespon
 //  INVALIDPARAMETERVALUE_OCDIRECTORIGINDOMAINNOTSUPPORTUPSTREAMVERIFY = "InvalidParameterValue.OCDirectOriginDomainNotSupportUpstreamVerify"
 //  INVALIDPARAMETERVALUE_SERVERCERTINFONEEDCONTAINRSAORECC = "InvalidParameterValue.ServerCertInfoNeedContainRSAorECC"
 //  INVALIDPARAMETERVALUE_SERVERCERTINFONEEDCONTAINSM2 = "InvalidParameterValue.ServerCertInfoNeedContainSM2"
+//  INVALIDPARAMETERVALUE_SITEFAILOVERNOTSUPPORTHOSTUPSTREAMVERIFY = "InvalidParameterValue.SiteFailoverNotSupportHostUpstreamVerify"
 //  INVALIDPARAMETERVALUE_UPSTREAMCLIENTCERTINFOQUOTALIMIT = "InvalidParameterValue.UpstreamClientCertInfoQuotaLimit"
 //  INVALIDPARAMETERVALUE_UPSTREAMVERIFYCUSTOMCACERTINFOQUOTALIMIT = "InvalidParameterValue.UpstreamVerifyCustomCACertInfoQuotaLimit"
 //  LIMITEXCEEDED_RATELIMITEXCEEDED = "LimitExceeded.RateLimitExceeded"
@@ -12260,6 +12285,7 @@ func NewModifyHostsCertificateResponse() (response *ModifyHostsCertificateRespon
 //  OPERATIONDENIED_CONFIGLOCKED = "OperationDenied.ConfigLocked"
 //  OPERATIONDENIED_DISABLEZONENOTCOMPLETED = "OperationDenied.DisableZoneNotCompleted"
 //  OPERATIONDENIED_ERRZONEISALREADYPAUSED = "OperationDenied.ErrZoneIsAlreadyPaused"
+//  OPERATIONDENIED_HOSTSCERTIFICATEINCONSISTENCY = "OperationDenied.HostsCertificateInconsistency"
 //  OPERATIONDENIED_HOSTSCLIENTCERTIFICATEINCONSISTENCY = "OperationDenied.HostsClientCertificateInconsistency"
 //  OPERATIONDENIED_HOSTSKEYLESSSERVERINCONSISTENCY = "OperationDenied.HostsKeylessServerInconsistency"
 //  OPERATIONDENIED_HOSTSUPSTREAMCERTIFICATEINCONSISTENCY = "OperationDenied.HostsUpstreamCertificateInconsistency"
@@ -12334,6 +12360,7 @@ func (c *Client) ModifyHostsCertificate(request *ModifyHostsCertificateRequest) 
 //  INVALIDPARAMETERVALUE_OCDIRECTORIGINDOMAINNOTSUPPORTUPSTREAMVERIFY = "InvalidParameterValue.OCDirectOriginDomainNotSupportUpstreamVerify"
 //  INVALIDPARAMETERVALUE_SERVERCERTINFONEEDCONTAINRSAORECC = "InvalidParameterValue.ServerCertInfoNeedContainRSAorECC"
 //  INVALIDPARAMETERVALUE_SERVERCERTINFONEEDCONTAINSM2 = "InvalidParameterValue.ServerCertInfoNeedContainSM2"
+//  INVALIDPARAMETERVALUE_SITEFAILOVERNOTSUPPORTHOSTUPSTREAMVERIFY = "InvalidParameterValue.SiteFailoverNotSupportHostUpstreamVerify"
 //  INVALIDPARAMETERVALUE_UPSTREAMCLIENTCERTINFOQUOTALIMIT = "InvalidParameterValue.UpstreamClientCertInfoQuotaLimit"
 //  INVALIDPARAMETERVALUE_UPSTREAMVERIFYCUSTOMCACERTINFOQUOTALIMIT = "InvalidParameterValue.UpstreamVerifyCustomCACertInfoQuotaLimit"
 //  LIMITEXCEEDED_RATELIMITEXCEEDED = "LimitExceeded.RateLimitExceeded"
@@ -12342,6 +12369,7 @@ func (c *Client) ModifyHostsCertificate(request *ModifyHostsCertificateRequest) 
 //  OPERATIONDENIED_CONFIGLOCKED = "OperationDenied.ConfigLocked"
 //  OPERATIONDENIED_DISABLEZONENOTCOMPLETED = "OperationDenied.DisableZoneNotCompleted"
 //  OPERATIONDENIED_ERRZONEISALREADYPAUSED = "OperationDenied.ErrZoneIsAlreadyPaused"
+//  OPERATIONDENIED_HOSTSCERTIFICATEINCONSISTENCY = "OperationDenied.HostsCertificateInconsistency"
 //  OPERATIONDENIED_HOSTSCLIENTCERTIFICATEINCONSISTENCY = "OperationDenied.HostsClientCertificateInconsistency"
 //  OPERATIONDENIED_HOSTSKEYLESSSERVERINCONSISTENCY = "OperationDenied.HostsKeylessServerInconsistency"
 //  OPERATIONDENIED_HOSTSUPSTREAMCERTIFICATEINCONSISTENCY = "OperationDenied.HostsUpstreamCertificateInconsistency"
@@ -15011,6 +15039,7 @@ func NewModifyZoneResponse() (response *ModifyZoneResponse) {
 //  OPERATIONDENIED_NODOMAINACCESSZONEONLYSUPPORTMODIFYTYPE = "OperationDenied.NoDomainAccessZoneOnlySupportModifyType"
 //  OPERATIONDENIED_PLANNOTSUPPORTMODIFYZONEAREA = "OperationDenied.PlanNotSupportModifyZoneArea"
 //  OPERATIONDENIED_RESOURCELOCKEDTEMPORARY = "OperationDenied.ResourceLockedTemporary"
+//  OPERATIONDENIED_ZONEHASHOSTSMODIFYCONFLICT = "OperationDenied.ZoneHasHostsModifyConflict"
 //  RESOURCEINUSE_CNAME = "ResourceInUse.Cname"
 //  RESOURCEINUSE_DNS = "ResourceInUse.Dns"
 //  RESOURCEINUSE_GENERICHOST = "ResourceInUse.GenericHost"
@@ -15056,6 +15085,7 @@ func (c *Client) ModifyZone(request *ModifyZoneRequest) (response *ModifyZoneRes
 //  OPERATIONDENIED_NODOMAINACCESSZONEONLYSUPPORTMODIFYTYPE = "OperationDenied.NoDomainAccessZoneOnlySupportModifyType"
 //  OPERATIONDENIED_PLANNOTSUPPORTMODIFYZONEAREA = "OperationDenied.PlanNotSupportModifyZoneArea"
 //  OPERATIONDENIED_RESOURCELOCKEDTEMPORARY = "OperationDenied.ResourceLockedTemporary"
+//  OPERATIONDENIED_ZONEHASHOSTSMODIFYCONFLICT = "OperationDenied.ZoneHasHostsModifyConflict"
 //  RESOURCEINUSE_CNAME = "ResourceInUse.Cname"
 //  RESOURCEINUSE_DNS = "ResourceInUse.Dns"
 //  RESOURCEINUSE_GENERICHOST = "ResourceInUse.GenericHost"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/errors.go
@@ -605,7 +605,7 @@ const (
 	// 无效的回源Host。
 	INVALIDPARAMETER_INVALIDSERVERNAME = "InvalidParameter.InvalidServerName"
 
-	// 设置的匹配条件不支持EdgeOne Shield操作，请删除相关配置项或联系智能客服提交工单处理。
+	// 设置的匹配条件不支持 EdgeOne Shield 操作，请删除相关配置项。
 	INVALIDPARAMETER_INVALIDSHIELDUNSUPPORTED = "InvalidParameter.InvalidShieldUnsupported"
 
 	// 排序字段不合法。
@@ -977,7 +977,7 @@ const (
 	// DNS 代理域名源站错误。
 	INVALIDPARAMETERVALUE_INVALIDPROXYORIGIN = "InvalidParameterValue.InvalidProxyOrigin"
 
-	// 存在源站故障转移配置项配置在不支持的匹配条件下，请删除相关配置项或联系智能客服提交工单处理。
+	// 存在源站故障转移配置项配置在不支持的匹配条件下，请删除相关配置。
 	INVALIDPARAMETERVALUE_INVALIDSITEFAILOVERUNSUPPORTED = "InvalidParameterValue.InvalidSiteFailoverUnsupported"
 
 	// 标签值存在不合法字符。
@@ -1187,6 +1187,9 @@ const (
 	// 站点处于停用状态，请开启后重试。
 	OPERATIONDENIED_ERRZONEISALREADYPAUSED = "OperationDenied.ErrZoneIsAlreadyPaused"
 
+	// 待变更域名边缘HTTPS证书不一致，请确认变更域名证书一致后重试。
+	OPERATIONDENIED_HOSTSCERTIFICATEINCONSISTENCY = "OperationDenied.HostsCertificateInconsistency"
+
 	// 待变更域名边缘双向认证证书不一致，请确认变更域名证书一致后重试。
 	OPERATIONDENIED_HOSTSCLIENTCERTIFICATEINCONSISTENCY = "OperationDenied.HostsClientCertificateInconsistency"
 
@@ -1381,6 +1384,9 @@ const (
 
 	// 站点工作模式不属于版本管理模式。
 	OPERATIONDENIED_WORKMODENOTINVERSIONCONTROL = "OperationDenied.WorkModeNotInVersionControl"
+
+	// 修改加速区域时，如果站点下存在域名，则不允许同时修改其他信息。
+	OPERATIONDENIED_ZONEHASHOSTSMODIFYCONFLICT = "OperationDenied.ZoneHasHostsModifyConflict"
 
 	// 共享CNAME已被其他站点绑定，请先解绑才能删除站点
 	OPERATIONDENIED_ZONEISBINDINGSHAREDCNAME = "OperationDenied.ZoneIsBindingSharedCNAME"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/models.go
@@ -573,7 +573,7 @@ type ApplicationProxy struct {
 	// <li>1：开启加速。</li>
 	AccelerateType *int64 `json:"AccelerateType,omitnil,omitempty" name:"AccelerateType"`
 
-	// 会话保持时间。
+	// 会话保持时间，单位为秒。
 	SessionPersistTime *uint64 `json:"SessionPersistTime,omitnil,omitempty" name:"SessionPersistTime"`
 
 	// 状态，取值有：
@@ -631,7 +631,7 @@ type ApplicationProxyRule struct {
 
 	// 源站信息：
 	// <li>当 OriginType 为 custom 时，表示一个或多个源站，如`["8.8.8.8","9.9.9.9"]` 或 `OriginValue=["test.com"]`；</li>
-	// <li>当 OriginType 为 loadbalancer 时，表示一个负载均衡，如`["lb-xdffsfasdfs"]`；</li>
+	// <li>当 OriginType 为 loadbalancer 时，表示一个负载均衡，如`["lb-3pbiw4d9iqz0"]`；</li>
 	// <li>当 OriginType 为 origins 时，要求有且仅有一个元素，表示源站组ID，如`["origin-537f5b41-162a-11ed-abaa-525400c5da15"]`。</li>
 	OriginValue []*string `json:"OriginValue,omitnil,omitempty" name:"OriginValue"`
 
@@ -658,7 +658,7 @@ type ApplicationProxyRule struct {
 	// <li>false：关闭。</li>默认值：false。
 	SessionPersist *bool `json:"SessionPersist,omitnil,omitempty" name:"SessionPersist"`
 
-	// 会话保持的时间，只有当SessionPersist为true时，该值才会生效。
+	// 会话保持的时间，单位为秒，只有当SessionPersist为true时，该值才会生效。
 	SessionPersistTime *uint64 `json:"SessionPersistTime,omitnil,omitempty" name:"SessionPersistTime"`
 
 	// 源站端口，支持格式：
@@ -2635,7 +2635,7 @@ type CreateApplicationProxyRuleRequestParams struct {
 	// <li>false：关闭。</li>默认值：false。
 	SessionPersist *bool `json:"SessionPersist,omitnil,omitempty" name:"SessionPersist"`
 
-	// 会话保持的时间，只有当SessionPersist为true时，该值才会生效。
+	// 会话保持的时间，单位为秒，只有当SessionPersist为true时，该值才会生效。
 	SessionPersistTime *uint64 `json:"SessionPersistTime,omitnil,omitempty" name:"SessionPersistTime"`
 
 	// 源站端口，支持格式：
@@ -2690,7 +2690,7 @@ type CreateApplicationProxyRuleRequest struct {
 	// <li>false：关闭。</li>默认值：false。
 	SessionPersist *bool `json:"SessionPersist,omitnil,omitempty" name:"SessionPersist"`
 
-	// 会话保持的时间，只有当SessionPersist为true时，该值才会生效。
+	// 会话保持的时间，单位为秒，只有当SessionPersist为true时，该值才会生效。
 	SessionPersistTime *uint64 `json:"SessionPersistTime,omitnil,omitempty" name:"SessionPersistTime"`
 
 	// 源站端口，支持格式：
@@ -3230,6 +3230,88 @@ func (r *CreateEdgeKVNamespaceResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateEdgeKVNamespaceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateFunctionReplicaRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 边缘函数副本名称。限制可输入 1-50 个字符，允许的字符为a-z、0-9、-，且-不能单独注册或连续使用，不能放在开头或结尾。同一 FunctionId 下副本名称需唯一。
+	ReplicaName *string `json:"ReplicaName,omitnil,omitempty" name:"ReplicaName"`
+
+	// 边缘函数副本内容，当前仅支持 JavaScript 代码，最大支持 5MB。
+	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
+
+	// 边缘函数副本描述。最大支持 50 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+}
+
+type CreateFunctionReplicaRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 边缘函数副本名称。限制可输入 1-50 个字符，允许的字符为a-z、0-9、-，且-不能单独注册或连续使用，不能放在开头或结尾。同一 FunctionId 下副本名称需唯一。
+	ReplicaName *string `json:"ReplicaName,omitnil,omitempty" name:"ReplicaName"`
+
+	// 边缘函数副本内容，当前仅支持 JavaScript 代码，最大支持 5MB。
+	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
+
+	// 边缘函数副本描述。最大支持 50 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+}
+
+func (r *CreateFunctionReplicaRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateFunctionReplicaRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "FunctionId")
+	delete(f, "ReplicaName")
+	delete(f, "Content")
+	delete(f, "Remark")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateFunctionReplicaRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateFunctionReplicaResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateFunctionReplicaResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateFunctionReplicaResponseParams `json:"Response"`
+}
+
+func (r *CreateFunctionReplicaResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateFunctionReplicaResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -4660,41 +4742,22 @@ type CreateRealtimeLogDeliveryTaskRequestParams struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
+	// 数据投递区域，可选值：<ul><li>mainland：中国大陆境内；</li><li>overseas：全球（不含中国大陆）。</li></ul>
+	Area *string `json:"Area,omitnil,omitempty" name:"Area"`
+
+	// 数据投递类型，可选值：<ul><li>domain：站点加速日志；</li><li>application：四层代理日志；</li><li>function：边缘函数运行日志；</li><li>web-rateLiming：速率限制和 CC 攻击防护日志；</li><li>web-attack：托管规则日志；</li><li>web-rule：自定义规则日志；</li><li>web-bot：Bot管理日志。</li></ul>
+	LogType *string `json:"LogType,omitnil,omitempty" name:"LogType"`
+
 	// 实时日志投递任务的名称，格式为数字、英文、-和_组合，最多 200 个字符。
 	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
 
-	// 实时日志投递任务类型，取值有：
-	// <li>cls: 推送到腾讯云 CLS；</li>
-	// <li>custom_endpoint：推送到自定义 HTTP(S) 地址；</li>
-	// <li>s3：推送到 AWS S3 兼容存储桶地址；</li>
-	// <li>log_analysis：推送到 EdgeOne 日志分析，该任务类型仅支持“站点加速日志”这一数据投递类型。</li>
+	// 实时日志投递任务类型，取值有：<ul><li>cls: 推送到腾讯云 CLS；</li><li>custom_endpoint：推送到自定义 HTTP(S) 地址；</li><li>s3：推送到 AWS S3 兼容存储桶地址；</li><li>log_analysis：推送到 EdgeOne 日志分析，仅当 LogType = domain 或 web-attack 时支持。</li></ul>
 	TaskType *string `json:"TaskType,omitnil,omitempty" name:"TaskType"`
 
-	// 实时日志投递任务对应的实体列表。取值示例如下：
-	// <li>七层域名：domain.example.com</li>
-	// <li>四层代理实例：sid-2s69eb5wcms7</li>
-	// <li>边缘函数实例：test-zone-2mxigizoh9l9-1257626257</li>
+	// 实时日志投递任务对应的实体列表。取值示例如下：<ul><li>七层域名：domain.example.com</li><li>四层代理实例：sid-2s69eb5wcms7</li><li>边缘函数实例：test-zone-2mxigizoh9l9-1257626257</li></ul>
 	EntityList []*string `json:"EntityList,omitnil,omitempty" name:"EntityList"`
 
-	// 数据投递类型，取值有：
-	// <li>domain：站点加速日志；</li>
-	// <li>application：四层代理日志；</li>
-	// <li>function：边缘函数运行日志；</li>
-	// <li>web-rateLiming：速率限制和 CC 攻击防护日志；</li>
-	// <li>web-attack：托管规则日志；</li>
-	// <li>web-rule：自定义规则日志；</li>
-	// <li>web-bot：Bot管理日志。</li>
-	LogType *string `json:"LogType,omitnil,omitempty" name:"LogType"`
-
-	// 数据投递区域，取值有：
-	// <li>mainland：中国大陆境内；</li>
-	// <li>overseas：全球（不含中国大陆）。</li>
-	Area *string `json:"Area,omitnil,omitempty" name:"Area"`
-
-	// 投递的预设字段列表。取值参考：
-	// <li>[站点加速日志（七层访问日志）](https://cloud.tencent.com/document/product/1552/105791)</li>
-	// <li>[四层代理日志](https://cloud.tencent.com/document/product/1552/105792)</li>
-	// <li>[边缘函数运行日志](https://cloud.tencent.com/document/product/1552/115585)</li>
+	// 投递的预设字段列表。取值参考：<ul><li>[站点加速日志（七层访问日志）](https://cloud.tencent.com/document/product/1552/105791)</li><li>[四层代理日志](https://cloud.tencent.com/document/product/1552/105792)</li><li>[边缘函数运行日志](https://cloud.tencent.com/document/product/1552/115585)</li></ul>
 	Fields []*string `json:"Fields,omitnil,omitempty" name:"Fields"`
 
 	// 投递的自定义字段列表，支持在 HTTP 请求头、响应头、Cookie、请求正文中提取指定内容。自定义字段名称不能重复，且最多不能超过 200 个字段。单个实时日志推送任务最多添加 5 个请求正文类型的自定义字段。目前仅站点加速日志（LogType=domain）支持添加自定义字段。
@@ -4706,9 +4769,7 @@ type CreateRealtimeLogDeliveryTaskRequestParams struct {
 	// 采样比例，采用千分制，取值范围为1-1000，例如：填写 605 表示采样比例为 60.5%。不填表示采样比例为 100%。
 	Sample *uint64 `json:"Sample,omitnil,omitempty" name:"Sample"`
 
-	// 日志投递的输出格式。不填表示为默认格式，默认格式逻辑如下：
-	// <li>当 TaskType 取值为 custom_endpoint 时，默认格式为多个 JSON 对象组成的数组，每个 JSON 对象为一条日志；</li>
-	// <li>当 TaskType 取值为 s3 时，默认格式为 JSON Lines；</li>特别地，当 TaskType 取值为 cls 或 log_analysis 时，LogFormat.FormatType 的值只能为 json，且 LogFormat 中其他参数将被忽略，建议不传 LogFormat。
+	// 日志投递的输出格式。不填表示为默认格式，默认格式逻辑如下：<ul><li>当 TaskType 取值为 custom_endpoint 时，默认格式为多个 JSON 对象组成的数组，每个 JSON 对象为一条日志；</li><li>当 TaskType 取值为 s3 时，默认格式为 JSON Lines；</li></ul>特别地，当 TaskType 取值为 cls 或 log_analysis 时，LogFormat.FormatType 的值只能为 json，且 LogFormat 中其他参数将被忽略，建议不传 LogFormat。
 	LogFormat *LogFormat `json:"LogFormat,omitnil,omitempty" name:"LogFormat"`
 
 	// CLS 的配置信息。当 TaskType 取值为 cls 时，该参数必填。
@@ -4727,41 +4788,22 @@ type CreateRealtimeLogDeliveryTaskRequest struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
+	// 数据投递区域，可选值：<ul><li>mainland：中国大陆境内；</li><li>overseas：全球（不含中国大陆）。</li></ul>
+	Area *string `json:"Area,omitnil,omitempty" name:"Area"`
+
+	// 数据投递类型，可选值：<ul><li>domain：站点加速日志；</li><li>application：四层代理日志；</li><li>function：边缘函数运行日志；</li><li>web-rateLiming：速率限制和 CC 攻击防护日志；</li><li>web-attack：托管规则日志；</li><li>web-rule：自定义规则日志；</li><li>web-bot：Bot管理日志。</li></ul>
+	LogType *string `json:"LogType,omitnil,omitempty" name:"LogType"`
+
 	// 实时日志投递任务的名称，格式为数字、英文、-和_组合，最多 200 个字符。
 	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
 
-	// 实时日志投递任务类型，取值有：
-	// <li>cls: 推送到腾讯云 CLS；</li>
-	// <li>custom_endpoint：推送到自定义 HTTP(S) 地址；</li>
-	// <li>s3：推送到 AWS S3 兼容存储桶地址；</li>
-	// <li>log_analysis：推送到 EdgeOne 日志分析，该任务类型仅支持“站点加速日志”这一数据投递类型。</li>
+	// 实时日志投递任务类型，取值有：<ul><li>cls: 推送到腾讯云 CLS；</li><li>custom_endpoint：推送到自定义 HTTP(S) 地址；</li><li>s3：推送到 AWS S3 兼容存储桶地址；</li><li>log_analysis：推送到 EdgeOne 日志分析，仅当 LogType = domain 或 web-attack 时支持。</li></ul>
 	TaskType *string `json:"TaskType,omitnil,omitempty" name:"TaskType"`
 
-	// 实时日志投递任务对应的实体列表。取值示例如下：
-	// <li>七层域名：domain.example.com</li>
-	// <li>四层代理实例：sid-2s69eb5wcms7</li>
-	// <li>边缘函数实例：test-zone-2mxigizoh9l9-1257626257</li>
+	// 实时日志投递任务对应的实体列表。取值示例如下：<ul><li>七层域名：domain.example.com</li><li>四层代理实例：sid-2s69eb5wcms7</li><li>边缘函数实例：test-zone-2mxigizoh9l9-1257626257</li></ul>
 	EntityList []*string `json:"EntityList,omitnil,omitempty" name:"EntityList"`
 
-	// 数据投递类型，取值有：
-	// <li>domain：站点加速日志；</li>
-	// <li>application：四层代理日志；</li>
-	// <li>function：边缘函数运行日志；</li>
-	// <li>web-rateLiming：速率限制和 CC 攻击防护日志；</li>
-	// <li>web-attack：托管规则日志；</li>
-	// <li>web-rule：自定义规则日志；</li>
-	// <li>web-bot：Bot管理日志。</li>
-	LogType *string `json:"LogType,omitnil,omitempty" name:"LogType"`
-
-	// 数据投递区域，取值有：
-	// <li>mainland：中国大陆境内；</li>
-	// <li>overseas：全球（不含中国大陆）。</li>
-	Area *string `json:"Area,omitnil,omitempty" name:"Area"`
-
-	// 投递的预设字段列表。取值参考：
-	// <li>[站点加速日志（七层访问日志）](https://cloud.tencent.com/document/product/1552/105791)</li>
-	// <li>[四层代理日志](https://cloud.tencent.com/document/product/1552/105792)</li>
-	// <li>[边缘函数运行日志](https://cloud.tencent.com/document/product/1552/115585)</li>
+	// 投递的预设字段列表。取值参考：<ul><li>[站点加速日志（七层访问日志）](https://cloud.tencent.com/document/product/1552/105791)</li><li>[四层代理日志](https://cloud.tencent.com/document/product/1552/105792)</li><li>[边缘函数运行日志](https://cloud.tencent.com/document/product/1552/115585)</li></ul>
 	Fields []*string `json:"Fields,omitnil,omitempty" name:"Fields"`
 
 	// 投递的自定义字段列表，支持在 HTTP 请求头、响应头、Cookie、请求正文中提取指定内容。自定义字段名称不能重复，且最多不能超过 200 个字段。单个实时日志推送任务最多添加 5 个请求正文类型的自定义字段。目前仅站点加速日志（LogType=domain）支持添加自定义字段。
@@ -4773,9 +4815,7 @@ type CreateRealtimeLogDeliveryTaskRequest struct {
 	// 采样比例，采用千分制，取值范围为1-1000，例如：填写 605 表示采样比例为 60.5%。不填表示采样比例为 100%。
 	Sample *uint64 `json:"Sample,omitnil,omitempty" name:"Sample"`
 
-	// 日志投递的输出格式。不填表示为默认格式，默认格式逻辑如下：
-	// <li>当 TaskType 取值为 custom_endpoint 时，默认格式为多个 JSON 对象组成的数组，每个 JSON 对象为一条日志；</li>
-	// <li>当 TaskType 取值为 s3 时，默认格式为 JSON Lines；</li>特别地，当 TaskType 取值为 cls 或 log_analysis 时，LogFormat.FormatType 的值只能为 json，且 LogFormat 中其他参数将被忽略，建议不传 LogFormat。
+	// 日志投递的输出格式。不填表示为默认格式，默认格式逻辑如下：<ul><li>当 TaskType 取值为 custom_endpoint 时，默认格式为多个 JSON 对象组成的数组，每个 JSON 对象为一条日志；</li><li>当 TaskType 取值为 s3 时，默认格式为 JSON Lines；</li></ul>特别地，当 TaskType 取值为 cls 或 log_analysis 时，LogFormat.FormatType 的值只能为 json，且 LogFormat 中其他参数将被忽略，建议不传 LogFormat。
 	LogFormat *LogFormat `json:"LogFormat,omitnil,omitempty" name:"LogFormat"`
 
 	// CLS 的配置信息。当 TaskType 取值为 cls 时，该参数必填。
@@ -4801,11 +4841,11 @@ func (r *CreateRealtimeLogDeliveryTaskRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "ZoneId")
+	delete(f, "Area")
+	delete(f, "LogType")
 	delete(f, "TaskName")
 	delete(f, "TaskType")
 	delete(f, "EntityList")
-	delete(f, "LogType")
-	delete(f, "Area")
 	delete(f, "Fields")
 	delete(f, "CustomFields")
 	delete(f, "DeliveryConditions")
@@ -6325,6 +6365,74 @@ func (r *DeleteEdgeKVNamespaceResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteEdgeKVNamespaceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteFunctionReplicaRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 需要删除的函数的副本名称。支持以列表的形式传入。
+	ReplicaNames []*string `json:"ReplicaNames,omitnil,omitempty" name:"ReplicaNames"`
+}
+
+type DeleteFunctionReplicaRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 需要删除的函数的副本名称。支持以列表的形式传入。
+	ReplicaNames []*string `json:"ReplicaNames,omitnil,omitempty" name:"ReplicaNames"`
+}
+
+func (r *DeleteFunctionReplicaRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteFunctionReplicaRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "FunctionId")
+	delete(f, "ReplicaNames")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteFunctionReplicaRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteFunctionReplicaResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteFunctionReplicaResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteFunctionReplicaResponseParams `json:"Response"`
+}
+
+func (r *DeleteFunctionReplicaResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteFunctionReplicaResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -9537,6 +9645,108 @@ func (r *DescribeFunctionComponentBindingsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeFunctionComponentBindingsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeFunctionReplicasRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 分页查询偏移量。默认值：0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 分页查询限制数目。默认值：20，最大值：200。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 排序依据，取值有：  <li>created-on：创建时间。</li>  默认根据 created-on 属性排序。
+	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
+
+	// 列表排序方式，取值有：  <li>asc：升序排列；</li>  <li>desc：降序排列。</li>  默认值为 asc。
+	SortOrder *string `json:"SortOrder,omitnil,omitempty" name:"SortOrder"`
+
+	// 过滤条件，Filters.Values 的上限为 20。该参数不填写时，返回函数 ID 下全部函数副本。详细的过滤条件如下：  <li> replica-name：按照函数副本名称进行过滤，支持模糊查询。</li> 
+	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+type DescribeFunctionReplicasRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 分页查询偏移量。默认值：0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 分页查询限制数目。默认值：20，最大值：200。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 排序依据，取值有：  <li>created-on：创建时间。</li>  默认根据 created-on 属性排序。
+	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
+
+	// 列表排序方式，取值有：  <li>asc：升序排列；</li>  <li>desc：降序排列。</li>  默认值为 asc。
+	SortOrder *string `json:"SortOrder,omitnil,omitempty" name:"SortOrder"`
+
+	// 过滤条件，Filters.Values 的上限为 20。该参数不填写时，返回函数 ID 下全部函数副本。详细的过滤条件如下：  <li> replica-name：按照函数副本名称进行过滤，支持模糊查询。</li> 
+	Filters []*AdvancedFilter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+func (r *DescribeFunctionReplicasRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeFunctionReplicasRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "FunctionId")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	delete(f, "SortBy")
+	delete(f, "SortOrder")
+	delete(f, "Filters")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeFunctionReplicasRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeFunctionReplicasResponseParams struct {
+	// 边缘函数副本总数。
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 边缘函数副本列表。
+	FunctionReplicas []*FunctionReplica `json:"FunctionReplicas,omitnil,omitempty" name:"FunctionReplicas"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeFunctionReplicasResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeFunctionReplicasResponseParams `json:"Response"`
+}
+
+func (r *DescribeFunctionReplicasResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeFunctionReplicasResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -14706,10 +14916,10 @@ type EdgeKVPutRequestParams struct {
 	// 键值。不能为空，最大支持 1 MB。支持存储字符串数据。
 	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
 
-	// 过期时间，绝对时间。表示从 1970 年 1 月 1 日（UTC/GMT 的午夜）开始所经过的秒数，不能小于当前时间。若 Expiration 和 ExpirationTTL 都填写，以 ExpirationTTL 为准。若 Expiration 和 ExpirationTTL 都不填写，则该键值对永不过期。
+	// 键值对的过期时间，绝对时间，单位为秒，表示从 1970 年 1 月 1 日 00:00:00（UTC）起经过的秒数（即 Unix 时间戳）。取值必须大于等于当前时间 + 60，即过期时间距当前至少 60 秒。当 Expiration 与 ExpirationTTL 同时填写时，以 ExpirationTTL 为准；当两者均不填写时，键值对永不过期。
 	Expiration *int64 `json:"Expiration,omitnil,omitempty" name:"Expiration"`
 
-	// 过期时间，相对时间，单位为秒。表示数据将在指定秒数后过期，必须大于 0。若 Expiration 和 ExpirationTTL 都填写，以 ExpirationTTL 为准。若 Expiration 和 ExpirationTTL 都不填写，则该键值对永不过期。
+	// 键值对的存活时长，相对时间，单位为秒，表示数据将在写入后经过指定秒数过期。取值范围：大于等于 60。当 Expiration 与 ExpirationTTL 同时填写时，以 ExpirationTTL 为准；当两者均不填写时，键值对永不过期。
 	ExpirationTTL *int64 `json:"ExpirationTTL,omitnil,omitempty" name:"ExpirationTTL"`
 }
 
@@ -14728,10 +14938,10 @@ type EdgeKVPutRequest struct {
 	// 键值。不能为空，最大支持 1 MB。支持存储字符串数据。
 	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
 
-	// 过期时间，绝对时间。表示从 1970 年 1 月 1 日（UTC/GMT 的午夜）开始所经过的秒数，不能小于当前时间。若 Expiration 和 ExpirationTTL 都填写，以 ExpirationTTL 为准。若 Expiration 和 ExpirationTTL 都不填写，则该键值对永不过期。
+	// 键值对的过期时间，绝对时间，单位为秒，表示从 1970 年 1 月 1 日 00:00:00（UTC）起经过的秒数（即 Unix 时间戳）。取值必须大于等于当前时间 + 60，即过期时间距当前至少 60 秒。当 Expiration 与 ExpirationTTL 同时填写时，以 ExpirationTTL 为准；当两者均不填写时，键值对永不过期。
 	Expiration *int64 `json:"Expiration,omitnil,omitempty" name:"Expiration"`
 
-	// 过期时间，相对时间，单位为秒。表示数据将在指定秒数后过期，必须大于 0。若 Expiration 和 ExpirationTTL 都填写，以 ExpirationTTL 为准。若 Expiration 和 ExpirationTTL 都不填写，则该键值对永不过期。
+	// 键值对的存活时长，相对时间，单位为秒，表示数据将在写入后经过指定秒数过期。取值范围：大于等于 60。当 Expiration 与 ExpirationTTL 同时填写时，以 ExpirationTTL 为准；当两者均不填写时，键值对永不过期。
 	ExpirationTTL *int64 `json:"ExpirationTTL,omitnil,omitempty" name:"ExpirationTTL"`
 }
 
@@ -15096,7 +15306,7 @@ type ExportZoneConfigRequestParams struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 导出配置项的类型列表，不填表示导出所有类型的配置，当前支持的取值有：<li>L7AccelerationConfig：表示导出七层加速配置，对应控制台「站点加速-全局加速配置」和「站点加速-规则引擎」。</li><li>WebSecurity：表示导出 Web 防护配置。</li> 需注意：后续支持导出的类型会随着迭代增加，导出所有类型时需要注意导出文件大小，建议使用时指定需要导出的配置类型，以便控制请求响应包负载大小。
+	// 导出配置项的类型列表，不填表示导出所有类型的配置，当前支持的取值有：<li>L7AccelerationConfig：表示导出七层加速配置，对应控制台「站点加速-全局加速配置」和「站点加速-规则引擎」。</li><li>WebSecurity：表示导出 Web 防护配置。</li><li> AccelerationDomain：表示导出加速域名配置，对应控制台「域名服务-域名管理」和「域名服务-共享 CNAME 管理」。</li><li> Origin：表示导出源站配置，对应控制台「源站配置-源站组」和「源站配置-负载均衡」。</li> 需注意：后续支持导出的类型会随着迭代增加，导出所有类型时需要注意导出文件大小，建议使用时指定需要导出的配置类型，以便控制请求响应包负载大小。
 	Types []*string `json:"Types,omitnil,omitempty" name:"Types"`
 }
 
@@ -15106,7 +15316,7 @@ type ExportZoneConfigRequest struct {
 	// 站点 ID。
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 导出配置项的类型列表，不填表示导出所有类型的配置，当前支持的取值有：<li>L7AccelerationConfig：表示导出七层加速配置，对应控制台「站点加速-全局加速配置」和「站点加速-规则引擎」。</li><li>WebSecurity：表示导出 Web 防护配置。</li> 需注意：后续支持导出的类型会随着迭代增加，导出所有类型时需要注意导出文件大小，建议使用时指定需要导出的配置类型，以便控制请求响应包负载大小。
+	// 导出配置项的类型列表，不填表示导出所有类型的配置，当前支持的取值有：<li>L7AccelerationConfig：表示导出七层加速配置，对应控制台「站点加速-全局加速配置」和「站点加速-规则引擎」。</li><li>WebSecurity：表示导出 Web 防护配置。</li><li> AccelerationDomain：表示导出加速域名配置，对应控制台「域名服务-域名管理」和「域名服务-共享 CNAME 管理」。</li><li> Origin：表示导出源站配置，对应控制台「源站配置-源站组」和「源站配置-负载均衡」。</li> 需注意：后续支持导出的类型会随着迭代增加，导出所有类型时需要注意导出文件大小，建议使用时指定需要导出的配置类型，以便控制请求响应包负载大小。
 	Types []*string `json:"Types,omitnil,omitempty" name:"Types"`
 }
 
@@ -15352,6 +15562,26 @@ type FunctionRegionSelection struct {
 	Regions []*string `json:"Regions,omitnil,omitempty" name:"Regions"`
 }
 
+type FunctionReplica struct {
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 边缘函数副本名称。
+	ReplicaName *string `json:"ReplicaName,omitnil,omitempty" name:"ReplicaName"`
+
+	// 边缘函数副本内容。格式为 JavaScript 代码。
+	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
+
+	// 边缘函数副本描述。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+
+	// 边缘函数副本创建时间。
+	CreatedOn *string `json:"CreatedOn,omitnil,omitempty" name:"CreatedOn"`
+
+	// 边缘函数副本更新时间。
+	ModifiedOn *string `json:"ModifiedOn,omitnil,omitempty" name:"ModifiedOn"`
+}
+
 type FunctionRule struct {
 	// 规则ID。
 	RuleId *string `json:"RuleId,omitnil,omitempty" name:"RuleId"`
@@ -15589,10 +15819,10 @@ type HealthChecker struct {
 	// 检查端口。当 Type=HTTP 或 Type=HTTPS 或 Type=TCP 或 Type=UDP 时为必填。
 	Port *uint64 `json:"Port,omitnil,omitempty" name:"Port"`
 
-	// 检查频率，表示多久发起一次健康检查任务，单位为秒。可取值有：30，60，180，300 或 600。
+	// 检查频率，表示多久发起一次健康检查任务，单位为秒。可配置 10-600 秒。
 	Interval *uint64 `json:"Interval,omitnil,omitempty" name:"Interval"`
 
-	// 每一次健康检查的超时时间，若健康检查消耗时间大于此值，则检查结果判定为”不健康“， 单位为秒，默认值为 5s，取值必须小于 Interval。
+	// 每一次健康检查的超时时间，若健康检查消耗时间大于此值，则检查结果判定为“不健康”， 单位为秒，默认值为 5s，取值必须小于 Interval。
 	Timeout *uint64 `json:"Timeout,omitnil,omitempty" name:"Timeout"`
 
 	// 健康阈值，表示连续几次健康检查结果为"健康"，则判断源站为"健康"，单位为次，默认 3 次，最小取值 1 次。
@@ -17148,7 +17378,7 @@ type ModifyApplicationProxyRuleRequestParams struct {
 	// <li>false：关闭。</li>不填为false。
 	SessionPersist *bool `json:"SessionPersist,omitnil,omitempty" name:"SessionPersist"`
 
-	// 会话保持的时间，只有当SessionPersist为true时，该值才会生效。
+	// 会话保持的时间，单位为秒，只有当SessionPersist为true时，该值才会生效。
 	SessionPersistTime *uint64 `json:"SessionPersistTime,omitnil,omitempty" name:"SessionPersistTime"`
 
 	// 源站端口，支持格式：
@@ -17206,7 +17436,7 @@ type ModifyApplicationProxyRuleRequest struct {
 	// <li>false：关闭。</li>不填为false。
 	SessionPersist *bool `json:"SessionPersist,omitnil,omitempty" name:"SessionPersist"`
 
-	// 会话保持的时间，只有当SessionPersist为true时，该值才会生效。
+	// 会话保持的时间，单位为秒，只有当SessionPersist为true时，该值才会生效。
 	SessionPersistTime *uint64 `json:"SessionPersistTime,omitnil,omitempty" name:"SessionPersistTime"`
 
 	// 源站端口，支持格式：
@@ -17909,6 +18139,88 @@ func (r *ModifyFunctionComponentBindingsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyFunctionComponentBindingsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyFunctionReplicaRequestParams struct {
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 需要修改的边缘函数副本名称。
+	ReplicaName *string `json:"ReplicaName,omitnil,omitempty" name:"ReplicaName"`
+
+	// 边缘函数副本内容，当前仅支持 JavaScript 代码，最大支持 5MB。
+	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
+
+	// 边缘函数副本描述。最大支持 50 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+}
+
+type ModifyFunctionReplicaRequest struct {
+	*tchttp.BaseRequest
+	
+	// 站点 ID。
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 函数 ID。
+	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
+
+	// 需要修改的边缘函数副本名称。
+	ReplicaName *string `json:"ReplicaName,omitnil,omitempty" name:"ReplicaName"`
+
+	// 边缘函数副本内容，当前仅支持 JavaScript 代码，最大支持 5MB。
+	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
+
+	// 边缘函数副本描述。最大支持 50 个字符。
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+}
+
+func (r *ModifyFunctionReplicaRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyFunctionReplicaRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ZoneId")
+	delete(f, "FunctionId")
+	delete(f, "ReplicaName")
+	delete(f, "Content")
+	delete(f, "Remark")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyFunctionReplicaRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyFunctionReplicaResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyFunctionReplicaResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyFunctionReplicaResponseParams `json:"Response"`
+}
+
+func (r *ModifyFunctionReplicaResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyFunctionReplicaResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -19364,7 +19676,7 @@ type ModifyOriginParameters struct {
 	// 源站类型。取值有：
 	// <li>IPDomain：IPV4、IPV6 或域名类型源站；</li>
 	// <li>OriginGroup：源站组类型源站；</li>
-	// <li>LoadBalance：负载均衡，该功能内测中，如需使用，请提工单或联系智能客服；</li>
+	// <li>LoadBalance：负载均衡，该功能内测中，如需使用，请提工单；</li>
 	// <li>COS：腾讯云 COS 对象存储源站；</li>
 	// <li>AWSS3：支持 AWS S3 协议的所有对象存储源站。</li>
 	OriginType *string `json:"OriginType,omitnil,omitempty" name:"OriginType"`
@@ -21895,6 +22207,9 @@ type RateLimitingRule struct {
 	// 精准速率限制的具体内容，需符合表达式语法，详细规范参见[产品文档](https://cloud.tencent.com/document/product/1552/125343)。
 	Condition *string `json:"Condition,omitnil,omitempty" name:"Condition"`
 
+	// 限速方式。在统计时间窗口 CountingPeriod 内，对满足特征 CountBy 的请求，支持配置以下限速方式：<li>Block: 阻断访问源。当统计次数超过阈值 MaxRequestThreshold 时，在 ActionDuration 时长内，对满足特征的所有后续请求执行 Action 处置；</li><li>Throttle: 仅处置超额请求。当统计次数超过阈值 MaxRequestThreshold 时，仅对超过阈值的请求执行 Action 处置，窗口结束后停止处置。此时，ActionDuration 参数将被忽略。</li><br />默认值为 Block。
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
 	// 速率阈值请求特征的匹配方式， 当 Enabled 为 on 时，此字段必填。<br /><br />当条件有多个时，将组合多个条件共同进行统计计算，条件最多不可超过5条。取值有：<br/><li><b>http.request.ip</b>：客户端 IP；</li><li><b>http.request.xff_header_ip</b>：客户端 IP（优先匹配 XFF 头部）；</li><li><b>http.request.uri.path</b>：请求的访问路径；</li><li><b>http.request.cookies['session']</b>：名称为 session 的 Cookie，其中 session 可替换为自己指定的参数；</li><li><b>http.request.headers['user-agent']</b>：名称为 user-agent 的 HTTP 头部，其中 user-agent 可替换为自己指定的参数；</li><li><b>http.request.ja3</b>：请求的 JA3 指纹；</li><li><b>http.request.ja4</b>：请求的 JA4 指纹；</li><li><b>http.request.uri.query['test']</b>：名称为 test 的 URL 查询参数，其中 test 可替换为自己指定的参数。</li> 
 	CountBy []*string `json:"CountBy,omitnil,omitempty" name:"CountBy"`
 
@@ -21904,7 +22219,7 @@ type RateLimitingRule struct {
 	// 统计的时间窗口，取值有：<li>1s：1秒；</li><li>5s：5秒；</li><li>10s：10秒；</li><li>20s：20秒；</li><li>30s：30秒；</li><li>40s：40秒；</li><li>50s：50秒；</li><li>1m：1分钟；</li><li>2m：2分钟；</li><li>5m：5分钟；</li><li>10m：10分钟；</li><li>1h：1小时。</li> 
 	CountingPeriod *string `json:"CountingPeriod,omitnil,omitempty" name:"CountingPeriod"`
 
-	// Action 动作的持续时长，单位仅支持：<li>s：秒，取值 1 ~ 120；</li><li>m：分钟，取值 1 ~ 120；</li><li>h：小时，取值 1 ~ 48；</li><li>d：天，取值 1 ~ 30。</li>
+	// Action 动作的持续时长，单位仅支持：<li>s：秒，取值 1 ~ 120；</li><li>m：分钟，取值 1 ~ 120；</li><li>h：小时，取值 1 ~ 48；</li><li>d：天，取值 1 ~ 30。</li><br />当 Mode 为 Throttle 时，此参数将被忽略，不会生效。
 	ActionDuration *string `json:"ActionDuration,omitnil,omitempty" name:"ActionDuration"`
 
 	// 精准速率限制的处置方式。取值有：<li>Monitor：观察；</li><li>Deny：拦截，其中DenyActionParameters.Name支持Deny和ReturnCustomPage；</li><li>Challenge：挑战，其中ChallengeActionParameters.Name支持JSChallenge和ManagedChallenge；</li><li>Redirect：重定向至URL；</li>
@@ -22404,6 +22719,7 @@ type RuleEngineAction struct {
 	// <li>Shield：源站卸载配置；</li>
 	// <li>TLSConfig：SSL/TLS 安全；</li>
 	// <li>ModifyOrigin：修改源站；</li>
+	// <li> SiteFailover：源站故障转移；</li>
 	// <li>HTTPUpstreamTimeout：七层回源超时配置；</li>
 	// <li>HttpResponse：HTTP 应答；</li>
 	// <li>ErrorPage：自定义错误页面；</li>
@@ -22531,6 +22847,10 @@ type RuleEngineAction struct {
 	// 修改源站配置参数，当 Name 取值为 ModifyOrigin 时，该参数必填。
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ModifyOriginParameters *ModifyOriginParameters `json:"ModifyOriginParameters,omitnil,omitempty" name:"ModifyOriginParameters"`
+
+	// 源站故障转移配置参数，当 Name 取值为 SiteFailover 时，该参数必填。
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SiteFailoverParameters *SiteFailoverParameters `json:"SiteFailoverParameters,omitnil,omitempty" name:"SiteFailoverParameters"`
 
 	// 七层回源超时配置，当 Name 取值为 HTTPUpstreamTimeout 时，该参数必填。
 	// 注意：此字段可能返回 null，表示取不到有效值。
@@ -22989,6 +23309,73 @@ type SharedCNAMEInfo struct {
 type ShieldParameters struct {
 	// 源站卸载空间 ID。
 	ShieldSpaceId *string `json:"ShieldSpaceId,omitnil,omitempty" name:"ShieldSpaceId"`
+}
+
+type SiteFailover struct {
+	// 源站故障转移类型。取值有：
+	// <li>FailoverToHost:回源到指定 IP/域名；</li>
+	// <li> FailoverToCOS:回源到腾讯云 COS；</li>
+	// <li>FailoverToS3CompatibleObjectStorage:回源到 S3 兼容；</li>
+	// <li> FailoverRedirectToURL :重定向至指定 URL；</li>
+	// <li> FailoverCustomResponsePage:使用自定义响应页面。</li>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// 源站地址，根据 Mode 的取值分为以下情况：
+	// <li>当 Mode = FailoverToHost 时，该参数请填写 IPV4、IPV6 地址或域名；</li>
+	// <li>当 Mode = FailoverToCOS 时，该参数请填写 COS 桶的访问域名；</li>
+	// <li>当 Mode = FailoverToS3CompatibleObjectStorage，该参数请填写 S3 桶的访问域名。</li>
+	Origin *string `json:"Origin,omitnil,omitempty" name:"Origin"`
+
+	// 回源协议配置。当 Mode 取值为 FailoverToHost 时该参数必填。取值有：
+	// <li>http：使用 HTTP 协议；</li>
+	// <li>https：使用 HTTPS 协议；</li>
+	// <li>follow：协议跟随。</li>
+	OriginProtocol *string `json:"OriginProtocol,omitnil,omitempty" name:"OriginProtocol"`
+
+	// HTTP 回源端口，取值范围 1～65535。当回源协议 OriginProtocol 为 http 或者 follow 时该参数必填。
+	HTTPOriginPort *int64 `json:"HTTPOriginPort,omitnil,omitempty" name:"HTTPOriginPort"`
+
+	// HTTPS 回源端口，取值范围 1～65535。当回源协议 OriginProtocol 为 https 或者 follow 时该参数必填。
+	HTTPSOriginPort *int64 `json:"HTTPSOriginPort,omitnil,omitempty" name:"HTTPSOriginPort"`
+
+	// 回源Host Header 重写配置，
+	UpstreamHostHeader *HostHeaderParameters `json:"UpstreamHostHeader,omitnil,omitempty" name:"UpstreamHostHeader"`
+
+	// 回源 URL 重写配置。
+	UpstreamURLRewrite *UpstreamURLRewriteParameters `json:"UpstreamURLRewrite,omitnil,omitempty" name:"UpstreamURLRewrite"`
+
+	// 回源请求参数配置。
+	UpstreamRequestParameters *UpstreamRequestParameters `json:"UpstreamRequestParameters,omitnil,omitempty" name:"UpstreamRequestParameters"`
+
+	// HTTP2 回源配置参数。
+	UpstreamHTTP2Parameters *UpstreamHTTP2Parameters `json:"UpstreamHTTP2Parameters,omitnil,omitempty" name:"UpstreamHTTP2Parameters"`
+
+	// 指定是否允许访问私有对象存储源站，当源站类型 Mode = FailoverToCOS 或 FailoverToS3CompatibleObjectStorage 时该参数必填，取值有：
+	// <li>on：使用私有鉴权；</li>
+	// <li>off：不使用私有鉴权。</li>
+	PrivateAccess *string `json:"PrivateAccess,omitnil,omitempty" name:"PrivateAccess"`
+
+	// 私有鉴权使用参数，该参数仅当 Mode = FailoverToS3CompatibleObjectStorage 且 PrivateAccess = on 时会生效。
+	PrivateParameters *OriginPrivateParameters `json:"PrivateParameters,omitnil,omitempty" name:"PrivateParameters"`
+
+	// 重定向目标 URL。当 Mode 取值为 FailoverRedirectToURL 时该参数必填。
+	RedirectURL *string `json:"RedirectURL,omitnil,omitempty" name:"RedirectURL"`
+
+	// 响应页面 ID。当 Mode 取值为 FailoverCustomResponsePage 时该参数必填。
+	ResponsePageId *string `json:"ResponsePageId,omitnil,omitempty" name:"ResponsePageId"`
+
+	// 响应状态码。当 Mode 取值为 FailoverRedirectToURL 或 FailoverCustomResponsePage 时该参数必填。取值有：
+	// <li>当 Mode = FailoverRedirectToURL 时，该参数取值为 301、302、303、307、308 之一；</li>
+	// <li>当 Mode = FailoverCustomResponsePage 时，该参数取值为 400、403、404、405、414、416、451、500、501、502、503、504 之一。</li>
+	StatusCode *int64 `json:"StatusCode,omitnil,omitempty" name:"StatusCode"`
+}
+
+type SiteFailoverParameters struct {
+	// 源站故障转移条件状态码。当源站返回的响应状态码命中本字段返回时，才会按照SiteFailoverParams执行源站转移。该参数取值为 4xx、5xx 之一。
+	SiteFailoverStatusCodes []*int64 `json:"SiteFailoverStatusCodes,omitnil,omitempty" name:"SiteFailoverStatusCodes"`
+
+	// 源站故障转移配置参数列表。最小长度为1，最大长度为2。
+	SiteFailoverParams []*SiteFailover `json:"SiteFailoverParams,omitnil,omitempty" name:"SiteFailoverParams"`
 }
 
 type SkipCondition struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1359,7 +1359,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq/v20200217
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem/v20210701
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.90
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.108
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998


### PR DESCRIPTION
Add security_policy parameter to the tencentcloud_teo_security_policy_config resource, enabling users to configure security policy settings including custom rules, rate limiting, and bot management through the Terraform provider.