### PR TITLE
fix: pagination on describe accounts in postgresql

### DIFF
--- a/.changelog/4211.txt
+++ b/.changelog/4211.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_postgresql_account: supports pagination
+```

--- a/tencentcloud/services/postgresql/service_tencentcloud_postgresql.go
+++ b/tencentcloud/services/postgresql/service_tencentcloud_postgresql.go
@@ -2149,7 +2149,7 @@ func (me *PostgresqlService) DescribePostgresqlAccountById(ctx context.Context, 
 		response, err := me.client.UsePostgresqlClient().DescribeAccounts(request)
 		if err != nil {
 			errRet = err
-			return // errRet will trigger the defer block logging
+			return
 		}
 
 		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())

--- a/tencentcloud/services/postgresql/service_tencentcloud_postgresql.go
+++ b/tencentcloud/services/postgresql/service_tencentcloud_postgresql.go
@@ -2131,30 +2131,54 @@ func (me *PostgresqlService) DescribePostgresqlAccountById(ctx context.Context, 
 	request := postgresql.NewDescribeAccountsRequest()
 	request.DBInstanceId = &dBInstanceId
 
+	// Set to max limit of 100 to reduce total API calls required
+	var limit int64 = 100
+	var offset int64 = 0
+	request.Limit = &limit
+
 	defer func() {
 		if errRet != nil {
 			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
 		}
 	}()
 
-	ratelimit.Check(request.GetAction())
+	for {
+		request.Offset = &offset
+		ratelimit.Check(request.GetAction())
 
-	response, err := me.client.UsePostgresqlClient().DescribeAccounts(request)
-	if err != nil {
-		errRet = err
-		return
-	}
-
-	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
-
-	if response == nil || len(response.Response.Details) < 1 {
-		return
-	}
-
-	for _, item := range response.Response.Details {
-		if *item.UserName == userName {
-			account = item
+		response, err := me.client.UsePostgresqlClient().DescribeAccounts(request)
+		if err != nil {
+			errRet = err
+			return // errRet will trigger the defer block logging
 		}
+
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+		if response == nil || len(response.Response.Details) < 1 {
+			return
+		}
+
+		for _, item := range response.Response.Details {
+			if item.UserName != nil && *item.UserName == userName {
+				account = item
+				return
+			}
+		}
+
+		// Both condition checks if we hit the total count
+		// with additional fallback check if TotalCount somehow becomes nil
+		if response.Response.TotalCount != nil {
+			totalCount := *response.Response.TotalCount
+			if totalCount == 0 || offset+int64(len(response.Response.Details)) >= totalCount {
+				break
+			}
+		} else {
+			if int64(len(response.Response.Details)) < limit {
+				break
+			}
+		}
+
+		offset += limit
 	}
 
 	return


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

Add pagination to describe accounts postgresql service.

## Why

The problem relates to tencentcloud_postgresql_account where it only read the first 20 user in a database instance when checking with the current tfstate.

the function TencentCloudPostgresqlAccountRead is not able to capture all of the users above 20 users in a single database instance. Hence it will return an empty user if the user index is above 20 even though the user exists in the database instance.
```go
func resourceTencentCloudPostgresqlAccountRead(d *schema.ResourceData, meta interface{}) error {
// -------
// DescribePostgresqlAccountById does not read all of the users in the instance due to pagination not being implemented
	account, err := service.DescribePostgresqlAccountById(ctx, dBInstanceId, userName)
	if err != nil {
		return err
	}
// -------
}
``` 
## Related Problems
I've realized similar function in different database type also doesn't handle pagination as well.

`DescribeMongodbInstanceAccountById`:
https://github.com/tencentcloudstack/terraform-provider-tencentcloud/blob/1cf5f7fc6b3ed64faedb9f4fb33513bbc8f3269c/tencentcloud/services/mongodb/service_tencentcloud_mongodb.go#L572-L604

`DescribeCynosdbAccountById`:
https://github.com/tencentcloudstack/terraform-provider-tencentcloud/blob/1cf5f7fc6b3ed64faedb9f4fb33513bbc8f3269c/tencentcloud/services/cynosdb/service_tencentcloud_cynosdb.go#L2063-L2092

`DescribeCynosdbAccountsByFilter`:
https://github.com/tencentcloudstack/terraform-provider-tencentcloud/blob/1cf5f7fc6b3ed64faedb9f4fb33513bbc8f3269c/tencentcloud/services/cynosdb/service_tencentcloud_cynosdb.go#L906-L938

Let me know if you also want me to make changes as well to those other databases to implement pagination.

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [X] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [X] `make build` succeeds locally
- [X] `make fmt` produces no diff
- [X] `make lint` passes (or pre-existing failures are unrelated)
- [X] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
