### PR TITLE
docs(clb): [135882901] update clb_instance internet_max_bandwidth_out description

### DIFF
--- a/.changelog/4273.txt
+++ b/.changelog/4273.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_clb_instance: update internet_max_bandwidth_out description
+```

--- a/tencentcloud/services/clb/resource_tc_clb_instance.go
+++ b/tencentcloud/services/clb/resource_tc_clb_instance.go
@@ -105,10 +105,13 @@ func ResourceTencentCloudClbInstance() *schema.Resource {
 				Description: "Bandwidth package id. If set, the `internet_charge_type` must be `BANDWIDTH_PACKAGE`.",
 			},
 			"internet_bandwidth_max_out": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				Description: "Max bandwidth out, only applicable to open CLB. Valid value ranges is [1, 2048]. Unit is Mbps.",
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				Description: "Maximum outbound bandwidth, in Mbps. This parameter is valid only for public network shared, LCU-supported, and exclusive CLB instances and private network LCU-supported CLB instances.\n" +
+					"- The range of the maximum outbound bandwidth for public network shared and exclusive CLB instances is 1-2,048 Mbps.\n" +
+					"- The range of the maximum outbound bandwidth for public network and private network LCU-supported CLB instances is 1-61,440 Mbps.\n" +
+					"(Default to 10Mbps when CreateLoadBalancer is call.).",
 			},
 			"security_groups": {
 				Type:        schema.TypeList,

--- a/website/docs/r/clb_instance.html.markdown
+++ b/website/docs/r/clb_instance.html.markdown
@@ -556,7 +556,10 @@ The following arguments are supported:
 * `dynamic_vip` - (Optional, Bool) If create dynamic vip CLB instance, `true` or `false`.
 * `eip_address_id` - (Optional, String) The unique ID of the EIP, such as eip-1v2rmbwk, is only applicable to the intranet load balancing binding EIP. During the EIP change, there may be a brief network interruption.
 * `exclusive_cluster` - (Optional, List, ForceNew) Information about the dedicated CLB instance. You must specify this parameter when you create a dedicated CLB instance in a private network.
-* `internet_bandwidth_max_out` - (Optional, Int) Max bandwidth out, only applicable to open CLB. Valid value ranges is [1, 2048]. Unit is Mbps.
+* `internet_bandwidth_max_out` - (Optional, Int) Maximum outbound bandwidth, in Mbps. This parameter is valid only for public network shared, LCU-supported, and exclusive CLB instances and private network LCU-supported CLB instances.
+- The range of the maximum outbound bandwidth for public network shared and exclusive CLB instances is 1-2,048 Mbps.
+- The range of the maximum outbound bandwidth for public network and private network LCU-supported CLB instances is 1-61,440 Mbps.
+(Default to 10Mbps when CreateLoadBalancer is call.).
 * `internet_charge_type` - (Optional, String) Internet charge type, only applicable to open CLB. Valid values are `TRAFFIC_POSTPAID_BY_HOUR`, `BANDWIDTH_POSTPAID_BY_HOUR` and `BANDWIDTH_PACKAGE`.
 * `load_balancer_pass_to_target` - (Optional, Bool) Whether the target allow flow come from clb. If value is true, only check security group of clb, or check both clb and backend instance security group.
 * `log_set_id` - (Optional, String) The id of log set.


### PR DESCRIPTION
Update the description of `internet_max_bandwidth_out` field in `tencentcloud_clb_instance` resource to provide more detailed bandwidth range information for different CLB instance types (shared, exclusive, and LCU-supported).