### PR TITLE
fix(tke): [132912372] `tencentcloud_kubernetes_cluster_endpoint` support `existed_load_balancer_id`

### DIFF
--- a/.changelog/4289.txt
+++ b/.changelog/4289.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_kubernetes_cluster_endpoint: support `existed_load_balancer_id`
+```

--- a/tencentcloud/services/tke/resource_tc_kubernetes_cluster_endpoint.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_cluster_endpoint.go
@@ -84,6 +84,12 @@ func ResourceTencentCloudTkeClusterEndpoint() *schema.Resource {
 				Description: "Subnet id who can access this independent cluster, this field must and can only set  when `cluster_intranet` is true." +
 					" `cluster_intranet_subnet_id` can not modify once be set.",
 			},
+			"existed_load_balancer_id": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "Enable internal or external access using an existing CLB.",
+			},
 			// Computed
 			"cluster_deploy_type": {
 				Type:        schema.TypeString,
@@ -248,6 +254,7 @@ func resourceTencentCloudTkeClusterEndpointCreate(d *schema.ResourceData, meta i
 		clusterInternetDomain        = d.Get("cluster_internet_domain").(string)
 		clusterIntranetDomain        = d.Get("cluster_intranet_domain").(string)
 		extensiveParameters          = d.Get("extensive_parameters").(string)
+		existedLoadBalancerId        = d.Get("existed_load_balancer_id").(string)
 	)
 
 	if err != nil {
@@ -267,7 +274,7 @@ func resourceTencentCloudTkeClusterEndpointCreate(d *schema.ResourceData, meta i
 
 	// Create Intranet(Private) Network
 	if clusterIntranet {
-		err := tencentCloudClusterIntranetSwitch(ctx, &service, id, intranetSubnetId, clusterIntranetSecurityGroup, true, clusterIntranetDomain)
+		err := tencentCloudClusterIntranetSwitch(ctx, &service, id, intranetSubnetId, clusterIntranetSecurityGroup, true, clusterIntranetDomain, existedLoadBalancerId)
 		if err != nil {
 			return err
 		}
@@ -279,7 +286,7 @@ func resourceTencentCloudTkeClusterEndpointCreate(d *schema.ResourceData, meta i
 
 	//TKE_DEPLOY_TYPE_INDEPENDENT Open the internet
 	if clusterInternet {
-		err := tencentCloudClusterInternetSwitch(ctx, &service, id, true, clusterInternetSecurityGroup, clusterInternetDomain, extensiveParameters)
+		err := tencentCloudClusterInternetSwitch(ctx, &service, id, true, clusterInternetSecurityGroup, clusterInternetDomain, extensiveParameters, existedLoadBalancerId)
 		if err != nil {
 			return err
 		}
@@ -312,6 +319,7 @@ func resourceTencentCloudTkeClusterEndpointUpdate(d *schema.ResourceData, meta i
 		clusterIntranetDomain        = d.Get("cluster_intranet_domain").(string)
 		subnetId                     = d.Get("cluster_intranet_subnet_id").(string)
 		extensiveParameters          = d.Get("extensive_parameters").(string)
+		existedLoadBalancerId        = d.Get("existed_load_balancer_id").(string)
 	)
 
 	var (
@@ -328,7 +336,7 @@ func resourceTencentCloudTkeClusterEndpointUpdate(d *schema.ResourceData, meta i
 	}
 
 	if d.HasChange("cluster_internet") {
-		err = tencentCloudClusterInternetSwitch(ctx, &service, id, clusterInternet, clusterInternetSecurityGroup, clusterInternetDomain, extensiveParameters)
+		err = tencentCloudClusterInternetSwitch(ctx, &service, id, clusterInternet, clusterInternetSecurityGroup, clusterInternetDomain, extensiveParameters, existedLoadBalancerId)
 		if err != nil {
 			return err
 		}
@@ -339,7 +347,7 @@ func resourceTencentCloudTkeClusterEndpointUpdate(d *schema.ResourceData, meta i
 	} else if clusterInternet && d.HasChange("cluster_internet_domain") {
 		// only domain changed, need to close and reopen
 		// close
-		err = tencentCloudClusterInternetSwitch(ctx, &service, id, false, clusterInternetSecurityGroup, clusterInternetDomain, "")
+		err = tencentCloudClusterInternetSwitch(ctx, &service, id, false, clusterInternetSecurityGroup, clusterInternetDomain, "", existedLoadBalancerId)
 		if err != nil {
 			return err
 		}
@@ -348,7 +356,7 @@ func resourceTencentCloudTkeClusterEndpointUpdate(d *schema.ResourceData, meta i
 			return err
 		}
 		// reopen
-		err = tencentCloudClusterInternetSwitch(ctx, &service, id, true, clusterInternetSecurityGroup, clusterInternetDomain, extensiveParameters)
+		err = tencentCloudClusterInternetSwitch(ctx, &service, id, true, clusterInternetSecurityGroup, clusterInternetDomain, extensiveParameters, existedLoadBalancerId)
 		if err != nil {
 			return err
 		}
@@ -359,7 +367,7 @@ func resourceTencentCloudTkeClusterEndpointUpdate(d *schema.ResourceData, meta i
 	}
 
 	if d.HasChange("cluster_intranet") {
-		err = tencentCloudClusterIntranetSwitch(ctx, &service, id, subnetId, "", clusterIntranet, clusterIntranetDomain)
+		err = tencentCloudClusterIntranetSwitch(ctx, &service, id, subnetId, "", clusterIntranet, clusterIntranetDomain, existedLoadBalancerId)
 		if err != nil {
 			return err
 		}
@@ -370,7 +378,7 @@ func resourceTencentCloudTkeClusterEndpointUpdate(d *schema.ResourceData, meta i
 	} else if clusterIntranet && d.HasChange("cluster_intranet_domain") {
 		// only domain changed, need to close and reopen
 		// close
-		err = tencentCloudClusterIntranetSwitch(ctx, &service, id, subnetId, "", false, clusterIntranetDomain)
+		err = tencentCloudClusterIntranetSwitch(ctx, &service, id, subnetId, "", false, clusterIntranetDomain, existedLoadBalancerId)
 		if err != nil {
 			return err
 		}
@@ -379,7 +387,7 @@ func resourceTencentCloudTkeClusterEndpointUpdate(d *schema.ResourceData, meta i
 			return err
 		}
 		// reopen
-		err = tencentCloudClusterIntranetSwitch(ctx, &service, id, subnetId, "", true, clusterIntranetDomain)
+		err = tencentCloudClusterIntranetSwitch(ctx, &service, id, subnetId, "", true, clusterIntranetDomain, existedLoadBalancerId)
 		if err != nil {
 			return err
 		}
@@ -418,7 +426,7 @@ func resourceTencentCloudTkeClusterEndpointDelete(d *schema.ResourceData, meta i
 	)
 
 	if clusterInternet {
-		err = tencentCloudClusterInternetSwitch(ctx, &service, id, false, "", "", "")
+		err = tencentCloudClusterInternetSwitch(ctx, &service, id, false, "", "", "", "")
 		if err != nil {
 			errs = *multierror.Append(err)
 		} else {
@@ -430,7 +438,7 @@ func resourceTencentCloudTkeClusterEndpointDelete(d *schema.ResourceData, meta i
 	}
 
 	if clusterIntranet {
-		err = tencentCloudClusterIntranetSwitch(ctx, &service, id, "", "", false, "")
+		err = tencentCloudClusterIntranetSwitch(ctx, &service, id, "", "", false, "", "")
 		if err != nil {
 			errs = *multierror.Append(err)
 		} else {
@@ -470,10 +478,10 @@ func waitForClusterEndpointFinish(ctx context.Context, service *TkeService, id s
 	})
 }
 
-func tencentCloudClusterInternetSwitch(ctx context.Context, service *TkeService, id string, enable bool, sg string, domain string, extensiveParameters string) (err error) {
+func tencentCloudClusterInternetSwitch(ctx context.Context, service *TkeService, id string, enable bool, sg string, domain string, extensiveParameters string, existedLoadBalancerId string) (err error) {
 	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		if enable {
-			err = service.CreateClusterEndpoint(ctx, id, "", sg, true, domain, extensiveParameters)
+			err = service.CreateClusterEndpoint(ctx, id, "", sg, true, domain, extensiveParameters, existedLoadBalancerId)
 			if err != nil {
 				return tccommon.RetryError(err, tke.RESOURCEUNAVAILABLE_CLUSTERSTATE)
 			}
@@ -491,10 +499,10 @@ func tencentCloudClusterInternetSwitch(ctx context.Context, service *TkeService,
 	return nil
 }
 
-func tencentCloudClusterIntranetSwitch(ctx context.Context, service *TkeService, id, subnetId, securityGroup string, enable bool, domain string) (err error) {
+func tencentCloudClusterIntranetSwitch(ctx context.Context, service *TkeService, id, subnetId, securityGroup string, enable bool, domain string, existedLoadBalancerId string) (err error) {
 	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		if enable {
-			err = service.CreateClusterEndpoint(ctx, id, subnetId, securityGroup, false, domain, "")
+			err = service.CreateClusterEndpoint(ctx, id, subnetId, securityGroup, false, domain, "", existedLoadBalancerId)
 			if err != nil {
 				return tccommon.RetryError(err, tke.RESOURCEUNAVAILABLE_CLUSTERSTATE)
 			}

--- a/tencentcloud/services/tke/resource_tc_kubernetes_cluster_extension.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_cluster_extension.go
@@ -415,7 +415,7 @@ func resourceTencentCloudKubernetesClusterCreatePostHandleResponse0(ctx context.
 	//intranet
 	if clusterIntranet {
 		err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-			inErr := service.CreateClusterEndpoint(ctx, id, intranetSubnetId, clusterInternetSecurityGroup, false, clusterIntranetDomain, "")
+			inErr := service.CreateClusterEndpoint(ctx, id, intranetSubnetId, clusterInternetSecurityGroup, false, clusterIntranetDomain, "", "")
 			if inErr != nil {
 				return tccommon.RetryError(inErr)
 			}
@@ -446,7 +446,7 @@ func resourceTencentCloudKubernetesClusterCreatePostHandleResponse0(ctx context.
 
 	if clusterInternet {
 		err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-			inErr := service.CreateClusterEndpoint(ctx, id, "", clusterInternetSecurityGroup, true, clusterInternetDomain, "")
+			inErr := service.CreateClusterEndpoint(ctx, id, "", clusterInternetSecurityGroup, true, clusterInternetDomain, "", "")
 			if inErr != nil {
 				return tccommon.RetryError(inErr)
 			}

--- a/tencentcloud/services/tke/service_tencentcloud_tke.go
+++ b/tencentcloud/services/tke/service_tencentcloud_tke.go
@@ -1125,7 +1125,7 @@ func (me *TkeService) DeleteClusterAsGroups(ctx context.Context, id, asGroupId s
 /*
 open internet access
 */
-func (me *TkeService) CreateClusterEndpoint(ctx context.Context, id string, subnetId, securityGroupId string, internet bool, domain string, extensiveParameters string) (errRet error) {
+func (me *TkeService) CreateClusterEndpoint(ctx context.Context, id string, subnetId, securityGroupId string, internet bool, domain string, extensiveParameters string, existedLoadBalancerId string) (errRet error) {
 	logId := tccommon.GetLogId(ctx)
 
 	request := tke.NewCreateClusterEndpointRequest()
@@ -1152,6 +1152,10 @@ func (me *TkeService) CreateClusterEndpoint(ctx context.Context, id string, subn
 
 	if extensiveParameters != "" {
 		request.ExtensiveParameters = helper.String(extensiveParameters)
+	}
+
+	if existedLoadBalancerId != "" {
+		request.ExistedLoadBalancerId = helper.String(existedLoadBalancerId)
 	}
 
 	ratelimit.Check(request.GetAction())
@@ -2646,7 +2650,7 @@ func ModifyClusterInternetOrIntranetAccess(ctx context.Context, d *schema.Resour
 	// open access
 	if enable {
 		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-			inErr := tkeSvc.CreateClusterEndpoint(ctx, id, subnetId, sg, isInternet, domain, "")
+			inErr := tkeSvc.CreateClusterEndpoint(ctx, id, subnetId, sg, isInternet, domain, "", "")
 			if inErr != nil {
 				return tccommon.RetryError(inErr)
 			}

--- a/website/docs/r/kubernetes_cluster_endpoint.html.markdown
+++ b/website/docs/r/kubernetes_cluster_endpoint.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `cluster_intranet_security_group` - (Optional, String, ForceNew) Security group ID for intranet cluster endpoint.
 * `cluster_intranet_subnet_id` - (Optional, String) Subnet id who can access this independent cluster, this field must and can only set  when `cluster_intranet` is true. `cluster_intranet_subnet_id` can not modify once be set.
 * `cluster_intranet` - (Optional, Bool) Open intranet access or not.
+* `existed_load_balancer_id` - (Optional, String, ForceNew) Enable internal or external access using an existing CLB.
 * `extensive_parameters` - (Optional, String, ForceNew) The LB parameter. Only used for public network access.
 * `managed_cluster_internet_security_policies` - (Optional, List: [`String`], **Deprecated**) this argument was deprecated, use `cluster_internet_security_group` instead. Security policies for managed cluster internet, like:'192.168.1.0/24' or '113.116.51.27', '0.0.0.0/0' means all. This field can only set when field `cluster_deploy_type` is 'MANAGED_CLUSTER' and `cluster_internet` is true. `managed_cluster_internet_security_policies` can not delete or empty once be set.
 


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
