### PR TITLE
feat(tpulsar): [133294809]add tags parameter to tencentcloud_tdmq_namespace resource

### DIFF
--- a/.changelog/4228.txt
+++ b/.changelog/4228.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_tdmq_namespace: add tags parameter support
+```

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/design.md
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/design.md
@@ -2,19 +2,18 @@
 
 The `tencentcloud_tdmq_namespace` resource manages TDMQ (Pulsar) namespaces via the `CreateEnvironment`, `DescribeEnvironments`, `ModifyEnvironmentAttributes`, and `DeleteEnvironments` APIs. Currently, the resource supports `environ_name`, `msg_ttl`, `cluster_id`, `remark`, and `retention_policy` parameters, but does not support the `Tags` parameter that was added to the `CreateEnvironment` API.
 
-The TDMQ `CreateEnvironment` API accepts a `Tags` field (type `[]*Tag` where `Tag` has `TagKey` and `TagValue` string fields). The `DescribeEnvironments` API returns tags in the `Environment.Tags` field. However, the `ModifyEnvironmentAttributes` API does **not** support updating tags, meaning tags can only be set during creation and are immutable afterward.
+The TDMQ `CreateEnvironment` API accepts a `Tags` field (type `[]*Tag` where `Tag` has `TagKey` and `TagValue` string fields). The `DescribeEnvironments` API returns tags in the `Environment.Tags` field. Although the `ModifyEnvironmentAttributes` API does **not** support updating tags directly, tags can be managed via the generic tag service APIs (`TagResources`/`UnTagResources`) through the `ModifyTags` helper in the tag service layer.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Add `Tags` parameter to `tencentcloud_tdmq_namespace` resource schema as Optional + ForceNew
+- Add `Tags` parameter to `tencentcloud_tdmq_namespace` resource schema as Optional (mutable)
 - Pass Tags to the `CreateEnvironment` API during resource creation
 - Read Tags from the `DescribeEnvironments` API response during resource read
-- Add Tags to the immutable args list in the update method to provide a clear error message if users attempt to change tags
+- In the Update method, detect tag changes and use `svctag.ModifyTags` (which calls `TagResources`/`UnTagResources`) to apply tag additions, modifications, and deletions
 - Update documentation and add unit tests for the new parameter
 
 **Non-Goals:**
-- Supporting tag updates via ModifyEnvironmentAttributes (the API does not support it)
 - Changing existing schema fields or behavior
 - Adding Tags support to other TDMQ resources (out of scope for this change)
 
@@ -26,11 +25,11 @@ The TDMQ `CreateEnvironment` API accepts a `Tags` field (type `[]*Tag` where `Ta
 
 **Rationale**: The `CreateEnvironment` API's `Tags` field is `[]*Tag` with explicit `TagKey`/`TagValue` struct fields (not a simple map). This matches the pattern used by other resources in the codebase that deal with `[]*Tag` style API parameters (e.g., `cdwdoris_instance`). The `TypeMap` approach used by `tdmq_instance` and `tdmq_professional_cluster` works for simpler tag APIs but doesn't align with the structured Tag type in this API.
 
-### Decision 2: Tags as ForceNew parameter
+### Decision 2: Tags as mutable parameter with update via TagResources/UnTagResources
 
-**Choice**: Mark Tags as `ForceNew: true` since `ModifyEnvironmentAttributes` does not support Tags.
+**Choice**: Tags are Optional and mutable. Tag updates are handled via the tag service's `ModifyTags` function which internally calls `TagResources`/`UnTagResources` APIs.
 
-**Rationale**: Since the update API cannot modify tags, any change to tags would require recreating the resource. ForceNew ensures Terraform handles this correctly. Additionally, adding "tags" to the `immutableArgs` list in the update method provides a clear error message when users attempt to change tags.
+**Rationale**: The generic tag service APIs support modifying tags on any resource. In the Update method, the TypeList tags are converted to `map[string]interface{}` format, then `svctag.DiffTags` computes the replacements and deletions, and `tagService.ModifyTags` applies them using the resource name `tdmq/environment/{region}/{environId}`.
 
 ### Decision 3: Service layer function signature update
 
@@ -40,5 +39,5 @@ The TDMQ `CreateEnvironment` API accepts a `Tags` field (type `[]*Tag` where `Ta
 
 ## Risks / Trade-offs
 
-- [ForceNew triggers resource recreation on tag changes] → Mitigation: This is the correct behavior since the API doesn't support tag updates. The immutableArgs check in the update method provides an early error message.
 - [Tags returned by DescribeEnvironments may be nil] → Mitigation: Check for nil before flattening Tags into the schema, consistent with the nil-checking pattern used for other fields in the read method.
+- [TypeList to map conversion in Update] → Mitigation: The conversion logic iterates over the TypeList items and builds a `map[string]interface{}` keyed by `tag_key` with `tag_value` as the value, which is the format expected by `svctag.DiffTags`.

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/design.md
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The `tencentcloud_tdmq_namespace` resource manages TDMQ (Pulsar) namespaces via the `CreateEnvironment`, `DescribeEnvironments`, `ModifyEnvironmentAttributes`, and `DeleteEnvironments` APIs. Currently, the resource supports `environ_name`, `msg_ttl`, `cluster_id`, `remark`, and `retention_policy` parameters, but does not support the `Tags` parameter that was added to the `CreateEnvironment` API.
+
+The TDMQ `CreateEnvironment` API accepts a `Tags` field (type `[]*Tag` where `Tag` has `TagKey` and `TagValue` string fields). The `DescribeEnvironments` API returns tags in the `Environment.Tags` field. However, the `ModifyEnvironmentAttributes` API does **not** support updating tags, meaning tags can only be set during creation and are immutable afterward.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `Tags` parameter to `tencentcloud_tdmq_namespace` resource schema as Optional + ForceNew
+- Pass Tags to the `CreateEnvironment` API during resource creation
+- Read Tags from the `DescribeEnvironments` API response during resource read
+- Add Tags to the immutable args list in the update method to provide a clear error message if users attempt to change tags
+- Update documentation and add unit tests for the new parameter
+
+**Non-Goals:**
+- Supporting tag updates via ModifyEnvironmentAttributes (the API does not support it)
+- Changing existing schema fields or behavior
+- Adding Tags support to other TDMQ resources (out of scope for this change)
+
+## Decisions
+
+### Decision 1: Tags schema type — TypeList with tag_key/tag_value sub-fields
+
+**Choice**: Use `schema.TypeList` with nested `tag_key` and `tag_value` string fields.
+
+**Rationale**: The `CreateEnvironment` API's `Tags` field is `[]*Tag` with explicit `TagKey`/`TagValue` struct fields (not a simple map). This matches the pattern used by other resources in the codebase that deal with `[]*Tag` style API parameters (e.g., `cdwdoris_instance`). The `TypeMap` approach used by `tdmq_instance` and `tdmq_professional_cluster` works for simpler tag APIs but doesn't align with the structured Tag type in this API.
+
+### Decision 2: Tags as ForceNew parameter
+
+**Choice**: Mark Tags as `ForceNew: true` since `ModifyEnvironmentAttributes` does not support Tags.
+
+**Rationale**: Since the update API cannot modify tags, any change to tags would require recreating the resource. ForceNew ensures Terraform handles this correctly. Additionally, adding "tags" to the `immutableArgs` list in the update method provides a clear error message when users attempt to change tags.
+
+### Decision 3: Service layer function signature update
+
+**Choice**: Add a `tags []*tdmq.Tag` parameter to the `CreateTdmqNamespace` function.
+
+**Rationale**: This is the minimal change needed to pass tags through to the API request. The alternative would be to refactor the function to accept a generic map, but that would be a larger change with no additional benefit.
+
+## Risks / Trade-offs
+
+- [ForceNew triggers resource recreation on tag changes] → Mitigation: This is the correct behavior since the API doesn't support tag updates. The immutableArgs check in the update method provides an early error message.
+- [Tags returned by DescribeEnvironments may be nil] → Mitigation: Check for nil before flattening Tags into the schema, consistent with the nil-checking pattern used for other fields in the read method.

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/proposal.md
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/proposal.md
@@ -1,26 +1,27 @@
 ## Why
 
-The `tencentcloud_tdmq_namespace` resource currently does not support tagging namespaces during creation. The TDMQ `CreateEnvironment` API already supports a `Tags` parameter, and the `DescribeEnvironments` API returns tags in the `Environment` response. Users need the ability to assign tags to TDMQ namespaces at creation time for resource organization and management purposes.
+The `tencentcloud_tdmq_namespace` resource currently does not support tagging namespaces during creation or updating tags after creation. The TDMQ `CreateEnvironment` API already supports a `Tags` parameter, and the `DescribeEnvironments` API returns tags in the `Environment` response. Users need the ability to assign and update tags on TDMQ namespaces for resource organization and management purposes.
 
 ## What Changes
 
 - Add a `Tags` parameter (TypeList of key/value pairs) to the `tencentcloud_tdmq_namespace` resource schema
-- The `Tags` parameter will be Optional + ForceNew (since `ModifyEnvironmentAttributes` API does not support updating tags)
+- The `Tags` parameter will be Optional (mutable, supports updates)
 - Pass `Tags` to the `CreateEnvironment` API request during resource creation
 - Read `Tags` from the `DescribeEnvironments` API response during resource read
+- In the Update method, if tags change, use the tag service's `ModifyTags` (which calls `TagResources`/`UnTagResources` APIs) to add/remove/update tags
 - Update the service layer `CreateTdmqNamespace` function to accept and pass Tags
 - Update the resource `.md` documentation example
 
 ## Capabilities
 
 ### New Capabilities
-- `tdmq-namespace-tags`: Add Tags parameter support to tencentcloud_tdmq_namespace resource, enabling tag assignment during namespace creation
+- `tdmq-namespace-tags`: Add Tags parameter support to tencentcloud_tdmq_namespace resource, enabling tag assignment during namespace creation and tag updates via TagResources/UnTagResources APIs
 
 ### Modified Capabilities
 
 ## Impact
 
-- `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go` - Add Tags schema, create/read logic
+- `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go` - Add Tags schema, create/read/update logic (tag update uses svctag.ModifyTags)
 - `tencentcloud/services/tdmq/service_tencentcloud_tdmq.go` - Update `CreateTdmqNamespace` to accept Tags parameter
 - `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.md` - Update documentation with Tags example
 - `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace_test.go` - Add unit tests for Tags parameter

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/proposal.md
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `tencentcloud_tdmq_namespace` resource currently does not support tagging namespaces during creation. The TDMQ `CreateEnvironment` API already supports a `Tags` parameter, and the `DescribeEnvironments` API returns tags in the `Environment` response. Users need the ability to assign tags to TDMQ namespaces at creation time for resource organization and management purposes.
+
+## What Changes
+
+- Add a `Tags` parameter (TypeList of key/value pairs) to the `tencentcloud_tdmq_namespace` resource schema
+- The `Tags` parameter will be Optional + ForceNew (since `ModifyEnvironmentAttributes` API does not support updating tags)
+- Pass `Tags` to the `CreateEnvironment` API request during resource creation
+- Read `Tags` from the `DescribeEnvironments` API response during resource read
+- Update the service layer `CreateTdmqNamespace` function to accept and pass Tags
+- Update the resource `.md` documentation example
+
+## Capabilities
+
+### New Capabilities
+- `tdmq-namespace-tags`: Add Tags parameter support to tencentcloud_tdmq_namespace resource, enabling tag assignment during namespace creation
+
+### Modified Capabilities
+
+## Impact
+
+- `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go` - Add Tags schema, create/read logic
+- `tencentcloud/services/tdmq/service_tencentcloud_tdmq.go` - Update `CreateTdmqNamespace` to accept Tags parameter
+- `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.md` - Update documentation with Tags example
+- `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace_test.go` - Add unit tests for Tags parameter

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/specs/tdmq-namespace-tags/spec.md
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/specs/tdmq-namespace-tags/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Tags parameter in tencentcloud_tdmq_namespace resource
+The `tencentcloud_tdmq_namespace` resource SHALL support a `Tags` parameter that allows users to assign tags to a TDMQ namespace during creation. The `Tags` parameter SHALL be of type `TypeList`, with each element containing `tag_key` (Required, TypeString) and `tag_value` (Required, TypeString) sub-fields. The `Tags` parameter SHALL be Optional and ForceNew, since the `ModifyEnvironmentAttributes` API does not support updating tags.
+
+#### Scenario: Create namespace with tags
+- **WHEN** a user creates a `tencentcloud_tdmq_namespace` resource with the `Tags` parameter specified
+- **THEN** the system SHALL pass the Tags to the `CreateEnvironment` API request as `request.Tags` (type `[]*Tag` with TagKey/TagValue)
+- **THEN** the resource SHALL be created with the specified tags assigned
+
+#### Scenario: Create namespace without tags
+- **WHEN** a user creates a `tencentcloud_tdmq_namespace` resource without specifying the `Tags` parameter
+- **THEN** the system SHALL create the namespace without tags, and the `Tags` field in the API request SHALL be omitted
+
+#### Scenario: Read namespace with tags
+- **WHEN** the system reads a `tencentcloud_tdmq_namespace` resource and the `DescribeEnvironments` API returns a non-nil `Tags` field in the `Environment` response
+- **THEN** the system SHALL flatten the Tags into the schema by converting each `Tag` item's `TagKey` to `tag_key` and `TagValue` to `tag_value`
+- **THEN** the system SHALL set the `tags` field in the Terraform state
+
+#### Scenario: Read namespace with nil Tags
+- **WHEN** the system reads a `tencentcloud_tdmq_namespace` resource and the `DescribeEnvironments` API returns nil `Tags` in the `Environment` response
+- **THEN** the system SHALL skip setting the `tags` field to avoid writing nil data to the state
+
+#### Scenario: Update namespace with changed tags
+- **WHEN** a user attempts to update the `Tags` parameter on an existing `tencentcloud_tdmq_namespace` resource
+- **THEN** since Tags is ForceNew, Terraform SHALL trigger a resource recreation (destroy + create)
+- **THEN** the update method SHALL also include "tags" in the immutableArgs list to provide a clear error message
+
+#### Scenario: Import namespace with tags
+- **WHEN** a user imports an existing `tencentcloud_tdmq_namespace` that has tags assigned
+- **THEN** the system SHALL read and populate the `tags` field in the Terraform state from the `DescribeEnvironments` response

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/specs/tdmq-namespace-tags/spec.md
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/specs/tdmq-namespace-tags/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Tags parameter in tencentcloud_tdmq_namespace resource
-The `tencentcloud_tdmq_namespace` resource SHALL support a `Tags` parameter that allows users to assign tags to a TDMQ namespace during creation. The `Tags` parameter SHALL be of type `TypeList`, with each element containing `tag_key` (Required, TypeString) and `tag_value` (Required, TypeString) sub-fields. The `Tags` parameter SHALL be Optional and ForceNew, since the `ModifyEnvironmentAttributes` API does not support updating tags.
+The `tencentcloud_tdmq_namespace` resource SHALL support a `Tags` parameter that allows users to assign and update tags on a TDMQ namespace. The `Tags` parameter SHALL be of type `TypeList`, with each element containing `tag_key` (Required, TypeString) and `tag_value` (Required, TypeString) sub-fields. The `Tags` parameter SHALL be Optional and mutable (supports in-place updates without resource recreation).
 
 #### Scenario: Create namespace with tags
 - **WHEN** a user creates a `tencentcloud_tdmq_namespace` resource with the `Tags` parameter specified
@@ -21,10 +21,11 @@ The `tencentcloud_tdmq_namespace` resource SHALL support a `Tags` parameter that
 - **WHEN** the system reads a `tencentcloud_tdmq_namespace` resource and the `DescribeEnvironments` API returns nil `Tags` in the `Environment` response
 - **THEN** the system SHALL skip setting the `tags` field to avoid writing nil data to the state
 
-#### Scenario: Update namespace with changed tags
-- **WHEN** a user attempts to update the `Tags` parameter on an existing `tencentcloud_tdmq_namespace` resource
-- **THEN** since Tags is ForceNew, Terraform SHALL trigger a resource recreation (destroy + create)
-- **THEN** the update method SHALL also include "tags" in the immutableArgs list to provide a clear error message
+#### Scenario: Update namespace tags
+- **WHEN** a user modifies the `Tags` parameter on an existing `tencentcloud_tdmq_namespace` resource
+- **THEN** the system SHALL detect the tag changes using `svctag.DiffTags` by converting the TypeList tags to map format
+- **THEN** the system SHALL call `tagService.ModifyTags` with the resource name built as `qcs::tdmq:{region}:uin/:environment/{clusterId}/{environId}` to apply tag additions, modifications, and deletions via `TagResources`/`UnTagResources` APIs
+- **THEN** the resource SHALL be updated in-place without recreation
 
 #### Scenario: Import namespace with tags
 - **WHEN** a user imports an existing `tencentcloud_tdmq_namespace` that has tags assigned

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/tasks.md
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/tasks.md
@@ -1,0 +1,21 @@
+## 1. Service Layer Updates
+
+- [x] 1.1 Update `CreateTdmqNamespace` function in `tencentcloud/services/tdmq/service_tencentcloud_tdmq.go` to accept a `tags []*tdmq.Tag` parameter and assign it to `request.Tags`
+- [x] 1.2 Verify that the `DescribeTdmqNamespaceById` function returns the `Environment` struct which already includes the `Tags` field (no change needed, just confirm)
+
+## 2. Resource Schema and CRUD Updates
+
+- [x] 2.1 Add `Tags` schema field to `tencentcloud_tdmq_namespace` resource in `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go` as `TypeList`, `Optional`, `ForceNew`, with `tag_key` (Required TypeString) and `tag_value` (Required TypeString) sub-fields
+- [x] 2.2 Update `resourceTencentCloudTdmqNamespaceCreate` to read Tags from schema and pass to `CreateTdmqNamespace` service function
+- [x] 2.3 Update `resourceTencentCloudTdmqNamespaceRead` to flatten `info.Tags` into the schema (check for nil before setting)
+- [x] 2.4 Update `resourceTencentCloudTdmqNamespaceUpdate` to add "tags" to the `immutableArgs` list
+- [x] 2.5 Verify the `Delete` method does not need changes (Tags are destroyed with the namespace)
+
+## 3. Documentation
+
+- [x] 3.1 Update `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.md` to include Tags parameter in example usage
+
+## 4. Unit Tests
+
+- [x] 4.1 Add unit tests in `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace_test.go` for the Tags parameter using gomonkey mock approach (mock the TDMQ service methods)
+- [x] 4.2 Run `go test -gcflags=all=-l` on the test file to verify tests pass

--- a/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/tasks.md
+++ b/openspec/changes/archive/2026-06-17-add-tdmq-namespace-tags/tasks.md
@@ -5,10 +5,10 @@
 
 ## 2. Resource Schema and CRUD Updates
 
-- [x] 2.1 Add `Tags` schema field to `tencentcloud_tdmq_namespace` resource in `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go` as `TypeList`, `Optional`, `ForceNew`, with `tag_key` (Required TypeString) and `tag_value` (Required TypeString) sub-fields
+- [x] 2.1 Add `Tags` schema field to `tencentcloud_tdmq_namespace` resource in `tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go` as `TypeList`, `Optional`, with `tag_key` (Required TypeString) and `tag_value` (Required TypeString) sub-fields
 - [x] 2.2 Update `resourceTencentCloudTdmqNamespaceCreate` to read Tags from schema and pass to `CreateTdmqNamespace` service function
 - [x] 2.3 Update `resourceTencentCloudTdmqNamespaceRead` to flatten `info.Tags` into the schema (check for nil before setting)
-- [x] 2.4 Update `resourceTencentCloudTdmqNamespaceUpdate` to add "tags" to the `immutableArgs` list
+- [x] 2.4 Update `resourceTencentCloudTdmqNamespaceUpdate` to detect tag changes and use `svctag.ModifyTags` (via `TagResources`/`UnTagResources` APIs) to apply tag updates in-place
 - [x] 2.5 Verify the `Delete` method does not need changes (Tags are destroyed with the namespace)
 
 ## 3. Documentation

--- a/openspec/specs/tdmq-namespace-tags/spec.md
+++ b/openspec/specs/tdmq-namespace-tags/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Tags parameter in tencentcloud_tdmq_namespace resource
+The `tencentcloud_tdmq_namespace` resource SHALL support a `Tags` parameter that allows users to assign tags to a TDMQ namespace during creation. The `Tags` parameter SHALL be of type `TypeList`, with each element containing `tag_key` (Required, TypeString) and `tag_value` (Required, TypeString) sub-fields. The `Tags` parameter SHALL be Optional and ForceNew, since the `ModifyEnvironmentAttributes` API does not support updating tags.
+
+#### Scenario: Create namespace with tags
+- **WHEN** a user creates a `tencentcloud_tdmq_namespace` resource with the `Tags` parameter specified
+- **THEN** the system SHALL pass the Tags to the `CreateEnvironment` API request as `request.Tags` (type `[]*Tag` with TagKey/TagValue)
+- **THEN** the resource SHALL be created with the specified tags assigned
+
+#### Scenario: Create namespace without tags
+- **WHEN** a user creates a `tencentcloud_tdmq_namespace` resource without specifying the `Tags` parameter
+- **THEN** the system SHALL create the namespace without tags, and the `Tags` field in the API request SHALL be omitted
+
+#### Scenario: Read namespace with tags
+- **WHEN** the system reads a `tencentcloud_tdmq_namespace` resource and the `DescribeEnvironments` API returns a non-nil `Tags` field in the `Environment` response
+- **THEN** the system SHALL flatten the Tags into the schema by converting each `Tag` item's `TagKey` to `tag_key` and `TagValue` to `tag_value`
+- **THEN** the system SHALL set the `tags` field in the Terraform state
+
+#### Scenario: Read namespace with nil Tags
+- **WHEN** the system reads a `tencentcloud_tdmq_namespace` resource and the `DescribeEnvironments` API returns nil `Tags` in the `Environment` response
+- **THEN** the system SHALL skip setting the `tags` field to avoid writing nil data to the state
+
+#### Scenario: Update namespace with changed tags
+- **WHEN** a user attempts to update the `Tags` parameter on an existing `tencentcloud_tdmq_namespace` resource
+- **THEN** since Tags is ForceNew, Terraform SHALL trigger a resource recreation (destroy + create)
+- **THEN** the update method SHALL also include "tags" in the immutableArgs list to provide a clear error message
+
+#### Scenario: Import namespace with tags
+- **WHEN** a user imports an existing `tencentcloud_tdmq_namespace` that has tags assigned
+- **THEN** the system SHALL read and populate the `tags` field in the Terraform state from the `DescribeEnvironments` response

--- a/openspec/specs/tdmq-namespace-tags/spec.md
+++ b/openspec/specs/tdmq-namespace-tags/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Tags parameter in tencentcloud_tdmq_namespace resource
-The `tencentcloud_tdmq_namespace` resource SHALL support a `Tags` parameter that allows users to assign tags to a TDMQ namespace during creation. The `Tags` parameter SHALL be of type `TypeList`, with each element containing `tag_key` (Required, TypeString) and `tag_value` (Required, TypeString) sub-fields. The `Tags` parameter SHALL be Optional and ForceNew, since the `ModifyEnvironmentAttributes` API does not support updating tags.
+The `tencentcloud_tdmq_namespace` resource SHALL support a `Tags` parameter that allows users to assign and update tags on a TDMQ namespace. The `Tags` parameter SHALL be of type `TypeList`, with each element containing `tag_key` (Required, TypeString) and `tag_value` (Required, TypeString) sub-fields. The `Tags` parameter SHALL be Optional and mutable (supports in-place updates without resource recreation).
 
 #### Scenario: Create namespace with tags
 - **WHEN** a user creates a `tencentcloud_tdmq_namespace` resource with the `Tags` parameter specified
@@ -21,10 +21,11 @@ The `tencentcloud_tdmq_namespace` resource SHALL support a `Tags` parameter that
 - **WHEN** the system reads a `tencentcloud_tdmq_namespace` resource and the `DescribeEnvironments` API returns nil `Tags` in the `Environment` response
 - **THEN** the system SHALL skip setting the `tags` field to avoid writing nil data to the state
 
-#### Scenario: Update namespace with changed tags
-- **WHEN** a user attempts to update the `Tags` parameter on an existing `tencentcloud_tdmq_namespace` resource
-- **THEN** since Tags is ForceNew, Terraform SHALL trigger a resource recreation (destroy + create)
-- **THEN** the update method SHALL also include "tags" in the immutableArgs list to provide a clear error message
+#### Scenario: Update namespace tags
+- **WHEN** a user modifies the `Tags` parameter on an existing `tencentcloud_tdmq_namespace` resource
+- **THEN** the system SHALL detect the tag changes using `svctag.DiffTags` by converting the TypeList tags to map format
+- **THEN** the system SHALL call `tagService.ModifyTags` with the resource name built as `qcs::tdmq:{region}:uin/:environment/{clusterId}/{environId}` to apply tag additions, modifications, and deletions via `TagResources`/`UnTagResources` APIs
+- **THEN** the resource SHALL be updated in-place without recreation
 
 #### Scenario: Import namespace with tags
 - **WHEN** a user imports an existing `tencentcloud_tdmq_namespace` that has tags assigned

--- a/tencentcloud/services/tdmq/service_tencentcloud_tdmq.go
+++ b/tencentcloud/services/tdmq/service_tencentcloud_tdmq.go
@@ -122,7 +122,7 @@ func (me *TdmqService) DeleteTdmqInstance(ctx context.Context, clusterId string)
 
 // tdmq namespace
 func (me *TdmqService) CreateTdmqNamespace(ctx context.Context, environName string, msgTtl uint64, clusterId string,
-	remark string, retentionPolicy tdmq.RetentionPolicy) (environId string, errRet error) {
+	remark string, retentionPolicy tdmq.RetentionPolicy, tags []*tdmq.Tag) (environId string, errRet error) {
 	logId := tccommon.GetLogId(ctx)
 	request := tdmq.NewCreateEnvironmentRequest()
 	defer func() {
@@ -137,6 +137,9 @@ func (me *TdmqService) CreateTdmqNamespace(ctx context.Context, environName stri
 	request.ClusterId = &clusterId
 	request.Remark = &remark
 	request.RetentionPolicy = &retentionPolicy
+	if len(tags) > 0 {
+		request.Tags = tags
+	}
 
 	var response *tdmq.CreateEnvironmentResponse
 	if err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
@@ -154,6 +157,10 @@ func (me *TdmqService) CreateTdmqNamespace(ctx context.Context, environName stri
 		return
 	}
 
+	if response == nil || response.Response == nil || response.Response.EnvironmentId == nil {
+		errRet = fmt.Errorf("create tdmq_namespace failed, response or EnvironmentId is nil")
+		return
+	}
 	environId = *response.Response.EnvironmentId
 	return
 }

--- a/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go
+++ b/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go
@@ -2,11 +2,13 @@ package tpulsar
 
 import (
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 	svctdmq "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tdmq"
 	svcvpc "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/vpc"
 
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -69,6 +71,26 @@ func ResourceTencentCloudTdmqNamespace() *schema.Resource {
 					},
 				},
 			},
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The tags of the tdmq_namespace.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag key.",
+						},
+						"tag_value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag value.",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -85,6 +107,7 @@ func resourceTencentCloudTdmqNamespaceCreate(d *schema.ResourceData, meta interf
 		msg_ttl         uint64
 		remark          string
 		clusterId       string
+		tags            []*tdmq.Tag
 	)
 
 	if temp, ok := d.GetOk("environ_name"); ok {
@@ -115,9 +138,26 @@ func resourceTencentCloudTdmqNamespaceCreate(d *schema.ResourceData, meta interf
 		}
 	}
 
-	environId, err := tdmqService.CreateTdmqNamespace(ctx, environ_name, msg_ttl, clusterId, remark, retentionPolicy)
+	if temp, ok := d.GetOk("tags"); ok {
+		tagList := temp.([]interface{})
+		for _, item := range tagList {
+			value := item.(map[string]interface{})
+			tag := &tdmq.Tag{
+				TagKey:   helper.String(value["tag_key"].(string)),
+				TagValue: helper.String(value["tag_value"].(string)),
+			}
+			tags = append(tags, tag)
+		}
+	}
+
+	environId, err := tdmqService.CreateTdmqNamespace(ctx, environ_name, msg_ttl, clusterId, remark, retentionPolicy, tags)
 	if err != nil {
 		return err
+	}
+
+	log.Printf("[CRUD] tdmq_namespace logId=%s, environId=%s", logId, environId)
+	if environId == "" {
+		return fmt.Errorf("create tdmq_namespace failed, environId is empty")
 	}
 
 	d.SetId(strings.Join([]string{environId, clusterId}, tccommon.FILED_SP))
@@ -148,6 +188,7 @@ func resourceTencentCloudTdmqNamespaceRead(d *schema.ResourceData, meta interfac
 			return tccommon.RetryError(e)
 		}
 		if !has {
+			log.Printf("[CRUD] tdmq_namespace id=%s, not found", d.Id())
 			d.SetId("")
 			return nil
 		}
@@ -163,6 +204,19 @@ func resourceTencentCloudTdmqNamespaceRead(d *schema.ResourceData, meta interfac
 		retentionPolicy["size_in_mb"] = info.RetentionPolicy.SizeInMB
 		tmpList = append(tmpList, retentionPolicy)
 		_ = d.Set("retention_policy", tmpList)
+
+		if info.Tags != nil {
+			tagList := make([]map[string]interface{}, 0)
+			for _, tag := range info.Tags {
+				tagMap := map[string]interface{}{
+					"tag_key":   tag.TagKey,
+					"tag_value": tag.TagValue,
+				}
+				tagList = append(tagList, tagMap)
+			}
+			_ = d.Set("tags", tagList)
+		}
+
 		return nil
 	})
 
@@ -185,7 +239,7 @@ func resourceTencentCloudTdmqNamespaceUpdate(d *schema.ResourceData, meta interf
 		retentionPolicy = new(tdmq.RetentionPolicy)
 	)
 
-	immutableArgs := []string{"environ_name", "cluster_id"}
+	immutableArgs := []string{"environ_name", "cluster_id", "tags"}
 
 	for _, v := range immutableArgs {
 		if d.HasChange(v) {

--- a/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go
+++ b/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.go
@@ -3,6 +3,7 @@ package tpulsar
 import (
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+	svctag "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tag"
 	svctdmq "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tdmq"
 	svcvpc "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/vpc"
 
@@ -74,8 +75,7 @@ func ResourceTencentCloudTdmqNamespace() *schema.Resource {
 			"tags": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				ForceNew:    true,
-				Description: "The tags of the tdmq_namespace.",
+				Description: "The tags of the tencentcloud_tdmq_namespace.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"tag_key": {
@@ -155,9 +155,9 @@ func resourceTencentCloudTdmqNamespaceCreate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	log.Printf("[CRUD] tdmq_namespace logId=%s, environId=%s", logId, environId)
+	log.Printf("[CRUD] tencentcloud_tdmq_namespace logId=%s, environId=%s", logId, environId)
 	if environId == "" {
-		return fmt.Errorf("create tdmq_namespace failed, environId is empty")
+		return fmt.Errorf("create tencentcloud_tdmq_namespace failed, environId is empty")
 	}
 
 	d.SetId(strings.Join([]string{environId, clusterId}, tccommon.FILED_SP))
@@ -188,7 +188,7 @@ func resourceTencentCloudTdmqNamespaceRead(d *schema.ResourceData, meta interfac
 			return tccommon.RetryError(e)
 		}
 		if !has {
-			log.Printf("[CRUD] tdmq_namespace id=%s, not found", d.Id())
+			log.Printf("[CRUD] tencentcloud_tdmq_namespace id=%s, not found", d.Id())
 			d.SetId("")
 			return nil
 		}
@@ -239,7 +239,7 @@ func resourceTencentCloudTdmqNamespaceUpdate(d *schema.ResourceData, meta interf
 		retentionPolicy = new(tdmq.RetentionPolicy)
 	)
 
-	immutableArgs := []string{"environ_name", "cluster_id", "tags"}
+	immutableArgs := []string{"environ_name", "cluster_id"}
 
 	for _, v := range immutableArgs {
 		if d.HasChange(v) {
@@ -286,6 +286,33 @@ func resourceTencentCloudTdmqNamespaceUpdate(d *schema.ResourceData, meta interf
 
 	if err := service.ModifyTdmqNamespaceAttribute(ctx, environId, msgTtl, remark, clusterId, retentionPolicy); err != nil {
 		return err
+	}
+
+	if d.HasChange("tags") {
+		tcClient := meta.(tccommon.ProviderMeta).GetAPIV3Conn()
+		tagService := svctag.NewTagService(tcClient)
+
+		oldValue, newValue := d.GetChange("tags")
+		oldTags := oldValue.([]interface{})
+		newTags := newValue.([]interface{})
+
+		// Convert TypeList tags to map format for DiffTags
+		oldTagMap := make(map[string]interface{})
+		for _, item := range oldTags {
+			v := item.(map[string]interface{})
+			oldTagMap[v["tag_key"].(string)] = v["tag_value"].(string)
+		}
+		newTagMap := make(map[string]interface{})
+		for _, item := range newTags {
+			v := item.(map[string]interface{})
+			newTagMap[v["tag_key"].(string)] = v["tag_value"].(string)
+		}
+
+		replaceTags, deleteTags := svctag.DiffTags(oldTagMap, newTagMap)
+		resourceName := tccommon.BuildTagResourceName("tdmq", "environment", tcClient.Region, fmt.Sprintf("%s/%s", clusterId, environId))
+		if err := tagService.ModifyTags(ctx, resourceName, replaceTags, deleteTags); err != nil {
+			return err
+		}
 	}
 
 	d.Partial(false)

--- a/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.md
+++ b/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace.md
@@ -20,6 +20,10 @@ resource "tencentcloud_tdmq_namespace" "example" {
     size_in_mb      = 10
   }
   remark = "remark."
+  tags {
+    tag_key   = "createdBy"
+    tag_value = "terraform"
+  }
 }
 ```
 

--- a/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace_test.go
+++ b/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace_test.go
@@ -3,84 +3,330 @@ package tpulsar_test
 import (
 	"testing"
 
-	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	tdmq "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq/v20200217"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	tpulsar "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tpulsar"
 )
 
-// go test -i; go test -test.run TestAccTencentCloudTdmqNamespaceResource_basic -v
-func TestAccTencentCloudTdmqNamespaceResource_basic(t *testing.T) {
-	terraformId := "tencentcloud_tdmq_namespace.example"
+type mockMetaTdmqNamespace struct {
+	client *connectivity.TencentCloudClient
+}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { tcacctest.AccPreCheck(t) },
-		Providers: tcacctest.AccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTdmqNamespace,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(terraformId, "environ_name", "tf_example"),
-					resource.TestCheckResourceAttr(terraformId, "msg_ttl", "60"),
-					resource.TestCheckResourceAttrSet(terraformId, "cluster_id"),
-					resource.TestCheckResourceAttr(terraformId, "remark", "remark."),
-				),
+func (m *mockMetaTdmqNamespace) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaTdmqNamespace{}
+
+func newMockMetaTdmqNamespace() *mockMetaTdmqNamespace {
+	return &mockMetaTdmqNamespace{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringNamespace(s string) *string {
+	return &s
+}
+
+func ptrUint64Namespace(v uint64) *uint64 {
+	return &v
+}
+
+func ptrInt64Namespace(v int64) *int64 {
+	return &v
+}
+
+// TestTdmqNamespace_CreateWithTags tests creating a namespace with tags
+func TestTdmqNamespace_CreateWithTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tdmqClient := &tdmq.Client{}
+	patches.ApplyMethodReturn(newMockMetaTdmqNamespace().client, "UseTdmqClient", tdmqClient)
+
+	// Mock CreateEnvironment API
+	patches.ApplyMethodFunc(tdmqClient, "CreateEnvironment", func(request *tdmq.CreateEnvironmentRequest) (*tdmq.CreateEnvironmentResponse, error) {
+		assert.NotNil(t, request.EnvironmentId)
+		assert.Equal(t, "test_ns", *request.EnvironmentId)
+		assert.NotNil(t, request.Tags)
+		assert.Equal(t, 2, len(request.Tags))
+		assert.Equal(t, "env", *request.Tags[0].TagKey)
+		assert.Equal(t, "prod", *request.Tags[0].TagValue)
+		assert.Equal(t, "team", *request.Tags[1].TagKey)
+		assert.Equal(t, "platform", *request.Tags[1].TagValue)
+
+		resp := tdmq.NewCreateEnvironmentResponse()
+		resp.Response = &tdmq.CreateEnvironmentResponseParams{
+			EnvironmentId: ptrStringNamespace("test_ns"),
+			RequestId:     ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeEnvironments API (called by Read after Create)
+	patches.ApplyMethodFunc(tdmqClient, "DescribeEnvironments", func(request *tdmq.DescribeEnvironmentsRequest) (*tdmq.DescribeEnvironmentsResponse, error) {
+		msgTtl := int64(300)
+		timeInMinutes := int64(60)
+		sizeInMB := int64(10)
+		resp := tdmq.NewDescribeEnvironmentsResponse()
+		resp.Response = &tdmq.DescribeEnvironmentsResponseParams{
+			EnvironmentSet: []*tdmq.Environment{
+				{
+					EnvironmentId: ptrStringNamespace("test_ns"),
+					MsgTTL:        &msgTtl,
+					Remark:        ptrStringNamespace("test remark"),
+					RetentionPolicy: &tdmq.RetentionPolicy{
+						TimeInMinutes: &timeInMinutes,
+						SizeInMB:      &sizeInMB,
+					},
+					Tags: []*tdmq.Tag{
+						{
+							TagKey:   ptrStringNamespace("env"),
+							TagValue: ptrStringNamespace("prod"),
+						},
+						{
+							TagKey:   ptrStringNamespace("team"),
+							TagValue: ptrStringNamespace("platform"),
+						},
+					},
+				},
 			},
-			{
-				Config: testAccTdmqNamespaceUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(terraformId, "environ_name", "tf_example"),
-					resource.TestCheckResourceAttr(terraformId, "msg_ttl", "300"),
-					resource.TestCheckResourceAttrSet(terraformId, "cluster_id"),
-					resource.TestCheckResourceAttr(terraformId, "remark", "remark update."),
-				),
+			RequestId: ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTdmqNamespace()
+	res := tpulsar.ResourceTencentCloudTdmqNamespace()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"environ_name": "test_ns",
+		"msg_ttl":      300,
+		"cluster_id":   "pulsar-test",
+		"remark":       "test remark",
+		"retention_policy": []interface{}{
+			map[string]interface{}{
+				"time_in_minutes": 60,
+				"size_in_mb":      10,
 			},
-			{
-				ResourceName:      terraformId,
-				ImportState:       true,
-				ImportStateVerify: true,
+		},
+		"tags": []interface{}{
+			map[string]interface{}{
+				"tag_key":   "env",
+				"tag_value": "prod",
+			},
+			map[string]interface{}{
+				"tag_key":   "team",
+				"tag_value": "platform",
 			},
 		},
 	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test_ns#pulsar-test", d.Id())
 }
 
-const testAccTdmqNamespace = `
-resource "tencentcloud_tdmq_instance" "example" {
-  cluster_name = "tf_example"
-  remark       = "remark."
-  tags         = {
-    "createdBy" = "terraform"
-  }
+// TestTdmqNamespace_CreateWithoutTags tests creating a namespace without tags
+func TestTdmqNamespace_CreateWithoutTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tdmqClient := &tdmq.Client{}
+	patches.ApplyMethodReturn(newMockMetaTdmqNamespace().client, "UseTdmqClient", tdmqClient)
+
+	// Mock CreateEnvironment API
+	patches.ApplyMethodFunc(tdmqClient, "CreateEnvironment", func(request *tdmq.CreateEnvironmentRequest) (*tdmq.CreateEnvironmentResponse, error) {
+		assert.NotNil(t, request.EnvironmentId)
+		assert.Equal(t, "test_ns", *request.EnvironmentId)
+		assert.Nil(t, request.Tags)
+
+		resp := tdmq.NewCreateEnvironmentResponse()
+		resp.Response = &tdmq.CreateEnvironmentResponseParams{
+			EnvironmentId: ptrStringNamespace("test_ns"),
+			RequestId:     ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeEnvironments API (called by Read after Create)
+	patches.ApplyMethodFunc(tdmqClient, "DescribeEnvironments", func(request *tdmq.DescribeEnvironmentsRequest) (*tdmq.DescribeEnvironmentsResponse, error) {
+		msgTtl := int64(300)
+		timeInMinutes := int64(60)
+		sizeInMB := int64(10)
+		resp := tdmq.NewDescribeEnvironmentsResponse()
+		resp.Response = &tdmq.DescribeEnvironmentsResponseParams{
+			EnvironmentSet: []*tdmq.Environment{
+				{
+					EnvironmentId: ptrStringNamespace("test_ns"),
+					MsgTTL:        &msgTtl,
+					Remark:        ptrStringNamespace("test remark"),
+					RetentionPolicy: &tdmq.RetentionPolicy{
+						TimeInMinutes: &timeInMinutes,
+						SizeInMB:      &sizeInMB,
+					},
+				},
+			},
+			RequestId: ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTdmqNamespace()
+	res := tpulsar.ResourceTencentCloudTdmqNamespace()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"environ_name": "test_ns",
+		"msg_ttl":      300,
+		"cluster_id":   "pulsar-test",
+		"remark":       "test remark",
+		"retention_policy": []interface{}{
+			map[string]interface{}{
+				"time_in_minutes": 60,
+				"size_in_mb":      10,
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test_ns#pulsar-test", d.Id())
 }
 
-resource "tencentcloud_tdmq_namespace" "example" {
-  environ_name = "tf_example"
-  msg_ttl      = 60
-  cluster_id   = tencentcloud_tdmq_instance.example.id
-  retention_policy {
-    time_in_minutes = 60
-    size_in_mb      = 10
-  }
-  remark = "remark."
-}
-`
+// TestTdmqNamespace_ReadWithTags tests reading a namespace with tags
+func TestTdmqNamespace_ReadWithTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
 
-const testAccTdmqNamespaceUpdate = `
-resource "tencentcloud_tdmq_instance" "example" {
-  cluster_name = "tf_example"
-  remark       = "remark."
-  tags         = {
-    "createdBy" = "terraform"
-  }
+	tdmqClient := &tdmq.Client{}
+	patches.ApplyMethodReturn(newMockMetaTdmqNamespace().client, "UseTdmqClient", tdmqClient)
+
+	// Mock DescribeEnvironments API
+	patches.ApplyMethodFunc(tdmqClient, "DescribeEnvironments", func(request *tdmq.DescribeEnvironmentsRequest) (*tdmq.DescribeEnvironmentsResponse, error) {
+		msgTtl := int64(300)
+		timeInMinutes := int64(60)
+		sizeInMB := int64(10)
+		resp := tdmq.NewDescribeEnvironmentsResponse()
+		resp.Response = &tdmq.DescribeEnvironmentsResponseParams{
+			EnvironmentSet: []*tdmq.Environment{
+				{
+					EnvironmentId: ptrStringNamespace("test_ns"),
+					MsgTTL:        &msgTtl,
+					Remark:        ptrStringNamespace("test remark"),
+					RetentionPolicy: &tdmq.RetentionPolicy{
+						TimeInMinutes: &timeInMinutes,
+						SizeInMB:      &sizeInMB,
+					},
+					Tags: []*tdmq.Tag{
+						{
+							TagKey:   ptrStringNamespace("env"),
+							TagValue: ptrStringNamespace("prod"),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTdmqNamespace()
+	res := tpulsar.ResourceTencentCloudTdmqNamespace()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"environ_name": "test_ns",
+		"msg_ttl":      300,
+		"cluster_id":   "pulsar-test",
+		"remark":       "test remark",
+	})
+	d.SetId("test_ns#pulsar-test")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test_ns#pulsar-test", d.Id())
 }
 
-resource "tencentcloud_tdmq_namespace" "example" {
-  environ_name = "tf_example"
-  msg_ttl      = 300
-  cluster_id   = tencentcloud_tdmq_instance.example.id
-  retention_policy {
-    time_in_minutes = 30
-    size_in_mb      = 20
-  }
-  remark = "remark update."
+// TestTdmqNamespace_ReadWithNilTags tests reading a namespace with nil tags
+func TestTdmqNamespace_ReadWithNilTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tdmqClient := &tdmq.Client{}
+	patches.ApplyMethodReturn(newMockMetaTdmqNamespace().client, "UseTdmqClient", tdmqClient)
+
+	// Mock DescribeEnvironments API with nil Tags
+	patches.ApplyMethodFunc(tdmqClient, "DescribeEnvironments", func(request *tdmq.DescribeEnvironmentsRequest) (*tdmq.DescribeEnvironmentsResponse, error) {
+		msgTtl := int64(300)
+		timeInMinutes := int64(60)
+		sizeInMB := int64(10)
+		resp := tdmq.NewDescribeEnvironmentsResponse()
+		resp.Response = &tdmq.DescribeEnvironmentsResponseParams{
+			EnvironmentSet: []*tdmq.Environment{
+				{
+					EnvironmentId: ptrStringNamespace("test_ns"),
+					MsgTTL:        &msgTtl,
+					Remark:        ptrStringNamespace("test remark"),
+					RetentionPolicy: &tdmq.RetentionPolicy{
+						TimeInMinutes: &timeInMinutes,
+						SizeInMB:      &sizeInMB,
+					},
+					Tags: nil,
+				},
+			},
+			RequestId: ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTdmqNamespace()
+	res := tpulsar.ResourceTencentCloudTdmqNamespace()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"environ_name": "test_ns",
+		"msg_ttl":      300,
+		"cluster_id":   "pulsar-test",
+		"remark":       "test remark",
+	})
+	d.SetId("test_ns#pulsar-test")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test_ns#pulsar-test", d.Id())
 }
-`
+
+// TestTdmqNamespace_UpdateWithTagsImmutable tests that updating tags returns an error
+func TestTdmqNamespace_UpdateWithTagsImmutable(t *testing.T) {
+	// Verify that "tags" is in the immutableArgs list
+	immutableArgs := []string{"environ_name", "cluster_id", "tags"}
+	assert.Contains(t, immutableArgs, "tags", "tags should be in immutableArgs list")
+}
+
+// TestTdmqNamespace_Delete tests deleting a namespace
+func TestTdmqNamespace_Delete(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tdmqClient := &tdmq.Client{}
+	patches.ApplyMethodReturn(newMockMetaTdmqNamespace().client, "UseTdmqClient", tdmqClient)
+
+	// Mock DeleteEnvironments API
+	patches.ApplyMethodFunc(tdmqClient, "DeleteEnvironments", func(request *tdmq.DeleteEnvironmentsRequest) (*tdmq.DeleteEnvironmentsResponse, error) {
+		resp := tdmq.NewDeleteEnvironmentsResponse()
+		resp.Response = &tdmq.DeleteEnvironmentsResponseParams{
+			RequestId: ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTdmqNamespace()
+	res := tpulsar.ResourceTencentCloudTdmqNamespace()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"environ_name": "test_ns",
+		"msg_ttl":      300,
+		"cluster_id":   "pulsar-test",
+		"remark":       "test remark",
+	})
+	d.SetId("test_ns#pulsar-test")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+}

--- a/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace_test.go
+++ b/tencentcloud/services/tpulsar/resource_tc_tdmq_namespace_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	tag "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813"
 	tdmq "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq/v20200217"
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
@@ -29,14 +30,6 @@ func newMockMetaTdmqNamespace() *mockMetaTdmqNamespace {
 
 func ptrStringNamespace(s string) *string {
 	return &s
-}
-
-func ptrUint64Namespace(v uint64) *uint64 {
-	return &v
-}
-
-func ptrInt64Namespace(v int64) *int64 {
-	return &v
 }
 
 // TestTdmqNamespace_CreateWithTags tests creating a namespace with tags
@@ -296,8 +289,136 @@ func TestTdmqNamespace_ReadWithNilTags(t *testing.T) {
 // TestTdmqNamespace_UpdateWithTagsImmutable tests that updating tags returns an error
 func TestTdmqNamespace_UpdateWithTagsImmutable(t *testing.T) {
 	// Verify that "tags" is in the immutableArgs list
-	immutableArgs := []string{"environ_name", "cluster_id", "tags"}
-	assert.Contains(t, immutableArgs, "tags", "tags should be in immutableArgs list")
+	immutableArgs := []string{"environ_name", "cluster_id"}
+	assert.NotContains(t, immutableArgs, "tags", "tags should not be in immutableArgs list as it is updatable")
+}
+
+// TestTdmqNamespace_UpdateTags tests updating namespace tags
+func TestTdmqNamespace_UpdateTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tdmqClient := &tdmq.Client{}
+	tagClient := &tag.Client{}
+
+	// Mock TDMQ client
+	patches.ApplyMethodReturn(newMockMetaTdmqNamespace().client, "UseTdmqClient", tdmqClient)
+	// Mock Tag client
+	patches.ApplyMethodReturn(newMockMetaTdmqNamespace().client, "UseTagClient", tagClient)
+
+	// Mock ModifyEnvironmentAttributes API
+	patches.ApplyMethodFunc(tdmqClient, "ModifyEnvironmentAttributes", func(request *tdmq.ModifyEnvironmentAttributesRequest) (*tdmq.ModifyEnvironmentAttributesResponse, error) {
+		assert.NotNil(t, request.EnvironmentId)
+		assert.Equal(t, "test_ns", *request.EnvironmentId)
+		assert.NotNil(t, request.MsgTTL)
+		assert.Equal(t, uint64(400), *request.MsgTTL)
+		assert.NotNil(t, request.Remark)
+		assert.Equal(t, "updated remark", *request.Remark)
+
+		resp := tdmq.NewModifyEnvironmentAttributesResponse()
+		resp.Response = &tdmq.ModifyEnvironmentAttributesResponseParams{
+			EnvironmentId: ptrStringNamespace("test_ns"),
+			RequestId:     ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock ModifyResourceTags API
+	patches.ApplyMethodFunc(tagClient, "ModifyResourceTags", func(request *tag.ModifyResourceTagsRequest) (*tag.ModifyResourceTagsResponse, error) {
+		resp := tag.NewModifyResourceTagsResponse()
+		resp.Response = &tag.ModifyResourceTagsResponseParams{
+			RequestId: ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeEnvironments API (called by Read after Update)
+	patches.ApplyMethodFunc(tdmqClient, "DescribeEnvironments", func(request *tdmq.DescribeEnvironmentsRequest) (*tdmq.DescribeEnvironmentsResponse, error) {
+		msgTtl := int64(400)
+		timeInMinutes := int64(60)
+		sizeInMB := int64(10)
+		resp := tdmq.NewDescribeEnvironmentsResponse()
+		resp.Response = &tdmq.DescribeEnvironmentsResponseParams{
+			EnvironmentSet: []*tdmq.Environment{
+				{
+					EnvironmentId: ptrStringNamespace("test_ns"),
+					MsgTTL:        &msgTtl,
+					Remark:        ptrStringNamespace("updated remark"),
+					RetentionPolicy: &tdmq.RetentionPolicy{
+						TimeInMinutes: &timeInMinutes,
+						SizeInMB:      &sizeInMB,
+					},
+					Tags: []*tdmq.Tag{
+						{
+							TagKey:   ptrStringNamespace("env"),
+							TagValue: ptrStringNamespace("staging"),
+						},
+						{
+							TagKey:   ptrStringNamespace("team"),
+							TagValue: ptrStringNamespace("backend"),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringNamespace("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTdmqNamespace()
+	res := tpulsar.ResourceTencentCloudTdmqNamespace()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"environ_name": "test_ns",
+		"msg_ttl":      300,
+		"cluster_id":   "pulsar-test",
+		"remark":       "test remark",
+		"retention_policy": []interface{}{
+			map[string]interface{}{
+				"time_in_minutes": 60,
+				"size_in_mb":      10,
+			},
+		},
+		"tags": []interface{}{
+			map[string]interface{}{
+				"tag_key":   "env",
+				"tag_value": "prod",
+			},
+			map[string]interface{}{
+				"tag_key":   "team",
+				"tag_value": "platform",
+			},
+		},
+	})
+	d.SetId("test_ns#pulsar-test")
+
+	// Create new ResourceData with updated values to simulate update operation
+	// Note: environ_name and cluster_id are immutable and should not be included in update
+	updatedData := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"msg_ttl": 400,
+		"remark":  "updated remark",
+		"retention_policy": []interface{}{
+			map[string]interface{}{
+				"time_in_minutes": 60,
+				"size_in_mb":      10,
+			},
+		},
+		"tags": []interface{}{
+			map[string]interface{}{
+				"tag_key":   "env",
+				"tag_value": "staging",
+			},
+			map[string]interface{}{
+				"tag_key":   "team",
+				"tag_value": "backend",
+			},
+		},
+	})
+	updatedData.SetId("test_ns#pulsar-test")
+
+	// Simulate the update by calling Update method with the new data
+	err := res.Update(updatedData, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test_ns#pulsar-test", updatedData.Id())
 }
 
 // TestTdmqNamespace_Delete tests deleting a namespace

--- a/website/docs/r/tdmq_namespace.html.markdown
+++ b/website/docs/r/tdmq_namespace.html.markdown
@@ -31,6 +31,10 @@ resource "tencentcloud_tdmq_namespace" "example" {
     size_in_mb      = 10
   }
   remark = "remark."
+  tags {
+    tag_key   = "createdBy"
+    tag_value = "terraform"
+  }
 }
 ```
 
@@ -43,11 +47,17 @@ The following arguments are supported:
 * `msg_ttl` - (Required, Int) The expiration time of unconsumed message.
 * `remark` - (Optional, String) Description of the namespace.
 * `retention_policy` - (Optional, List) The Policy of message to retain. Format like: `{time_in_minutes: Int, size_in_mb: Int}`. `time_in_minutes`: the time of message to retain; `size_in_mb`: the size of message to retain.
+* `tags` - (Optional, List, ForceNew) The tags of the tdmq_namespace.
 
 The `retention_policy` object supports the following:
 
 * `size_in_mb` - (Optional, Int) the size of message to retain.
 * `time_in_minutes` - (Optional, Int) the time of message to retain.
+
+The `tags` object supports the following:
+
+* `tag_key` - (Required, String) Tag key.
+* `tag_value` - (Required, String) Tag value.
 
 ## Attributes Reference
 

--- a/website/docs/r/tdmq_namespace.html.markdown
+++ b/website/docs/r/tdmq_namespace.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `msg_ttl` - (Required, Int) The expiration time of unconsumed message.
 * `remark` - (Optional, String) Description of the namespace.
 * `retention_policy` - (Optional, List) The Policy of message to retain. Format like: `{time_in_minutes: Int, size_in_mb: Int}`. `time_in_minutes`: the time of message to retain; `size_in_mb`: the size of message to retain.
-* `tags` - (Optional, List, ForceNew) The tags of the tdmq_namespace.
+* `tags` - (Optional, List) The tags of the tencentcloud_tdmq_namespace.
 
 The `retention_policy` object supports the following:
 


### PR DESCRIPTION
Add tags parameter support to tencentcloud_tdmq_namespace resource. This allows users to specify tags when creating a TDMQ namespace, enabling better resource organization and management.