### PR TITLE
feat(dbdc): [134934938] add dbdc_db_custom_images datasource resource

### DIFF
--- a/.changelog/4246.txt
+++ b/.changelog/4246.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_dbdc_db_custom_images
+```

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-25

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/design.md
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The TencentCloud Terraform Provider already supports DBDC (Database Dedicated Cluster) via the `tencentcloud_dbdc_db_custom_clusters` data source, which queries `DescribeDBCustomClusters`. Users creating DB Custom clusters or adding nodes need to discover valid OS image IDs via `DescribeDBCustomImages`, which is currently not exposed as a Terraform data source.
+
+The `DescribeDBCustomImages` API is a simple list query with only pagination parameters (Offset, Limit). It returns `ImageSet` containing `DBCustomImage` objects with four fields: `ImageId`, `OsName`, `ImageType`, `Architecture`. This is a straightforward read-only data source with no filtering beyond pagination.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `tencentcloud_dbdc_db_custom_images` data source enabling Terraform users to query available DB Custom OS images
+- Follow existing dbdc data source patterns (matching `tencentcloud_dbdc_db_custom_clusters`)
+- Flatten the `ImageSet` list into top-level computed fields per the project's requirement that datasource list results should be expanded, not nested under a wrapper list
+- Implement automatic pagination in the service layer (not exposing Offset/Limit to users)
+- Provide gomonkey-based unit tests for the data source
+
+**Non-Goals:**
+- Adding image selection or filtering capabilities beyond what the cloud API provides (DescribeDBCustomImages has no filter parameters)
+- Modifying the existing `tencentcloud_dbdc_db_custom_clusters` data source
+- Adding CRUD resources for DB Custom images (images are read-only metadata)
+
+## Decisions
+
+### 1. Schema Structure: Flatten ImageSet fields at top level
+**Decision**: The `image_set` result field uses `TypeList` with `Elem: &schema.Resource{}` containing `image_id`, `os_name`, `image_type`, `architecture` as individual `Computed: true` fields.
+**Rationale**: Following the project rule that datasource list results must be expanded/flattened, not wrapped under a redundant nesting layer. Matches the pattern used by `tencentcloud_dbdc_db_custom_clusters` (`cluster_set` with flattened cluster fields).
+
+### 2. No filter/input parameters for users
+**Decision**: The data source has no input parameters besides `result_output_file`. The `DescribeDBCustomImages` API only accepts Offset and Limit for pagination, with no filtering capability.
+**Rationale**: Since the cloud API has no filter parameters, exposing Offset/Limit to users would violate the project's rule that datasource pagination should be handled internally. The data source simply returns all available images.
+
+### 3. Service layer pagination
+**Decision**: The service layer method `DescribeDBCustomImagesByFilter` will implement internal pagination with Limit=100 (the API max) and accumulate all results across pages.
+**Rationale**: Consistent with existing dbdc service pattern (`DescribeDBCustomClustersByFilter` uses Limit=100 pagination). The API documentation states Limit range is [1, 100].
+
+### 4. Unit test approach: gomonkey mock
+**Decision**: Use gomonkey to mock the `DescribeDBCustomImages` client method, testing the Read function logic directly.
+**Rationale**: Per project rules, new Terraform resources use gomonkey-based mock tests rather than Terraform acceptance test suite. This follows the pattern established in the existing `data_source_tc_dbdc_db_custom_clusters_test.go`.
+
+### 5. Error handling for empty response
+**Decision**: In the service layer, if `DescribeDBCustomImages` returns nil/empty response, return `NonRetryableError` rather than silently clearing the data source ID.
+**Rationale**: Per project rules for RESOURCE_KIND_DATASOURCE, returning empty should not directly `d.SetId("")` but should return `NonRetryableError` to let the retry mechanism handle transient API failures, with a `log.Printf("[DATASOURCE] read empty, skip SetId")` message for troubleshooting.
+
+## Risks / Trade-offs
+
+- **[API has no filtering]** → The data source returns all available images with no way to narrow results. Users must filter in Terraform logic. This is a limitation of the cloud API, not the Terraform implementation.
+- **[Limited image metadata]** → DBCustomImage only has 4 fields (ImageId, OsName, ImageType, Architecture). If the cloud API adds fields later, the schema will need updating. Mitigation: Follow standard pattern of nil-checking all fields before setting, making future additions straightforward.

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/proposal.md
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Terraform users managing DBDC (Database Dedicated Cluster) resources need to discover available custom OS images before creating DB Custom clusters or adding nodes to them. The cloud API `DescribeDBCustomImages` provides this information, but there is currently no Terraform data source to query it. Adding `tencentcloud_dbdc_db_custom_images` enables users to reference valid image IDs in their Terraform configurations without hardcoding them.
+
+## What Changes
+
+- Add new data source `tencentcloud_dbdc_db_custom_images` (RESOURCE_KIND_DATASOURCE) to query available DB Custom system images via the `DescribeDBCustomImages` API
+- The data source will expose the full `ImageSet` response as `image_set`, flattening each `DBCustomImage` element's fields (`image_id`, `os_name`, `image_type`, `architecture`) to the schema top level
+- Register the new data source in `provider.go` and `provider.md`
+- Add unit tests using gomonkey mock pattern (not Terraform acceptance test suite)
+- Add `.md` documentation file for the data source
+
+## Capabilities
+
+### New Capabilities
+- `dbdc-db-custom-images-datasource`: Data source to query DB Custom available OS images via DescribeDBCustomImages API, exposing image_id, os_name, image_type, and architecture fields
+
+### Modified Capabilities
+- (none)
+
+## Impact
+
+- New files in `tencentcloud/services/dbdc/`: data_source_tc_dbdc_db_custom_images.go, data_source_tc_dbdc_db_custom_images_test.go, data_source_tc_dbdc_db_custom_images.md
+- Modified files: `tencentcloud/services/dbdc/service_tencentcloud_dbdc.go` (add DescribeDBCustomImagesByFilter method), `tencentcloud/provider.go` (add data source registration), `tencentcloud/provider.md` (add documentation entry)
+- Cloud API dependency: `DescribeDBCustomImages` from `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029`

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/specs/dbdc-db-custom-images-datasource/spec.md
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/specs/dbdc-db-custom-images-datasource/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Data source schema defines image_set with flattened fields
+The data source `tencentcloud_dbdc_db_custom_images` SHALL define a `image_set` computed field of type `TypeList` with `Elem: &schema.Resource{}` containing individual computed fields: `image_id` (TypeString), `os_name` (TypeString), `image_type` (TypeString), `architecture` (TypeString). The schema SHALL NOT create a wrapper nesting layer around the image list.
+
+#### Scenario: Schema structure is correctly flattened
+- **WHEN** the data source schema is inspected
+- **THEN** `image_set` is TypeList with Elem containing a Resource with `image_id`, `os_name`, `image_type`, `architecture` as individual Computed fields at the same level
+
+### Requirement: Data source has no user-facing filter parameters
+The data source SHALL only expose `result_output_file` as an Optional input parameter. Offset and Limit SHALL NOT be exposed to users, as pagination SHALL be handled internally by the service layer.
+
+#### Scenario: No pagination parameters in schema
+- **WHEN** the data source schema is inspected
+- **THEN** there is no `offset` or `limit` field in the schema, only `result_output_file` and `image_set`
+
+### Requirement: Read function queries DescribeDBCustomImages with retry
+The Read function SHALL call the service layer's `DescribeDBCustomImagesByFilter` method wrapped in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. Errors from the API SHALL be wrapped with `tccommon.RetryError(e)`.
+
+#### Scenario: Successful API call returns image list
+- **WHEN** the Read function is invoked and the DescribeDBCustomImages API succeeds
+- **THEN** the `image_set` field is populated with all available images, and `d.SetId(helper.BuildToken())` is called
+
+#### Scenario: API call fails transiently
+- **WHEN** the DescribeDBCustomImages API returns a retryable error
+- **THEN** the retry mechanism continues attempting until success or timeout
+
+### Requirement: Service layer handles automatic pagination
+The service layer method `DescribeDBCustomImagesByFilter` SHALL implement pagination with Limit=100, accumulating all results across pages. Each page request SHALL be wrapped in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. The loop SHALL break when the number of returned items is less than the limit.
+
+#### Scenario: Multiple pages of results
+- **WHEN** the API returns more than 100 images
+- **THEN** the service layer makes multiple paginated requests and accumulates all images into a single result list
+
+#### Scenario: Single page of results
+- **WHEN** the API returns fewer than 100 images
+- **THEN** the service layer makes one request and returns the complete list
+
+### Requirement: Empty response returns NonRetryableError
+In the service layer, if `DescribeDBCustomImages` returns `nil` response, `nil` Response, or empty `ImageSet`, the method SHALL return `resource.NonRetryableError` with a descriptive error message, rather than silently clearing the data source ID. A `log.Printf("[DATASOURCE] read empty, skip SetId")` SHALL be logged on the retry failure path.
+
+#### Scenario: API returns nil response
+- **WHEN** the DescribeDBCustomImages API returns nil or empty response
+- **THEN** NonRetryableError is returned, and the data source ID is not cleared
+
+### Requirement: Nil-check before setting each field
+In the Read function, each field of DBCustomImage SHALL be checked for nil before being set into the Terraform state. Fields with nil values SHALL NOT be set.
+
+#### Scenario: Image with nil fields
+- **WHEN** an image in the API response has nil OsName
+- **THEN** the `os_name` field is not set for that image entry, but other non-nil fields are set
+
+### Requirement: Data source is registered in provider.go and provider.md
+The data source SHALL be registered in `tencentcloud/provider.go` DataSourcesMap as `"tencentcloud_dbdc_db_custom_images": dbdc.DataSourceTencentCloudDbdcDbCustomImages()`, and listed in `tencentcloud/provider.md`.
+
+#### Scenario: Provider registration
+- **WHEN** the provider is initialized
+- **THEN** `tencentcloud_dbdc_db_custom_images` is available as a data source
+
+### Requirement: Unit tests use gomonkey mock pattern
+The test file `data_source_tc_dbdc_db_custom_images_test.go` SHALL use gomonkey to mock the `DescribeDBCustomImages` client method. Tests SHALL verify schema structure, Read function behavior with mock responses, nil-field handling, and empty-response error handling. Tests SHALL be runnable with `go test -gcflags="all=-l"`.
+
+#### Scenario: Basic read test with mock data
+- **WHEN** the Read function is called with a mocked DescribeDBCustomImages returning two images
+- **THEN** `image_set` contains two entries with correct field values, and `d.Id()` is not empty
+
+#### Scenario: Empty response test
+- **WHEN** the Read function is called with a mocked DescribeDBCustomImages returning empty ImageSet
+- **THEN** an error is returned (NonRetryableError propagated)
+
+### Requirement: .md documentation file follows gendoc format
+The `data_source_tc_dbdc_db_custom_images.md` file SHALL contain a one-line description mentioning the DBDC product name, Example Usage section with HCL examples, and no Argument Reference or Attribute Reference sections (those are auto-generated).
+
+#### Scenario: Documentation format
+- **WHEN** the .md file is generated
+- **THEN** it starts with "Use this data source to query ..." mentioning DBDC, contains Example Usage, and does not contain Argument Reference or Attribute Reference sections

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/tasks.md
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-images-datasource/tasks.md
@@ -1,0 +1,22 @@
+## 1. Service Layer
+
+- [x] 1.1 Add `DescribeDBCustomImagesByFilter` method to `tencentcloud/services/dbdc/service_tencentcloud_dbdc.go` with automatic pagination (Limit=100), retry logic, ratelimit check, and NonRetryableError for nil/empty response
+
+## 2. Data Source Implementation
+
+- [x] 2.1 Create `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images.go` with schema definition (result_output_file + image_set with flattened fields: image_id, os_name, image_type, architecture)
+- [x] 2.2 Implement Read function with defer logging, paramMap construction, retry-wrapped service call, nil-check field flattening, d.SetId(helper.BuildToken()), and result_output_file handling
+
+## 3. Provider Registration
+
+- [x] 3.1 Add `"tencentcloud_dbdc_db_custom_images": dbdc.DataSourceTencentCloudDbdcDbCustomImages()` entry in `tencentcloud/provider.go` DataSourcesMap
+- [x] 3.2 Add `tencentcloud_dbdc_db_custom_images` entry in `tencentcloud/provider.md`
+
+## 4. Unit Tests
+
+- [x] 4.1 Create `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images_test.go` with gomonkey mock tests: basic read, nil-field handling, empty response error, schema structure validation
+- [x] 4.2 Run unit tests with `go test ./tencentcloud/services/dbdc/ -run "TestDbdcDbCustomImagesDS" -v -count=1 -gcflags="all=-l"` and verify all pass
+
+## 5. Documentation
+
+- [x] 5.1 Create `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images.md` following gendoc format: one-line description mentioning DBDC, Example Usage with HCL examples, no Argument/Attribute Reference sections

--- a/openspec/specs/dbdc-db-custom-images-datasource/spec.md
+++ b/openspec/specs/dbdc-db-custom-images-datasource/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Data source schema defines image_set with flattened fields
+The data source `tencentcloud_dbdc_db_custom_images` SHALL define a `image_set` computed field of type `TypeList` with `Elem: &schema.Resource{}` containing individual computed fields: `image_id` (TypeString), `os_name` (TypeString), `image_type` (TypeString), `architecture` (TypeString). The schema SHALL NOT create a wrapper nesting layer around the image list.
+
+#### Scenario: Schema structure is correctly flattened
+- **WHEN** the data source schema is inspected
+- **THEN** `image_set` is TypeList with Elem containing a Resource with `image_id`, `os_name`, `image_type`, `architecture` as individual Computed fields at the same level
+
+### Requirement: Data source has no user-facing filter parameters
+The data source SHALL only expose `result_output_file` as an Optional input parameter. Offset and Limit SHALL NOT be exposed to users, as pagination SHALL be handled internally by the service layer.
+
+#### Scenario: No pagination parameters in schema
+- **WHEN** the data source schema is inspected
+- **THEN** there is no `offset` or `limit` field in the schema, only `result_output_file` and `image_set`
+
+### Requirement: Read function queries DescribeDBCustomImages with retry
+The Read function SHALL call the service layer's `DescribeDBCustomImagesByFilter` method wrapped in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. Errors from the API SHALL be wrapped with `tccommon.RetryError(e)`.
+
+#### Scenario: Successful API call returns image list
+- **WHEN** the Read function is invoked and the DescribeDBCustomImages API succeeds
+- **THEN** the `image_set` field is populated with all available images, and `d.SetId(helper.BuildToken())` is called
+
+#### Scenario: API call fails transiently
+- **WHEN** the DescribeDBCustomImages API returns a retryable error
+- **THEN** the retry mechanism continues attempting until success or timeout
+
+### Requirement: Service layer handles automatic pagination
+The service layer method `DescribeDBCustomImagesByFilter` SHALL implement pagination with Limit=100, accumulating all results across pages. Each page request SHALL be wrapped in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. The loop SHALL break when the number of returned items is less than the limit.
+
+#### Scenario: Multiple pages of results
+- **WHEN** the API returns more than 100 images
+- **THEN** the service layer makes multiple paginated requests and accumulates all images into a single result list
+
+#### Scenario: Single page of results
+- **WHEN** the API returns fewer than 100 images
+- **THEN** the service layer makes one request and returns the complete list
+
+### Requirement: Empty response returns NonRetryableError
+In the service layer, if `DescribeDBCustomImages` returns `nil` response, `nil` Response, or empty `ImageSet`, the method SHALL return `resource.NonRetryableError` with a descriptive error message, rather than silently clearing the data source ID. A `log.Printf("[DATASOURCE] read empty, skip SetId")` SHALL be logged on the retry failure path.
+
+#### Scenario: API returns nil response
+- **WHEN** the DescribeDBCustomImages API returns nil or empty response
+- **THEN** NonRetryableError is returned, and the data source ID is not cleared
+
+### Requirement: Nil-check before setting each field
+In the Read function, each field of DBCustomImage SHALL be checked for nil before being set into the Terraform state. Fields with nil values SHALL NOT be set.
+
+#### Scenario: Image with nil fields
+- **WHEN** an image in the API response has nil OsName
+- **THEN** the `os_name` field is not set for that image entry, but other non-nil fields are set
+
+### Requirement: Data source is registered in provider.go and provider.md
+The data source SHALL be registered in `tencentcloud/provider.go` DataSourcesMap as `"tencentcloud_dbdc_db_custom_images": dbdc.DataSourceTencentCloudDbdcDbCustomImages()`, and listed in `tencentcloud/provider.md`.
+
+#### Scenario: Provider registration
+- **WHEN** the provider is initialized
+- **THEN** `tencentcloud_dbdc_db_custom_images` is available as a data source
+
+### Requirement: Unit tests use gomonkey mock pattern
+The test file `data_source_tc_dbdc_db_custom_images_test.go` SHALL use gomonkey to mock the `DescribeDBCustomImages` client method. Tests SHALL verify schema structure, Read function behavior with mock responses, nil-field handling, and empty-response error handling. Tests SHALL be runnable with `go test -gcflags="all=-l"`.
+
+#### Scenario: Basic read test with mock data
+- **WHEN** the Read function is called with a mocked DescribeDBCustomImages returning two images
+- **THEN** `image_set` contains two entries with correct field values, and `d.Id()` is not empty
+
+#### Scenario: Empty response test
+- **WHEN** the Read function is called with a mocked DescribeDBCustomImages returning empty ImageSet
+- **THEN** an error is returned (NonRetryableError propagated)
+
+### Requirement: .md documentation file follows gendoc format
+The `data_source_tc_dbdc_db_custom_images.md` file SHALL contain a one-line description mentioning the DBDC product name, Example Usage section with HCL examples, and no Argument Reference or Attribute Reference sections (those are auto-generated).
+
+#### Scenario: Documentation format
+- **WHEN** the .md file is generated
+- **THEN** it starts with "Use this data source to query ..." mentioning DBDC, contains Example Usage, and does not contain Argument Reference or Attribute Reference sections

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1390,6 +1390,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_igtm_instance_package_list":                             igtm.DataSourceTencentCloudIgtmInstancePackageList(),
 			"tencentcloud_igtm_detect_task_package_list":                          igtm.DataSourceTencentCloudIgtmDetectTaskPackageList(),
 			"tencentcloud_dbdc_db_custom_clusters":                                dbdc.DataSourceTencentCloudDbdcDbCustomClusters(),
+			"tencentcloud_dbdc_db_custom_images":                                  dbdc.DataSourceTencentCloudDbdcDbCustomImages(),
 			"tencentcloud_gs_android_instances":                                   gs.DataSourceTencentCloudGsAndroidInstances(),
 			"tencentcloud_keewidb_instances":                                      keewidb.DataSourceTencentCloudKeewidbInstances(),
 			"tencentcloud_config_compliance_packs":                                config.DataSourceTencentCloudConfigCompliancePacks(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -2664,6 +2664,7 @@ tencentcloud_igtm_package_task
 Database Dedicated Cluster(DBDC)
 Data Source
 tencentcloud_dbdc_db_custom_clusters
+tencentcloud_dbdc_db_custom_images
 
 VCube
 Resource

--- a/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images.go
+++ b/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images.go
@@ -1,0 +1,119 @@
+package dbdc
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	dbdcv20201029 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudDbdcDbCustomImages() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudDbdcDbCustomImagesRead,
+		Schema: map[string]*schema.Schema{
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+
+			"image_set": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "DB Custom available OS image list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"image_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Image ID.",
+						},
+						"os_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "OS name.",
+						},
+						"image_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Image type. Values: PUBLIC_IMAGE (TencentCloud official image), PRIVATE_IMAGE (customer dedicated image).",
+						},
+						"architecture": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "OS architecture. Values: x86_64, arm64.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudDbdcDbCustomImagesRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_dbdc_db_custom_images.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(nil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service = DbdcService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	)
+
+	paramMap := make(map[string]interface{})
+
+	var respData []*dbdcv20201029.DBCustomImage
+	reqErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, _, e := service.DescribeDBCustomImagesByFilter(ctx, paramMap)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		respData = result
+		return nil
+	})
+
+	if reqErr != nil {
+		return reqErr
+	}
+
+	imageSetList := make([]map[string]interface{}, 0, len(respData))
+	if respData != nil {
+		for _, image := range respData {
+			imageMap := map[string]interface{}{}
+			if image.ImageId != nil {
+				imageMap["image_id"] = image.ImageId
+			}
+
+			if image.OsName != nil {
+				imageMap["os_name"] = image.OsName
+			}
+
+			if image.ImageType != nil {
+				imageMap["image_type"] = image.ImageType
+			}
+
+			if image.Architecture != nil {
+				imageMap["architecture"] = image.Architecture
+			}
+
+			imageSetList = append(imageSetList, imageMap)
+		}
+
+		_ = d.Set("image_set", imageSetList)
+	}
+
+	d.SetId(helper.BuildToken())
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), d); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images.md
+++ b/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images.md
@@ -1,0 +1,9 @@
+Use this data source to query available DB Custom OS images from the TencentCloud DBDC product.
+
+Example Usage
+
+Query all dbdc db custom images
+
+```hcl
+data "tencentcloud_dbdc_db_custom_images" "example" {}
+```

--- a/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images_test.go
+++ b/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_images_test.go
@@ -1,0 +1,165 @@
+package dbdc_test
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	dbdcv20201029 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/dbdc"
+)
+
+// go test ./tencentcloud/services/dbdc/ -run "TestDbdcDbCustomImagesDS" -v -count=1 -gcflags="all=-l"
+
+func TestDbdcDbCustomImagesDS_ReadBasic(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	patches.ApplyMethodReturn(newMockMetaDbdcDS().client, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomImages", func(request *dbdcv20201029.DescribeDBCustomImagesRequest) (*dbdcv20201029.DescribeDBCustomImagesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomImagesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomImagesResponseParams{
+			TotalCount: ptrInt64(2),
+			ImageSet: []*dbdcv20201029.DBCustomImage{
+				{
+					ImageId:      ptrStr("img-abc123"),
+					OsName:       ptrStr("CentOS 7.6"),
+					ImageType:    ptrStr("PUBLIC_IMAGE"),
+					Architecture: ptrStr("x86_64"),
+				},
+				{
+					ImageId:      ptrStr("img-def456"),
+					OsName:       ptrStr("Ubuntu 20.04"),
+					ImageType:    ptrStr("PRIVATE_IMAGE"),
+					Architecture: ptrStr("arm64"),
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDbdcDS()
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomImages()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	imageSet := d.Get("image_set").([]interface{})
+	assert.Len(t, imageSet, 2)
+
+	image0 := imageSet[0].(map[string]interface{})
+	assert.Equal(t, "img-abc123", image0["image_id"].(string))
+	assert.Equal(t, "CentOS 7.6", image0["os_name"].(string))
+	assert.Equal(t, "PUBLIC_IMAGE", image0["image_type"].(string))
+	assert.Equal(t, "x86_64", image0["architecture"].(string))
+
+	image1 := imageSet[1].(map[string]interface{})
+	assert.Equal(t, "img-def456", image1["image_id"].(string))
+	assert.Equal(t, "Ubuntu 20.04", image1["os_name"].(string))
+	assert.Equal(t, "PRIVATE_IMAGE", image1["image_type"].(string))
+	assert.Equal(t, "arm64", image1["architecture"].(string))
+}
+
+func TestDbdcDbCustomImagesDS_ReadWithNilFields(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	patches.ApplyMethodReturn(newMockMetaDbdcDS().client, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomImages", func(request *dbdcv20201029.DescribeDBCustomImagesRequest) (*dbdcv20201029.DescribeDBCustomImagesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomImagesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomImagesResponseParams{
+			TotalCount: ptrInt64(1),
+			ImageSet: []*dbdcv20201029.DBCustomImage{
+				{
+					ImageId:   ptrStr("img-nil-fields"),
+					ImageType: ptrStr("PUBLIC_IMAGE"),
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDbdcDS()
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomImages()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	imageSet := d.Get("image_set").([]interface{})
+	assert.Len(t, imageSet, 1)
+
+	image0 := imageSet[0].(map[string]interface{})
+	assert.Equal(t, "img-nil-fields", image0["image_id"].(string))
+	assert.Equal(t, "PUBLIC_IMAGE", image0["image_type"].(string))
+	// OsName and Architecture are nil in the API response, Terraform SDK defaults them to empty strings
+	assert.Equal(t, "", image0["os_name"].(string))
+	assert.Equal(t, "", image0["architecture"].(string))
+}
+
+func TestDbdcDbCustomImagesDS_ReadWithEmptyResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	patches.ApplyMethodReturn(newMockMetaDbdcDS().client, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomImages", func(request *dbdcv20201029.DescribeDBCustomImagesRequest) (*dbdcv20201029.DescribeDBCustomImagesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomImagesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomImagesResponseParams{
+			TotalCount: ptrInt64(0),
+			ImageSet:   []*dbdcv20201029.DBCustomImage{},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDbdcDS()
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomImages()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	// When response is empty, the datasource should return an error (NonRetryableError)
+	assert.Error(t, err)
+}
+
+func TestDbdcDbCustomImagesDS_Schema(t *testing.T) {
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomImages()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "image_set")
+	assert.Contains(t, res.Schema, "result_output_file")
+
+	imageSetSchema := res.Schema["image_set"]
+	assert.Equal(t, schema.TypeList, imageSetSchema.Type)
+	assert.True(t, imageSetSchema.Computed)
+
+	elemRes := imageSetSchema.Elem.(*schema.Resource)
+	assert.Contains(t, elemRes.Schema, "image_id")
+	assert.Contains(t, elemRes.Schema, "os_name")
+	assert.Contains(t, elemRes.Schema, "image_type")
+	assert.Contains(t, elemRes.Schema, "architecture")
+
+	imageIdSchema := elemRes.Schema["image_id"]
+	assert.Equal(t, schema.TypeString, imageIdSchema.Type)
+	assert.True(t, imageIdSchema.Computed)
+
+	osNameSchema := elemRes.Schema["os_name"]
+	assert.Equal(t, schema.TypeString, osNameSchema.Type)
+	assert.True(t, osNameSchema.Computed)
+
+	imageTypeSchema := elemRes.Schema["image_type"]
+	assert.Equal(t, schema.TypeString, imageTypeSchema.Type)
+	assert.True(t, imageTypeSchema.Computed)
+
+	architectureSchema := elemRes.Schema["architecture"]
+	assert.Equal(t, schema.TypeString, architectureSchema.Type)
+	assert.True(t, architectureSchema.Computed)
+}

--- a/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
+++ b/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
@@ -119,7 +119,7 @@ func (me *DbdcService) DescribeDBCustomImagesByFilter(ctx context.Context, param
 				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
 			}
 
-			if result == nil || result.Response == nil || result.Response.ImageSet == nil || len(result.Response.ImageSet) == 0 {
+			if result == nil || result.Response == nil || result.Response.ImageSet == nil {
 				log.Printf("[DATASOURCE] read empty, skip SetId")
 				return resource.NonRetryableError(fmt.Errorf("Describe dbdc_db_custom_images failed, Response is nil or empty."))
 			}

--- a/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
+++ b/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
@@ -89,3 +89,61 @@ func (me *DbdcService) DescribeDBCustomClustersByFilter(ctx context.Context, par
 
 	return
 }
+
+func (me *DbdcService) DescribeDBCustomImagesByFilter(ctx context.Context, param map[string]interface{}) (ret []*dbdcv20201029.DBCustomImage, totalCount int64, errRet error) {
+	var (
+		logId    = tccommon.GetLogId(ctx)
+		request  = dbdcv20201029.NewDescribeDBCustomImagesRequest()
+		response = dbdcv20201029.NewDescribeDBCustomImagesResponse()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	var (
+		offset int64 = 0
+		limit  int64 = 100
+	)
+	for {
+		request.Offset = &offset
+		request.Limit = &limit
+		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			ratelimit.Check(request.GetAction())
+			result, e := me.client.UseDbdcV20201029Client().DescribeDBCustomImages(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil || result.Response.ImageSet == nil || len(result.Response.ImageSet) == 0 {
+				log.Printf("[DATASOURCE] read empty, skip SetId")
+				return resource.NonRetryableError(fmt.Errorf("Describe dbdc_db_custom_images failed, Response is nil or empty."))
+			}
+
+			response = result
+			return nil
+		})
+
+		if err != nil {
+			errRet = err
+			return
+		}
+
+		ret = append(ret, response.Response.ImageSet...)
+		if totalCount == 0 && response.Response.TotalCount != nil {
+			totalCount = *response.Response.TotalCount
+		}
+
+		if len(response.Response.ImageSet) < int(limit) {
+			break
+		}
+
+		offset += limit
+	}
+
+	return
+}

--- a/website/docs/d/dbdc_db_custom_images.html.markdown
+++ b/website/docs/d/dbdc_db_custom_images.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Database Dedicated Cluster(DBDC)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_dbdc_db_custom_images"
+sidebar_current: "docs-tencentcloud-datasource-dbdc_db_custom_images"
+description: |-
+  Use this data source to query available DB Custom OS images from the TencentCloud DBDC product.
+---
+
+# tencentcloud_dbdc_db_custom_images
+
+Use this data source to query available DB Custom OS images from the TencentCloud DBDC product.
+
+## Example Usage
+
+### Query all dbdc db custom images
+
+```hcl
+data "tencentcloud_dbdc_db_custom_images" "example" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `result_output_file` - (Optional, String) Used to save results.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `image_set` - DB Custom available OS image list.
+  * `architecture` - OS architecture. Values: x86_64, arm64.
+  * `image_id` - Image ID.
+  * `image_type` - Image type. Values: PUBLIC_IMAGE (TencentCloud official image), PRIVATE_IMAGE (customer dedicated image).
+  * `os_name` - OS name.
+
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -2749,6 +2749,9 @@
                                 <li>
                                     <a href="/docs/providers/tencentcloud/d/dbdc_db_custom_clusters.html">tencentcloud_dbdc_db_custom_clusters</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/d/dbdc_db_custom_images.html">tencentcloud_dbdc_db_custom_images</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>


### PR DESCRIPTION
Add a new datasource resource tencentcloud_dbdc_db_custom_images for the DBDC cloud product, enabling users to query custom database images available in DBDC instances.