### PR TITLE
feat(dbdc): [134934938] add datasource tencentcloud_dbdc_db_custom_nodes

### DIFF
--- a/.changelog/4247.txt
+++ b/.changelog/4247.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_dbdc_db_custom_nodes
+```

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-25

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/design.md
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The Terraform Provider for TencentCloud currently supports the dbdc (Database Dedicated Cluster) product but lacks a datasource for querying DB Custom nodes. Users who manage DB Custom nodes need a way to discover and reference existing nodes in their Terraform configurations without hardcoding values. The `DescribeDBCustomNodes` cloud API (dbdc v20201029) provides the capability to query nodes by IDs, filters, or tags, and returns detailed node attributes including CPU, memory, disk info, network info, status, and billing info.
+
+The existing provider pattern for datasource resources follows a consistent structure: schema definition in `data_source_tc_<service>_<name>.go`, service layer method in `service_tencentcloud_<service>.go`, registration in `provider.go`, and documentation in `.md` files. The reference implementation `tencentcloud_igtm_instance_list` demonstrates the standard datasource pattern with filters and list output.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a RESOURCE_KIND_DATASOURCE `tencentcloud_dbdc_db_custom_nodes` that queries DB Custom nodes via `DescribeDBCustomNodes` API
+- Support optional filter inputs: `node_ids`, `filters`, and `tags`
+- Expose full node attribute details in `node_set` computed output (flattened, no nested wrapper)
+- Implement internal pagination to fetch all results without exposing `limit`/`offset` to users
+- Follow the established datasource pattern (retry, error handling, nil checks)
+
+**Non-Goals:**
+- Creating CRUD resources for DB Custom nodes (only datasource needed)
+- Modifying any existing dbdc resources or datasources
+- Adding write operations (create, update, delete) for DB Custom nodes
+
+## Decisions
+
+1. **Pagination approach**: Internal pagination using `Offset`/`Limit` parameters in the API call, with `Limit` set to 100 (max per API docs). Users will NOT see `limit`/`offset` in the schema. The service layer will loop until all results are collected.
+
+2. **Schema flattening**: The `node_set` output will be a `TypeList` of `TypeMap` (schema.Resource) where each element's fields are flattened at the top level. No `xxx_set`/`xxx_list` wrapper around all fields. Nested structures (`SystemDisk`, `DataDisks`, `Tags`) will be represented as `TypeList`/`TypeMap` sub-blocks within each node element.
+
+3. **Filter input format**: `filters` uses `TypeList` with `name` (Required, string) and `values` (Required, TypeSet of string) sub-fields, matching the standard Filter pattern. `tags` uses `TypeList` with `key` (Required, string) and `value` (Required, string) sub-fields. `node_ids` uses `TypeList` of string.
+
+4. **Result ID**: Use `helper.BuildToken()` as the datasource ID (standard pattern for list datasources).
+
+5. **Retry and error handling**: Use `tccommon.ReadRetryTimeout` with `resource.Retry()` for the Read operation. If the API returns empty results (nil response/empty NodeSet), return `NonRetryableError` instead of silently clearing the ID, per the datasource guidelines.
+
+6. **Nil field checks**: Before calling `d.Set()` for any response field, check if the corresponding API response field is nil. Skip setting if nil.
+
+7. **Service layer**: Add a `DescribeDbdcDbCustomNodesByFilter` method in `service_tencentcloud_dbdc.go` that handles pagination, request construction, and response parsing.
+
+## Risks / Trade-offs
+
+- **[API pagination limits]** The API allows max Limit=100 per request. If a user has more than 100 nodes, multiple API calls are needed internally. → Mitigation: Implement pagination loop in service layer.
+- **[Nil response fields]** Some fields like `SystemDisk`, `DataDisks`, and `Tags` in `DBCustomNode` may return nil per API documentation. → Mitigation: Check nil before setting each field.
+- **[No result validation]** As a datasource, there's no strong guarantee the API will return data for every query combination. → Mitigation: Return `NonRetryableError` on empty results to let retry mechanism handle transient API issues.

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/proposal.md
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Terraform Provider for TencentCloud currently lacks a datasource for querying DB Custom node list in the dbdc (Database Dedicated Cluster) product. Users need to query DB Custom nodes by node IDs, filters, or tags to reference existing node attributes in their Terraform configurations. Adding this datasource enables users to discover and reference DB Custom nodes without hardcoding values.
+
+## What Changes
+
+- Add a new RESOURCE_KIND_DATASOURCE `tencentcloud_dbdc_db_custom_nodes` to the Terraform provider
+- Implement the Read operation using the `DescribeDBCustomNodes` cloud API (dbdc v20201029)
+- Support query parameters: `node_ids`, `filters`, `tags` as optional input filters
+- Expose `node_set` as computed output containing the list of DB Custom nodes with all their attributes
+- Register the new datasource in `tencentcloud/provider.go`
+- Add corresponding documentation in `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.md`
+
+## Capabilities
+
+### New Capabilities
+- `dbdc-db-custom-nodes-datasource`: A datasource that queries DB Custom node list via the DescribeDBCustomNodes API, supporting filtering by node_ids, filters, and tags, and exposing the full node set attributes.
+
+### Modified Capabilities
+(No existing capabilities are modified)
+
+## Impact
+
+- New files: `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.go`, `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes_test.go`, `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.md`
+- Modified files: `tencentcloud/provider.go` (datasource registration), `tencentcloud/services/dbdc/service_tencentcloud_dbdc.go` (service layer method for DescribeDBCustomNodes)
+- Cloud API dependency: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029` (DescribeDBCustomNodes)

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/specs/dbdc-db-custom-nodes-datasource/spec.md
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/specs/dbdc-db-custom-nodes-datasource/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Datasource schema definition
+The system SHALL define a Terraform datasource schema for `tencentcloud_dbdc_db_custom_nodes` with the following input parameters:
+- `node_ids`: Optional, TypeList of string - filter by one or more node IDs (max 100 per request)
+- `filters`: Optional, TypeList of schema.Resource with sub-fields `name` (Required, string) and `values` (Required, TypeSet of string) - filter by cluster-id, node-name, status, zone
+- `tags`: Optional, TypeList of schema.Resource with sub-fields `key` (Required, string) and `value` (Required, string) - filter by tag key-value pairs
+- `result_output_file`: Optional, TypeString - used to save results to file
+
+The system SHALL define computed output parameters:
+- `node_set`: Computed, TypeList of schema.Resource containing flattened node attributes
+- Each node element SHALL contain: `node_id`, `node_name`, `ssh_endpoint`, `lan_ip`, `cluster_id`, `zone`, `node_type`, `cpu`, `memory`, `system_disk` (TypeList of schema.Resource with `disk_type`, `disk_size`), `data_disks` (TypeList of schema.Resource with `disk_type`, `disk_size`, `disk_name`), `os_name`, `image_id`, `vpc_id`, `subnet_id`, `status`, `charge_type`, `expire_time`, `created_time`, `isolated_time`, `tags` (TypeList of schema.Resource with `key`, `value`), `auto_renew`, `switch_id`, `rack_id`, `host_ip`
+
+#### Scenario: Datasource with filters input
+- **WHEN** a user provides `filters` with `name` = "cluster-id" and `values` = ["cluster-123"]
+- **THEN** the system SHALL call DescribeDBCustomNodes API with the corresponding Filter parameter and return matching nodes
+
+#### Scenario: Datasource with node_ids input
+- **WHEN** a user provides `node_ids` = ["node-1", "node-2"]
+- **THEN** the system SHALL call DescribeDBCustomNodes API with NodeIds parameter containing those IDs
+
+#### Scenario: Datasource with tags input
+- **WHEN** a user provides `tags` with `key` = "env" and `value` = "prod"
+- **THEN** the system SHALL call DescribeDBCustomNodes API with Tags parameter containing that key-value pair
+
+#### Scenario: Datasource with no filter inputs
+- **WHEN** a user provides no filter inputs (node_ids, filters, tags all empty)
+- **THEN** the system SHALL call DescribeDBCustomNodes API without filters and return all nodes the account has access to
+
+### Requirement: Read operation with retry and pagination
+The system SHALL implement a Read function that calls `DescribeDBCustomNodes` API with `tccommon.ReadRetryTimeout` retry logic. The system SHALL implement internal pagination by setting `Limit` to 100 (API max) and incrementing `Offset` until all results are collected. The system SHALL NOT expose `limit` or `offset` parameters to users in the schema.
+
+#### Scenario: Successful read with pagination
+- **WHEN** the API returns more than 100 nodes total
+- **THEN** the system SHALL make multiple API calls with incremented Offset values and concatenate all NodeSet results into a single `node_set` output
+
+#### Scenario: API retry on transient failure
+- **WHEN** the DescribeDBCustomNodes API call fails with a transient error
+- **THEN** the system SHALL retry the call using `tccommon.ReadRetryTimeout` and `tccommon.RetryError()` for error wrapping
+
+#### Scenario: Empty API response
+- **WHEN** the DescribeDBCustomNodes API returns nil response or empty NodeSet
+- **THEN** the system SHALL return `NonRetryableError` instead of clearing `d.SetId("")`, and SHALL log `log.Printf("[DATASOURCE] read empty, skip SetId")`
+
+### Requirement: Nil field handling in response
+The system SHALL check each response field for nil before calling `d.Set()` or adding it to the output map. Fields that may be nil according to API documentation (`SystemDisk`, `DataDisks`, `Tags` in DBCustomNode) SHALL be skipped when nil rather than set to empty values.
+
+#### Scenario: Node with nil SystemDisk
+- **WHEN** a DBCustomNode has nil `SystemDisk` field
+- **THEN** the system SHALL skip setting `system_disk` for that node element
+
+#### Scenario: Node with nil DataDisks
+- **WHEN** a DBCustomNode has nil `DataDisks` field
+- **THEN** the system SHALL skip setting `data_disks` for that node element
+
+### Requirement: Datasource ID generation
+The system SHALL use `helper.BuildToken()` as the datasource ID after successful read, following the standard pattern for list-type datasources.
+
+#### Scenario: Successful datasource read
+- **WHEN** the Read function completes successfully with data
+- **THEN** the system SHALL set `d.SetId(helper.BuildToken())`
+
+### Requirement: Provider registration
+The system SHALL register the new datasource `tencentcloud_dbdc_db_custom_nodes` in `tencentcloud/provider.go` with the datasource mapping entry.
+
+#### Scenario: Provider registration
+- **WHEN** the provider is initialized
+- **THEN** `tencentcloud_dbdc_db_custom_nodes` SHALL be available as a datasource in Terraform configurations
+
+### Requirement: Documentation
+The system SHALL provide documentation in `data_source_tc_dbdc_db_custom_nodes.md` with:
+- One-sentence description using format "Use this data source to query ..." mentioning the dbdc product
+- Example Usage section showing filter and output usage
+- No Import section (datasource type does not have import)
+- No Argument Reference or Attribute Reference sections (auto-generated)
+
+#### Scenario: Documentation file creation
+- **WHEN** the datasource is added
+- **THEN** the .md file SHALL contain description, example usage, and follow the standard datasource documentation format
+
+### Requirement: Unit tests with mock
+The system SHALL provide unit tests in `data_source_tc_dbdc_db_custom_nodes_test.go` using gomonkey mock approach (not Terraform test suite). The tests SHALL cover the Read function logic including request construction and response parsing. Tests SHALL be runnable with `go test -gcflags=all=-l`.
+
+#### Scenario: Mock-based unit test for Read
+- **WHEN** unit tests are executed
+- **THEN** the gomonkey mock SHALL replace the API client call and verify correct schema population from mock response data

--- a/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/tasks.md
+++ b/openspec/changes/archive/2026-06-25-add-dbdc-db-custom-nodes-datasource/tasks.md
@@ -1,0 +1,21 @@
+## 1. Service Layer
+
+- [x] 1.1 Add `DescribeDbdcDbCustomNodesByFilter` method in `tencentcloud/services/dbdc/service_tencentcloud_dbdc.go` with internal pagination (Limit=100, increment Offset until all results collected), request construction from paramMap, and response parsing returning NodeSet list
+
+## 2. Datasource Schema and Read Function
+
+- [x] 2.1 Create `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.go` with `DataSourceTencentCloudDbdcDbCustomNodes()` schema definition including input parameters: `node_ids` (Optional, TypeList of string), `filters` (Optional, TypeList with `name` and `values` sub-fields), `tags` (Optional, TypeList with `key` and `value` sub-fields), `result_output_file` (Optional, TypeString), and computed output `node_set` (TypeList of schema.Resource with all flattened DBCustomNode fields)
+- [x] 2.2 Implement `dataSourceTencentCloudDbdcDbCustomNodesRead` function with: defer LogElapsed/InconsistentCheck, paramMap construction from schema inputs, resource.Retry with ReadRetryTimeout calling service method, nil checks before d.Set(), NonRetryableError on empty response, and d.SetId(helper.BuildToken()) on success
+
+## 3. Provider Registration
+
+- [x] 3.1 Add `tencentcloud_dbdc_db_custom_nodes` datasource entry in `tencentcloud/provider.go` mapping to `dbdc.DataSourceTencentCloudDbdcDbCustomNodes()`
+
+## 4. Documentation
+
+- [x] 4.1 Create `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.md` with: one-sentence description ("Use this data source to query DB Custom node list in dbdc product"), Example Usage section showing filters/node_ids/tags inputs and node_set output, no Import section, no Argument/Attribute Reference sections
+
+## 5. Unit Tests
+
+- [x] 5.1 Create `tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes_test.go` with gomonkey mock-based unit tests covering: Read function request construction, response parsing with nil field handling, and pagination logic; runnable with `go test -gcflags=all=-l`
+- [x] 5.2 Run unit tests with `go test -gcflags=all=-l` to verify all test cases pass

--- a/openspec/specs/dbdc-db-custom-nodes-datasource/spec.md
+++ b/openspec/specs/dbdc-db-custom-nodes-datasource/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Datasource schema definition
+The system SHALL define a Terraform datasource schema for `tencentcloud_dbdc_db_custom_nodes` with the following input parameters:
+- `node_ids`: Optional, TypeList of string - filter by one or more node IDs (max 100 per request)
+- `filters`: Optional, TypeList of schema.Resource with sub-fields `name` (Required, string) and `values` (Required, TypeSet of string) - filter by cluster-id, node-name, status, zone
+- `tags`: Optional, TypeList of schema.Resource with sub-fields `key` (Required, string) and `value` (Required, string) - filter by tag key-value pairs
+- `result_output_file`: Optional, TypeString - used to save results to file
+
+The system SHALL define computed output parameters:
+- `node_set`: Computed, TypeList of schema.Resource containing flattened node attributes
+- Each node element SHALL contain: `node_id`, `node_name`, `ssh_endpoint`, `lan_ip`, `cluster_id`, `zone`, `node_type`, `cpu`, `memory`, `system_disk` (TypeList of schema.Resource with `disk_type`, `disk_size`), `data_disks` (TypeList of schema.Resource with `disk_type`, `disk_size`, `disk_name`), `os_name`, `image_id`, `vpc_id`, `subnet_id`, `status`, `charge_type`, `expire_time`, `created_time`, `isolated_time`, `tags` (TypeList of schema.Resource with `key`, `value`), `auto_renew`, `switch_id`, `rack_id`, `host_ip`
+
+#### Scenario: Datasource with filters input
+- **WHEN** a user provides `filters` with `name` = "cluster-id" and `values` = ["cluster-123"]
+- **THEN** the system SHALL call DescribeDBCustomNodes API with the corresponding Filter parameter and return matching nodes
+
+#### Scenario: Datasource with node_ids input
+- **WHEN** a user provides `node_ids` = ["node-1", "node-2"]
+- **THEN** the system SHALL call DescribeDBCustomNodes API with NodeIds parameter containing those IDs
+
+#### Scenario: Datasource with tags input
+- **WHEN** a user provides `tags` with `key` = "env" and `value` = "prod"
+- **THEN** the system SHALL call DescribeDBCustomNodes API with Tags parameter containing that key-value pair
+
+#### Scenario: Datasource with no filter inputs
+- **WHEN** a user provides no filter inputs (node_ids, filters, tags all empty)
+- **THEN** the system SHALL call DescribeDBCustomNodes API without filters and return all nodes the account has access to
+
+### Requirement: Read operation with retry and pagination
+The system SHALL implement a Read function that calls `DescribeDBCustomNodes` API with `tccommon.ReadRetryTimeout` retry logic. The system SHALL implement internal pagination by setting `Limit` to 100 (API max) and incrementing `Offset` until all results are collected. The system SHALL NOT expose `limit` or `offset` parameters to users in the schema.
+
+#### Scenario: Successful read with pagination
+- **WHEN** the API returns more than 100 nodes total
+- **THEN** the system SHALL make multiple API calls with incremented Offset values and concatenate all NodeSet results into a single `node_set` output
+
+#### Scenario: API retry on transient failure
+- **WHEN** the DescribeDBCustomNodes API call fails with a transient error
+- **THEN** the system SHALL retry the call using `tccommon.ReadRetryTimeout` and `tccommon.RetryError()` for error wrapping
+
+#### Scenario: Empty API response
+- **WHEN** the DescribeDBCustomNodes API returns nil response or empty NodeSet
+- **THEN** the system SHALL return `NonRetryableError` instead of clearing `d.SetId("")`, and SHALL log `log.Printf("[DATASOURCE] read empty, skip SetId")`
+
+### Requirement: Nil field handling in response
+The system SHALL check each response field for nil before calling `d.Set()` or adding it to the output map. Fields that may be nil according to API documentation (`SystemDisk`, `DataDisks`, `Tags` in DBCustomNode) SHALL be skipped when nil rather than set to empty values.
+
+#### Scenario: Node with nil SystemDisk
+- **WHEN** a DBCustomNode has nil `SystemDisk` field
+- **THEN** the system SHALL skip setting `system_disk` for that node element
+
+#### Scenario: Node with nil DataDisks
+- **WHEN** a DBCustomNode has nil `DataDisks` field
+- **THEN** the system SHALL skip setting `data_disks` for that node element
+
+### Requirement: Datasource ID generation
+The system SHALL use `helper.BuildToken()` as the datasource ID after successful read, following the standard pattern for list-type datasources.
+
+#### Scenario: Successful datasource read
+- **WHEN** the Read function completes successfully with data
+- **THEN** the system SHALL set `d.SetId(helper.BuildToken())`
+
+### Requirement: Provider registration
+The system SHALL register the new datasource `tencentcloud_dbdc_db_custom_nodes` in `tencentcloud/provider.go` with the datasource mapping entry.
+
+#### Scenario: Provider registration
+- **WHEN** the provider is initialized
+- **THEN** `tencentcloud_dbdc_db_custom_nodes` SHALL be available as a datasource in Terraform configurations
+
+### Requirement: Documentation
+The system SHALL provide documentation in `data_source_tc_dbdc_db_custom_nodes.md` with:
+- One-sentence description using format "Use this data source to query ..." mentioning the dbdc product
+- Example Usage section showing filter and output usage
+- No Import section (datasource type does not have import)
+- No Argument Reference or Attribute Reference sections (auto-generated)
+
+#### Scenario: Documentation file creation
+- **WHEN** the datasource is added
+- **THEN** the .md file SHALL contain description, example usage, and follow the standard datasource documentation format
+
+### Requirement: Unit tests with mock
+The system SHALL provide unit tests in `data_source_tc_dbdc_db_custom_nodes_test.go` using gomonkey mock approach (not Terraform test suite). The tests SHALL cover the Read function logic including request construction and response parsing. Tests SHALL be runnable with `go test -gcflags=all=-l`.
+
+#### Scenario: Mock-based unit test for Read
+- **WHEN** unit tests are executed
+- **THEN** the gomonkey mock SHALL replace the API client call and verify correct schema population from mock response data

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1390,6 +1390,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_igtm_instance_package_list":                             igtm.DataSourceTencentCloudIgtmInstancePackageList(),
 			"tencentcloud_igtm_detect_task_package_list":                          igtm.DataSourceTencentCloudIgtmDetectTaskPackageList(),
 			"tencentcloud_dbdc_db_custom_clusters":                                dbdc.DataSourceTencentCloudDbdcDbCustomClusters(),
+			"tencentcloud_dbdc_db_custom_nodes":                                   dbdc.DataSourceTencentCloudDbdcDbCustomNodes(),
 			"tencentcloud_gs_android_instances":                                   gs.DataSourceTencentCloudGsAndroidInstances(),
 			"tencentcloud_keewidb_instances":                                      keewidb.DataSourceTencentCloudKeewidbInstances(),
 			"tencentcloud_config_compliance_packs":                                config.DataSourceTencentCloudConfigCompliancePacks(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -2664,6 +2664,7 @@ tencentcloud_igtm_package_task
 Database Dedicated Cluster(DBDC)
 Data Source
 tencentcloud_dbdc_db_custom_clusters
+tencentcloud_dbdc_db_custom_nodes
 
 VCube
 Resource

--- a/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.go
+++ b/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.go
@@ -1,0 +1,492 @@
+package dbdc
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	dbdcv20201029 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudDbdcDbCustomNodes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudDbdcDbCustomNodesRead,
+		Schema: map[string]*schema.Schema{
+			"node_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Query by one or more Node IDs. Maximum 100 IDs per request.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"filters": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Filter conditions. Supported filter names: cluster-id, node-name (exact match), status (Creating, Running, Isolating, Isolated, Activating, Destroying), zone.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Filter field name.",
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "Filter field values.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Filter by tag Key and Value.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag key.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag value.",
+						},
+					},
+				},
+			},
+
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+
+			"node_set": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "DB Custom node list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node ID.",
+						},
+						"node_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node name.",
+						},
+						"ssh_endpoint": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "SSH endpoint for accessing the node, format: IP:Port.",
+						},
+						"lan_ip": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Internal network IP address of the node.",
+						},
+						"cluster_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Cluster ID the node belongs to.",
+						},
+						"zone": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Availability zone the node belongs to.",
+						},
+						"node_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node type/spec.",
+						},
+						"cpu": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Node CPU size in cores.",
+						},
+						"memory": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Node memory size in GiB.",
+						},
+						"system_disk": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "System disk info. Note: This field may return null, indicating that no valid value can be obtained.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"disk_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Disk type.",
+									},
+									"disk_size": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "Disk size in GiB.",
+									},
+								},
+							},
+						},
+						"data_disks": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Data disk list. Note: This field may return null, indicating that no valid value can be obtained.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"disk_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Disk type.",
+									},
+									"disk_size": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "Disk size in GiB.",
+									},
+									"disk_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Disk name.",
+									},
+								},
+							},
+						},
+						"os_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node OS name.",
+						},
+						"image_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node OS image ID.",
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "VPC ID the node SSH endpoint belongs to.",
+						},
+						"subnet_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Subnet ID the node SSH endpoint belongs to.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node status.",
+						},
+						"charge_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Payment type.",
+						},
+						"expire_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node expiration time.",
+						},
+						"created_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node creation time.",
+						},
+						"isolated_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node isolation time.",
+						},
+						"tags": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Node tag information. Note: This field may return null, indicating that no valid value can be obtained.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Tag key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Tag value.",
+									},
+								},
+							},
+						},
+						"auto_renew": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Auto-renew flag. 1=auto renew, 0=no auto renew.",
+						},
+						"switch_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Switch ID.",
+						},
+						"rack_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Rack ID.",
+						},
+						"host_ip": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Host IP.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudDbdcDbCustomNodesRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_dbdc_db_custom_nodes.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(nil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service = DbdcService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	)
+
+	paramMap := make(map[string]interface{})
+	if v, ok := d.GetOk("node_ids"); ok {
+		nodeIdsSet := v.([]interface{})
+		tmpSet := make([]*string, 0, len(nodeIdsSet))
+		for _, item := range nodeIdsSet {
+			nodeId := item.(string)
+			tmpSet = append(tmpSet, helper.String(nodeId))
+		}
+		paramMap["NodeIds"] = tmpSet
+	}
+
+	if v, ok := d.GetOk("filters"); ok {
+		filtersSet := v.([]interface{})
+		tmpSet := make([]*dbdcv20201029.Filter, 0, len(filtersSet))
+		for _, item := range filtersSet {
+			filtersMap := item.(map[string]interface{})
+			filter := dbdcv20201029.Filter{}
+			if v, ok := filtersMap["name"].(string); ok && v != "" {
+				filter.Name = helper.String(v)
+			}
+
+			if v, ok := filtersMap["values"]; ok {
+				valuesSet := v.([]interface{})
+				for i := range valuesSet {
+					value := valuesSet[i].(string)
+					filter.Values = append(filter.Values, helper.String(value))
+				}
+			}
+			tmpSet = append(tmpSet, &filter)
+		}
+		paramMap["Filters"] = tmpSet
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		tagsSet := v.([]interface{})
+		tmpSet := make([]*dbdcv20201029.Tag, 0, len(tagsSet))
+		for _, item := range tagsSet {
+			tagsMap := item.(map[string]interface{})
+			tag := dbdcv20201029.Tag{}
+			if v, ok := tagsMap["key"].(string); ok && v != "" {
+				tag.Key = helper.String(v)
+			}
+
+			if v, ok := tagsMap["value"].(string); ok {
+				tag.Value = helper.String(v)
+			}
+			tmpSet = append(tmpSet, &tag)
+		}
+		paramMap["Tags"] = tmpSet
+	}
+
+	var respData []*dbdcv20201029.DBCustomNode
+	reqErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, _, e := service.DescribeDBCustomNodesByFilter(ctx, paramMap)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		respData = result
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[DATASOURCE] read empty, skip SetId")
+		return reqErr
+	}
+
+	nodeSetList := make([]map[string]interface{}, 0, len(respData))
+	if respData != nil {
+		for _, node := range respData {
+			nodeMap := map[string]interface{}{}
+			if node.NodeId != nil {
+				nodeMap["node_id"] = node.NodeId
+			}
+
+			if node.NodeName != nil {
+				nodeMap["node_name"] = node.NodeName
+			}
+
+			if node.SSHEndpoint != nil {
+				nodeMap["ssh_endpoint"] = node.SSHEndpoint
+			}
+
+			if node.LanIP != nil {
+				nodeMap["lan_ip"] = node.LanIP
+			}
+
+			if node.ClusterId != nil {
+				nodeMap["cluster_id"] = node.ClusterId
+			}
+
+			if node.Zone != nil {
+				nodeMap["zone"] = node.Zone
+			}
+
+			if node.NodeType != nil {
+				nodeMap["node_type"] = node.NodeType
+			}
+
+			if node.CPU != nil {
+				nodeMap["cpu"] = node.CPU
+			}
+
+			if node.Memory != nil {
+				nodeMap["memory"] = node.Memory
+			}
+
+			if node.SystemDisk != nil {
+				systemDiskList := make([]map[string]interface{}, 0, 1)
+				systemDiskMap := map[string]interface{}{}
+				if node.SystemDisk.DiskType != nil {
+					systemDiskMap["disk_type"] = node.SystemDisk.DiskType
+				}
+				if node.SystemDisk.DiskSize != nil {
+					systemDiskMap["disk_size"] = node.SystemDisk.DiskSize
+				}
+				systemDiskList = append(systemDiskList, systemDiskMap)
+				nodeMap["system_disk"] = systemDiskList
+			}
+
+			if node.DataDisks != nil {
+				dataDisksList := make([]map[string]interface{}, 0, len(node.DataDisks))
+				for _, dataDisk := range node.DataDisks {
+					dataDiskMap := map[string]interface{}{}
+					if dataDisk.DiskType != nil {
+						dataDiskMap["disk_type"] = dataDisk.DiskType
+					}
+					if dataDisk.DiskSize != nil {
+						dataDiskMap["disk_size"] = dataDisk.DiskSize
+					}
+					if dataDisk.DiskName != nil {
+						dataDiskMap["disk_name"] = dataDisk.DiskName
+					}
+					dataDisksList = append(dataDisksList, dataDiskMap)
+				}
+				nodeMap["data_disks"] = dataDisksList
+			}
+
+			if node.OsName != nil {
+				nodeMap["os_name"] = node.OsName
+			}
+
+			if node.ImageId != nil {
+				nodeMap["image_id"] = node.ImageId
+			}
+
+			if node.VpcId != nil {
+				nodeMap["vpc_id"] = node.VpcId
+			}
+
+			if node.SubnetId != nil {
+				nodeMap["subnet_id"] = node.SubnetId
+			}
+
+			if node.Status != nil {
+				nodeMap["status"] = node.Status
+			}
+
+			if node.ChargeType != nil {
+				nodeMap["charge_type"] = node.ChargeType
+			}
+
+			if node.ExpireTime != nil {
+				nodeMap["expire_time"] = node.ExpireTime
+			}
+
+			if node.CreatedTime != nil {
+				nodeMap["created_time"] = node.CreatedTime
+			}
+
+			if node.IsolatedTime != nil {
+				nodeMap["isolated_time"] = node.IsolatedTime
+			}
+
+			if node.Tags != nil {
+				tagsList := make([]map[string]interface{}, 0, len(node.Tags))
+				for _, tag := range node.Tags {
+					tagMap := map[string]interface{}{}
+					if tag.Key != nil {
+						tagMap["key"] = tag.Key
+					}
+					if tag.Value != nil {
+						tagMap["value"] = tag.Value
+					}
+					tagsList = append(tagsList, tagMap)
+				}
+				nodeMap["tags"] = tagsList
+			}
+
+			if node.AutoRenew != nil {
+				nodeMap["auto_renew"] = node.AutoRenew
+			}
+
+			if node.SwitchId != nil {
+				nodeMap["switch_id"] = node.SwitchId
+			}
+
+			if node.RackId != nil {
+				nodeMap["rack_id"] = node.RackId
+			}
+
+			if node.HostIp != nil {
+				nodeMap["host_ip"] = node.HostIp
+			}
+
+			nodeSetList = append(nodeSetList, nodeMap)
+		}
+
+		_ = d.Set("node_set", nodeSetList)
+	}
+
+	d.SetId(helper.BuildToken())
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), d); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.md
+++ b/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.md
@@ -13,8 +13,8 @@ Query dbdc db custom nodes by node_ids
 ```hcl
 data "tencentcloud_dbdc_db_custom_nodes" "example" {
   node_ids = [
-    "dbcn-abc12345",
-    "dbcn-def67890"
+    "dbcn-wamuy21e",
+    "dbcn-hjuz19sx"
   ]
 }
 ```

--- a/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.md
+++ b/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes.md
@@ -1,0 +1,47 @@
+Use this data source to query DB Custom node list from TencentCloud DBDC product.
+
+Example Usage
+
+Query all dbdc db custom nodes
+
+```hcl
+data "tencentcloud_dbdc_db_custom_nodes" "example" {}
+```
+
+Query dbdc db custom nodes by node_ids
+
+```hcl
+data "tencentcloud_dbdc_db_custom_nodes" "example" {
+  node_ids = [
+    "dbcn-abc12345",
+    "dbcn-def67890"
+  ]
+}
+```
+
+Query dbdc db custom nodes by filters
+
+```hcl
+data "tencentcloud_dbdc_db_custom_nodes" "example" {
+  filters {
+    name   = "cluster-id"
+    values = ["dbcc-nmtmsew8"]
+  }
+
+  filters {
+    name   = "status"
+    values = ["Running"]
+  }
+}
+```
+
+Query dbdc db custom nodes by tags
+
+```hcl
+data "tencentcloud_dbdc_db_custom_nodes" "example" {
+  tags {
+    key   = "env"
+    value = "production"
+  }
+}
+```

--- a/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes_test.go
+++ b/tencentcloud/services/dbdc/data_source_tc_dbdc_db_custom_nodes_test.go
@@ -1,0 +1,339 @@
+package dbdc_test
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	dbdcv20201029 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/dbdc"
+)
+
+// go test ./tencentcloud/services/dbdc/ -run "TestDbdcDbCustomNodesDS" -v -count=1 -gcflags="all=-l"
+
+func TestDbdcDbCustomNodesDS_ReadBasic(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	patches.ApplyMethodReturn(newMockMetaDbdcDS().client, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodes", func(request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrInt64(2),
+			NodeSet: []*dbdcv20201029.DBCustomNode{
+				{
+					NodeId:      ptrStr("dbcn-abc12345"),
+					NodeName:    ptrStr("test-node-1"),
+					SSHEndpoint: ptrStr("10.0.0.1:22"),
+					LanIP:       ptrStr("10.0.0.1"),
+					ClusterId:   ptrStr("dbcc-nmtmsew8"),
+					Zone:        ptrStr("ap-guangzhou-3"),
+					NodeType:    ptrStr("DB.AT5.32XLARGE512"),
+					CPU:         ptrInt64(128),
+					Memory:      ptrInt64(512),
+					SystemDisk: &dbdcv20201029.SystemDisk{
+						DiskType: ptrStr("CLOUD_HSSD"),
+						DiskSize: ptrInt64(50),
+					},
+					DataDisks: []*dbdcv20201029.DataDisk{
+						{
+							DiskType: ptrStr("LOCAL_NVME"),
+							DiskSize: ptrInt64(7180),
+							DiskName: ptrStr("data-disk-1"),
+						},
+					},
+					OsName:       ptrStr("CentOS 7.6"),
+					ImageId:      ptrStr("img-abc123"),
+					VpcId:        ptrStr("vpc-abc123"),
+					SubnetId:     ptrStr("subnet-abc123"),
+					Status:       ptrStr("Running"),
+					ChargeType:   ptrStr("PREPAID"),
+					ExpireTime:   ptrStr("2025-01-01 00:00:00"),
+					CreatedTime:  ptrStr("2024-01-01 00:00:00"),
+					IsolatedTime: ptrStr(""),
+					Tags: []*dbdcv20201029.Tag{
+						{Key: ptrStr("env"), Value: ptrStr("production")},
+					},
+					AutoRenew: ptrInt64(1),
+					SwitchId:  ptrStr("switch-abc123"),
+					RackId:    ptrStr("rack-abc123"),
+					HostIp:    ptrStr("192.168.1.1"),
+				},
+				{
+					NodeId:     ptrStr("dbcn-def67890"),
+					NodeName:   ptrStr("test-node-2"),
+					ClusterId:  ptrStr("dbcc-nmtmsew8"),
+					Status:     ptrStr("Creating"),
+					ChargeType: ptrStr("PREPAID"),
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDbdcDS()
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomNodes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	nodeSet := d.Get("node_set").([]interface{})
+	assert.Len(t, nodeSet, 2)
+
+	node0 := nodeSet[0].(map[string]interface{})
+	assert.Equal(t, "dbcn-abc12345", node0["node_id"].(string))
+	assert.Equal(t, "test-node-1", node0["node_name"].(string))
+	assert.Equal(t, "10.0.0.1:22", node0["ssh_endpoint"].(string))
+	assert.Equal(t, "10.0.0.1", node0["lan_ip"].(string))
+	assert.Equal(t, "dbcc-nmtmsew8", node0["cluster_id"].(string))
+	assert.Equal(t, "ap-guangzhou-3", node0["zone"].(string))
+	assert.Equal(t, "DB.AT5.32XLARGE512", node0["node_type"].(string))
+	assert.Equal(t, 128, node0["cpu"].(int))
+	assert.Equal(t, 512, node0["memory"].(int))
+
+	systemDisk0 := node0["system_disk"].([]interface{})
+	assert.Len(t, systemDisk0, 1)
+	systemDiskMap0 := systemDisk0[0].(map[string]interface{})
+	assert.Equal(t, "CLOUD_HSSD", systemDiskMap0["disk_type"].(string))
+	assert.Equal(t, 50, systemDiskMap0["disk_size"].(int))
+
+	dataDisks0 := node0["data_disks"].([]interface{})
+	assert.Len(t, dataDisks0, 1)
+	dataDiskMap0 := dataDisks0[0].(map[string]interface{})
+	assert.Equal(t, "LOCAL_NVME", dataDiskMap0["disk_type"].(string))
+	assert.Equal(t, 7180, dataDiskMap0["disk_size"].(int))
+	assert.Equal(t, "data-disk-1", dataDiskMap0["disk_name"].(string))
+
+	assert.Equal(t, "CentOS 7.6", node0["os_name"].(string))
+	assert.Equal(t, "img-abc123", node0["image_id"].(string))
+	assert.Equal(t, "vpc-abc123", node0["vpc_id"].(string))
+	assert.Equal(t, "subnet-abc123", node0["subnet_id"].(string))
+	assert.Equal(t, "Running", node0["status"].(string))
+	assert.Equal(t, "PREPAID", node0["charge_type"].(string))
+	assert.Equal(t, "2025-01-01 00:00:00", node0["expire_time"].(string))
+	assert.Equal(t, "2024-01-01 00:00:00", node0["created_time"].(string))
+	assert.Equal(t, 1, node0["auto_renew"].(int))
+	assert.Equal(t, "switch-abc123", node0["switch_id"].(string))
+	assert.Equal(t, "rack-abc123", node0["rack_id"].(string))
+	assert.Equal(t, "192.168.1.1", node0["host_ip"].(string))
+
+	tags0 := node0["tags"].([]interface{})
+	assert.Len(t, tags0, 1)
+	tagMap0 := tags0[0].(map[string]interface{})
+	assert.Equal(t, "env", tagMap0["key"].(string))
+	assert.Equal(t, "production", tagMap0["value"].(string))
+
+	node1 := nodeSet[1].(map[string]interface{})
+	assert.Equal(t, "dbcn-def67890", node1["node_id"].(string))
+	assert.Equal(t, "test-node-2", node1["node_name"].(string))
+	assert.Equal(t, "Creating", node1["status"].(string))
+}
+
+func TestDbdcDbCustomNodesDS_ReadWithNilFields(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	patches.ApplyMethodReturn(newMockMetaDbdcDS().client, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodes", func(request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrInt64(1),
+			NodeSet: []*dbdcv20201029.DBCustomNode{
+				{
+					NodeId:   ptrStr("dbcn-nil-fields"),
+					NodeName: ptrStr("node-no-disks-tags"),
+					Status:   ptrStr("Running"),
+					// SystemDisk, DataDisks, Tags are nil
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDbdcDS()
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomNodes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	nodeSet := d.Get("node_set").([]interface{})
+	assert.Len(t, nodeSet, 1)
+
+	node0 := nodeSet[0].(map[string]interface{})
+	assert.Equal(t, "dbcn-nil-fields", node0["node_id"].(string))
+	// SystemDisk is nil, should not have system_disk in output
+	systemDiskField := node0["system_disk"]
+	if systemDiskField != nil {
+		systemDiskList := systemDiskField.([]interface{})
+		assert.Len(t, systemDiskList, 0)
+	}
+	// DataDisks is nil, should not have data_disks in output
+	dataDisksField := node0["data_disks"]
+	if dataDisksField != nil {
+		dataDisksList := dataDisksField.([]interface{})
+		assert.Len(t, dataDisksList, 0)
+	}
+	// Tags is nil, should not have tags in output
+	tagsField := node0["tags"]
+	if tagsField != nil {
+		tagsList := tagsField.([]interface{})
+		assert.Len(t, tagsList, 0)
+	}
+}
+
+func TestDbdcDbCustomNodesDS_ReadWithNodeIds(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	patches.ApplyMethodReturn(newMockMetaDbdcDS().client, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodes", func(request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrInt64(1),
+			NodeSet: []*dbdcv20201029.DBCustomNode{
+				{
+					NodeId:   ptrStr("dbcn-abc12345"),
+					NodeName: ptrStr("test-node-1"),
+					Status:   ptrStr("Running"),
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDbdcDS()
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomNodes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"node_ids": []interface{}{"dbcn-abc12345"},
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	nodeSet := d.Get("node_set").([]interface{})
+	assert.Len(t, nodeSet, 1)
+}
+
+func TestDbdcDbCustomNodesDS_ReadWithFilters(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	patches.ApplyMethodReturn(newMockMetaDbdcDS().client, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodes", func(request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrInt64(1),
+			NodeSet: []*dbdcv20201029.DBCustomNode{
+				{
+					NodeId:    ptrStr("dbcn-filter-test"),
+					ClusterId: ptrStr("dbcc-nmtmsew8"),
+					Status:    ptrStr("Running"),
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDbdcDS()
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomNodes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"filters": []interface{}{
+			map[string]interface{}{
+				"name":   "cluster-id",
+				"values": []interface{}{"dbcc-nmtmsew8"},
+			},
+		},
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	nodeSet := d.Get("node_set").([]interface{})
+	assert.Len(t, nodeSet, 1)
+}
+
+func TestDbdcDbCustomNodesDS_ReadWithEmptyResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	patches.ApplyMethodReturn(newMockMetaDbdcDS().client, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodes", func(request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrInt64(0),
+			NodeSet:    []*dbdcv20201029.DBCustomNode{},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDbdcDS()
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomNodes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	// When response is empty, the datasource should return an error (NonRetryableError)
+	assert.Error(t, err)
+}
+
+func TestDbdcDbCustomNodesDS_Schema(t *testing.T) {
+	res := dbdc.DataSourceTencentCloudDbdcDbCustomNodes()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "node_ids")
+	assert.Contains(t, res.Schema, "filters")
+	assert.Contains(t, res.Schema, "tags")
+	assert.Contains(t, res.Schema, "node_set")
+	assert.Contains(t, res.Schema, "result_output_file")
+
+	nodeIdsSchema := res.Schema["node_ids"]
+	assert.Equal(t, schema.TypeList, nodeIdsSchema.Type)
+	assert.True(t, nodeIdsSchema.Optional)
+
+	nodeSetSchema := res.Schema["node_set"]
+	assert.Equal(t, schema.TypeList, nodeSetSchema.Type)
+	assert.True(t, nodeSetSchema.Computed)
+
+	elemRes := nodeSetSchema.Elem.(*schema.Resource)
+	assert.Contains(t, elemRes.Schema, "node_id")
+	assert.Contains(t, elemRes.Schema, "node_name")
+	assert.Contains(t, elemRes.Schema, "ssh_endpoint")
+	assert.Contains(t, elemRes.Schema, "lan_ip")
+	assert.Contains(t, elemRes.Schema, "cluster_id")
+	assert.Contains(t, elemRes.Schema, "zone")
+	assert.Contains(t, elemRes.Schema, "node_type")
+	assert.Contains(t, elemRes.Schema, "cpu")
+	assert.Contains(t, elemRes.Schema, "memory")
+	assert.Contains(t, elemRes.Schema, "system_disk")
+	assert.Contains(t, elemRes.Schema, "data_disks")
+	assert.Contains(t, elemRes.Schema, "os_name")
+	assert.Contains(t, elemRes.Schema, "image_id")
+	assert.Contains(t, elemRes.Schema, "vpc_id")
+	assert.Contains(t, elemRes.Schema, "subnet_id")
+	assert.Contains(t, elemRes.Schema, "status")
+	assert.Contains(t, elemRes.Schema, "charge_type")
+	assert.Contains(t, elemRes.Schema, "expire_time")
+	assert.Contains(t, elemRes.Schema, "created_time")
+	assert.Contains(t, elemRes.Schema, "isolated_time")
+	assert.Contains(t, elemRes.Schema, "tags")
+	assert.Contains(t, elemRes.Schema, "auto_renew")
+	assert.Contains(t, elemRes.Schema, "switch_id")
+	assert.Contains(t, elemRes.Schema, "rack_id")
+	assert.Contains(t, elemRes.Schema, "host_ip")
+}

--- a/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
+++ b/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
@@ -131,7 +131,7 @@ func (me *DbdcService) DescribeDBCustomNodesByFilter(ctx context.Context, param 
 				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
 			}
 
-			if result == nil || result.Response == nil || result.Response.NodeSet == nil || len(result.Response.NodeSet) == 0 {
+			if result == nil || result.Response == nil || result.Response.NodeSet == nil {
 				return resource.NonRetryableError(fmt.Errorf("Describe dbdc_db_custom_nodes failed, Response is nil."))
 			}
 

--- a/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
+++ b/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
@@ -89,3 +89,72 @@ func (me *DbdcService) DescribeDBCustomClustersByFilter(ctx context.Context, par
 
 	return
 }
+
+func (me *DbdcService) DescribeDBCustomNodesByFilter(ctx context.Context, param map[string]interface{}) (ret []*dbdcv20201029.DBCustomNode, totalCount int64, errRet error) {
+	var (
+		logId    = tccommon.GetLogId(ctx)
+		request  = dbdcv20201029.NewDescribeDBCustomNodesRequest()
+		response = dbdcv20201029.NewDescribeDBCustomNodesResponse()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	for k, v := range param {
+		if k == "NodeIds" {
+			request.NodeIds = v.([]*string)
+		}
+		if k == "Filters" {
+			request.Filters = v.([]*dbdcv20201029.Filter)
+		}
+		if k == "Tags" {
+			request.Tags = v.([]*dbdcv20201029.Tag)
+		}
+	}
+
+	var (
+		offset int64 = 0
+		limit  int64 = 100
+	)
+	for {
+		request.Offset = &offset
+		request.Limit = &limit
+		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			ratelimit.Check(request.GetAction())
+			result, e := me.client.UseDbdcV20201029Client().DescribeDBCustomNodes(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil || result.Response.NodeSet == nil || len(result.Response.NodeSet) == 0 {
+				return resource.NonRetryableError(fmt.Errorf("Describe dbdc_db_custom_nodes failed, Response is nil."))
+			}
+
+			response = result
+			return nil
+		})
+
+		if err != nil {
+			errRet = err
+			return
+		}
+
+		ret = append(ret, response.Response.NodeSet...)
+		if totalCount == 0 && response.Response.TotalCount != nil {
+			totalCount = *response.Response.TotalCount
+		}
+
+		if len(response.Response.NodeSet) < int(limit) {
+			break
+		}
+
+		offset += limit
+	}
+
+	return
+}

--- a/website/docs/d/dbdc_db_custom_nodes.html.markdown
+++ b/website/docs/d/dbdc_db_custom_nodes.html.markdown
@@ -1,0 +1,117 @@
+---
+subcategory: "Database Dedicated Cluster(DBDC)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_dbdc_db_custom_nodes"
+sidebar_current: "docs-tencentcloud-datasource-dbdc_db_custom_nodes"
+description: |-
+  Use this data source to query DB Custom node list from TencentCloud DBDC product.
+---
+
+# tencentcloud_dbdc_db_custom_nodes
+
+Use this data source to query DB Custom node list from TencentCloud DBDC product.
+
+## Example Usage
+
+### Query all dbdc db custom nodes
+
+```hcl
+data "tencentcloud_dbdc_db_custom_nodes" "example" {}
+```
+
+### Query dbdc db custom nodes by node_ids
+
+```hcl
+data "tencentcloud_dbdc_db_custom_nodes" "example" {
+  node_ids = [
+    "dbcn-abc12345",
+    "dbcn-def67890"
+  ]
+}
+```
+
+### Query dbdc db custom nodes by filters
+
+```hcl
+data "tencentcloud_dbdc_db_custom_nodes" "example" {
+  filters {
+    name   = "cluster-id"
+    values = ["dbcc-nmtmsew8"]
+  }
+
+  filters {
+    name   = "status"
+    values = ["Running"]
+  }
+}
+```
+
+### Query dbdc db custom nodes by tags
+
+```hcl
+data "tencentcloud_dbdc_db_custom_nodes" "example" {
+  tags {
+    key   = "env"
+    value = "production"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filters` - (Optional, List) Filter conditions. Supported filter names: cluster-id, node-name (exact match), status (Creating, Running, Isolating, Isolated, Activating, Destroying), zone.
+* `node_ids` - (Optional, List: [`String`]) Query by one or more Node IDs. Maximum 100 IDs per request.
+* `result_output_file` - (Optional, String) Used to save results.
+* `tags` - (Optional, List) Filter by tag Key and Value.
+
+The `filters` object supports the following:
+
+* `name` - (Required, String) Filter field name.
+* `values` - (Required, List) Filter field values.
+
+The `tags` object supports the following:
+
+* `key` - (Required, String) Tag key.
+* `value` - (Required, String) Tag value.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `node_set` - DB Custom node list.
+  * `auto_renew` - Auto-renew flag. 1=auto renew, 0=no auto renew.
+  * `charge_type` - Payment type.
+  * `cluster_id` - Cluster ID the node belongs to.
+  * `cpu` - Node CPU size in cores.
+  * `created_time` - Node creation time.
+  * `data_disks` - Data disk list. Note: This field may return null, indicating that no valid value can be obtained.
+    * `disk_name` - Disk name.
+    * `disk_size` - Disk size in GiB.
+    * `disk_type` - Disk type.
+  * `expire_time` - Node expiration time.
+  * `host_ip` - Host IP.
+  * `image_id` - Node OS image ID.
+  * `isolated_time` - Node isolation time.
+  * `lan_ip` - Internal network IP address of the node.
+  * `memory` - Node memory size in GiB.
+  * `node_id` - Node ID.
+  * `node_name` - Node name.
+  * `node_type` - Node type/spec.
+  * `os_name` - Node OS name.
+  * `rack_id` - Rack ID.
+  * `ssh_endpoint` - SSH endpoint for accessing the node, format: IP:Port.
+  * `status` - Node status.
+  * `subnet_id` - Subnet ID the node SSH endpoint belongs to.
+  * `switch_id` - Switch ID.
+  * `system_disk` - System disk info. Note: This field may return null, indicating that no valid value can be obtained.
+    * `disk_size` - Disk size in GiB.
+    * `disk_type` - Disk type.
+  * `tags` - Node tag information. Note: This field may return null, indicating that no valid value can be obtained.
+    * `key` - Tag key.
+    * `value` - Tag value.
+  * `vpc_id` - VPC ID the node SSH endpoint belongs to.
+  * `zone` - Availability zone the node belongs to.
+
+

--- a/website/docs/d/dbdc_db_custom_nodes.html.markdown
+++ b/website/docs/d/dbdc_db_custom_nodes.html.markdown
@@ -24,8 +24,8 @@ data "tencentcloud_dbdc_db_custom_nodes" "example" {}
 ```hcl
 data "tencentcloud_dbdc_db_custom_nodes" "example" {
   node_ids = [
-    "dbcn-abc12345",
-    "dbcn-def67890"
+    "dbcn-wamuy21e",
+    "dbcn-hjuz19sx"
   ]
 }
 ```

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -2749,6 +2749,9 @@
                                 <li>
                                     <a href="/docs/providers/tencentcloud/d/dbdc_db_custom_clusters.html">tencentcloud_dbdc_db_custom_clusters</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/d/dbdc_db_custom_nodes.html">tencentcloud_dbdc_db_custom_nodes</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>


### PR DESCRIPTION
Add a new RESOURCE_KIND_DATASOURCE tencentcloud_dbdc_db_custom_nodes to the Terraform provider for the DBDC (Database Dedicated Cluster) product. This datasource queries DB Custom node list via the DescribeDBCustomNodes API, supporting filtering by node_ids, filters, and tags, and exposing the full node set attributes.