### PR TITLE
fix(emr): [132026918] `tencentcloud_emr_cluster_v2` support `router_resource_spec`

### DIFF
--- a/.changelog/4270.txt
+++ b/.changelog/4270.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_emr_cluster_v2: support `router_resource_spec`
+```

--- a/tencentcloud/services/emr/resource_tc_emr_cluster_v2.go
+++ b/tencentcloud/services/emr/resource_tc_emr_cluster_v2.go
@@ -396,6 +396,16 @@ func ResourceTencentCloudEmrClusterV2() *schema.Resource {
 											"This field is a `TypeSet` keyed by `_node_index` only  block order in HCL is irrelevant.",
 										Elem: emrNodeSpecElem(),
 									},
+									"router_resource_spec": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Set:      hashEmrNodeResourceSpec,
+										Description: "Router node resource specifications. Router nodes are NOT created by `CreateCluster`; " +
+											"instead they are added via `ScaleOutCluster` (NodeFlag=ROUTER) after the cluster becomes running. " +
+											"Unlike the other roles, router blocks are NOT required to be identical to each other. " +
+											"This field is a `TypeSet` keyed by `_node_index` only  block order in HCL is irrelevant.",
+										Elem: emrNodeSpecElem(),
+									},
 								},
 							},
 						},
@@ -852,6 +862,41 @@ func resourceTencentCloudEmrClusterV2Create(d *schema.ResourceData, meta interfa
 		return waitErr
 	}
 
+	// Router nodes are not part of CreateCluster. Once the cluster is running,
+	// add any configured router nodes via ScaleOutCluster (NodeFlag=ROUTER),
+	// one node per spec block, reusing the shared scale-out helper. Failures
+	// fall through to Read so state reflects the nodes that were actually
+	// created.
+	if v, ok := d.GetOk("zone_resource_configuration"); ok {
+		for zoneIdx, item := range v.([]interface{}) {
+			zrcMap, _ := item.(map[string]interface{})
+			if zrcMap == nil {
+				continue
+			}
+			zone := emrZoneOf(zrcMap)
+			allList, _ := zrcMap["all_node_resource_spec"].([]interface{})
+			if len(allList) == 0 {
+				continue
+			}
+			allMap, _ := allList[0].(map[string]interface{})
+			if allMap == nil {
+				continue
+			}
+			for addedIdx, raw := range emrNodeSetToList(allMap["router_resource_spec"]) {
+				routerSpec, _ := raw.(map[string]interface{})
+				if routerSpec == nil {
+					continue
+				}
+				if err := emrScaleOutSingleNode(ctx, meta, d, logId, instanceId,
+					"ROUTER", zone, zoneIdx, addedIdx, routerSpec); err != nil {
+					log.Printf("[CRITAL]%s zone[%d] router scale-out failed during create: %+v", logId, zoneIdx, err)
+					_ = resourceTencentCloudEmrClusterV2Read(d, meta)
+					return err
+				}
+			}
+		}
+	}
+
 	return resourceTencentCloudEmrClusterV2Read(d, meta)
 }
 
@@ -1047,12 +1092,13 @@ func resourceTencentCloudEmrClusterV2Read(d *schema.ResourceData, meta interface
 				node["placement"] = []interface{}{placementItem}
 
 				// all_node_resource_spec: group nodes in this Zone by Flag.
-				// Flag: 1=master, 2=core, 3=task, 0=common
+				// Flag: 1=master, 2=core, 3=task, 0=common, 4=router
 				roleKeyMap := map[int64]string{
 					1: "master_resource_spec",
 					2: "core_resource_spec",
 					3: "task_resource_spec",
 					0: "common_resource_spec",
+					4: "router_resource_spec",
 				}
 				grouped := make(map[int64][]*emr.NodeHardwareInfo)
 				for _, n := range zoneNodes {
@@ -1098,7 +1144,7 @@ func resourceTencentCloudEmrClusterV2Read(d *schema.ResourceData, meta interface
 						if allMap == nil {
 							break
 						}
-						for _, rk := range []string{"master_resource_spec", "core_resource_spec", "task_resource_spec", "common_resource_spec"} {
+						for _, rk := range []string{"master_resource_spec", "core_resource_spec", "task_resource_spec", "common_resource_spec", "router_resource_spec"} {
 							rawList := emrNodeSetToList(allMap[rk])
 							nodeMap := map[string]string{}
 							diskMap := map[string]map[string]string{}
@@ -1180,7 +1226,7 @@ func resourceTencentCloudEmrClusterV2Read(d *schema.ResourceData, meta interface
 						if allMap == nil {
 							break
 						}
-						for _, rk := range []string{"master_resource_spec", "core_resource_spec", "task_resource_spec", "common_resource_spec"} {
+						for _, rk := range []string{"master_resource_spec", "core_resource_spec", "task_resource_spec", "common_resource_spec", "router_resource_spec"} {
 							rawList := emrNodeSetToList(allMap[rk])
 							nodeOrd := make([]string, 0, len(rawList))
 							perNodeMap := make(map[string][]cfgDiskEntry, len(rawList))
@@ -1826,6 +1872,74 @@ func resourceTencentCloudEmrClusterV2Update(d *schema.ResourceData, meta interfa
 				}
 			}
 
+			// ---------- router_resource_spec ----------
+			// Router behaves like task: it supports in-place reconfiguration
+			// (instance_type / data_disk), scale-out and scale-in, all via the
+			// shared helpers with NodeFlag=ROUTER. Router blocks are not subject
+			// to the cross-block uniformity requirement of the other roles.
+			if oldRouterList, newRouterList, changed := nodeRoleChanged(oldAll, newAll, "router_resource_spec"); changed {
+				pairedOldRouter, pairedNewRouter, addedRouter, removedOldRouter := alignNodeListByNodeIndex(oldRouterList, newRouterList)
+
+				// Content changes on existing nodes.
+				for nodeIdx := 0; nodeIdx < len(pairedNewRouter); nodeIdx++ {
+					oldSpec, _ := pairedOldRouter[nodeIdx].(map[string]interface{})
+					newSpec, _ := pairedNewRouter[nodeIdx].(map[string]interface{})
+
+					// Skip nodes that were never actually provisioned.
+					if orderNo, _ := oldSpec["order_no"].(string); orderNo == "" {
+						continue
+					}
+
+					if rid, _ := oldSpec["emr_resource_id"].(string); rid != "" {
+						if sysDiskChanged(oldSpec, newSpec) {
+							return fmt.Errorf("modifying system_disk of an existing node (emr_resource_id=%s) is not supported", rid)
+						}
+					}
+					if instanceTypeChanged(oldSpec, newSpec) {
+						if err := emrModifyNodeInstanceType(ctx, meta, d, logId, instanceId,
+							"router_resource_spec", zoneIdx, nodeIdx, oldSpec, newSpec); err != nil {
+							return err
+						}
+					}
+					if dataDiskChanged(oldSpec, newSpec) {
+						orderNo, _ := oldSpec["order_no"].(string)
+						oldDisks := emrDiskSetToList(oldSpec["data_disk"])
+						newDisks := emrDiskSetToList(newSpec["data_disk"])
+						if err := handleNodeDataDiskChange(ctx, meta, d, logId, instanceId, orderNo, oldDisks, newDisks, "router_resource_spec", zoneIdx, nodeIdx); err != nil {
+							return err
+						}
+					}
+				}
+
+				// Scale-in first: terminate old router nodes that have no matching
+				// new entry. Doing scale-in before scale-out frees capacity
+				// before new nodes are added.
+				var removedRouterOrderNos []*string
+				for _, raw := range removedOldRouter {
+					m, _ := raw.(map[string]interface{})
+					orderNo, _ := m["order_no"].(string)
+					if orderNo != "" {
+						removedRouterOrderNos = append(removedRouterOrderNos, helper.String(orderNo))
+					}
+				}
+				if err := emrTerminateNodes(ctx, meta, d, logId, instanceId, "ROUTER", zoneIdx, removedRouterOrderNos); err != nil {
+					return err
+				}
+
+				// Scale-out: new nodes.
+				zone := emrZoneOf(newZrcMap)
+				for addedIdx, addedRaw := range addedRouter {
+					addedSpec, _ := addedRaw.(map[string]interface{})
+					if addedSpec == nil {
+						continue
+					}
+					if err := emrScaleOutSingleNode(ctx, meta, d, logId, instanceId,
+						"ROUTER", zone, zoneIdx, addedIdx, addedSpec); err != nil {
+						return err
+					}
+				}
+			}
+
 			// ---------- common_resource_spec ----------
 			if oldCommonList, newCommonList, changed := nodeRoleChanged(oldAll, newAll, "common_resource_spec"); changed {
 				// common_resource_spec does not support scaling (add or remove nodes).
@@ -1954,7 +2068,7 @@ func resourceTencentCloudEmrClusterV2Update(d *schema.ResourceData, meta interfa
 			oldAll := oldAllList[0].(map[string]interface{})
 			newAll := newAllList[0].(map[string]interface{})
 
-			for _, roleKey := range []string{"master_resource_spec", "core_resource_spec", "task_resource_spec", "common_resource_spec"} {
+			for _, roleKey := range []string{"master_resource_spec", "core_resource_spec", "task_resource_spec", "common_resource_spec", "router_resource_spec"} {
 				oldList, newList, changed := nodeRoleChanged(oldAll, newAll, roleKey)
 				if !changed {
 					continue
@@ -2220,12 +2334,14 @@ func customizeDiffEmrClusterV2(ctx context.Context, d *schema.ResourceDiff, meta
 		"core_resource_spec",
 		"task_resource_spec",
 		"common_resource_spec",
+		"router_resource_spec",
 	}
 	roleLabel := map[string]string{
 		"master_resource_spec": "master",
 		"core_resource_spec":   "core",
 		"task_resource_spec":   "task",
 		"common_resource_spec": "common",
+		"router_resource_spec": "router",
 	}
 
 	for zoneIdx, nz := range newZones {
@@ -3743,7 +3859,7 @@ func emrRevertFailedNodeSoftware(d *schema.ResourceData, failedNodeSoftware map[
 		return nil
 	}
 
-	roleKeys := []string{"master_resource_spec", "core_resource_spec", "task_resource_spec", "common_resource_spec"}
+	roleKeys := []string{"master_resource_spec", "core_resource_spec", "task_resource_spec", "common_resource_spec", "router_resource_spec"}
 
 	newZones := make([]interface{}, 0, len(zoneList))
 	for _, zRaw := range zoneList {

--- a/tencentcloud/services/emr/resource_tc_emr_cluster_v2.go
+++ b/tencentcloud/services/emr/resource_tc_emr_cluster_v2.go
@@ -770,7 +770,8 @@ func resourceTencentCloudEmrClusterV2Create(d *schema.ResourceData, meta interfa
 		tmpList := []*string{}
 		for _, item := range serviceList {
 			if item != nil {
-				if strings.HasPrefix(*item, "RUNTIME") || strings.HasPrefix(*item, "FILEBEAT") {
+				// Temporary filtering
+				if strings.HasPrefix(*item, "RUNTIME") || strings.HasPrefix(*item, "FILEBEAT") || strings.HasPrefix(*item, "KRB5") {
 					continue
 				}
 			}

--- a/tencentcloud/services/emr/resource_tc_emr_cluster_v2.md
+++ b/tencentcloud/services/emr/resource_tc_emr_cluster_v2.md
@@ -1,6 +1,6 @@
 Provides a resource to create a EMR cluster (v2).
 
-~> **NOTE:** At create time, every block of the same role within a zone (i.e. all `master_resource_spec` blocks, all `core_resource_spec` blocks, etc.) must declare an identical configuration — including `instance_type`, `system_disk`, `data_disk`, and `software`. The EMR `CreateCluster` API only accepts a single resource template per role and provisions the requested count of identical nodes from it. To run heterogeneous configurations within the same role, first create the cluster with uniform blocks, then customize individual nodes via subsequent `terraform apply` updates (resize disks, change `instance_type`, add data disks, etc.).
+~> **NOTE:** At create time, every block of the same role within a zone (i.e. all `master_resource_spec` blocks, all `core_resource_spec` blocks, etc. —excluding the `router_resource_spec`) must declare an identical configuration — including `instance_type`, `system_disk`, `data_disk`, and `software`. The EMR `CreateCluster` API only accepts a single resource template per role and provisions the requested count of identical nodes from it. To run heterogeneous configurations within the same role, first create the cluster with uniform blocks, then customize individual nodes via subsequent `terraform apply` updates (resize disks, change `instance_type`, add data disks, etc.).
 
 Example Usage
 

--- a/website/docs/r/emr_cluster_v2.html.markdown
+++ b/website/docs/r/emr_cluster_v2.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Provides a resource to create a EMR cluster (v2).
 
-~> **NOTE:** At create time, every block of the same role within a zone (i.e. all `master_resource_spec` blocks, all `core_resource_spec` blocks, etc.) must declare an identical configuration — including `instance_type`, `system_disk`, `data_disk`, and `software`. The EMR `CreateCluster` API only accepts a single resource template per role and provisions the requested count of identical nodes from it. To run heterogeneous configurations within the same role, first create the cluster with uniform blocks, then customize individual nodes via subsequent `terraform apply` updates (resize disks, change `instance_type`, add data disks, etc.).
+~> **NOTE:** At create time, every block of the same role within a zone (i.e. all `master_resource_spec` blocks, all `core_resource_spec` blocks, etc. —excluding the `router_resource_spec`) must declare an identical configuration — including `instance_type`, `system_disk`, `data_disk`, and `software`. The EMR `CreateCluster` API only accepts a single resource template per role and provisions the requested count of identical nodes from it. To run heterogeneous configurations within the same role, first create the cluster with uniform blocks, then customize individual nodes via subsequent `terraform apply` updates (resize disks, change `instance_type`, add data disks, etc.).
 
 ## Example Usage
 
@@ -497,6 +497,7 @@ The `all_node_resource_spec` object of `zone_resource_configuration` supports th
 * `common_resource_spec` - (Optional, Set) Common node resource specifications. Number of blocks = `CommonCount`. All blocks must have identical configuration; the first block is the single resource template sent to the API. This field is a `TypeSet` keyed by `_node_index` only  block order in HCL is irrelevant.
 * `core_resource_spec` - (Optional, Set) Core node resource specifications. Number of blocks = `CoreCount`. All blocks must have identical configuration; the first block is the single resource template sent to the API. This field is a `TypeSet` keyed by `_node_index` only  block order in HCL is irrelevant.
 * `master_resource_spec` - (Optional, Set) Master node resource specifications. Number of blocks = `MasterCount`. All blocks must have identical configuration; the first block is the single resource template sent to the API. This field is a `TypeSet` keyed by `_node_index` only  block order in HCL is irrelevant.
+* `router_resource_spec` - (Optional, Set) Router node resource specifications. Router nodes are NOT created by `CreateCluster`; instead they are added via `ScaleOutCluster` (NodeFlag=ROUTER) after the cluster becomes running. Unlike the other roles, router blocks are NOT required to be identical to each other. This field is a `TypeSet` keyed by `_node_index` only  block order in HCL is irrelevant.
 * `task_resource_spec` - (Optional, Set) Task node resource specifications. Number of blocks = `TaskCount`. All blocks must have identical configuration; the first block is the single resource template sent to the API. This field is a `TypeSet` keyed by `_node_index` only  block order in HCL is irrelevant.
 
 The `common_resource_spec` object of `all_node_resource_spec` supports the following:
@@ -528,6 +529,12 @@ The `data_disk` object of `core_resource_spec` supports the following:
 * `disk_type` - (Optional, String) Disk type. Valid values: `CLOUD_SSD`, `CLOUD_PREMIUM`, `CLOUD_BASIC`, `LOCAL_BASIC`, `LOCAL_SSD`, `CLOUD_HSSD`, `CLOUD_THROUGHPUT`, `CLOUD_TSSD`, `CLOUD_BIGDATA`, `CLOUD_HIGHIO`, `CLOUD_BSSD`, `REMOTE_SSD`. Immutable after creation.
 
 The `data_disk` object of `master_resource_spec` supports the following:
+
+* `_disk_index` - (Required, String) **Required** stable identity key for this `data_disk` block. Must be unique within the same node's `data_disk` set, and must remain stable across plan/apply once written to state. Renaming an existing `_disk_index` is rejected (treated as remove+add, which violates the no-shrink rule).
+* `disk_size` - (Optional, Int) Disk size in GB. Can only be increased after creation; shrinking is rejected at plan time.
+* `disk_type` - (Optional, String) Disk type. Valid values: `CLOUD_SSD`, `CLOUD_PREMIUM`, `CLOUD_BASIC`, `LOCAL_BASIC`, `LOCAL_SSD`, `CLOUD_HSSD`, `CLOUD_THROUGHPUT`, `CLOUD_TSSD`, `CLOUD_BIGDATA`, `CLOUD_HIGHIO`, `CLOUD_BSSD`, `REMOTE_SSD`. Immutable after creation.
+
+The `data_disk` object of `router_resource_spec` supports the following:
 
 * `_disk_index` - (Required, String) **Required** stable identity key for this `data_disk` block. Must be unique within the same node's `data_disk` set, and must remain stable across plan/apply once written to state. Renaming an existing `_disk_index` is rejected (treated as remove+add, which violates the no-shrink rule).
 * `disk_size` - (Optional, Int) Disk size in GB. Can only be increased after creation; shrinking is rejected at plan time.
@@ -575,6 +582,14 @@ The `placement` object of `zone_resource_configuration` supports the following:
 * `project_id` - (Optional, Int, ForceNew) Project ID. Defaults to default project if omitted.
 * `zone` - (Optional, String, ForceNew) Availability zone, e.g., `ap-guangzhou-7`.
 
+The `router_resource_spec` object of `all_node_resource_spec` supports the following:
+
+* `_node_index` - (Required, String) **Required** stable identity key for this node spec block. Must be unique within the same role's set, and must remain stable across plan/apply. Used by the Update handler to pair old/new blocks for in-place modification. Renaming an existing `_node_index` is rejected by CustomizeDiff for master/common (length immutable); for core/task it is interpreted as scale-in old + scale-out new.
+* `software` - (Required, Set) Per-role software components (with their role/process lists) deployed on this node role. Must be identical across every block of the same role at create time. Aggregated across all four roles (deduped by `services`) and passed to `CreateCluster` as `SceneSoftwareConfig.Software`. Immutable after create modification is rejected at plan time by CustomizeDiff.
+* `data_disk` - (Optional, Set) Cloud data disk specifications. `TypeSet` keyed by full content (including `_disk_index`); block order in HCL is irrelevant.
+* `instance_type` - (Optional, String) CVM instance type, e.g., `S6.2XLARGE32`, `SA4.8XLARGE64`.
+* `system_disk` - (Optional, List) System disk specifications.
+
 The `scene_software_config` object supports the following:
 
 * `scene_name` - (Optional, String, ForceNew) Scenario name, e.g., `Hadoop-Default`, `Hadoop-Kudu`, `Hadoop-Zookeeper`, `Hadoop-Presto`, `Hadoop-Hbase`.
@@ -602,6 +617,11 @@ The `software` object of `master_resource_spec` supports the following:
 * `roles` - (Required, Set) Process list for this component on this role, e.g., `["NameNode", "ZKFailoverController"]` for hdfs.
 * `services` - (Required, String) Component name with version, e.g., `hdfs-3.2.2`.
 
+The `software` object of `router_resource_spec` supports the following:
+
+* `roles` - (Required, Set) Process list for this component on this role, e.g., `["NameNode", "ZKFailoverController"]` for hdfs.
+* `services` - (Required, String) Component name with version, e.g., `hdfs-3.2.2`.
+
 The `software` object of `task_resource_spec` supports the following:
 
 * `roles` - (Required, Set) Process list for this component on this role, e.g., `["NameNode", "ZKFailoverController"]` for hdfs.
@@ -618,6 +638,11 @@ The `system_disk` object of `core_resource_spec` supports the following:
 * `disk_type` - (Optional, String) Disk type. Valid values: `CLOUD_SSD`, `CLOUD_PREMIUM`, `CLOUD_BASIC`, `LOCAL_BASIC`, `LOCAL_SSD`.
 
 The `system_disk` object of `master_resource_spec` supports the following:
+
+* `disk_size` - (Optional, Int) Disk size in GB.
+* `disk_type` - (Optional, String) Disk type. Valid values: `CLOUD_SSD`, `CLOUD_PREMIUM`, `CLOUD_BASIC`, `LOCAL_BASIC`, `LOCAL_SSD`.
+
+The `system_disk` object of `router_resource_spec` supports the following:
 
 * `disk_size` - (Optional, Int) Disk size in GB.
 * `disk_type` - (Optional, String) Disk type. Valid values: `CLOUD_SSD`, `CLOUD_PREMIUM`, `CLOUD_BASIC`, `LOCAL_BASIC`, `LOCAL_SSD`.


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
