### PR TITLE
feat(postgresql): [135432809] add backup_method parameter to tencentcloud_postgresql_instance backup_plan

### DIFF
--- a/.changelog/4274.txt
+++ b/.changelog/4274.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_postgresql_instance: add `backup_method` parameter to `backup_plan` block
+```

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.101
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mps v1.3.45
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/organization v1.3.110
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.89
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.123
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/privatedns v1.1.42
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/pts v1.0.762
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.73

--- a/go.sum
+++ b/go.sum
@@ -1002,6 +1002,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.115/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.118/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.121/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.122/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.123/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.124/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.125/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127 h1:/Z1234g1ixp6dR5YR8+CHYKcf6A3HgOWiJjBU96vvng=
@@ -1077,8 +1078,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/oceanus v1.0.831 h1:oya
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/oceanus v1.0.831/go.mod h1:2WuTlTnKCnZoa6l0JxY9GNfo0UG6nU7AEsljF8rMMsM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/organization v1.3.110 h1:3hLFcHVgG8y+6+MqfOB8Uodqn3wl1RX1i0bZFXjKuXA=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/organization v1.3.110/go.mod h1:ICHm80O3Lq/iNLLnNeCK+UbiWhgnPZyyHJoeqxqJEiw=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.89 h1:4HdSGx6XJb0/HVLKzWp7YdqvdeiISPAYsMjL9IJaXPI=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.89/go.mod h1:7JNIsh6G2GmRhPIYUM4Sa/x1t57cWIBAempwHoMDMp4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.123 h1:AzLUCnjGjeBwVEeFG3pOuZeQe5U23YfnFnBI1b/bdl4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.123/go.mod h1:i91Na8Oym6hfVAJZzwwWeMvjnGPsVkz44q3U58RGcI4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/privatedns v1.1.42 h1:iTpAHqJrenwbFF1kE4DqYeuOMcm50L0YEoVTOQ3n/Ck=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/privatedns v1.1.42/go.mod h1:nhF6hHhT7CJZC03MMwL1/QYDI/0q9rAcW/4tf0nhfFc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/pts v1.0.762 h1:rZDKucVVtTnmnbZFDyh6t47dHswkb2oSuOxOHTTkygA=

--- a/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/design.md
+++ b/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/design.md
@@ -1,0 +1,52 @@
+## Context
+
+`tencentcloud_postgresql_instance` 是管理腾讯云 PostgreSQL 实例全生命周期的 RESOURCE_KIND_GENERAL 资源。其中 `backup_plan` 是一个 `TypeList`（`MaxItems: 1`）嵌套块，用于管理实例的备份计划。
+
+现有的 `backup_plan` CRUD 逻辑如下：
+- **Create**：若用户配置了 `monthly_backup_period`，先调用 `CreateBackupPlan`（`BackupPeriodType=month`）创建月度备份计划；随后始终调用 `ModifyBackupPlan` 修改默认（week）备份计划，将 `min_backup_start_time`、`max_backup_start_time`、`base_backup_retention_period`、`backup_period` 等字段传入。
+- **Read**：调用 `DescribeBackupPlans` 获取备份计划列表，按 `BackupPeriodType` 区分 `week`（默认计划）与 `month`（自定义月度计划），将各字段回填到 `backup_plan` 块。
+- **Update**：当 `d.HasChange("backup_plan")` 时，调用 `ModifyBackupPlan` 更新默认计划，并对月度计划执行 create/modify/delete 分支处理。
+
+腾讯云 `ModifyBackupPlan` 接口（`postgres/v20170312`）近期新增了 `BackupMethod` 入参（枚举值：`physical` 物理备份、`logical` 逻辑备份、`snapshot` 快照备份），同时 `BackupPlan` 响应结构也已包含 `BackupMethod` 字段。本次变更将该参数透传到 Terraform 资源。
+
+vendor 中的 SDK 已更新到位（`ModifyBackupPlanRequest.BackupMethod`、`BackupPlan.BackupMethod` 均已存在），无需额外升级 SDK。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 `backup_plan` 嵌套块中新增 `backup_method` 参数，使用户可指定备份方式。
+- 在 Create/Update 流程中将 `backup_method` 通过 `ModifyBackupPlanRequest.BackupMethod` 传递给云API。
+- 在 Read 流程中从 `BackupPlan.BackupMethod` 回填到 state。
+- 保持向后兼容：参数为 Optional + Computed，不影响现有配置。
+
+**Non-Goals:**
+- 不修改 `CreateBackupPlan` 接口的调用（该接口不支持 `BackupMethod`，仅用于创建 month 类型计划）。
+- 不改变 `backup_plan` 块的其他字段语义。
+- 不调整月度备份计划（month）的逻辑，`backup_method` 仅作用于通过 `ModifyBackupPlan` 修改的默认（week）备份计划。
+- 不修改 provider.go 注册（资源已注册）。
+
+## Decisions
+
+### 决策 1：`backup_method` 作为 `backup_plan` 嵌套块字段，而非顶层字段
+**选择**：将 `backup_method` 放入 `backup_plan` 块内。
+**理由**：`BackupMethod` 是备份计划的属性，与 `min_backup_start_time`、`backup_period` 等同级，语义上属于备份计划配置。云API `ModifyBackupPlan` 也是在备份计划维度设置该参数。放入顶层会破坏与现有 `backup_plan` 字段的一致性。
+**备选**：作为顶层字段——已否决，语义不符。
+
+### 决策 2：`backup_method` 标记为 Optional + Computed
+**选择**：`Optional: true, Computed: true`。
+**理由**：用户可不指定该参数（由云API使用默认备份方式），此时 Read 时需从 API 回填实际值，故 Computed。这符合"不能修改已有资源 schema（除非只新增 Optional 字段）"的硬约束，保证向后兼容。
+
+### 决策 3：仅在 `ModifyBackupPlan` 调用中传递 `BackupMethod`
+**选择**：在 Create 和 Update 流程中调用 `ModifyBackupPlan`（修改默认 week 计划）时设置 `request.BackupMethod`；不为月度计划的 `CreateBackupPlan`/`ModifyBackupPlan` 设置该参数。
+**理由**：`CreateBackupPlanRequest` 不支持 `BackupMethod` 字段；需求明确指定 `BackupMethod` 为 `ModifyBackupPlan` 接口的新增入参。现有代码中默认计划的修改均通过 `ModifyBackupPlanRequest` 完成，在此处透传即可覆盖主要场景。月度计划保持原有逻辑不变，避免引入不一致。
+**备选**：同时在月度计划的 `ModifyBackupPlanRequest`（`request1`）中设置——暂不采用，避免扩大改动范围，聚焦需求中明确的单一参数。
+
+### 决策 4：Read 时回填 `backup_method`
+**选择**：在 Read 流程中，当 `backupPlan`（week 类型）的 `BackupMethod` 非 nil 时，写入 `planMap["backup_method"]`。
+**理由**：遵循现有 nil 安全模式（先判断非 nil 再 set），与同块内其他字段处理方式一致。
+
+## Risks / Trade-offs
+
+- [风险] 用户设置了不被实例版本/规格支持的 `BackupMethod` 枚举值 → 由云API校验并返回错误，Terraform 透传错误信息；schema 层不强制枚举校验，以兼容未来云API可能新增的枚举值。
+- [风险] 旧版本 state 中无 `backup_method` 字段 → 由于该字段为 Optional+Computed，Terraform 在 Read 后会自动回填，不影响现有资源。
+- [权衡] 仅对默认（week）计划设置 `BackupMethod`，月度计划不设置 → 月度计划的备份方式由云API默认值决定；如后续云API在 `CreateBackupPlan` 支持 `BackupMethod`，可再扩展。

--- a/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/proposal.md
+++ b/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+腾讯云 PostgreSQL 的 `ModifyBackupPlan` 云API新增了 `BackupMethod` 入参，支持配置备份方式（物理备份 `physical`、逻辑备份 `logical`、快照备份 `snapshot`）。当前 `tencentcloud_postgresql_instance` 资源的 `backup_plan` 块未暴露该参数，用户无法通过 Terraform 指定备份计划采用的备份方式，导致无法使用云API最新提供的能力。本次变更新增该参数，使 Terraform 资源与云API能力保持同步。
+
+## What Changes
+
+- 在 `tencentcloud_postgresql_instance` 资源的 `backup_plan` 嵌套块 schema 中新增 `backup_method` 字段（`schema.TypeString`，Optional，Computed）。
+- 在资源 Create 流程中，调用 `ModifyBackupPlan` 设置默认备份计划时，将用户配置的 `backup_method` 传入 `ModifyBackupPlanRequest.BackupMethod`。
+- 在资源 Update 流程中，当 `backup_plan` 发生变更时，将 `backup_method` 传入 `ModifyBackupPlanRequest.BackupMethod`。
+- 在资源 Read 流程中，从 `DescribeBackupPlans` 返回的 `BackupPlan.BackupMethod` 读取并回填到 state。
+- 更新资源文档 `resource_tc_postgresql_instance.md`，补充 `backup_method` 参数说明与示例。
+
+## Capabilities
+
+### New Capabilities
+- `postgresql-instance-backup-method`: 为 `tencentcloud_postgresql_instance` 资源的 `backup_plan` 块新增 `backup_method` 参数，支持配置备份方式（physical/logical/snapshot），覆盖 schema 定义、Create/Update/Read 流程及文档。
+
+### Modified Capabilities
+<!-- 无现有 spec 需要修改 -->
+
+## Impact
+
+- **受影响代码**:
+  - `tencentcloud/services/postgresql/resource_tc_postgresql_instance.go` - schema 定义及 CRUD 逻辑（Create、Update、Read 中 `backup_plan` 相关处理）
+  - `tencentcloud/services/postgresql/resource_tc_postgresql_instance.md` - 资源示例文档
+- **云API依赖**: `ModifyBackupPlan` 接口（`postgres/v20170312`）已新增 `BackupMethod` 入参；`BackupPlan` 响应结构已包含 `BackupMethod` 字段。vendor 中的 SDK 已更新到位，无需额外升级 SDK。
+- **向后兼容**: `backup_method` 为 Optional 且 Computed 字段，不破坏现有配置与 state。

--- a/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/specs/postgresql-instance-backup-method/spec.md
+++ b/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/specs/postgresql-instance-backup-method/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: backup_plan 块新增 backup_method 字段
+
+`tencentcloud_postgresql_instance` 资源的 `backup_plan` 嵌套块 SHALL 包含 `backup_method` 字段，用于指定备份计划采用的备份方式。
+
+#### Scenario: Schema 定义 backup_method 字段
+
+- **假设** 定义 `tencentcloud_postgresql_instance` 资源的 `backup_plan` 嵌套块 schema
+- **当** schema 定义完成时
+- **那么** `backup_plan` 块 SHALL 包含 `backup_method` 字段，具备以下属性：
+  - 类型: `schema.TypeString`
+  - Optional: `true`
+  - Computed: `true`
+  - Description 说明备份方式枚举值（`physical` 物理备份、`logical` 逻辑备份、`snapshot` 快照备份）
+
+### Requirement: Create 流程传递 BackupMethod
+
+资源 Create 流程在调用 `ModifyBackupPlan` 修改默认备份计划时，SHALL 将用户配置的 `backup_method` 传入 `ModifyBackupPlanRequest.BackupMethod`。
+
+#### Scenario: 创建时设置备份方式
+
+- **假设** 用户在 `backup_plan` 块中配置了 `backup_method = "logical"`
+- **当** 执行资源 Create 流程，调用 `ModifyBackupPlan` 修改默认（week）备份计划时
+- **那么** SHALL 将 `request.BackupMethod` 设置为 `"logical"` 传递给云API
+
+#### Scenario: 创建时未配置备份方式
+
+- **假设** 用户未在 `backup_plan` 块中配置 `backup_method`
+- **当** 执行资源 Create 流程，调用 `ModifyBackupPlan` 修改默认（week）备份计划时
+- **那么** SHALL 不设置 `request.BackupMethod`，由云API使用默认备份方式
+
+### Requirement: Update 流程传递 BackupMethod
+
+资源 Update 流程在 `backup_plan` 发生变更调用 `ModifyBackupPlan` 时，SHALL 将用户配置的 `backup_method` 传入 `ModifyBackupPlanRequest.BackupMethod`。
+
+#### Scenario: 更新时修改备份方式
+
+- **假设** 存在一个已创建的 postgresql instance 资源
+- **当** 用户修改 `backup_plan` 块中的 `backup_method` 值并执行 Update 流程时
+- **那么** 调用 `ModifyBackupPlan` 修改默认（week）备份计划时，SHALL 将新的 `backup_method` 值传入 `request.BackupMethod`
+
+#### Scenario: 更新时未配置备份方式
+
+- **假设** 存在一个已创建的 postgresql instance 资源
+- **当** 用户修改 `backup_plan` 其他字段但未配置 `backup_method` 并执行 Update 流程时
+- **那么** 调用 `ModifyBackupPlan` 时 SHALL 不设置 `request.BackupMethod`
+
+### Requirement: Read 流程回填 backup_method
+
+资源 Read 流程 SHALL 从 `DescribeBackupPlans` 返回的默认（week）备份计划中读取 `BackupMethod` 字段并回填到 state。
+
+#### Scenario: 读取并回填备份方式
+
+- **假设** 调用 `DescribeBackupPlans` 返回的默认（week）备份计划中 `BackupMethod` 字段非 nil
+- **当** 执行资源 Read 流程，构造 `backup_plan` 的 `planMap` 时
+- **那么** SHALL 将 `backupPlan.BackupMethod` 写入 `planMap["backup_method"]` 并通过 `d.Set("backup_plan", ...)` 回填到 state
+
+#### Scenario: 读取时备份方式为空不回填
+
+- **假设** 调用 `DescribeBackupPlans` 返回的默认（week）备份计划中 `BackupMethod` 字段为 nil
+- **当** 执行资源 Read 流程，构造 `backup_plan` 的 `planMap` 时
+- **那么** SHALL 不设置 `planMap["backup_method"]`，保持 nil 安全
+
+### Requirement: 资源文档更新
+
+资源文档 `resource_tc_postgresql_instance.md` SHALL 包含 `backup_method` 参数的说明与示例。
+
+#### Scenario: 文档包含 backup_method 说明
+
+- **假设** 存在资源文档文件 `tencentcloud/services/postgresql/resource_tc_postgresql_instance.md`
+- **当** 更新文档时
+- **那么** 文档 SHALL 在 `backup_plan` 块示例中包含 `backup_method` 参数的用法，并说明其枚举值含义

--- a/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/tasks.md
+++ b/openspec/changes/archive/2026-07-07-add-postgresql-instance-backup-method-param/tasks.md
@@ -1,0 +1,22 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/postgresql/resource_tc_postgresql_instance.go` 的 `backup_plan` 嵌套块 schema 中新增 `backup_method` 字段（`schema.TypeString`，Optional: true，Computed: true），Description 说明枚举值 `physical`（物理备份）、`logical`（逻辑备份）、`snapshot`（快照备份）
+
+## 2. CRUD 函数实现
+
+- [x] 2.1 在 Create 流程的 `resourceTencentCloudPostgresqlInstanceCreate` 函数中，调用 `ModifyBackupPlan` 修改默认（week）备份计划时，从 `plan["backup_method"]` 读取用户配置，非空时设置 `request.BackupMethod`
+- [x] 2.2 在 Update 流程的 `resourceTencentCloudPostgresqlInstanceUpdate` 函数中，当 `d.HasChange("backup_plan")` 且调用 `ModifyBackupPlan` 修改默认（week）备份计划时，从 `plan["backup_method"]` 读取用户配置，非空时设置 `request.BackupMethod`
+- [x] 2.3 在 Read 流程的 `resourceTencentCloudPostgresqlInstanceRead` 函数中，构造默认（week）备份计划的 `planMap` 时，判断 `backupPlan.BackupMethod` 非 nil 后写入 `planMap["backup_method"]`，保持 nil 安全
+
+## 3. 文档更新
+
+- [x] 3.1 更新 `tencentcloud/services/postgresql/resource_tc_postgresql_instance.md`，在 `backup_plan` 块示例中补充 `backup_method` 参数用法及枚举值说明
+
+## 4. 测试
+
+- [x] 4.1 在 `tencentcloud/services/postgresql/resource_tc_postgresql_instance_test.go` 中补充 `backup_method` 参数的单元测试用例（使用 gomonkey mock 云API，验证 Create/Update 传入 BackupMethod、Read 回填逻辑）
+
+## 5. 验证
+
+- [x] 5.1 使用 `go test -gcflags=all=-l` 运行涉及的单元测试文件，确保测试通过
+- [x] 5.2 运行 `openspec validate add-postgresql-instance-backup-method-param --strict` 验证提案完整性

--- a/openspec/specs/postgresql-instance-backup-method/spec.md
+++ b/openspec/specs/postgresql-instance-backup-method/spec.md
@@ -1,0 +1,77 @@
+# postgresql-instance-backup-method Specification
+
+## Purpose
+TBD - created by archiving change add-postgresql-instance-backup-method-param. Update Purpose after archive.
+## Requirements
+### Requirement: backup_plan 块新增 backup_method 字段
+
+`tencentcloud_postgresql_instance` 资源的 `backup_plan` 嵌套块 SHALL 包含 `backup_method` 字段，用于指定备份计划采用的备份方式。
+
+#### Scenario: Schema 定义 backup_method 字段
+
+- **假设** 定义 `tencentcloud_postgresql_instance` 资源的 `backup_plan` 嵌套块 schema
+- **当** schema 定义完成时
+- **那么** `backup_plan` 块 SHALL 包含 `backup_method` 字段，具备以下属性：
+  - 类型: `schema.TypeString`
+  - Optional: `true`
+  - Computed: `true`
+  - Description 说明备份方式枚举值（`physical` 物理备份、`logical` 逻辑备份、`snapshot` 快照备份）
+
+### Requirement: Create 流程传递 BackupMethod
+
+资源 Create 流程在调用 `ModifyBackupPlan` 修改默认备份计划时，SHALL 将用户配置的 `backup_method` 传入 `ModifyBackupPlanRequest.BackupMethod`。
+
+#### Scenario: 创建时设置备份方式
+
+- **假设** 用户在 `backup_plan` 块中配置了 `backup_method = "logical"`
+- **当** 执行资源 Create 流程，调用 `ModifyBackupPlan` 修改默认（week）备份计划时
+- **那么** SHALL 将 `request.BackupMethod` 设置为 `"logical"` 传递给云API
+
+#### Scenario: 创建时未配置备份方式
+
+- **假设** 用户未在 `backup_plan` 块中配置 `backup_method`
+- **当** 执行资源 Create 流程，调用 `ModifyBackupPlan` 修改默认（week）备份计划时
+- **那么** SHALL 不设置 `request.BackupMethod`，由云API使用默认备份方式
+
+### Requirement: Update 流程传递 BackupMethod
+
+资源 Update 流程在 `backup_plan` 发生变更调用 `ModifyBackupPlan` 时，SHALL 将用户配置的 `backup_method` 传入 `ModifyBackupPlanRequest.BackupMethod`。
+
+#### Scenario: 更新时修改备份方式
+
+- **假设** 存在一个已创建的 postgresql instance 资源
+- **当** 用户修改 `backup_plan` 块中的 `backup_method` 值并执行 Update 流程时
+- **那么** 调用 `ModifyBackupPlan` 修改默认（week）备份计划时，SHALL 将新的 `backup_method` 值传入 `request.BackupMethod`
+
+#### Scenario: 更新时未配置备份方式
+
+- **假设** 存在一个已创建的 postgresql instance 资源
+- **当** 用户修改 `backup_plan` 其他字段但未配置 `backup_method` 并执行 Update 流程时
+- **那么** 调用 `ModifyBackupPlan` 时 SHALL 不设置 `request.BackupMethod`
+
+### Requirement: Read 流程回填 backup_method
+
+资源 Read 流程 SHALL 从 `DescribeBackupPlans` 返回的默认（week）备份计划中读取 `BackupMethod` 字段并回填到 state。
+
+#### Scenario: 读取并回填备份方式
+
+- **假设** 调用 `DescribeBackupPlans` 返回的默认（week）备份计划中 `BackupMethod` 字段非 nil
+- **当** 执行资源 Read 流程，构造 `backup_plan` 的 `planMap` 时
+- **那么** SHALL 将 `backupPlan.BackupMethod` 写入 `planMap["backup_method"]` 并通过 `d.Set("backup_plan", ...)` 回填到 state
+
+#### Scenario: 读取时备份方式为空不回填
+
+- **假设** 调用 `DescribeBackupPlans` 返回的默认（week）备份计划中 `BackupMethod` 字段为 nil
+- **当** 执行资源 Read 流程，构造 `backup_plan` 的 `planMap` 时
+- **那么** SHALL 不设置 `planMap["backup_method"]`，保持 nil 安全
+
+### Requirement: 资源文档更新
+
+资源文档 `resource_tc_postgresql_instance.md` SHALL 包含 `backup_method` 参数的说明与示例。
+
+#### Scenario: 文档包含 backup_method 说明
+
+- **假设** 存在资源文档文件 `tencentcloud/services/postgresql/resource_tc_postgresql_instance.md`
+- **当** 更新文档时
+- **那么** 文档 SHALL 在 `backup_plan` 块示例中包含 `backup_method` 参数的用法，并说明其枚举值含义
+

--- a/tencentcloud/services/postgresql/resource_tc_postgresql_instance.go
+++ b/tencentcloud/services/postgresql/resource_tc_postgresql_instance.go
@@ -292,6 +292,13 @@ func ResourceTencentCloudPostgresqlInstance() *schema.Resource {
 							Computed:    true,
 							Description: "Monthly plan id.",
 						},
+						"backup_method": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							Description: "Backup method. Valid values: `physical` (physical backup), `logical` (logical backup), " +
+								"`snapshot` (snapshot backup). Only takes effect on the default (week) backup plan.",
+						},
 					},
 				},
 			},
@@ -788,6 +795,10 @@ func resourceTencentCloudPostgresqlInstanceCreate(d *schema.ResourceData, meta i
 			request.BackupPeriod = helper.InterfacesStringsPoint(v)
 		}
 
+		if v, ok := plan["backup_method"].(string); ok && v != "" {
+			request.BackupMethod = &v
+		}
+
 		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 			err := postgresqlService.ModifyBackupPlan(ctx, request)
 			if err != nil {
@@ -1098,6 +1109,10 @@ func resourceTencentCloudPostgresqlInstanceRead(d *schema.ResourceData, meta int
 			}
 
 			planMap["backup_period"] = strSlice
+		}
+
+		if backupPlan.BackupMethod != nil {
+			planMap["backup_method"] = backupPlan.BackupMethod
 		}
 
 		if monthlyBackupPlan != nil && monthlyBackupPlan.PlanId != nil {
@@ -1604,6 +1619,10 @@ func resourceTencentCloudPostgresqlInstanceUpdate(d *schema.ResourceData, meta i
 
 			if v, ok := plan["backup_period"].([]interface{}); ok && len(v) > 0 {
 				request.BackupPeriod = helper.InterfacesStringsPoint(v)
+			}
+
+			if v, ok := plan["backup_method"].(string); ok && v != "" {
+				request.BackupMethod = &v
 			}
 
 			err := postgresqlService.ModifyBackupPlan(ctx, request)

--- a/tencentcloud/services/postgresql/resource_tc_postgresql_instance.md
+++ b/tencentcloud/services/postgresql/resource_tc_postgresql_instance.md
@@ -248,6 +248,45 @@ resource "tencentcloud_postgresql_instance" "example" {
     max_backup_start_time        = "01:10:11"
     base_backup_retention_period = 7
     backup_period                = ["tuesday", "wednesday"]
+    backup_method                = "physical"
+  }
+
+  tags = {
+    CreateBy = "Terraform"
+  }
+}
+```
+
+Create pgsql with backup plan and backup method
+
+The `backup_method` field specifies the backup method of the default (week) backup plan. Valid values: `physical` (physical backup), `logical` (logical backup), `snapshot` (snapshot backup). If not specified, the cloud API uses the default backup method.
+
+```hcl
+variable "availability_zone" {
+  default = "ap-guangzhou-6"
+}
+
+resource "tencentcloud_postgresql_instance" "example" {
+  name              = "tf_postsql_instance"
+  availability_zone = var.availability_zone
+  charge_type       = "POSTPAID_BY_HOUR"
+  vpc_id            = "vpc-86v957zb"
+  subnet_id         = "subnet-enm92y0m"
+  db_major_version  = "11"
+  engine_version    = "11.12"
+  db_kernel_version = "v11.12_r1.3"
+  root_password     = "Root123$"
+  charset           = "LATIN1"
+  project_id        = 0
+  memory            = 4
+  storage           = 100
+
+  backup_plan {
+    min_backup_start_time        = "00:10:11"
+    max_backup_start_time        = "01:10:11"
+    base_backup_retention_period = 7
+    backup_period                = ["tuesday", "wednesday"]
+    backup_method                = "snapshot"
   }
 
   tags = {
@@ -285,6 +324,7 @@ resource "tencentcloud_postgresql_instance" "example" {
     max_backup_start_time        = "02:10:11"
     base_backup_retention_period = 5
     backup_period                = ["monday", "thursday", "sunday"]
+    backup_method                = "logical"
   }
 
   tags = {

--- a/tencentcloud/services/postgresql/resource_tc_postgresql_instance_backup_method_test.go
+++ b/tencentcloud/services/postgresql/resource_tc_postgresql_instance_backup_method_test.go
@@ -1,0 +1,723 @@
+package postgresql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	postgresql "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres/v20170312"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	svcpostgresql "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/postgresql"
+	svctag "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tag"
+)
+
+type mockMetaPostgresqlInstance struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaPostgresqlInstance) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaPostgresqlInstance{}
+
+func newMockMetaPostgresqlInstance() *mockMetaPostgresqlInstance {
+	return &mockMetaPostgresqlInstance{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrInst(s string) *string {
+	return &s
+}
+
+func ptrUint64Inst(i uint64) *uint64 {
+	return &i
+}
+
+func ptrInt64Inst(i int64) *int64 {
+	return &i
+}
+
+// go test ./tencentcloud/services/postgresql/ -run "TestPostgresqlInstanceBackupMethod_Read" -v -count=1 -gcflags="all=-l"
+func TestPostgresqlInstanceBackupMethod_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	pgServiceType := svcpostgresql.PostgresqlService{}
+	instanceId := "postgres-backup-method-test"
+
+	// 1. DescribePostgresqlInstanceById -> running instance with 2 net infos
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstanceById", func(ctx context.Context, id string) (*postgresql.DBInstance, bool, error) {
+		assert.Equal(t, instanceId, id)
+		running := "running"
+		zone := "ap-guangzhou-3"
+		netTypePrivate := "private"
+		ip := "10.0.0.1"
+		port := uint64(5432)
+		netTypePublic := "public"
+		statusClosed := "closed"
+		pubHost := "1.2.3.4"
+		pubPort := uint64(6432)
+		vpcId := "vpc-test"
+		subnetId := "subnet-test"
+		instance := &postgresql.DBInstance{
+			DBInstanceId:      &instanceId,
+			DBInstanceName:    ptrStrInst("tf_postsql_instance"),
+			DBInstanceStatus:  &running,
+			Zone:              &zone,
+			DBVersion:         ptrStrInst("13.3"),
+			DBMajorVersion:    ptrStrInst("13"),
+			DBKernelVersion:   ptrStrInst("v13.3_r1.1"),
+			DBCharset:         ptrStrInst("UTF8"),
+			ProjectId:         ptrUint64Inst(0),
+			PayType:           ptrStrInst("postpaid"),
+			AutoRenew:         ptrUint64Inst(0),
+			DBInstanceMemory:  ptrUint64Inst(4 * 1024),
+			DBInstanceStorage: ptrUint64Inst(100),
+			DBInstanceCpu:     ptrUint64Inst(1),
+			CreateTime:        ptrStrInst("2024-01-01 00:00:00"),
+			VpcId:             &vpcId,
+			SubnetId:          &subnetId,
+			DBInstanceNetInfo: []*postgresql.DBInstanceNetInfo{
+				{
+					NetType:  &netTypePrivate,
+					Ip:       &ip,
+					Port:     &port,
+					VpcId:    &vpcId,
+					SubnetId: &subnetId,
+				},
+				{
+					NetType: &netTypePublic,
+					Status:  &statusClosed,
+					Address: &pubHost,
+					Port:    &pubPort,
+				},
+			},
+		}
+		return instance, true, nil
+	})
+
+	// 2. DescribeRootUser -> empty
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeRootUser", func(ctx context.Context, id string) ([]*postgresql.AccountInfo, error) {
+		return []*postgresql.AccountInfo{}, nil
+	})
+
+	// 3. DescribeDBInstanceSecurityGroupsById -> empty
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBInstanceSecurityGroupsById", func(ctx context.Context, id string) ([]string, error) {
+		return []string{}, nil
+	})
+
+	// 4. DescribeDBInstanceAttribute -> ins with storage type and deletion protection
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBInstanceAttribute", func(ctx context.Context, request *postgresql.DescribeDBInstanceAttributeRequest) (*postgresql.DBInstance, error) {
+		storageType := "CLOUD_SSD"
+		deletionProtection := false
+		return &postgresql.DBInstance{
+			DBInstanceStorageType: &storageType,
+			DeletionProtection:    &deletionProtection,
+			DBNodeSet:             []*postgresql.DBNode{},
+		}, nil
+	})
+
+	// 5. DescribeDBEncryptionKeys -> has=false
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBEncryptionKeys", func(ctx context.Context, request *postgresql.DescribeEncryptionKeysRequest) (bool, *postgresql.EncryptionKey, error) {
+		return false, nil, nil
+	})
+
+	// 6. DescribePostgresqlInstances -> one instance with Uid
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstances", func(ctx context.Context, filter []*postgresql.Filter) ([]*postgresql.DBInstance, error) {
+		return []*postgresql.DBInstance{
+			{
+				DBInstanceId: &instanceId,
+				Uid:          ptrUint64Inst(123456),
+			},
+		}, nil
+	})
+
+	// 7. DescribeBackupPlans -> week plan with BackupMethod
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeBackupPlans", func(ctx context.Context, request *postgresql.DescribeBackupPlansRequest) ([]*postgresql.BackupPlan, error) {
+		periodTypeWeek := "week"
+		minTime := "00:10:11"
+		maxTime := "01:10:11"
+		retention := uint64(7)
+		backupPeriod := "[\"tuesday\",\"wednesday\"]"
+		backupMethod := "logical"
+		return []*postgresql.BackupPlan{
+			{
+				BackupPeriodType:          &periodTypeWeek,
+				MinBackupStartTime:        &minTime,
+				MaxBackupStartTime:        &maxTime,
+				BaseBackupRetentionPeriod: &retention,
+				BackupPeriod:              &backupPeriod,
+				BackupMethod:              &backupMethod,
+			},
+		}, nil
+	})
+
+	// 8. DescribePgParams -> params map
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePgParams", func(ctx context.Context, id string) (map[string]string, error) {
+		return map[string]string{
+			"max_standby_streaming_delay": "10000",
+			"max_standby_archive_delay":   "10000",
+		}, nil
+	})
+
+	// 9. tag NewTagService + DescribeResourceTags
+	tagServiceType := svctag.TagService{}
+	patches.ApplyMethodFunc(&tagServiceType, "DescribeResourceTags", func(ctx context.Context, serviceType, resourceType, region, resourceId string) (map[string]string, error) {
+		return map[string]string{}, nil
+	})
+
+	meta := newMockMetaPostgresqlInstance()
+	res := svcpostgresql.ResourceTencentCloudPostgresqlInstance()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":              "tf_postsql_instance",
+		"vpc_id":            "vpc-test",
+		"subnet_id":         "subnet-test",
+		"availability_zone": "ap-guangzhou-3",
+		"storage":           100,
+		"memory":            4,
+		"root_password":     "Root123$",
+		"backup_plan": []interface{}{
+			map[string]interface{}{
+				"min_backup_start_time":        "00:10:11",
+				"max_backup_start_time":        "01:10:11",
+				"base_backup_retention_period": 7,
+				"backup_period":                []interface{}{"tuesday", "wednesday"},
+				"backup_method":                "logical",
+			},
+		},
+	})
+	d.SetId(instanceId)
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, instanceId, d.Id())
+
+	// verify backup_method is read back from API
+	backupPlan := d.Get("backup_plan").([]interface{})
+	assert.Equal(t, 1, len(backupPlan))
+	planMap := backupPlan[0].(map[string]interface{})
+	assert.Equal(t, "logical", planMap["backup_method"])
+	assert.Equal(t, "00:10:11", planMap["min_backup_start_time"])
+	assert.Equal(t, "01:10:11", planMap["max_backup_start_time"])
+	assert.Equal(t, 7, planMap["base_backup_retention_period"])
+}
+
+// go test ./tencentcloud/services/postgresql/ -run "TestPostgresqlInstanceBackupMethod_ReadNil" -v -count=1 -gcflags="all=-l"
+func TestPostgresqlInstanceBackupMethod_ReadNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	pgServiceType := svcpostgresql.PostgresqlService{}
+	instanceId := "postgres-backup-method-nil-test"
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstanceById", func(ctx context.Context, id string) (*postgresql.DBInstance, bool, error) {
+		running := "running"
+		zone := "ap-guangzhou-3"
+		netTypePrivate := "private"
+		ip := "10.0.0.1"
+		port := uint64(5432)
+		netTypePublic := "public"
+		statusClosed := "closed"
+		pubHost := "1.2.3.4"
+		pubPort := uint64(6432)
+		vpcId := "vpc-test"
+		subnetId := "subnet-test"
+		instance := &postgresql.DBInstance{
+			DBInstanceId:     &instanceId,
+			DBInstanceName:   ptrStrInst("tf_postsql_instance"),
+			DBInstanceStatus: &running,
+			Zone:             &zone,
+			DBCharset:        ptrStrInst("UTF8"),
+			ProjectId:        ptrUint64Inst(0),
+			PayType:          ptrStrInst("postpaid"),
+			VpcId:            &vpcId,
+			SubnetId:         &subnetId,
+			DBInstanceNetInfo: []*postgresql.DBInstanceNetInfo{
+				{
+					NetType:  &netTypePrivate,
+					Ip:       &ip,
+					Port:     &port,
+					VpcId:    &vpcId,
+					SubnetId: &subnetId,
+				},
+				{
+					NetType: &netTypePublic,
+					Status:  &statusClosed,
+					Address: &pubHost,
+					Port:    &pubPort,
+				},
+			},
+		}
+		return instance, true, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeRootUser", func(ctx context.Context, id string) ([]*postgresql.AccountInfo, error) {
+		return []*postgresql.AccountInfo{}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBInstanceSecurityGroupsById", func(ctx context.Context, id string) ([]string, error) {
+		return []string{}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBInstanceAttribute", func(ctx context.Context, request *postgresql.DescribeDBInstanceAttributeRequest) (*postgresql.DBInstance, error) {
+		storageType := "CLOUD_SSD"
+		deletionProtection := false
+		return &postgresql.DBInstance{
+			DBInstanceStorageType: &storageType,
+			DeletionProtection:    &deletionProtection,
+			DBNodeSet:             []*postgresql.DBNode{},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBEncryptionKeys", func(ctx context.Context, request *postgresql.DescribeEncryptionKeysRequest) (bool, *postgresql.EncryptionKey, error) {
+		return false, nil, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstances", func(ctx context.Context, filter []*postgresql.Filter) ([]*postgresql.DBInstance, error) {
+		return []*postgresql.DBInstance{
+			{
+				DBInstanceId: &instanceId,
+				Uid:          ptrUint64Inst(123456),
+			},
+		}, nil
+	})
+
+	// BackupMethod is nil, should not be set
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeBackupPlans", func(ctx context.Context, request *postgresql.DescribeBackupPlansRequest) ([]*postgresql.BackupPlan, error) {
+		periodTypeWeek := "week"
+		minTime := "00:10:11"
+		maxTime := "01:10:11"
+		retention := uint64(7)
+		backupPeriod := "[\"tuesday\",\"wednesday\"]"
+		return []*postgresql.BackupPlan{
+			{
+				BackupPeriodType:          &periodTypeWeek,
+				MinBackupStartTime:        &minTime,
+				MaxBackupStartTime:        &maxTime,
+				BaseBackupRetentionPeriod: &retention,
+				BackupPeriod:              &backupPeriod,
+			},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePgParams", func(ctx context.Context, id string) (map[string]string, error) {
+		return map[string]string{
+			"max_standby_streaming_delay": "10000",
+			"max_standby_archive_delay":   "10000",
+		}, nil
+	})
+
+	tagServiceType := svctag.TagService{}
+	patches.ApplyMethodFunc(&tagServiceType, "DescribeResourceTags", func(ctx context.Context, serviceType, resourceType, region, resourceId string) (map[string]string, error) {
+		return map[string]string{}, nil
+	})
+
+	meta := newMockMetaPostgresqlInstance()
+	res := svcpostgresql.ResourceTencentCloudPostgresqlInstance()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":              "tf_postsql_instance",
+		"vpc_id":            "vpc-test",
+		"subnet_id":         "subnet-test",
+		"availability_zone": "ap-guangzhou-3",
+		"storage":           100,
+		"memory":            4,
+		"root_password":     "Root123$",
+	})
+	d.SetId(instanceId)
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, instanceId, d.Id())
+
+	// backup_plan should be set, but backup_method is empty since API returned nil
+	backupPlan := d.Get("backup_plan").([]interface{})
+	assert.Equal(t, 1, len(backupPlan))
+	planMap := backupPlan[0].(map[string]interface{})
+	assert.Equal(t, "", planMap["backup_method"])
+}
+
+// go test ./tencentcloud/services/postgresql/ -run "TestPostgresqlInstanceBackupMethod_Create" -v -count=1 -gcflags="all=-l"
+func TestPostgresqlInstanceBackupMethod_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	pgServiceType := svcpostgresql.PostgresqlService{}
+	instanceId := "postgres-backup-method-create-test"
+
+	// capture ModifyBackupPlan request to verify BackupMethod is passed
+	var capturedBackupMethod *string
+	patches.ApplyMethodFunc(&pgServiceType, "ModifyBackupPlan", func(ctx context.Context, request *postgresql.ModifyBackupPlanRequest) error {
+		capturedBackupMethod = request.BackupMethod
+		return nil
+	})
+
+	// mock all other Create-flow dependencies
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeSpecinfos", func(ctx context.Context, zone string, storageType string) ([]*postgresql.SpecItemInfo, error) {
+		majorVersion := "13"
+		version := "13.3"
+		memory := uint64(4 * 1024)
+		cpu := uint64(1)
+		specCode := "pgdb.test.1c4m"
+		return []*postgresql.SpecItemInfo{
+			{
+				MajorVersion: &majorVersion,
+				Version:      &version,
+				Memory:       &memory,
+				Cpu:          &cpu,
+				SpecCode:     &specCode,
+			},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "CreatePostgresqlInstance", func(ctx context.Context, args ...interface{}) (string, error) {
+		return instanceId, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstanceById", func(ctx context.Context, id string) (*postgresql.DBInstance, bool, error) {
+		running := "running"
+		memory := uint64(4 * 1024)
+		return &postgresql.DBInstance{
+			DBInstanceId:     &instanceId,
+			DBInstanceStatus: &running,
+			DBInstanceMemory: &memory,
+		}, true, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "CheckDBInstanceStatus", func(ctx context.Context, id string, retryMinutes ...int) error {
+		return nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "ModifyPublicService", func(ctx context.Context, openInternet bool, id string) error {
+		return nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "ModifyPostgresqlInstanceName", func(ctx context.Context, id, name string) error {
+		return nil
+	})
+
+	// Read flow mocks (Create calls Read at the end)
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeRootUser", func(ctx context.Context, id string) ([]*postgresql.AccountInfo, error) {
+		return []*postgresql.AccountInfo{}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBInstanceSecurityGroupsById", func(ctx context.Context, id string) ([]string, error) {
+		return []string{}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBInstanceAttribute", func(ctx context.Context, request *postgresql.DescribeDBInstanceAttributeRequest) (*postgresql.DBInstance, error) {
+		storageType := "CLOUD_SSD"
+		deletionProtection := false
+		return &postgresql.DBInstance{
+			DBInstanceStorageType: &storageType,
+			DeletionProtection:    &deletionProtection,
+			DBNodeSet:             []*postgresql.DBNode{},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBEncryptionKeys", func(ctx context.Context, request *postgresql.DescribeEncryptionKeysRequest) (bool, *postgresql.EncryptionKey, error) {
+		return false, nil, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstances", func(ctx context.Context, filter []*postgresql.Filter) ([]*postgresql.DBInstance, error) {
+		return []*postgresql.DBInstance{
+			{
+				DBInstanceId: &instanceId,
+				Uid:          ptrUint64Inst(123456),
+			},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeBackupPlans", func(ctx context.Context, request *postgresql.DescribeBackupPlansRequest) ([]*postgresql.BackupPlan, error) {
+		periodTypeWeek := "week"
+		minTime := "00:10:11"
+		maxTime := "01:10:11"
+		retention := uint64(7)
+		backupPeriod := "[\"tuesday\",\"wednesday\"]"
+		backupMethod := "snapshot"
+		return []*postgresql.BackupPlan{
+			{
+				BackupPeriodType:          &periodTypeWeek,
+				MinBackupStartTime:        &minTime,
+				MaxBackupStartTime:        &maxTime,
+				BaseBackupRetentionPeriod: &retention,
+				BackupPeriod:              &backupPeriod,
+				BackupMethod:              &backupMethod,
+			},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePgParams", func(ctx context.Context, id string) (map[string]string, error) {
+		return map[string]string{
+			"max_standby_streaming_delay": "10000",
+			"max_standby_archive_delay":   "10000",
+		}, nil
+	})
+
+	tagServiceType := svctag.TagService{}
+	patches.ApplyMethodFunc(&tagServiceType, "DescribeResourceTags", func(ctx context.Context, serviceType, resourceType, region, resourceId string) (map[string]string, error) {
+		return map[string]string{}, nil
+	})
+
+	// mock DescribePostgresqlInstanceById for Read (returns instance with net info)
+	// Override the earlier patch to return full instance info for Read
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstanceById", func(ctx context.Context, id string) (*postgresql.DBInstance, bool, error) {
+		running := "running"
+		zone := "ap-guangzhou-3"
+		netTypePrivate := "private"
+		ip := "10.0.0.1"
+		port := uint64(5432)
+		netTypePublic := "public"
+		statusClosed := "closed"
+		pubHost := "1.2.3.4"
+		pubPort := uint64(6432)
+		vpcId := "vpc-test"
+		subnetId := "subnet-test"
+		memory := uint64(4 * 1024)
+		instance := &postgresql.DBInstance{
+			DBInstanceId:     &instanceId,
+			DBInstanceName:   ptrStrInst("tf_postsql_instance"),
+			DBInstanceStatus: &running,
+			Zone:             &zone,
+			DBCharset:        ptrStrInst("UTF8"),
+			ProjectId:        ptrUint64Inst(0),
+			PayType:          ptrStrInst("postpaid"),
+			VpcId:            &vpcId,
+			SubnetId:         &subnetId,
+			DBInstanceMemory: &memory,
+			DBInstanceNetInfo: []*postgresql.DBInstanceNetInfo{
+				{
+					NetType:  &netTypePrivate,
+					Ip:       &ip,
+					Port:     &port,
+					VpcId:    &vpcId,
+					SubnetId: &subnetId,
+				},
+				{
+					NetType: &netTypePublic,
+					Status:  &statusClosed,
+					Address: &pubHost,
+					Port:    &pubPort,
+				},
+			},
+		}
+		return instance, true, nil
+	})
+
+	meta := newMockMetaPostgresqlInstance()
+	res := svcpostgresql.ResourceTencentCloudPostgresqlInstance()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":              "tf_postsql_instance",
+		"vpc_id":            "vpc-test",
+		"subnet_id":         "subnet-test",
+		"availability_zone": "ap-guangzhou-3",
+		"storage":           100,
+		"memory":            4,
+		"root_password":     "Root123$",
+		"engine_version":    "13.3",
+		"backup_plan": []interface{}{
+			map[string]interface{}{
+				"min_backup_start_time":        "00:10:11",
+				"max_backup_start_time":        "01:10:11",
+				"base_backup_retention_period": 7,
+				"backup_period":                []interface{}{"tuesday", "wednesday"},
+				"backup_method":                "snapshot",
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, instanceId, d.Id())
+
+	// verify BackupMethod was passed to ModifyBackupPlan during Create
+	assert.NotNil(t, capturedBackupMethod, "BackupMethod should be passed to ModifyBackupPlan during Create")
+	if capturedBackupMethod != nil {
+		assert.Equal(t, "snapshot", *capturedBackupMethod)
+	}
+}
+
+// go test ./tencentcloud/services/postgresql/ -run "TestPostgresqlInstanceBackupMethod_CreateWithoutBackupMethod" -v -count=1 -gcflags="all=-l"
+func TestPostgresqlInstanceBackupMethod_CreateWithoutBackupMethod(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	pgServiceType := svcpostgresql.PostgresqlService{}
+	instanceId := "postgres-backup-method-create-empty-test"
+
+	var capturedBackupMethod *string
+	patches.ApplyMethodFunc(&pgServiceType, "ModifyBackupPlan", func(ctx context.Context, request *postgresql.ModifyBackupPlanRequest) error {
+		capturedBackupMethod = request.BackupMethod
+		return nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeSpecinfos", func(ctx context.Context, zone string, storageType string) ([]*postgresql.SpecItemInfo, error) {
+		majorVersion := "13"
+		version := "13.3"
+		memory := uint64(4 * 1024)
+		cpu := uint64(1)
+		specCode := "pgdb.test.1c4m"
+		return []*postgresql.SpecItemInfo{
+			{
+				MajorVersion: &majorVersion,
+				Version:      &version,
+				Memory:       &memory,
+				Cpu:          &cpu,
+				SpecCode:     &specCode,
+			},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "CreatePostgresqlInstance", func(ctx context.Context, args ...interface{}) (string, error) {
+		return instanceId, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstanceById", func(ctx context.Context, id string) (*postgresql.DBInstance, bool, error) {
+		running := "running"
+		zone := "ap-guangzhou-3"
+		netTypePrivate := "private"
+		ip := "10.0.0.1"
+		port := uint64(5432)
+		netTypePublic := "public"
+		statusClosed := "closed"
+		pubHost := "1.2.3.4"
+		pubPort := uint64(6432)
+		vpcId := "vpc-test"
+		subnetId := "subnet-test"
+		memory := uint64(4 * 1024)
+		instance := &postgresql.DBInstance{
+			DBInstanceId:     &instanceId,
+			DBInstanceName:   ptrStrInst("tf_postsql_instance"),
+			DBInstanceStatus: &running,
+			Zone:             &zone,
+			DBCharset:        ptrStrInst("UTF8"),
+			ProjectId:        ptrUint64Inst(0),
+			PayType:          ptrStrInst("postpaid"),
+			VpcId:            &vpcId,
+			SubnetId:         &subnetId,
+			DBInstanceMemory: &memory,
+			DBInstanceNetInfo: []*postgresql.DBInstanceNetInfo{
+				{
+					NetType:  &netTypePrivate,
+					Ip:       &ip,
+					Port:     &port,
+					VpcId:    &vpcId,
+					SubnetId: &subnetId,
+				},
+				{
+					NetType: &netTypePublic,
+					Status:  &statusClosed,
+					Address: &pubHost,
+					Port:    &pubPort,
+				},
+			},
+		}
+		return instance, true, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "CheckDBInstanceStatus", func(ctx context.Context, id string, retryMinutes ...int) error {
+		return nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "ModifyPublicService", func(ctx context.Context, openInternet bool, id string) error {
+		return nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "ModifyPostgresqlInstanceName", func(ctx context.Context, id, name string) error {
+		return nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeRootUser", func(ctx context.Context, id string) ([]*postgresql.AccountInfo, error) {
+		return []*postgresql.AccountInfo{}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBInstanceSecurityGroupsById", func(ctx context.Context, id string) ([]string, error) {
+		return []string{}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBInstanceAttribute", func(ctx context.Context, request *postgresql.DescribeDBInstanceAttributeRequest) (*postgresql.DBInstance, error) {
+		storageType := "CLOUD_SSD"
+		deletionProtection := false
+		return &postgresql.DBInstance{
+			DBInstanceStorageType: &storageType,
+			DeletionProtection:    &deletionProtection,
+			DBNodeSet:             []*postgresql.DBNode{},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeDBEncryptionKeys", func(ctx context.Context, request *postgresql.DescribeEncryptionKeysRequest) (bool, *postgresql.EncryptionKey, error) {
+		return false, nil, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePostgresqlInstances", func(ctx context.Context, filter []*postgresql.Filter) ([]*postgresql.DBInstance, error) {
+		return []*postgresql.DBInstance{
+			{
+				DBInstanceId: &instanceId,
+				Uid:          ptrUint64Inst(123456),
+			},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribeBackupPlans", func(ctx context.Context, request *postgresql.DescribeBackupPlansRequest) ([]*postgresql.BackupPlan, error) {
+		periodTypeWeek := "week"
+		minTime := "00:10:11"
+		maxTime := "01:10:11"
+		retention := uint64(7)
+		backupPeriod := "[\"tuesday\",\"wednesday\"]"
+		return []*postgresql.BackupPlan{
+			{
+				BackupPeriodType:          &periodTypeWeek,
+				MinBackupStartTime:        &minTime,
+				MaxBackupStartTime:        &maxTime,
+				BaseBackupRetentionPeriod: &retention,
+				BackupPeriod:              &backupPeriod,
+			},
+		}, nil
+	})
+
+	patches.ApplyMethodFunc(&pgServiceType, "DescribePgParams", func(ctx context.Context, id string) (map[string]string, error) {
+		return map[string]string{
+			"max_standby_streaming_delay": "10000",
+			"max_standby_archive_delay":   "10000",
+		}, nil
+	})
+
+	tagServiceType := svctag.TagService{}
+	patches.ApplyMethodFunc(&tagServiceType, "DescribeResourceTags", func(ctx context.Context, serviceType, resourceType, region, resourceId string) (map[string]string, error) {
+		return map[string]string{}, nil
+	})
+
+	meta := newMockMetaPostgresqlInstance()
+	res := svcpostgresql.ResourceTencentCloudPostgresqlInstance()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":              "tf_postsql_instance",
+		"vpc_id":            "vpc-test",
+		"subnet_id":         "subnet-test",
+		"availability_zone": "ap-guangzhou-3",
+		"storage":           100,
+		"memory":            4,
+		"root_password":     "Root123$",
+		"engine_version":    "13.3",
+		"backup_plan": []interface{}{
+			map[string]interface{}{
+				"min_backup_start_time":        "00:10:11",
+				"max_backup_start_time":        "01:10:11",
+				"base_backup_retention_period": 7,
+				"backup_period":                []interface{}{"tuesday", "wednesday"},
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, instanceId, d.Id())
+
+	// when backup_method is not configured, BackupMethod should NOT be set on the request
+	assert.Nil(t, capturedBackupMethod, "BackupMethod should not be set when user does not configure backup_method")
+}
+
+// keep unused helpers to avoid lint issues; ptrInt64Inst reserved for future use
+var _ = ptrInt64Inst

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres/v20170312/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres/v20170312/models.go
@@ -321,37 +321,40 @@ type BackupDownloadRestriction struct {
 }
 
 type BackupPlan struct {
-	// 备份周期
+	// <p>备份周期</p>
 	BackupPeriod *string `json:"BackupPeriod,omitnil,omitempty" name:"BackupPeriod"`
 
-	// 数据备份保留时长。单位：天
+	// <p>数据备份保留时长。单位：天</p>
 	BaseBackupRetentionPeriod *uint64 `json:"BaseBackupRetentionPeriod,omitnil,omitempty" name:"BaseBackupRetentionPeriod"`
 
-	// 开始备份的最早时间
+	// <p>开始备份的最早时间</p>
 	MinBackupStartTime *string `json:"MinBackupStartTime,omitnil,omitempty" name:"MinBackupStartTime"`
 
-	// 开始备份的最晚时间
+	// <p>开始备份的最晚时间</p>
 	MaxBackupStartTime *string `json:"MaxBackupStartTime,omitnil,omitempty" name:"MaxBackupStartTime"`
 
-	// 备份计划ID
+	// <p>备份类型</p><p>枚举值：</p><ul><li>physical： 物理备份</li><li>logical： 逻辑备份</li><li>snapshot： 快照备份</li></ul>
+	BackupMethod *string `json:"BackupMethod,omitnil,omitempty" name:"BackupMethod"`
+
+	// <p>备份计划ID</p>
 	PlanId *string `json:"PlanId,omitnil,omitempty" name:"PlanId"`
 
-	// 备份计划自定义名称。
+	// <p>备份计划自定义名称。</p>
 	PlanName *string `json:"PlanName,omitnil,omitempty" name:"PlanName"`
 
-	// 日志备份保留时长。单位：天
+	// <p>日志备份保留时长。单位：天</p>
 	LogBackupRetentionPeriod *uint64 `json:"LogBackupRetentionPeriod,omitnil,omitempty" name:"LogBackupRetentionPeriod"`
 
-	// 创建时间。
+	// <p>创建时间。</p>
 	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
-	// 最近一次的修改时间。
+	// <p>最近一次的修改时间。</p>
 	UpdatedTime *string `json:"UpdatedTime,omitnil,omitempty" name:"UpdatedTime"`
 
-	// 备份计划类型。系统默认创建的为default，自定义的为custom。
+	// <p>备份计划类型。系统默认创建的为default，自定义的为custom。</p>
 	PlanType *string `json:"PlanType,omitnil,omitempty" name:"PlanType"`
 
-	// 备份周期类型。当前支持week、month。
+	// <p>备份周期类型。当前支持week、month。</p>
 	BackupPeriodType *string `json:"BackupPeriodType,omitnil,omitempty" name:"BackupPeriodType"`
 }
 
@@ -1173,15 +1176,21 @@ func (r *CreateBackupPlanResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateBaseBackupRequestParams struct {
-	// 实例ID。可通过[DescribeDBInstances](https://cloud.tencent.com/document/api/409/16773)接口获取
+	// <p>实例ID。可通过<a href="https://cloud.tencent.com/document/api/409/16773">DescribeDBInstances</a>接口获取</p>
 	DBInstanceId *string `json:"DBInstanceId,omitnil,omitempty" name:"DBInstanceId"`
+
+	// <p>备份方式</p><p>枚举值：</p><ul><li>physical： 物理备份</li><li>logical： 逻辑备份</li><li>snapshot： 快照备份</li></ul>
+	BackupMethod *string `json:"BackupMethod,omitnil,omitempty" name:"BackupMethod"`
 }
 
 type CreateBaseBackupRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例ID。可通过[DescribeDBInstances](https://cloud.tencent.com/document/api/409/16773)接口获取
+	// <p>实例ID。可通过<a href="https://cloud.tencent.com/document/api/409/16773">DescribeDBInstances</a>接口获取</p>
 	DBInstanceId *string `json:"DBInstanceId,omitnil,omitempty" name:"DBInstanceId"`
+
+	// <p>备份方式</p><p>枚举值：</p><ul><li>physical： 物理备份</li><li>logical： 逻辑备份</li><li>snapshot： 快照备份</li></ul>
+	BackupMethod *string `json:"BackupMethod,omitnil,omitempty" name:"BackupMethod"`
 }
 
 func (r *CreateBaseBackupRequest) ToJsonString() string {
@@ -1197,6 +1206,7 @@ func (r *CreateBaseBackupRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "DBInstanceId")
+	delete(f, "BackupMethod")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateBaseBackupRequest has unknown keys!", "")
 	}
@@ -1205,7 +1215,7 @@ func (r *CreateBaseBackupRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateBaseBackupResponseParams struct {
-	// 数据备份集ID
+	// <p>数据备份集ID</p>
 	BaseBackupId *string `json:"BaseBackupId,omitnil,omitempty" name:"BaseBackupId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -6442,12 +6452,15 @@ func (r *DescribeTasksResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeZonesRequestParams struct {
-
+	// <p>实例存储类型，根据磁盘类型返回支持的可用区</p><p>枚举值：</p><ul><li>PHYSICAL_LOCAL_SSD： 物理机本地ssd硬盘</li><li>CLOUD_PREMIUM： 高性能云硬盘</li><li>CLOUD_SSD： ssd云硬盘</li><li>CLOUD_HSSD： 增强型ssd云硬盘</li></ul><p>默认值：PHYSICAL_LOCAL_SSD</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
 }
 
 type DescribeZonesRequest struct {
 	*tchttp.BaseRequest
 	
+	// <p>实例存储类型，根据磁盘类型返回支持的可用区</p><p>枚举值：</p><ul><li>PHYSICAL_LOCAL_SSD： 物理机本地ssd硬盘</li><li>CLOUD_PREMIUM： 高性能云硬盘</li><li>CLOUD_SSD： ssd云硬盘</li><li>CLOUD_HSSD： 增强型ssd云硬盘</li></ul><p>默认值：PHYSICAL_LOCAL_SSD</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
 }
 
 func (r *DescribeZonesRequest) ToJsonString() string {
@@ -6462,7 +6475,7 @@ func (r *DescribeZonesRequest) FromJsonString(s string) error {
 	if err := json.Unmarshal([]byte(s), &f); err != nil {
 		return err
 	}
-	
+	delete(f, "StorageType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeZonesRequest has unknown keys!", "")
 	}
@@ -6471,10 +6484,10 @@ func (r *DescribeZonesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeZonesResponseParams struct {
-	// 返回的结果数量。
+	// <p>返回的结果数量。</p>
 	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 可用区信息集合。
+	// <p>可用区信息集合。</p>
 	ZoneSet []*ZoneInfo `json:"ZoneSet,omitnil,omitempty" name:"ZoneSet"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -7548,57 +7561,63 @@ func (r *ModifyBackupDownloadRestrictionResponse) FromJsonString(s string) error
 
 // Predefined struct for user
 type ModifyBackupPlanRequestParams struct {
-	// 实例ID。可通过[DescribeDBInstances](https://cloud.tencent.com/document/api/409/16773)接口获取
+	// <p>实例ID。可通过<a href="https://cloud.tencent.com/document/api/409/16773">DescribeDBInstances</a>接口获取</p>
 	DBInstanceId *string `json:"DBInstanceId,omitnil,omitempty" name:"DBInstanceId"`
 
-	// 实例最早开始备份时间
+	// <p>实例最早开始备份时间</p>
 	MinBackupStartTime *string `json:"MinBackupStartTime,omitnil,omitempty" name:"MinBackupStartTime"`
 
-	// 实例最晚开始备份时间
+	// <p>实例最晚开始备份时间</p>
 	MaxBackupStartTime *string `json:"MaxBackupStartTime,omitnil,omitempty" name:"MaxBackupStartTime"`
 
-	// 实例备份保留时长，取值范围为7-1830，单位是天
+	// <p>实例备份保留时长，取值范围为7-1830，单位是天</p>
 	BaseBackupRetentionPeriod *uint64 `json:"BaseBackupRetentionPeriod,omitnil,omitempty" name:"BaseBackupRetentionPeriod"`
 
-	// 实例备份周期，若是星期维度，格式为小写星期英文单词，且至少设置两天备份；若是按月维度，格式为数字字符，如["1","2"]。
+	// <p>实例备份周期，若是星期维度，格式为小写星期英文单词，且至少设置两天备份；若是按月维度，格式为数字字符，如[&quot;1&quot;,&quot;2&quot;]。</p>
 	BackupPeriod []*string `json:"BackupPeriod,omitnil,omitempty" name:"BackupPeriod"`
 
-	// 实例日志备份保留时长，取值范围为7-1830，单位是天
+	// <p>实例日志备份保留时长，取值范围为7-1830，单位是天</p>
 	LogBackupRetentionPeriod *uint64 `json:"LogBackupRetentionPeriod,omitnil,omitempty" name:"LogBackupRetentionPeriod"`
 
-	// 备份计划ID，用于指明要修改哪个备份计划，不传则是修改默认备份计划。
+	// <p>备份计划ID，用于指明要修改哪个备份计划，不传则是修改默认备份计划。</p>
 	PlanId *string `json:"PlanId,omitnil,omitempty" name:"PlanId"`
 
-	// 要修改的备份计划名称。
+	// <p>要修改的备份计划名称。</p>
 	PlanName *string `json:"PlanName,omitnil,omitempty" name:"PlanName"`
+
+	// <p>备份方式</p><p>枚举值：</p><ul><li>physical： 物理备份</li><li>logical： 逻辑备份</li><li>snapshot： 快照备份</li></ul>
+	BackupMethod *string `json:"BackupMethod,omitnil,omitempty" name:"BackupMethod"`
 }
 
 type ModifyBackupPlanRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例ID。可通过[DescribeDBInstances](https://cloud.tencent.com/document/api/409/16773)接口获取
+	// <p>实例ID。可通过<a href="https://cloud.tencent.com/document/api/409/16773">DescribeDBInstances</a>接口获取</p>
 	DBInstanceId *string `json:"DBInstanceId,omitnil,omitempty" name:"DBInstanceId"`
 
-	// 实例最早开始备份时间
+	// <p>实例最早开始备份时间</p>
 	MinBackupStartTime *string `json:"MinBackupStartTime,omitnil,omitempty" name:"MinBackupStartTime"`
 
-	// 实例最晚开始备份时间
+	// <p>实例最晚开始备份时间</p>
 	MaxBackupStartTime *string `json:"MaxBackupStartTime,omitnil,omitempty" name:"MaxBackupStartTime"`
 
-	// 实例备份保留时长，取值范围为7-1830，单位是天
+	// <p>实例备份保留时长，取值范围为7-1830，单位是天</p>
 	BaseBackupRetentionPeriod *uint64 `json:"BaseBackupRetentionPeriod,omitnil,omitempty" name:"BaseBackupRetentionPeriod"`
 
-	// 实例备份周期，若是星期维度，格式为小写星期英文单词，且至少设置两天备份；若是按月维度，格式为数字字符，如["1","2"]。
+	// <p>实例备份周期，若是星期维度，格式为小写星期英文单词，且至少设置两天备份；若是按月维度，格式为数字字符，如[&quot;1&quot;,&quot;2&quot;]。</p>
 	BackupPeriod []*string `json:"BackupPeriod,omitnil,omitempty" name:"BackupPeriod"`
 
-	// 实例日志备份保留时长，取值范围为7-1830，单位是天
+	// <p>实例日志备份保留时长，取值范围为7-1830，单位是天</p>
 	LogBackupRetentionPeriod *uint64 `json:"LogBackupRetentionPeriod,omitnil,omitempty" name:"LogBackupRetentionPeriod"`
 
-	// 备份计划ID，用于指明要修改哪个备份计划，不传则是修改默认备份计划。
+	// <p>备份计划ID，用于指明要修改哪个备份计划，不传则是修改默认备份计划。</p>
 	PlanId *string `json:"PlanId,omitnil,omitempty" name:"PlanId"`
 
-	// 要修改的备份计划名称。
+	// <p>要修改的备份计划名称。</p>
 	PlanName *string `json:"PlanName,omitnil,omitempty" name:"PlanName"`
+
+	// <p>备份方式</p><p>枚举值：</p><ul><li>physical： 物理备份</li><li>logical： 逻辑备份</li><li>snapshot： 快照备份</li></ul>
+	BackupMethod *string `json:"BackupMethod,omitnil,omitempty" name:"BackupMethod"`
 }
 
 func (r *ModifyBackupPlanRequest) ToJsonString() string {
@@ -7621,6 +7640,7 @@ func (r *ModifyBackupPlanRequest) FromJsonString(s string) error {
 	delete(f, "LogBackupRetentionPeriod")
 	delete(f, "PlanId")
 	delete(f, "PlanName")
+	delete(f, "BackupMethod")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyBackupPlanRequest has unknown keys!", "")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1376,7 +1376,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/oceanus/v20190422
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/organization v1.3.110
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/organization/v20210331
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.89
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.123
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres/v20170312
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/privatedns v1.1.42

--- a/website/docs/r/postgresql_instance.html.markdown
+++ b/website/docs/r/postgresql_instance.html.markdown
@@ -259,6 +259,43 @@ resource "tencentcloud_postgresql_instance" "example" {
     max_backup_start_time        = "01:10:11"
     base_backup_retention_period = 7
     backup_period                = ["tuesday", "wednesday"]
+    backup_method                = "physical"
+  }
+
+  tags = {
+    CreateBy = "Terraform"
+  }
+}
+```
+
+### (snapshot backup). If not specified, the cloud API uses the default backup method.
+
+```hcl
+variable "availability_zone" {
+  default = "ap-guangzhou-6"
+}
+
+resource "tencentcloud_postgresql_instance" "example" {
+  name              = "tf_postsql_instance"
+  availability_zone = var.availability_zone
+  charge_type       = "POSTPAID_BY_HOUR"
+  vpc_id            = "vpc-86v957zb"
+  subnet_id         = "subnet-enm92y0m"
+  db_major_version  = "11"
+  engine_version    = "11.12"
+  db_kernel_version = "v11.12_r1.3"
+  root_password     = "Root123$"
+  charset           = "LATIN1"
+  project_id        = 0
+  memory            = 4
+  storage           = 100
+
+  backup_plan {
+    min_backup_start_time        = "00:10:11"
+    max_backup_start_time        = "01:10:11"
+    base_backup_retention_period = 7
+    backup_period                = ["tuesday", "wednesday"]
+    backup_method                = "snapshot"
   }
 
   tags = {
@@ -296,6 +333,7 @@ resource "tencentcloud_postgresql_instance" "example" {
     max_backup_start_time        = "02:10:11"
     base_backup_retention_period = 5
     backup_period                = ["monday", "thursday", "sunday"]
+    backup_method                = "logical"
   }
 
   tags = {
@@ -350,6 +388,7 @@ The following arguments are supported:
 
 The `backup_plan` object supports the following:
 
+* `backup_method` - (Optional, String) Backup method. Valid values: `physical` (physical backup), `logical` (logical backup), `snapshot` (snapshot backup). Only takes effect on the default (week) backup plan.
 * `backup_period` - (Optional, List) List of backup period per week, available values: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`. NOTE: At least specify two days.
 * `base_backup_retention_period` - (Optional, Int) Specify days of the retention.
 * `max_backup_start_time` - (Optional, String) Specify latest backup start time, format `hh:mm:ss`.


### PR DESCRIPTION
## What this PR does

Add a new `backup_method` parameter to the `backup_plan` nested block of the `tencentcloud_postgresql_instance` resource.

## Why

The TencentCloud PostgreSQL `ModifyBackupPlan` cloud API now supports a `BackupMethod` input parameter, allowing users to configure the backup method (physical `physical`, logical `logical`, snapshot `snapshot`). Previously the Terraform resource did not expose this parameter, so users could not specify the backup method via Terraform.

## Changes

- Added `backup_method` field (Optional, Computed) to the `backup_plan` block schema in `resource_tc_postgresql_instance.go`.
- Pass `backup_method` to `ModifyBackupPlanRequest.BackupMethod` in the Create flow.
- Pass `backup_method` to `ModifyBackupPlanRequest.BackupMethod` in the Update flow.
- Read `BackupMethod` from `DescribeBackupPlans` response and populate state in the Read flow.
- Updated `resource_tc_postgresql_instance.md` documentation with `backup_method` usage and examples.
- Added unit tests (gomonkey mocks) covering Create/Update/Read paths.
- Updated vendor SDK (`postgres/v20170312/models.go`) with `BackupMethod` support.