### PR TITLE
feat(cam): [136061694] add auto_rotate_key param to cam_role_sso resource

### DIFF
--- a/.changelog/4295.txt
+++ b/.changelog/4295.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_cam_role_sso: support `auto_rotate_key` parameter for OIDC public key auto-rotation
+```

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/apm v1.3.8
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.3.16
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bi v1.0.824
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.21
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat v1.0.825
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.3.115
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb v1.3.122

--- a/go.sum
+++ b/go.sum
@@ -889,8 +889,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bi v1.0.824 h1:DVKvZ6h+
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bi v1.0.824/go.mod h1:DvBpDX/qdJG4KKLeULmRvhAjPYiw8za0HeTSu2y/lFw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing v1.3.39 h1:iJFhv4Z/EdTWeJ3INDX+nK7qoP7G5JF8NMsxcCZe7eY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing v1.3.39/go.mod h1:pQUClJeCf2vHSzhWkTM0rhC502Ac65S6G1WDWK/GiJ0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.21 h1:7YmUzsXuaNcr0FfKOIZ348yLw62A6LvTduvR/8ms1Og=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.21/go.mod h1:PoC3bMIS0YdABpLn7L6s2a+gc+s5ew1/nkymCYRcWF4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.130 h1:SJZA2P2k7Py8KUI4qGtxNN+ohWsoY3UwH+fBx8dGsOs=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.130/go.mod h1:tIYWmi/i2zzDWUwDBb0Y+Tn72xwefo/ql0c3pJIVxEs=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat v1.0.825 h1:TgO9L1yNPkWeXqrvys/9RL3u958xx9dcTAy4WmaxBnE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat v1.0.825/go.mod h1:1yCKeIioX4D0bcIDHs3JCS5lbyzndXh1E8wHyHaCjxY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.3.115 h1:0VngBttqkoB8pD4vsBDtDJpSubKSCVPNldKLTf91O4w=
@@ -967,7 +967,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.8/go.mod h1
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.15/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.16/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.20/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.21/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.26/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.27/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.29/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=

--- a/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/design.md
+++ b/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`tencentcloud_cam_role_sso` 是一个 RESOURCE_KIND_GENERAL 资源，管理腾讯云 CAM 的角色 SSO（OIDC）配置，位于 `tencentcloud/services/cam/resource_tc_cam_role_sso.go`。其 CRUD 分别对应：
+- Create → `CreateOIDCConfig`
+- Read → `DescribeOIDCConfig`
+- Update → `UpdateOIDCConfig`
+- Delete → `DeleteOIDCConfig`
+
+当前 schema 仅包含 `name`、`identity_url`、`identity_key`、`client_ids`、`description` 五个字段。腾讯云 CAM SDK（`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116`）中 `CreateOIDCConfigRequest`、`UpdateOIDCConfigRequest`、`DescribeOIDCConfigResponse` 均已新增 `AutoRotateKey`（`*uint64`）字段，表示 OIDC 公钥自动轮转开关（0=关闭，1=开启，默认 0）。本次变更将这个云 API 能力透传到 Terraform 资源。
+
+约束：
+- 必须保持向后兼容，只能新增 Optional 字段。
+- 遵循项目代码规范：retry 块内只调用云 API，错误用 `tccommon.RetryError()` 包装；Read 中 set 前判断 nil；Create 后检查返回值。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 `tencentcloud_cam_role_sso` 资源中新增 `auto_rotate_key` 参数，支持创建、更新、读取该字段。
+- 保证现有配置与 state 不受影响（向后兼容）。
+- 补充单元测试（gomonkey mock 云 API），覆盖新参数的创建/更新/读取逻辑。
+
+**Non-Goals:**
+- 不修改 `DeleteOIDCConfig` 调用逻辑（`DeleteOIDCConfigRequest` 不支持 `AutoRotateKey`）。
+- 不新增/修改其他 CAM 资源或数据源。
+- 不重构现有 schema 字段。
+- 不在本阶段执行 `gofmt`、`make doc`、`.changelog` 文件创建（统一由收尾阶段 tfpacer-finalize skill 处理）。
+
+## Decisions
+
+### Decision 1: 字段类型选择 `schema.TypeInt`
+云 API 中 `AutoRotateKey` 为 `*uint64`，取值枚举为 0/1。选择 `schema.TypeInt` 而非 `schema.TypeBool`：
+- 与同 SDK 中 `CreateUserOIDCConfigRequest.AutoRotateKey`（同样是 `*uint64`，0/1 枚举）保持一致，避免布尔与数值的转换歧义。
+- 直接与云 API 的数值语义对应，`helper.IntUint64()` / `helper.IntUint64Ptr()` 进行 int↔uint64 转换。
+- **替代方案**：使用 `schema.TypeBool`（true=1, false=0）。放弃，因为云 API 明确使用 0/1 枚举且默认值文档化，TypeInt 语义更直观，且资源文件中已有其他数值开关字段的惯例。
+
+### Decision 2: 字段为 Optional、非 ForceNew
+- `auto_rotate_key` 是可变更的运行时开关，应在 Update 中支持修改，因此不设 ForceNew。
+- 在 `resourceTencentCloudCamRoleSSOUpdate` 的 `d.HasChange(...)` 检测条件中加入 `auto_rotate_key`，使其变更触发 `UpdateOIDCConfig` 调用。
+
+### Decision 3: Create 中始终透传 auto_rotate_key
+在 `resourceTencentCloudCamRoleSSOCreate` 中，无论用户是否配置 `auto_rotate_key`，都将其从 schema 读取并设置到 `request.AutoRotateKey`。未配置时 schema 默认返回 0，与云 API 默认值一致，行为安全。这样实现简洁，且不会因为 omit 导致与用户预期不一致。
+
+### Decision 4: Read 中 nil 判断后回填
+`DescribeOIDCConfigResponse.Response.AutoRotateKey` 可能为 nil。遵循项目规范，在 `resourceTencentCloudCamRoleSSORead` 中先判断 `response.Response.AutoRotateKey != nil` 再 `d.Set("auto_rotate_key", *response.Response.AutoRotateKey)`，避免空指针。
+
+### Decision 5: 单元测试使用 gomonkey mock
+本资源为现有资源修改，按项目要求，现有资源的测试用例补充使用 Terraform 测试套件。但本次同时需用 `go test -gcflags=all=-l` 跑通涉及文件——为兼顾"新增参数"的可独立验证性，在 `resource_tc_cam_role_sso_test.go` 中使用 gomonkey 对 `UseCamClient().CreateOIDCConfig` / `UpdateOIDCConfig` / `DescribeOIDCConfig` / `DeleteOIDCConfig` 进行 mock，编写纯业务逻辑单元测试（不依赖 TF_ACC），验证 `auto_rotate_key` 在 Create/Update/Read 中的正确传递与回填。
+
+## Risks / Trade-offs
+
+- [风险] 云 API `DescribeOIDCConfig` 旧版本可能不返回 `AutoRotateKey`（返回 nil） → Read 中已加 nil 判断，跳过 set，state 中保留 schema 默认值，不影响现有资源。
+- [风险] 用户在配置中显式写 `auto_rotate_key = 0` 与不写的语义差异 → 两者行为一致（均传 0 给 API），无副作用。
+- [权衡] 使用 TypeInt 而非 TypeBool → 与云 API 数值语义一致，但用户需了解 0/1 枚举含义，已在 Description 中说明。
+
+## Migration Plan
+
+无需迁移。新增 Optional 字段，现有配置不受影响，直接部署即可。回滚仅需移除该 schema 字段及相关 CRUD 代码。

--- a/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/proposal.md
+++ b/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`tencentcloud_cam_role_sso` 资源当前仅支持配置 OIDC 身份提供商的 `name`、`identity_url`、`identity_key`、`client_ids`、`description` 五个参数，缺少 OIDC 公钥自动轮转开关的管理能力。腾讯云 CAM 的 OIDC 配置接口（CreateOIDCConfig / UpdateOIDCConfig / DescribeOIDCConfig）已支持 `AutoRotateKey` 参数，用户无法通过 Terraform 自动化开启公钥自动轮转，限制了安全运维的自动化水平。本次变更新增 `auto_rotate_key` 参数，让用户能够以声明式方式管理 OIDC 公钥的自动轮转开关。
+
+## What Changes
+
+- 在 `tencentcloud_cam_role_sso` 资源 schema 中新增可选参数 `auto_rotate_key`（类型 `schema.TypeInt`，OIDC 公钥自动轮转开关，枚举值 0=关闭、1=开启，默认值 0）。
+- 在 `resourceTencentCloudCamRoleSSOCreate` 中将 `auto_rotate_key` 透传到 `CreateOIDCConfigRequest.AutoRotateKey`。
+- 在 `resourceTencentCloudCamRoleSSOUpdate` 中将 `auto_rotate_key` 纳入变更检测并透传到 `UpdateOIDCConfigRequest.AutoRotateKey`。
+- 在 `resourceTencentCloudCamRoleSSORead` 中从 `DescribeOIDCConfigResponse.AutoRotateKey` 回填 `auto_rotate_key` 到 state（回填前判断字段是否为 nil）。
+- 在 `resource_tc_cam_role_sso.md` 文档的示例与 import 说明中补充新参数。
+
+## Capabilities
+
+### New Capabilities
+- `cam-role-sso-resource`: 新增能力，描述 `tencentcloud_cam_role_sso` 资源对 OIDC 公钥自动轮转开关（`auto_rotate_key`）参数的管理行为（创建、更新、读取、删除时的处理）。
+
+### Modified Capabilities
+<!-- 无既有 spec 需要修改。openspec/specs/ 中不存在 cam-role-sso 相关 spec，因此本次以新增能力 spec 的形式落地。 -->
+
+## Impact
+
+### 受影响的代码
+- `tencentcloud/services/cam/resource_tc_cam_role_sso.go` - 新增 `auto_rotate_key` schema 字段，并在 Create/Read/Update 函数中处理该参数。
+- `tencentcloud/services/cam/resource_tc_cam_role_sso_test.go` - 补充针对 `auto_rotate_key` 的单元测试用例（使用 gomonkey mock 云 API）。
+- `tencentcloud/services/cam/resource_tc_cam_role_sso.md` - 更新资源文档示例。
+
+### 云 API 依赖
+基于 `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116`（vendor 中已存在）：
+- `CreateOIDCConfigRequest.AutoRotateKey`（`*uint64`）- 创建时入参 ✓
+- `UpdateOIDCConfigRequest.AutoRotateKey`（`*uint64`）- 更新时入参 ✓
+- `DescribeOIDCConfigResponse.AutoRotateKey`（`*uint64`）- 查询时出参 ✓
+- `DeleteOIDCConfigRequest` 仅有 `Name` 字段，删除操作不涉及 `AutoRotateKey` ✓
+
+### 向后兼容性
+- ✅ 完全向后兼容，仅新增一个 Optional 字段，不修改已有 schema 行为。
+- ✅ 现有不带 `auto_rotate_key` 的 TF 配置继续正常工作，API 默认值（0）生效。
+- ✅ 无 state 迁移，无破坏性变更。
+
+### 测试影响
+- 新增参数需要补充单元测试（mock 云 API），覆盖创建、更新、读取场景下 `auto_rotate_key` 的设置与回填。

--- a/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/specs/cam-role-sso-resource/spec.md
+++ b/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/specs/cam-role-sso-resource/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Auto Rotate Key Parameter Management
+The `tencentcloud_cam_role_sso` resource SHALL support managing the OIDC public key auto-rotation switch through the `auto_rotate_key` parameter.
+
+#### Scenario: Define auto_rotate_key schema field
+- **WHEN** defining the resource schema for `tencentcloud_cam_role_sso`
+- **THEN** the schema SHALL include an `auto_rotate_key` field of type `schema.TypeInt`
+- **AND** the field SHALL be Optional (not Required)
+- **AND** the field SHALL NOT be ForceNew (changes SHALL trigger in-place update)
+- **AND** the field description SHALL document the enum values 0 (disabled) and 1 (enabled) with default value 0
+
+#### Scenario: Create resource with auto_rotate_key specified
+- **GIVEN** a user creates a `tencentcloud_cam_role_sso` resource with `auto_rotate_key = 1`
+- **WHEN** the create operation is invoked
+- **THEN** the system SHALL call `CreateOIDCConfig` API with `request.AutoRotateKey` set to the provided value (converted to `*uint64`)
+- **AND** after a successful API call, the system SHALL set the resource id to the resource `name`
+- **AND** invoke the read operation to refresh state
+
+#### Scenario: Create resource without auto_rotate_key specified
+- **GIVEN** a user creates a `tencentcloud_cam_role_sso` resource without specifying `auto_rotate_key`
+- **WHEN** the create operation is invoked
+- **THEN** the system SHALL NOT send `AutoRotateKey` (or send the zero value) to `CreateOIDCConfig`, letting the API apply its default value (0)
+
+#### Scenario: Update auto_rotate_key
+- **GIVEN** an existing `tencentcloud_cam_role_sso` resource
+- **WHEN** the user updates the `auto_rotate_key` field
+- **THEN** the system SHALL detect the change via `d.HasChange("auto_rotate_key")`
+- **AND** the system SHALL call `UpdateOIDCConfig` API with `request.AutoRotateKey` set to the new value (converted to `*uint64`)
+- **AND** the update SHALL be performed in-place without recreating the resource
+
+#### Scenario: Read auto_rotate_key from API
+- **GIVEN** a `tencentcloud_cam_role_sso` resource exists and is being read or refreshed
+- **WHEN** the `DescribeOIDCConfig` API returns a response
+- **THEN** the system SHALL check whether `response.Response.AutoRotateKey` is nil
+- **AND** if it is NOT nil, the system SHALL set `auto_rotate_key` in Terraform state to the returned value (converted from `*uint64` to `int`)
+- **AND** if it IS nil, the system SHALL skip setting `auto_rotate_key` to avoid a nil pointer dereference
+
+#### Scenario: Delete resource with auto_rotate_key
+- **GIVEN** a `tencentcloud_cam_role_sso` resource is being destroyed
+- **WHEN** the delete operation is invoked
+- **THEN** the system SHALL call `DeleteOIDCConfig` API with only the `Name` parameter (the resource id)
+- **AND** the system SHALL NOT include `AutoRotateKey` in the delete request, because `DeleteOIDCConfigRequest` does not support this field
+
+### Requirement: Backward Compatibility
+The addition of `auto_rotate_key` SHALL maintain full backward compatibility with existing `tencentcloud_cam_role_sso` configurations and state.
+
+#### Scenario: Existing configurations without auto_rotate_key
+- **GIVEN** an existing Terraform configuration for `tencentcloud_cam_role_sso` that does not specify `auto_rotate_key`
+- **WHEN** the user applies the configuration
+- **THEN** the resource SHALL continue to work normally without errors
+- **AND** the API default value (0, disabled) SHALL apply
+
+### Requirement: Documentation
+The resource documentation SHALL reflect the new `auto_rotate_key` parameter.
+
+#### Scenario: Update resource documentation
+- **WHEN** the resource documentation `resource_tc_cam_role_sso.md` is updated
+- **THEN** the example usage SHALL include the `auto_rotate_key` parameter
+- **AND** the documentation SHALL be regenerated via `make doc` (handled in the finalize phase) to update `website/docs/r/cam_role_sso.html.markdown`

--- a/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/tasks.md
+++ b/openspec/changes/archive/2026-07-13-add-cam-role-sso-auto-rotate-key/tasks.md
@@ -1,0 +1,27 @@
+## 1. Schema 定义与 CRUD 代码修改
+
+- [x] 1.1 在 `tencentcloud/services/cam/resource_tc_cam_role_sso.go` 的 `ResourceTencentCloudCamRoleSSO()` schema map 中新增 `auto_rotate_key` 字段（`schema.TypeInt`，Optional，非 ForceNew，Description 说明 0=关闭/1=开启/默认0）
+- [x] 1.2 在 `resourceTencentCloudCamRoleSSOCreate` 中读取 `auto_rotate_key` 并设置到 `request.AutoRotateKey`（使用 helper 将 int 转为 `*uint64`）
+- [x] 1.3 在 `resourceTencentCloudCamRoleSSORead` 中增加 nil 判断：当 `response.Response.AutoRotateKey != nil` 时回填 `auto_rotate_key` 到 state
+- [x] 1.4 在 `resourceTencentCloudCamRoleSSOUpdate` 的 `d.HasChange(...)` 检测条件中加入 `auto_rotate_key`，并在变更时将 `auto_rotate_key` 设置到 `request.AutoRotateKey`
+
+## 2. 文档更新
+
+- [x] 2.1 在 `tencentcloud/services/cam/resource_tc_cam_role_sso.md` 的 Example Usage 中补充 `auto_rotate_key` 参数示例
+
+## 3. 测试补充
+
+- [x] 3.1 在 `tencentcloud/services/cam/resource_tc_cam_role_sso_test.go` 中使用 gomonkey mock `CreateOIDCConfig` / `UpdateOIDCConfig` / `DescribeOIDCConfig` / `DeleteOIDCConfig`，新增覆盖 `auto_rotate_key` 创建场景的单元测试用例
+- [x] 3.2 新增覆盖 `auto_rotate_key` 更新场景的单元测试用例（验证变更触发 UpdateOIDCConfig 且参数正确传递）
+- [x] 3.3 新增覆盖 `auto_rotate_key` 读取回填场景的单元测试用例（验证 nil 判断与值回填逻辑）
+
+## 4. 验证
+
+- [x] 4.1 使用 `go test -gcflags=all=-l` 运行 `resource_tc_cam_role_sso_test.go` 涉及的单元测试并确保通过
+- [x] 4.2 检查所有函数返回的 error 已正确处理（无未使用变量）
+
+## 5. 收尾（由 tfpacer-finalize skill 统一执行，非本阶段任务）
+
+- [ ] 5.1 执行 `gofmt` 格式化变更的 Go 代码
+- [ ] 5.2 执行 `make doc` 生成 `website/docs/r/cam_role_sso.html.markdown` 文档
+- [ ] 5.3 在 `.changelog/` 目录下创建 changelog 文件

--- a/openspec/specs/cam-role-sso-resource/spec.md
+++ b/openspec/specs/cam-role-sso-resource/spec.md
@@ -1,0 +1,63 @@
+# CAM Role SSO Resource Specification
+
+## Purpose
+TBD - created by syncing change add-cam-role-sso-auto-rotate-key. Update Purpose after archive.
+## Requirements
+### Requirement: Auto Rotate Key Parameter Management
+The `tencentcloud_cam_role_sso` resource SHALL support managing the OIDC public key auto-rotation switch through the `auto_rotate_key` parameter.
+
+#### Scenario: Define auto_rotate_key schema field
+- **WHEN** defining the resource schema for `tencentcloud_cam_role_sso`
+- **THEN** the schema SHALL include an `auto_rotate_key` field of type `schema.TypeInt`
+- **AND** the field SHALL be Optional (not Required)
+- **AND** the field SHALL NOT be ForceNew (changes SHALL trigger in-place update)
+- **AND** the field description SHALL document the enum values 0 (disabled) and 1 (enabled) with default value 0
+
+#### Scenario: Create resource with auto_rotate_key specified
+- **GIVEN** a user creates a `tencentcloud_cam_role_sso` resource with `auto_rotate_key = 1`
+- **WHEN** the create operation is invoked
+- **THEN** the system SHALL call `CreateOIDCConfig` API with `request.AutoRotateKey` set to the provided value (converted to `*uint64`)
+- **AND** after a successful API call, the system SHALL set the resource id to the resource `name`
+- **AND** invoke the read operation to refresh state
+
+#### Scenario: Create resource without auto_rotate_key specified
+- **GIVEN** a user creates a `tencentcloud_cam_role_sso` resource without specifying `auto_rotate_key`
+- **WHEN** the create operation is invoked
+- **THEN** the system SHALL NOT send `AutoRotateKey` (or send the zero value) to `CreateOIDCConfig`, letting the API apply its default value (0)
+
+#### Scenario: Update auto_rotate_key
+- **GIVEN** an existing `tencentcloud_cam_role_sso` resource
+- **WHEN** the user updates the `auto_rotate_key` field
+- **THEN** the system SHALL detect the change via `d.HasChange("auto_rotate_key")`
+- **AND** the system SHALL call `UpdateOIDCConfig` API with `request.AutoRotateKey` set to the new value (converted to `*uint64`)
+- **AND** the update SHALL be performed in-place without recreating the resource
+
+#### Scenario: Read auto_rotate_key from API
+- **GIVEN** a `tencentcloud_cam_role_sso` resource exists and is being read or refreshed
+- **WHEN** the `DescribeOIDCConfig` API returns a response
+- **THEN** the system SHALL check whether `response.Response.AutoRotateKey` is nil
+- **AND** if it is NOT nil, the system SHALL set `auto_rotate_key` in Terraform state to the returned value (converted from `*uint64` to `int`)
+- **AND** if it IS nil, the system SHALL skip setting `auto_rotate_key` to avoid a nil pointer dereference
+
+#### Scenario: Delete resource with auto_rotate_key
+- **GIVEN** a `tencentcloud_cam_role_sso` resource is being destroyed
+- **WHEN** the delete operation is invoked
+- **THEN** the system SHALL call `DeleteOIDCConfig` API with only the `Name` parameter (the resource id)
+- **AND** the system SHALL NOT include `AutoRotateKey` in the delete request, because `DeleteOIDCConfigRequest` does not support this field
+
+### Requirement: Backward Compatibility
+The addition of `auto_rotate_key` SHALL maintain full backward compatibility with existing `tencentcloud_cam_role_sso` configurations and state.
+
+#### Scenario: Existing configurations without auto_rotate_key
+- **GIVEN** an existing Terraform configuration for `tencentcloud_cam_role_sso` that does not specify `auto_rotate_key`
+- **WHEN** the user applies the configuration
+- **THEN** the resource SHALL continue to work normally without errors
+- **AND** the API default value (0, disabled) SHALL apply
+
+### Requirement: Documentation
+The resource documentation SHALL reflect the new `auto_rotate_key` parameter.
+
+#### Scenario: Update resource documentation
+- **WHEN** the resource documentation `resource_tc_cam_role_sso.md` is updated
+- **THEN** the example usage SHALL include the `auto_rotate_key` parameter
+- **AND** the documentation SHALL be regenerated via `make doc` (handled in the finalize phase) to update `website/docs/r/cam_role_sso.html.markdown`

--- a/tencentcloud/services/cam/resource_tc_cam_role_sso.go
+++ b/tencentcloud/services/cam/resource_tc_cam_role_sso.go
@@ -37,7 +37,7 @@ func ResourceTencentCloudCamRoleSSO() *schema.Resource {
 			"identity_key": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Sign the public key.",
+				Description: "Sign the public key. Base64 encryption is required.",
 			},
 			"client_ids": {
 				Type:        schema.TypeSet,
@@ -72,6 +72,9 @@ func resourceTencentCloudCamRoleSSOCreate(d *schema.ResourceData, meta interface
 	request.Description = helper.String(d.Get("description").(string))
 	request.ClientId = helper.InterfacesStringsPoint(d.Get("client_ids").(*schema.Set).List())
 	request.AutoRotateKey = helper.IntUint64(d.Get("auto_rotate_key").(int))
+	if v, ok := d.GetOkExists("auto_rotate_key"); ok {
+		request.AutoRotateKey = helper.IntUint64(v.(int))
+	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseCamClient().CreateOIDCConfig(request)
@@ -105,6 +108,11 @@ func resourceTencentCloudCamRoleSSORead(d *schema.ResourceData, meta interface{}
 		if e != nil {
 			return tccommon.RetryError(e)
 		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe OIDC config failed, Response is nil."))
+		}
+
 		response = result
 		return nil
 	})
@@ -137,29 +145,34 @@ func resourceTencentCloudCamRoleSSORead(d *schema.ResourceData, meta interface{}
 func resourceTencentCloudCamRoleSSOUpdate(d *schema.ResourceData, meta interface{}) error {
 	defer tccommon.LogElapsed("resource.tencentcloud_cam_role_sso.update")()
 	logId := tccommon.GetLogId(tccommon.ContextNil)
-	request := cam.NewUpdateOIDCConfigRequest()
+
 	if d.HasChange("name") {
 		return fmt.Errorf("not support change name")
 	}
-	request.Name = helper.String(d.Id())
+
 	if d.HasChange("identity_url") || d.HasChange("identity_key") || d.HasChange("description") || d.HasChange("client_ids") || d.HasChange("auto_rotate_key") {
+		request := cam.NewUpdateOIDCConfigRequest()
+		request.Name = helper.String(d.Id())
 		request.IdentityKey = helper.String(d.Get("identity_key").(string))
 		request.IdentityUrl = helper.String(d.Get("identity_url").(string))
 		request.Description = helper.String(d.Get("description").(string))
 		request.ClientId = helper.InterfacesStringsPoint(d.Get("client_ids").(*schema.Set).List())
-		request.AutoRotateKey = helper.IntUint64(d.Get("auto_rotate_key").(int))
-	}
-
-	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-		_, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseCamClient().UpdateOIDCConfig(request)
-		if e != nil {
-			return tccommon.RetryError(e)
+		if v, ok := d.GetOkExists("auto_rotate_key"); ok {
+			request.AutoRotateKey = helper.IntUint64(v.(int))
 		}
-		return nil
-	})
-	if err != nil {
-		log.Printf("[CRITAL]%s update CAM Role SSO failed, reason:%s\n", logId, err.Error())
-		return err
+
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			_, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseCamClient().UpdateOIDCConfig(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			}
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s update CAM Role SSO failed, reason:%s\n", logId, err.Error())
+			return err
+		}
 	}
 
 	return resourceTencentCloudCamRoleSSORead(d, meta)

--- a/tencentcloud/services/cam/resource_tc_cam_role_sso.go
+++ b/tencentcloud/services/cam/resource_tc_cam_role_sso.go
@@ -53,7 +53,7 @@ func ResourceTencentCloudCamRoleSSO() *schema.Resource {
 			"auto_rotate_key": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     0,
+				Computed:    true,
 				Description: "OIDC public key auto-rotation switch. Enum values: 0 (disabled), 1 (enabled). Default value: 0.",
 			},
 		},

--- a/tencentcloud/services/cam/resource_tc_cam_role_sso.go
+++ b/tencentcloud/services/cam/resource_tc_cam_role_sso.go
@@ -50,6 +50,12 @@ func ResourceTencentCloudCamRoleSSO() *schema.Resource {
 				Optional:    true,
 				Description: "The description of resource.",
 			},
+			"auto_rotate_key": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: "OIDC public key auto-rotation switch. Enum values: 0 (disabled), 1 (enabled). Default value: 0.",
+			},
 		},
 	}
 }
@@ -65,6 +71,7 @@ func resourceTencentCloudCamRoleSSOCreate(d *schema.ResourceData, meta interface
 	request.IdentityKey = helper.String(d.Get("identity_key").(string))
 	request.Description = helper.String(d.Get("description").(string))
 	request.ClientId = helper.InterfacesStringsPoint(d.Get("client_ids").(*schema.Set).List())
+	request.AutoRotateKey = helper.IntUint64(d.Get("auto_rotate_key").(int))
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseCamClient().CreateOIDCConfig(request)
@@ -120,6 +127,9 @@ func resourceTencentCloudCamRoleSSORead(d *schema.ResourceData, meta interface{}
 		clientIds = append(clientIds, *clientId)
 	}
 	_ = d.Set("client_ids", clientIds)
+	if response.Response.AutoRotateKey != nil {
+		_ = d.Set("auto_rotate_key", int(*response.Response.AutoRotateKey))
+	}
 
 	return nil
 }
@@ -132,11 +142,12 @@ func resourceTencentCloudCamRoleSSOUpdate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("not support change name")
 	}
 	request.Name = helper.String(d.Id())
-	if d.HasChange("identity_url") || d.HasChange("identity_key") || d.HasChange("description") || d.HasChange("client_ids") {
+	if d.HasChange("identity_url") || d.HasChange("identity_key") || d.HasChange("description") || d.HasChange("client_ids") || d.HasChange("auto_rotate_key") {
 		request.IdentityKey = helper.String(d.Get("identity_key").(string))
 		request.IdentityUrl = helper.String(d.Get("identity_url").(string))
 		request.Description = helper.String(d.Get("description").(string))
 		request.ClientId = helper.InterfacesStringsPoint(d.Get("client_ids").(*schema.Set).List())
+		request.AutoRotateKey = helper.IntUint64(d.Get("auto_rotate_key").(int))
 	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {

--- a/tencentcloud/services/cam/resource_tc_cam_role_sso.md
+++ b/tencentcloud/services/cam/resource_tc_cam_role_sso.md
@@ -1,22 +1,22 @@
-Provides a resource to create a CAM-ROLE-SSO (Only support OIDC).
+Provides a resource to create a CAM-ROLE-SSO(Only support OIDC).
 
 Example Usage
 
 ```hcl
-resource "tencentcloud_cam_role_sso" "foo" {
-	name="tf_cam_role_sso"
-	identity_url="https://login.microsoftonline.com/.../v2.0"
-	identity_key="..."
-	client_ids=["..."]
-	description="this is a description"
-	auto_rotate_key=1
+resource "tencentcloud_cam_role_sso" "example" {
+  name            = "tf_example"
+  identity_url    = "https://login.microsoftonline.com/.../v2.0"
+  identity_key    = "baz****"
+  client_ids      = ["61adcf00620c31e3ddbc9546"]
+  description     = "this is a description"
+  auto_rotate_key = 1
 }
 ```
 
 Import
 
-CAM-ROLE-SSO can be imported using the `name`, e.g.
+CAM-ROLE-SSO(Only support OIDC) can be imported using the `name`, e.g.
 
 ```
-$ terraform import tencentcloud_cam_role_sso.foo "test"
+terraform import tencentcloud_cam_role_sso.example tf_example
 ```

--- a/tencentcloud/services/cam/resource_tc_cam_role_sso.md
+++ b/tencentcloud/services/cam/resource_tc_cam_role_sso.md
@@ -9,6 +9,7 @@ resource "tencentcloud_cam_role_sso" "foo" {
 	identity_key="..."
 	client_ids=["..."]
 	description="this is a description"
+	auto_rotate_key=1
 }
 ```
 

--- a/tencentcloud/services/cam/resource_tc_cam_role_sso_test.go
+++ b/tencentcloud/services/cam/resource_tc_cam_role_sso_test.go
@@ -6,15 +6,20 @@ import (
 	"log"
 	"testing"
 
-	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
-	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
-
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
 	cam "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+	camsvc "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cam"
+
+	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 )
 
 func init() {
@@ -158,3 +163,293 @@ resource "tencentcloud_cam_role_sso" "foo" {
 	description="this is a description1"
 }
 `
+
+// ---- gomonkey-based unit tests for auto_rotate_key ----
+// Run with: go test ./tencentcloud/services/cam/ -run "TestCamRoleSSOAutoRotateKey" -v -count=1 -gcflags="all=-l"
+
+type mockMetaCamRoleSSO struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaCamRoleSSO) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaCamRoleSSO{}
+
+func newMockMetaCamRoleSSO() *mockMetaCamRoleSSO {
+	return &mockMetaCamRoleSSO{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrUint64CamRoleSSO(v uint64) *uint64 {
+	return &v
+}
+
+func ptrStringCamRoleSSO(s string) *string {
+	return &s
+}
+
+// TestCamRoleSSOAutoRotateKey_Create verifies auto_rotate_key is passed to CreateOIDCConfig.
+func TestCamRoleSSOAutoRotateKey_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	camClient := &cam.Client{}
+	patches.ApplyMethodReturn(newMockMetaCamRoleSSO().client, "UseCamClient", camClient)
+
+	var capturedRequest *cam.CreateOIDCConfigRequest
+	patches.ApplyMethodFunc(camClient, "CreateOIDCConfig", func(request *cam.CreateOIDCConfigRequest) (*cam.CreateOIDCConfigResponse, error) {
+		capturedRequest = request
+		resp := cam.NewCreateOIDCConfigResponse()
+		resp.Response = &cam.CreateOIDCConfigResponseParams{
+			RequestId: ptrStringCamRoleSSO("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeOIDCConfig called by the read after create.
+	patches.ApplyMethodFunc(camClient, "DescribeOIDCConfig", func(request *cam.DescribeOIDCConfigRequest) (*cam.DescribeOIDCConfigResponse, error) {
+		resp := cam.NewDescribeOIDCConfigResponse()
+		resp.Response = &cam.DescribeOIDCConfigResponseParams{
+			Name:          ptrStringCamRoleSSO("tf_cam_role_sso"),
+			IdentityUrl:   ptrStringCamRoleSSO("https://login.microsoftonline.com/test/v2.0"),
+			IdentityKey:   ptrStringCamRoleSSO("fake-key"),
+			Description:   ptrStringCamRoleSSO("description"),
+			ClientId:      []*string{ptrStringCamRoleSSO("c2856e29-d344-49a9-88ed-de3a01d99753")},
+			AutoRotateKey: ptrUint64CamRoleSSO(1),
+			RequestId:     ptrStringCamRoleSSO("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCamRoleSSO()
+	res := camsvc.ResourceTencentCloudCamRoleSSO()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":            "tf_cam_role_sso",
+		"identity_url":    "https://login.microsoftonline.com/test/v2.0",
+		"identity_key":    "fake-key",
+		"client_ids":      []interface{}{"c2856e29-d344-49a9-88ed-de3a01d99753"},
+		"description":     "description",
+		"auto_rotate_key": 1,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "tf_cam_role_sso", d.Id())
+
+	// Verify auto_rotate_key was passed to the create request.
+	assert.NotNil(t, capturedRequest.AutoRotateKey)
+	assert.Equal(t, uint64(1), *capturedRequest.AutoRotateKey)
+
+	// Verify auto_rotate_key was read back into state.
+	assert.Equal(t, 1, d.Get("auto_rotate_key").(int))
+}
+
+// TestCamRoleSSOAutoRotateKey_CreateDefault verifies auto_rotate_key defaults to 0 when not specified.
+func TestCamRoleSSOAutoRotateKey_CreateDefault(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	camClient := &cam.Client{}
+	patches.ApplyMethodReturn(newMockMetaCamRoleSSO().client, "UseCamClient", camClient)
+
+	var capturedRequest *cam.CreateOIDCConfigRequest
+	patches.ApplyMethodFunc(camClient, "CreateOIDCConfig", func(request *cam.CreateOIDCConfigRequest) (*cam.CreateOIDCConfigResponse, error) {
+		capturedRequest = request
+		resp := cam.NewCreateOIDCConfigResponse()
+		resp.Response = &cam.CreateOIDCConfigResponseParams{
+			RequestId: ptrStringCamRoleSSO("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(camClient, "DescribeOIDCConfig", func(request *cam.DescribeOIDCConfigRequest) (*cam.DescribeOIDCConfigResponse, error) {
+		resp := cam.NewDescribeOIDCConfigResponse()
+		resp.Response = &cam.DescribeOIDCConfigResponseParams{
+			Name:          ptrStringCamRoleSSO("tf_cam_role_sso"),
+			IdentityUrl:   ptrStringCamRoleSSO("https://login.microsoftonline.com/test/v2.0"),
+			IdentityKey:   ptrStringCamRoleSSO("fake-key"),
+			Description:   ptrStringCamRoleSSO("description"),
+			ClientId:      []*string{ptrStringCamRoleSSO("c2856e29-d344-49a9-88ed-de3a01d99753")},
+			AutoRotateKey: ptrUint64CamRoleSSO(0),
+			RequestId:     ptrStringCamRoleSSO("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCamRoleSSO()
+	res := camsvc.ResourceTencentCloudCamRoleSSO()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":         "tf_cam_role_sso",
+		"identity_url": "https://login.microsoftonline.com/test/v2.0",
+		"identity_key": "fake-key",
+		"client_ids":   []interface{}{"c2856e29-d344-49a9-88ed-de3a01d99753"},
+		"description":  "description",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+
+	// Verify auto_rotate_key defaulted to 0 in the create request.
+	assert.NotNil(t, capturedRequest.AutoRotateKey)
+	assert.Equal(t, uint64(0), *capturedRequest.AutoRotateKey)
+	assert.Equal(t, 0, d.Get("auto_rotate_key").(int))
+}
+
+// TestCamRoleSSOAutoRotateKey_Update verifies auto_rotate_key change triggers UpdateOIDCConfig.
+func TestCamRoleSSOAutoRotateKey_Update(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	camClient := &cam.Client{}
+	patches.ApplyMethodReturn(newMockMetaCamRoleSSO().client, "UseCamClient", camClient)
+
+	var capturedRequest *cam.UpdateOIDCConfigRequest
+	patches.ApplyMethodFunc(camClient, "UpdateOIDCConfig", func(request *cam.UpdateOIDCConfigRequest) (*cam.UpdateOIDCConfigResponse, error) {
+		capturedRequest = request
+		resp := cam.NewUpdateOIDCConfigResponse()
+		resp.Response = &cam.UpdateOIDCConfigResponseParams{
+			RequestId: ptrStringCamRoleSSO("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(camClient, "DescribeOIDCConfig", func(request *cam.DescribeOIDCConfigRequest) (*cam.DescribeOIDCConfigResponse, error) {
+		resp := cam.NewDescribeOIDCConfigResponse()
+		resp.Response = &cam.DescribeOIDCConfigResponseParams{
+			Name:          ptrStringCamRoleSSO("tf_cam_role_sso"),
+			IdentityUrl:   ptrStringCamRoleSSO("https://login.microsoftonline.com/test/v2.0"),
+			IdentityKey:   ptrStringCamRoleSSO("fake-key"),
+			Description:   ptrStringCamRoleSSO("description"),
+			ClientId:      []*string{ptrStringCamRoleSSO("c2856e29-d344-49a9-88ed-de3a01d99753")},
+			AutoRotateKey: ptrUint64CamRoleSSO(1),
+			RequestId:     ptrStringCamRoleSSO("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCamRoleSSO()
+	res := camsvc.ResourceTencentCloudCamRoleSSO()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":            "tf_cam_role_sso",
+		"identity_url":    "https://login.microsoftonline.com/test/v2.0",
+		"identity_key":    "fake-key",
+		"client_ids":      []interface{}{"c2856e29-d344-49a9-88ed-de3a01d99753"},
+		"description":     "description",
+		"auto_rotate_key": 1,
+	})
+	d.SetId("tf_cam_role_sso")
+
+	// Patch HasChange to simulate a change in auto_rotate_key only (avoid the
+	// "not support change name" guard, since TestResourceDataRaw treats every
+	// configured key as a change vs. empty state).
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		return key == "auto_rotate_key"
+	})
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	// Verify auto_rotate_key was passed to the update request.
+	assert.NotNil(t, capturedRequest)
+	assert.NotNil(t, capturedRequest.AutoRotateKey)
+	assert.Equal(t, uint64(1), *capturedRequest.AutoRotateKey)
+
+	// Verify auto_rotate_key was read back into state.
+	assert.Equal(t, 1, d.Get("auto_rotate_key").(int))
+}
+
+// TestCamRoleSSOAutoRotateKey_ReadNil verifies Read skips setting auto_rotate_key when API returns nil.
+func TestCamRoleSSOAutoRotateKey_ReadNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	camClient := &cam.Client{}
+	patches.ApplyMethodReturn(newMockMetaCamRoleSSO().client, "UseCamClient", camClient)
+
+	patches.ApplyMethodFunc(camClient, "DescribeOIDCConfig", func(request *cam.DescribeOIDCConfigRequest) (*cam.DescribeOIDCConfigResponse, error) {
+		resp := cam.NewDescribeOIDCConfigResponse()
+		resp.Response = &cam.DescribeOIDCConfigResponseParams{
+			Name:        ptrStringCamRoleSSO("tf_cam_role_sso"),
+			IdentityUrl: ptrStringCamRoleSSO("https://login.microsoftonline.com/test/v2.0"),
+			IdentityKey: ptrStringCamRoleSSO("fake-key"),
+			Description: ptrStringCamRoleSSO("description"),
+			ClientId:    []*string{ptrStringCamRoleSSO("c2856e29-d344-49a9-88ed-de3a01d99753")},
+			// AutoRotateKey intentionally left nil to test the nil guard.
+			RequestId: ptrStringCamRoleSSO("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCamRoleSSO()
+	res := camsvc.ResourceTencentCloudCamRoleSSO()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":            "tf_cam_role_sso",
+		"identity_url":    "https://login.microsoftonline.com/test/v2.0",
+		"identity_key":    "fake-key",
+		"client_ids":      []interface{}{"c2856e29-d344-49a9-88ed-de3a01d99753"},
+		"description":     "description",
+		"auto_rotate_key": 1,
+	})
+	d.SetId("tf_cam_role_sso")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// When API returns nil, d.Set("auto_rotate_key", ...) is skipped (nil guard),
+	// so the existing configured value (1) is preserved rather than overwritten.
+	// This verifies the nil guard does not panic and leaves state untouched.
+	assert.Equal(t, 1, d.Get("auto_rotate_key").(int))
+}
+
+// TestCamRoleSSOAutoRotateKey_ReadValue verifies Read sets auto_rotate_key when API returns a value.
+func TestCamRoleSSOAutoRotateKey_ReadValue(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	camClient := &cam.Client{}
+	patches.ApplyMethodReturn(newMockMetaCamRoleSSO().client, "UseCamClient", camClient)
+
+	patches.ApplyMethodFunc(camClient, "DescribeOIDCConfig", func(request *cam.DescribeOIDCConfigRequest) (*cam.DescribeOIDCConfigResponse, error) {
+		resp := cam.NewDescribeOIDCConfigResponse()
+		resp.Response = &cam.DescribeOIDCConfigResponseParams{
+			Name:          ptrStringCamRoleSSO("tf_cam_role_sso"),
+			IdentityUrl:   ptrStringCamRoleSSO("https://login.microsoftonline.com/test/v2.0"),
+			IdentityKey:   ptrStringCamRoleSSO("fake-key"),
+			Description:   ptrStringCamRoleSSO("description"),
+			ClientId:      []*string{ptrStringCamRoleSSO("c2856e29-d344-49a9-88ed-de3a01d99753")},
+			AutoRotateKey: ptrUint64CamRoleSSO(1),
+			RequestId:     ptrStringCamRoleSSO("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCamRoleSSO()
+	res := camsvc.ResourceTencentCloudCamRoleSSO()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":            "tf_cam_role_sso",
+		"identity_url":    "https://login.microsoftonline.com/test/v2.0",
+		"identity_key":    "fake-key",
+		"client_ids":      []interface{}{"c2856e29-d344-49a9-88ed-de3a01d99753"},
+		"description":     "description",
+		"auto_rotate_key": 0,
+	})
+	d.SetId("tf_cam_role_sso")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// Verify the API value was read back into state.
+	assert.Equal(t, 1, d.Get("auto_rotate_key").(int))
+}
+
+// TestCamRoleSSOAutoRotateKey_Schema validates the auto_rotate_key schema definition.
+func TestCamRoleSSOAutoRotateKey_Schema(t *testing.T) {
+	res := camsvc.ResourceTencentCloudCamRoleSSO()
+
+	field, ok := res.Schema["auto_rotate_key"]
+	assert.True(t, ok, "auto_rotate_key should exist in schema")
+	assert.Equal(t, schema.TypeInt, field.Type)
+	assert.True(t, field.Optional)
+	assert.False(t, field.ForceNew, "auto_rotate_key should not be ForceNew")
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116/client.go
@@ -2957,6 +2957,58 @@ func (c *Client) GetGroupWithContext(ctx context.Context, request *GetGroupReque
     return
 }
 
+func NewGetPasswordRulesRequest() (request *GetPasswordRulesRequest) {
+    request = &GetPasswordRulesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cam", APIVersion, "GetPasswordRules")
+    
+    
+    return
+}
+
+func NewGetPasswordRulesResponse() (response *GetPasswordRulesResponse) {
+    response = &GetPasswordRulesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetPasswordRules
+// 获取CAM密码设置规则
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCENOTFOUND_USERNOTEXIST = "ResourceNotFound.UserNotExist"
+func (c *Client) GetPasswordRules(request *GetPasswordRulesRequest) (response *GetPasswordRulesResponse, err error) {
+    return c.GetPasswordRulesWithContext(context.Background(), request)
+}
+
+// GetPasswordRules
+// 获取CAM密码设置规则
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCENOTFOUND_USERNOTEXIST = "ResourceNotFound.UserNotExist"
+func (c *Client) GetPasswordRulesWithContext(ctx context.Context, request *GetPasswordRulesRequest) (response *GetPasswordRulesResponse, err error) {
+    if request == nil {
+        request = NewGetPasswordRulesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cam", APIVersion, "GetPasswordRules")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetPasswordRules require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetPasswordRulesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewGetPolicyRequest() (request *GetPolicyRequest) {
     request = &GetPolicyRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -3563,6 +3615,58 @@ func (c *Client) ListAccessKeysWithContext(ctx context.Context, request *ListAcc
     request.SetContext(ctx)
     
     response = NewListAccessKeysResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListAccountsRequest() (request *ListAccountsRequest) {
+    request = &ListAccountsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cam", APIVersion, "ListAccounts")
+    
+    
+    return
+}
+
+func NewListAccountsResponse() (response *ListAccountsResponse) {
+    response = &ListAccountsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListAccounts
+// 查询所有账号列表
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_PAGINATIONTOKENINVALID = "InvalidParameter.PaginationTokenInvalid"
+func (c *Client) ListAccounts(request *ListAccountsRequest) (response *ListAccountsResponse, err error) {
+    return c.ListAccountsWithContext(context.Background(), request)
+}
+
+// ListAccounts
+// 查询所有账号列表
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_PAGINATIONTOKENINVALID = "InvalidParameter.PaginationTokenInvalid"
+func (c *Client) ListAccountsWithContext(ctx context.Context, request *ListAccountsRequest) (response *ListAccountsResponse, err error) {
+    if request == nil {
+        request = NewListAccountsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cam", APIVersion, "ListAccounts")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListAccounts require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListAccountsResponse()
     err = c.Send(request, response)
     return
 }
@@ -5211,6 +5315,56 @@ func (c *Client) UpdateOIDCConfigWithContext(ctx context.Context, request *Updat
     request.SetContext(ctx)
     
     response = NewUpdateOIDCConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdatePasswordRulesRequest() (request *UpdatePasswordRulesRequest) {
+    request = &UpdatePasswordRulesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cam", APIVersion, "UpdatePasswordRules")
+    
+    
+    return
+}
+
+func NewUpdatePasswordRulesResponse() (response *UpdatePasswordRulesResponse) {
+    response = &UpdatePasswordRulesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdatePasswordRules
+// 更新CAM密码设置规则
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETER_PASSWORDRULEERROR = "InvalidParameter.PasswordRuleError"
+func (c *Client) UpdatePasswordRules(request *UpdatePasswordRulesRequest) (response *UpdatePasswordRulesResponse, err error) {
+    return c.UpdatePasswordRulesWithContext(context.Background(), request)
+}
+
+// UpdatePasswordRules
+// 更新CAM密码设置规则
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETER_PASSWORDRULEERROR = "InvalidParameter.PasswordRuleError"
+func (c *Client) UpdatePasswordRulesWithContext(ctx context.Context, request *UpdatePasswordRulesRequest) (response *UpdatePasswordRulesResponse, err error) {
+    if request == nil {
+        request = NewUpdatePasswordRulesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cam", APIVersion, "UpdatePasswordRules")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdatePasswordRules require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdatePasswordRulesResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116/errors.go
@@ -179,8 +179,14 @@ const (
 	// 当前角色仅支持企业管理员操作，如需修改，请联系企业管理员。
 	INVALIDPARAMETER_ORGANIZATIONROLEOPERATEERROR = "InvalidParameter.OrganizationRoleOperateError"
 
+	// 无效的pageToken
+	INVALIDPARAMETER_PAGINATIONTOKENINVALID = "InvalidParameter.PaginationTokenInvalid"
+
 	// 非法入参。
 	INVALIDPARAMETER_PARAMERROR = "InvalidParameter.ParamError"
+
+	// 密码规则错误。
+	INVALIDPARAMETER_PASSWORDRULEERROR = "InvalidParameter.PasswordRuleError"
 
 	// 密码不符合用户安全设置。
 	INVALIDPARAMETER_PASSWORDVIOLATEDRULES = "InvalidParameter.PasswordViolatedRules"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116/models.go
@@ -916,39 +916,45 @@ func (r *CreateMessageReceiverResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateOIDCConfigRequestParams struct {
-	// 身份提供商URL
+	// <p>身份提供商URL</p>
 	IdentityUrl *string `json:"IdentityUrl,omitnil,omitempty" name:"IdentityUrl"`
 
-	// 客户端ID
+	// <p>客户端ID</p>
 	ClientId []*string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
 
-	// 名称
+	// <p>名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 签名公钥，需要base64
+	// <p>签名公钥，需要base64</p>
 	IdentityKey *string `json:"IdentityKey,omitnil,omitempty" name:"IdentityKey"`
 
-	// 描述
+	// <p>描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>OIDC公钥自动轮转开关</p><p>枚举值：</p><ul><li>0： 关闭</li><li>1： 开启</li></ul><p>默认值：0</p>
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 }
 
 type CreateOIDCConfigRequest struct {
 	*tchttp.BaseRequest
 	
-	// 身份提供商URL
+	// <p>身份提供商URL</p>
 	IdentityUrl *string `json:"IdentityUrl,omitnil,omitempty" name:"IdentityUrl"`
 
-	// 客户端ID
+	// <p>客户端ID</p>
 	ClientId []*string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
 
-	// 名称
+	// <p>名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 签名公钥，需要base64
+	// <p>签名公钥，需要base64</p>
 	IdentityKey *string `json:"IdentityKey,omitnil,omitempty" name:"IdentityKey"`
 
-	// 描述
+	// <p>描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>OIDC公钥自动轮转开关</p><p>枚举值：</p><ul><li>0： 关闭</li><li>1： 开启</li></ul><p>默认值：0</p>
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 }
 
 func (r *CreateOIDCConfigRequest) ToJsonString() string {
@@ -968,6 +974,7 @@ func (r *CreateOIDCConfigRequest) FromJsonString(s string) error {
 	delete(f, "Name")
 	delete(f, "IdentityKey")
 	delete(f, "Description")
+	delete(f, "AutoRotateKey")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateOIDCConfigRequest has unknown keys!", "")
 	}
@@ -1499,6 +1506,9 @@ type CreateUserOIDCConfigRequestParams struct {
 
 	// 描述信息。由用户自行定义。
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// OIDC公钥自动轮转开关（默认为0代表关闭，1代表开启）如果不传的话会默认置0
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 }
 
 type CreateUserOIDCConfigRequest struct {
@@ -1531,6 +1541,9 @@ type CreateUserOIDCConfigRequest struct {
 
 	// 描述信息。由用户自行定义。
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// OIDC公钥自动轮转开关（默认为0代表关闭，1代表开启）如果不传的话会默认置0
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 }
 
 func (r *CreateUserOIDCConfigRequest) ToJsonString() string {
@@ -1554,6 +1567,7 @@ func (r *CreateUserOIDCConfigRequest) FromJsonString(s string) error {
 	delete(f, "IdentityKey")
 	delete(f, "Scope")
 	delete(f, "Description")
+	delete(f, "AutoRotateKey")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateUserOIDCConfigRequest has unknown keys!", "")
 	}
@@ -2331,14 +2345,14 @@ func (r *DeleteUserResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeOIDCConfigRequestParams struct {
-	// 名称
+	// <p>名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 }
 
 type DescribeOIDCConfigRequest struct {
 	*tchttp.BaseRequest
 	
-	// 名称
+	// <p>名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 }
 
@@ -2363,26 +2377,29 @@ func (r *DescribeOIDCConfigRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeOIDCConfigResponseParams struct {
-	// 身份提供商类型 11角色身份提供商
+	// <p>身份提供商类型 11角色身份提供商</p>
 	ProviderType *uint64 `json:"ProviderType,omitnil,omitempty" name:"ProviderType"`
 
-	// 身份提供商URL
+	// <p>身份提供商URL</p>
 	IdentityUrl *string `json:"IdentityUrl,omitnil,omitempty" name:"IdentityUrl"`
 
-	// 签名公钥
+	// <p>签名公钥</p>
 	IdentityKey *string `json:"IdentityKey,omitnil,omitempty" name:"IdentityKey"`
 
-	// 客户端id
+	// <p>客户端id</p>
 	ClientId []*string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
 
-	// 状态：0:未设置，11:已开启，2:已禁用
+	// <p>状态：0:未设置，11:已开启，2:已禁用</p>
 	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 描述
+	// <p>描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
-	// 名称
+	// <p>名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>OIDC公钥自动轮转开关</p><p>枚举值：</p><ul><li>0： 关闭</li><li>1： 开启</li></ul><p>默认值：0</p>
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -2406,26 +2423,26 @@ func (r *DescribeOIDCConfigResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeRoleListRequestParams struct {
-	// 页码，从1开始
+	// <p>页码，从1开始</p>
 	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
 
-	// 每页行数，不能大于200
+	// <p>每页行数，不能大于200</p>
 	Rp *uint64 `json:"Rp,omitnil,omitempty" name:"Rp"`
 
-	// 标签筛选
+	// <p>标签筛选</p>
 	Tags []*RoleTags `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type DescribeRoleListRequest struct {
 	*tchttp.BaseRequest
 	
-	// 页码，从1开始
+	// <p>页码，从1开始</p>
 	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
 
-	// 每页行数，不能大于200
+	// <p>每页行数，不能大于200</p>
 	Rp *uint64 `json:"Rp,omitnil,omitempty" name:"Rp"`
 
-	// 标签筛选
+	// <p>标签筛选</p>
 	Tags []*RoleTags `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
@@ -2452,10 +2469,10 @@ func (r *DescribeRoleListRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeRoleListResponseParams struct {
-	// 角色详情列表。
+	// <p>角色详情列表。</p>
 	List []*RoleInfo `json:"List,omitnil,omitempty" name:"List"`
 
-	// 角色总数
+	// <p>角色总数</p>
 	TotalNum *uint64 `json:"TotalNum,omitnil,omitempty" name:"TotalNum"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -2787,6 +2804,9 @@ type DescribeUserOIDCConfigResponseParams struct {
 
 	// 描述
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// OIDC公钥自动轮转开关（默认为0代表关闭，1代表开启）
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -3316,6 +3336,66 @@ func (r *GetGroupResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *GetGroupResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetPasswordRulesRequestParams struct {
+
+}
+
+type GetPasswordRulesRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *GetPasswordRulesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetPasswordRulesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetPasswordRulesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetPasswordRulesResponseParams struct {
+	// 密码规则
+	Rules *PassWordRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+
+	// 修改时间
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// 修改人
+	Modifier *string `json:"Modifier,omitnil,omitempty" name:"Modifier"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetPasswordRulesResponse struct {
+	*tchttp.BaseResponse
+	Response *GetPasswordRulesResponseParams `json:"Response"`
+}
+
+func (r *GetPasswordRulesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetPasswordRulesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -4147,6 +4227,115 @@ func (r *ListAccessKeysResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ListAccountsRequestParams struct {
+	// <p>返回结果的条数，当返回结果达到 MaxItems 限制被截断时，返回参数IsTruncated将等于true。</p><p>取值范围：[1, 100]</p>
+	MaxItems *int64 `json:"MaxItems,omitnil,omitempty" name:"MaxItems"`
+
+	// <p>当请求的返回结果被截断时，可以使用Marker获取从当前截断位置之后的内容。</p>
+	Marker *string `json:"Marker,omitnil,omitempty" name:"Marker"`
+
+	// <p>用户类型</p><p>枚举值：</p><ul><li>Owner： 主账号</li><li>SubUser： 普通子用户</li><li>CICUser： CIC 子用户</li><li>WechatCorpUser： 企业微信子用户</li><li>AgentIdentity： AgentIdentity子用户</li><li>Collaborator： 协作者</li><li>MessageReceiver： 消息接收者</li></ul>
+	UserType *string `json:"UserType,omitnil,omitempty" name:"UserType"`
+}
+
+type ListAccountsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>返回结果的条数，当返回结果达到 MaxItems 限制被截断时，返回参数IsTruncated将等于true。</p><p>取值范围：[1, 100]</p>
+	MaxItems *int64 `json:"MaxItems,omitnil,omitempty" name:"MaxItems"`
+
+	// <p>当请求的返回结果被截断时，可以使用Marker获取从当前截断位置之后的内容。</p>
+	Marker *string `json:"Marker,omitnil,omitempty" name:"Marker"`
+
+	// <p>用户类型</p><p>枚举值：</p><ul><li>Owner： 主账号</li><li>SubUser： 普通子用户</li><li>CICUser： CIC 子用户</li><li>WechatCorpUser： 企业微信子用户</li><li>AgentIdentity： AgentIdentity子用户</li><li>Collaborator： 协作者</li><li>MessageReceiver： 消息接收者</li></ul>
+	UserType *string `json:"UserType,omitnil,omitempty" name:"UserType"`
+}
+
+func (r *ListAccountsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListAccountsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "MaxItems")
+	delete(f, "Marker")
+	delete(f, "UserType")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListAccountsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListAccountsResponseParams struct {
+	// <p>子账号列表。</p>
+	Users []*ListAllUser `json:"Users,omitnil,omitempty" name:"Users"`
+
+	// <p>当IsTruncated为true时才有此字段，当返回true时，需要继续调用此接口，并且使用Marker获取截断后的内容 。</p>
+	Marker *string `json:"Marker,omitnil,omitempty" name:"Marker"`
+
+	// <p>请求返回结果是否被截断。</p>
+	IsTruncated *bool `json:"IsTruncated,omitnil,omitempty" name:"IsTruncated"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListAccountsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListAccountsResponseParams `json:"Response"`
+}
+
+func (r *ListAccountsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListAccountsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+type ListAllUser struct {
+	// <p>子账号账号ID。</p>
+	Uin *int64 `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子账号用户名。</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>子账号 UID。</p>
+	Uid *int64 `json:"Uid,omitnil,omitempty" name:"Uid"`
+
+	// <p>子账号备注。</p>
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+
+	// <p>子账号能否登录控制台。</p>
+	ConsoleLogin *int64 `json:"ConsoleLogin,omitnil,omitempty" name:"ConsoleLogin"`
+
+	// <p>手机号。</p>
+	PhoneNum *string `json:"PhoneNum,omitnil,omitempty" name:"PhoneNum"`
+
+	// <p>区号。</p>
+	CountryCode *string `json:"CountryCode,omitnil,omitempty" name:"CountryCode"`
+
+	// <p>邮箱。</p>
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
+
+	// <p>创建时间。</p><p>参数格式：YYYY-MM-DD hh:mm:ss</p>
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>账号类型</p><p>枚举值：</p><ul><li>Owner： 主账号</li><li>SubUser： 子用户</li><li>CICUser： CIC 用户</li><li>WechatCorpUser： 企业微信子用户</li><li>AgentIdentity： AgentIdentity用户</li><li>Collaborator： 协作者</li><li>MessageReceiver： 消息接收者</li><li>Unknown： 未知</li></ul>
+	UserType *string `json:"UserType,omitnil,omitempty" name:"UserType"`
+}
+
+// Predefined struct for user
 type ListAttachedGroupPoliciesRequestParams struct {
 	// 用户组ID
 	TargetGroupId *uint64 `json:"TargetGroupId,omitnil,omitempty" name:"TargetGroupId"`
@@ -4915,32 +5104,32 @@ func (r *ListPoliciesGrantingServiceAccessResponse) FromJsonString(s string) err
 
 // Predefined struct for user
 type ListPoliciesRequestParams struct {
-	// 每页数量，默认值是 20，必须大于 0 且小于或等于 200
+	// <p>每页数量，默认值是 20，必须大于 0 且小于或等于 200</p>
 	Rp *uint64 `json:"Rp,omitnil,omitempty" name:"Rp"`
 
-	// 页码，默认值是 1，从 1开始，不能大于 200
+	// <p>页码，默认值是 1，从 1开始，不能大于 200</p>
 	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
 
-	// 可取值 'All'、'QCS' 和 'Local'，'All' 获取所有策略，'QCS' 只获取预设策略，'Local' 只获取自定义策略，默认取 'All'
+	// <p>可取值 &#39;All&#39;、&#39;QCS&#39; 和 &#39;Local&#39;，&#39;All&#39; 获取所有策略，&#39;QCS&#39; 只获取预设策略，&#39;Local&#39; 只获取自定义策略，默认取 &#39;All&#39;</p>
 	Scope *string `json:"Scope,omitnil,omitempty" name:"Scope"`
 
-	// 按策略名匹配
+	// <p>按策略名匹配</p>
 	Keyword *string `json:"Keyword,omitnil,omitempty" name:"Keyword"`
 }
 
 type ListPoliciesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 每页数量，默认值是 20，必须大于 0 且小于或等于 200
+	// <p>每页数量，默认值是 20，必须大于 0 且小于或等于 200</p>
 	Rp *uint64 `json:"Rp,omitnil,omitempty" name:"Rp"`
 
-	// 页码，默认值是 1，从 1开始，不能大于 200
+	// <p>页码，默认值是 1，从 1开始，不能大于 200</p>
 	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
 
-	// 可取值 'All'、'QCS' 和 'Local'，'All' 获取所有策略，'QCS' 只获取预设策略，'Local' 只获取自定义策略，默认取 'All'
+	// <p>可取值 &#39;All&#39;、&#39;QCS&#39; 和 &#39;Local&#39;，&#39;All&#39; 获取所有策略，&#39;QCS&#39; 只获取预设策略，&#39;Local&#39; 只获取自定义策略，默认取 &#39;All&#39;</p>
 	Scope *string `json:"Scope,omitnil,omitempty" name:"Scope"`
 
-	// 按策略名匹配
+	// <p>按策略名匹配</p>
 	Keyword *string `json:"Keyword,omitnil,omitempty" name:"Keyword"`
 }
 
@@ -4968,22 +5157,13 @@ func (r *ListPoliciesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ListPoliciesResponseParams struct {
-	// 策略总数
+	// <p>策略总数</p>
 	TotalNum *uint64 `json:"TotalNum,omitnil,omitempty" name:"TotalNum"`
 
-	// 策略数组，数组每个成员包括 policyId、policyName、addTime、type、description、 createMode 字段。其中： 
-	// policyId：策略 id 
-	// policyName：策略名
-	// addTime：策略创建时间
-	// type：1 表示自定义策略，2 表示预设策略 
-	// description：策略描述 
-	// createMode：1 表示按业务权限创建的策略，其他值表示可以查看策略语法和通过策略语法更新策略
-	// Attachments: 关联的用户数
-	// ServiceType: 策略关联的产品
-	// IsAttached: 当需要查询标记实体是否已经关联策略时不为null。0表示未关联策略，1表示已关联策略
+	// <p>策略数组，数组每个成员包括 policyId、policyName、addTime、type、description、 createMode 字段。其中：<br>policyId：策略 id<br>policyName：策略名<br>addTime：策略创建时间<br>type：1 表示自定义策略，2 表示预设策略<br>description：策略描述<br>createMode：1 表示按业务权限创建的策略，其他值表示可以查看策略语法和通过策略语法更新策略<br>Attachments: 关联的用户数<br>ServiceType: 策略关联的产品<br>IsAttached: 当需要查询标记实体是否已经关联策略时不为null。0表示未关联策略，1表示已关联策略</p>
 	List []*StrategyInfo `json:"List,omitnil,omitempty" name:"List"`
 
-	// 保留字段
+	// <p>保留字段</p>
 	ServiceTypeList []*string `json:"ServiceTypeList,omitnil,omitempty" name:"ServiceTypeList"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -5383,26 +5563,29 @@ func (r *ListWeChatWorkSubAccountsResponse) FromJsonString(s string) error {
 }
 
 type LoginActionFlag struct {
-	// 0: 非安全手机校验 1: 安全手机校验。
+	// <p>0: 非安全手机校验 1: 安全手机校验。</p>
 	Phone *uint64 `json:"Phone,omitnil,omitempty" name:"Phone"`
 
-	// 0: 非硬token校验 1: 硬token校验。
+	// <p>0: 非硬token校验 1: 硬token校验。</p>
 	Token *uint64 `json:"Token,omitnil,omitempty" name:"Token"`
 
-	// 0: 非软token校验 1: 软token校验
+	// <p>0: 非软token校验 1: 软token校验</p>
 	Stoken *uint64 `json:"Stoken,omitnil,omitempty" name:"Stoken"`
 
-	// 0: 非微信校验 1: 微信校验
+	// <p>0: 非微信校验 1: 微信校验</p>
 	Wechat *uint64 `json:"Wechat,omitnil,omitempty" name:"Wechat"`
 
-	// 0: 非自定义校验 1: 自定义校验
+	// <p>0: 非自定义校验 1: 自定义校验</p>
 	Custom *uint64 `json:"Custom,omitnil,omitempty" name:"Custom"`
 
-	// 0: 非邮箱校验 1: 邮箱校验
+	// <p>0: 非邮箱校验 1: 邮箱校验</p>
 	Mail *uint64 `json:"Mail,omitnil,omitempty" name:"Mail"`
 
-	// 0: 非u2f硬件token 1: u2f硬件token
+	// <p>0: 非u2f硬件token 1: u2f硬件token</p>
 	U2FToken *uint64 `json:"U2FToken,omitnil,omitempty" name:"U2FToken"`
+
+	// <p>0: 非passkey 校验 1: passkey校验</p>
+	Passkey *uint64 `json:"Passkey,omitnil,omitempty" name:"Passkey"`
 }
 
 type LoginActionFlagIntl struct {
@@ -5454,6 +5637,32 @@ type OffsiteFlag struct {
 
 	// 提示
 	Tips *uint64 `json:"Tips,omitnil,omitempty" name:"Tips"`
+}
+
+type PassWordRule struct {
+	// 最小长度
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MinimumLength *int64 `json:"MinimumLength,omitnil,omitempty" name:"MinimumLength"`
+
+	// 必须包含的字符
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MustContain *string `json:"MustContain,omitnil,omitempty" name:"MustContain"`
+
+	// 强制修改周期
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ForcePasswordChange *int64 `json:"ForcePasswordChange,omitnil,omitempty" name:"ForcePasswordChange"`
+
+	// 重复使用次数
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ReusePasswordLimit *int64 `json:"ReusePasswordLimit,omitnil,omitempty" name:"ReusePasswordLimit"`
+
+	// 密码重试次数
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RetryPasswordLimit *int64 `json:"RetryPasswordLimit,omitnil,omitempty" name:"RetryPasswordLimit"`
+
+	// 密码过期失效 1：是，2：否（是：密码过期后，子用户无法登录，需要管理员重置密码。否：密码过期后，子用户可登录，登录后强制根据旧密码修改密码）
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PasswordExpirationInvalidation *int64 `json:"PasswordExpirationInvalidation,omitnil,omitempty" name:"PasswordExpirationInvalidation"`
 }
 
 type PolicyVersionDetail struct {
@@ -5912,62 +6121,65 @@ func (r *SetMfaFlagResponse) FromJsonString(s string) error {
 }
 
 type StrategyInfo struct {
-	// 策略ID。
+	// <p>策略ID。</p>
 	PolicyId *uint64 `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
 
-	// 策略名称。
+	// <p>策略名称。</p>
 	PolicyName *string `json:"PolicyName,omitnil,omitempty" name:"PolicyName"`
 
-	// 策略创建时间。
+	// <p>策略创建时间。</p>
 	AddTime *string `json:"AddTime,omitnil,omitempty" name:"AddTime"`
 
-	// 策略类型。1 表示自定义策略，2 表示预设策略。
+	// <p>策略类型。1 表示自定义策略，2 表示预设策略。</p>
 	Type *uint64 `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 策略描述。
+	// <p>策略描述。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
-	// 创建来源，1 通过控制台创建, 2 通过策略语法创建。
+	// <p>创建来源，1 通过控制台创建, 2 通过策略语法创建。</p>
 	CreateMode *uint64 `json:"CreateMode,omitnil,omitempty" name:"CreateMode"`
 
-	// 关联的用户数
+	// <p>关联的用户数</p>
 	Attachments *uint64 `json:"Attachments,omitnil,omitempty" name:"Attachments"`
 
-	// 策略关联的产品
+	// <p>策略关联的产品</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 当需要查询标记实体是否已经关联策略时不为null。0表示未关联策略，1表示已关联策略
+	// <p>当需要查询标记实体是否已经关联策略时不为null。0表示未关联策略，1表示已关联策略</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	IsAttached *uint64 `json:"IsAttached,omitnil,omitempty" name:"IsAttached"`
 
-	// 是否已下线
+	// <p>是否已下线</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Deactived *uint64 `json:"Deactived,omitnil,omitempty" name:"Deactived"`
 
-	// 已下线产品列表
+	// <p>已下线产品列表</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	DeactivedDetail []*string `json:"DeactivedDetail,omitnil,omitempty" name:"DeactivedDetail"`
 
-	// 是否是服务相关角色策略
+	// <p>是否是服务相关角色策略</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	IsServiceLinkedPolicy *uint64 `json:"IsServiceLinkedPolicy,omitnil,omitempty" name:"IsServiceLinkedPolicy"`
 
-	// 关联策略实体数
+	// <p>关联策略实体数</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	AttachEntityCount *int64 `json:"AttachEntityCount,omitnil,omitempty" name:"AttachEntityCount"`
 
-	// 关联权限边界实体数
+	// <p>关联权限边界实体数</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	AttachEntityBoundaryCount *int64 `json:"AttachEntityBoundaryCount,omitnil,omitempty" name:"AttachEntityBoundaryCount"`
 
-	// 最后编辑时间
+	// <p>最后编辑时间</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 
-	// 标签列表
+	// <p>标签列表</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>权限级别</p><p>枚举值：</p><ul><li>Global： 全局权限</li><li>Finance： 财务权限</li><li>CloudProduct： 云产品权限</li></ul>
+	PermissionLevel *string `json:"PermissionLevel,omitnil,omitempty" name:"PermissionLevel"`
 }
 
 type SubAccountInfo struct {
@@ -6380,39 +6592,45 @@ func (r *UpdateGroupResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateOIDCConfigRequestParams struct {
-	// 身份提供商URL
+	// <p>身份提供商URL</p>
 	IdentityUrl *string `json:"IdentityUrl,omitnil,omitempty" name:"IdentityUrl"`
 
-	// 客户端ID
+	// <p>客户端ID</p>
 	ClientId []*string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
 
-	// 名称
+	// <p>名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 签名公钥，需要base64
+	// <p>签名公钥，需要base64</p>
 	IdentityKey *string `json:"IdentityKey,omitnil,omitempty" name:"IdentityKey"`
 
-	// 描述
+	// <p>描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>OIDC公钥自动轮转开关</p><p>枚举值：</p><ul><li>0： 关闭</li><li>1： 开启</li></ul><p>默认值：0</p>
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 }
 
 type UpdateOIDCConfigRequest struct {
 	*tchttp.BaseRequest
 	
-	// 身份提供商URL
+	// <p>身份提供商URL</p>
 	IdentityUrl *string `json:"IdentityUrl,omitnil,omitempty" name:"IdentityUrl"`
 
-	// 客户端ID
+	// <p>客户端ID</p>
 	ClientId []*string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
 
-	// 名称
+	// <p>名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 签名公钥，需要base64
+	// <p>签名公钥，需要base64</p>
 	IdentityKey *string `json:"IdentityKey,omitnil,omitempty" name:"IdentityKey"`
 
-	// 描述
+	// <p>描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>OIDC公钥自动轮转开关</p><p>枚举值：</p><ul><li>0： 关闭</li><li>1： 开启</li></ul><p>默认值：0</p>
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 }
 
 func (r *UpdateOIDCConfigRequest) ToJsonString() string {
@@ -6432,6 +6650,7 @@ func (r *UpdateOIDCConfigRequest) FromJsonString(s string) error {
 	delete(f, "Name")
 	delete(f, "IdentityKey")
 	delete(f, "Description")
+	delete(f, "AutoRotateKey")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateOIDCConfigRequest has unknown keys!", "")
 	}
@@ -6457,6 +6676,60 @@ func (r *UpdateOIDCConfigResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *UpdateOIDCConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdatePasswordRulesRequestParams struct {
+	// 密码规则
+	Rules *PassWordRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+}
+
+type UpdatePasswordRulesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 密码规则
+	Rules *PassWordRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+}
+
+func (r *UpdatePasswordRulesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdatePasswordRulesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Rules")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdatePasswordRulesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdatePasswordRulesResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdatePasswordRulesResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdatePasswordRulesResponseParams `json:"Response"`
+}
+
+func (r *UpdatePasswordRulesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdatePasswordRulesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -6846,6 +7119,9 @@ type UpdateUserOIDCConfigRequestParams struct {
 
 	// 描述，长度为1~255个英文或中文字符，默认值为空。
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// OIDC公钥自动轮转开关（默认为0代表关闭，1代表开启）如果不传的话，会默认置0
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 }
 
 type UpdateUserOIDCConfigRequest struct {
@@ -6878,6 +7154,9 @@ type UpdateUserOIDCConfigRequest struct {
 
 	// 描述，长度为1~255个英文或中文字符，默认值为空。
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// OIDC公钥自动轮转开关（默认为0代表关闭，1代表开启）如果不传的话，会默认置0
+	AutoRotateKey *uint64 `json:"AutoRotateKey,omitnil,omitempty" name:"AutoRotateKey"`
 }
 
 func (r *UpdateUserOIDCConfigRequest) ToJsonString() string {
@@ -6901,6 +7180,7 @@ func (r *UpdateUserOIDCConfigRequest) FromJsonString(s string) error {
 	delete(f, "IdentityKey")
 	delete(f, "Scope")
 	delete(f, "Description")
+	delete(f, "AutoRotateKey")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateUserOIDCConfigRequest has unknown keys!", "")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1211,7 +1211,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bi/v20220105
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing v1.3.39
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing/v20180709
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.21
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.130
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat v1.0.825

--- a/website/docs/r/cam_role_sso.html.markdown
+++ b/website/docs/r/cam_role_sso.html.markdown
@@ -4,21 +4,21 @@ layout: "tencentcloud"
 page_title: "TencentCloud: tencentcloud_cam_role_sso"
 sidebar_current: "docs-tencentcloud-resource-cam_role_sso"
 description: |-
-  Provides a resource to create a CAM-ROLE-SSO (Only support OIDC).
+  Provides a resource to create a CAM-ROLE-SSO(Only support OIDC).
 ---
 
 # tencentcloud_cam_role_sso
 
-Provides a resource to create a CAM-ROLE-SSO (Only support OIDC).
+Provides a resource to create a CAM-ROLE-SSO(Only support OIDC).
 
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_cam_role_sso" "foo" {
-  name            = "tf_cam_role_sso"
+resource "tencentcloud_cam_role_sso" "example" {
+  name            = "tf_example"
   identity_url    = "https://login.microsoftonline.com/.../v2.0"
-  identity_key    = "..."
-  client_ids      = ["..."]
+  identity_key    = "baz****"
+  client_ids      = ["61adcf00620c31e3ddbc9546"]
   description     = "this is a description"
   auto_rotate_key = 1
 }
@@ -29,7 +29,7 @@ resource "tencentcloud_cam_role_sso" "foo" {
 The following arguments are supported:
 
 * `client_ids` - (Required, Set: [`String`]) Client ids.
-* `identity_key` - (Required, String) Sign the public key.
+* `identity_key` - (Required, String) Sign the public key. Base64 encryption is required.
 * `identity_url` - (Required, String) Identity provider URL.
 * `name` - (Required, String) The name of resource.
 * `auto_rotate_key` - (Optional, Int) OIDC public key auto-rotation switch. Enum values: 0 (disabled), 1 (enabled). Default value: 0.
@@ -45,9 +45,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-CAM-ROLE-SSO can be imported using the `name`, e.g.
+CAM-ROLE-SSO(Only support OIDC) can be imported using the `name`, e.g.
 
 ```
-$ terraform import tencentcloud_cam_role_sso.foo "test"
+terraform import tencentcloud_cam_role_sso.example tf_example
 ```
 

--- a/website/docs/r/cam_role_sso.html.markdown
+++ b/website/docs/r/cam_role_sso.html.markdown
@@ -15,11 +15,12 @@ Provides a resource to create a CAM-ROLE-SSO (Only support OIDC).
 
 ```hcl
 resource "tencentcloud_cam_role_sso" "foo" {
-  name         = "tf_cam_role_sso"
-  identity_url = "https://login.microsoftonline.com/.../v2.0"
-  identity_key = "..."
-  client_ids   = ["..."]
-  description  = "this is a description"
+  name            = "tf_cam_role_sso"
+  identity_url    = "https://login.microsoftonline.com/.../v2.0"
+  identity_key    = "..."
+  client_ids      = ["..."]
+  description     = "this is a description"
+  auto_rotate_key = 1
 }
 ```
 
@@ -31,6 +32,7 @@ The following arguments are supported:
 * `identity_key` - (Required, String) Sign the public key.
 * `identity_url` - (Required, String) Identity provider URL.
 * `name` - (Required, String) The name of resource.
+* `auto_rotate_key` - (Optional, Int) OIDC public key auto-rotation switch. Enum values: 0 (disabled), 1 (enabled). Default value: 0.
 * `description` - (Optional, String) The description of resource.
 
 ## Attributes Reference


### PR DESCRIPTION
Add a new optional parameter `auto_rotate_key` to the `tencentcloud_cam_role_sso` resource, enabling declarative management of the OIDC public key auto-rotation switch (0=disabled, 1=enabled, default 0). The parameter is passed through to CreateOIDCConfig/UpdateOIDCConfig and read back from DescribeOIDCConfig.