### PR TITLE
fix(waf): [135425948] `tencentcloud_waf_clb_domain` update doc

### DIFF
--- a/.changelog/4234.txt
+++ b/.changelog/4234.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_waf_clb_domain: update doc
+```

--- a/tencentcloud/services/waf/resource_tc_waf_clb_domain.md
+++ b/tencentcloud/services/waf/resource_tc_waf_clb_domain.md
@@ -1,5 +1,10 @@
 Provides a resource to create a Waf clb domain
 
+~> **NOTE:** There are two modes for the `flow_made` field:
+##### `Cleaning mode`: Business traffic is forwarded to the WAF cluster, which performs bypass detection and alerting, synchronizes requests for trusted status, and the gateway cluster intercepts or releases requests based on the status. (Recommended)
+##### `Mirror mode`: Mirror traffic to WAF cluster, WAF performs bypass detection and alarm, and does not return request trusted status.
+The default value for creating resources in TF is mirror mode. If WAF needs to handle traffic, please set it to clean mode.
+
 Example Usage
 
 Create a basic waf clb domain

--- a/website/docs/r/waf_clb_domain.html.markdown
+++ b/website/docs/r/waf_clb_domain.html.markdown
@@ -11,6 +11,11 @@ description: |-
 
 Provides a resource to create a Waf clb domain
 
+~> **NOTE:** There are two modes for the `flow_made` field:
+##### `Cleaning mode`: Business traffic is forwarded to the WAF cluster, which performs bypass detection and alerting, synchronizes requests for trusted status, and the gateway cluster intercepts or releases requests based on the status. (Recommended)
+##### `Mirror mode`: Mirror traffic to WAF cluster, WAF performs bypass detection and alarm, and does not return request trusted status.
+The default value for creating resources in TF is mirror mode. If WAF needs to handle traffic, please set it to clean mode.
+
 ## Example Usage
 
 ### Create a basic waf clb domain


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
