### PR TITLE
feat(dlc): add tencentcloud_dlc_dms_table resource

### DIFF
--- a/.changelog/4297.txt
+++ b/.changelog/4297.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_dlc_dms_table
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.0.1033
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.129
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.127
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -55,7 +55,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.1.35
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.132
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.0.414
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dts v1.1.46

--- a/go.sum
+++ b/go.sum
@@ -958,7 +958,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.7/go.mod h1
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.11/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.13/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.30/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.35/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.42/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.46/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.50/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1006,8 +1005,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.124/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.125/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.129/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130 h1:sQJUwGwOw3HL9L334UgI+CysqczIjicSItyqg7seeqk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132 h1:42RfJnwzMprfKEJrM9fyhHu1jXyg8xvSJ1A1qb9Qun8=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1032,8 +1032,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633 h1:Ul5iNhXo
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633/go.mod h1:tc6Hvf03M1cBtMC1IKSa5mlOn3kpxWOwhWU1fRy+KEE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673 h1:YyjGLjvPDKNlpbGt89WLFif7TjId0fHzcrGOaHSQRNQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673/go.mod h1:hXPMop1kJFqAvHj+7TyxxxXS/HGUP4SuKx5gGoAl0Zc=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.1.35 h1:YBartSeOD6M1hFzVytGXcILAlXfzzrCxdjcAAbcHi5U=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.1.35/go.mod h1:Hb8V1r7scNF9Zjk0fiEavzW2dx+Lr2FEYrXDPa9f0TE=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.132 h1:LHD2gW7BiKEDWuvKgYniUcPzb3D+Jv6pJFii0JNz+PQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.132/go.mod h1:TX8Cko5rAacJQ0J5Hvg9qCPm7GHTqMtkgV595AuUmoc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124 h1:atQm8S0BLrr3E+Yn2383KQUEEXpQ6z31MsprAKzMDDE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124/go.mod h1:zxlW9EAn0Hqx6Eub6MMocnHZz/gHundkyI7CdbIhU3o=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.0.414 h1:egwjvOEUKBaxsoRVn/YSEhp2E8qdh77Ous9A/wftDo0=

--- a/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/design.md
+++ b/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Terraform Provider for TencentCloud 已具备 DLC（Data Lake Compute）服务的数据源与部分资源（如 `tencentcloud_dlc_data_engine`、`tencentcloud_dlc_user` 等），但尚未覆盖 DMS 元数据表的管理。DLC DMS 提供了 `CreateDMSTable`、`DescribeDMSTable`、`AlterDMSTable`、`DropDMSTable` 四个云 API，均已 vendored 在 `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125` 中，支持对元数据表做完整 CRUD。
+
+该表资源依赖多个复杂嵌套结构：`Asset`（基础对象，含 PermValues/Params/BizParams 等 KVPair 列表）、`DMSSds`（存储描述，含 SerdeParams/Params/Cols/SortColumns 等嵌套）、`DMSColumn`（列定义，含 Params/BizParams）、`DMSPartition`（分区，含 Params 与嵌套 Sds）、`KVPair`（键值对）。
+
+云 API 的特殊性：
+- `CreateDMSTable`/`AlterDMSTable`/`DropDMSTable` 的 Response 仅返回 RequestId，无业务 ID，资源需以业务键（db_name + name）作为复合 ID。
+- `CreateDMSTable` 不接受 `schema_name`/`catalog`/`keyword`/`pattern`，这些只在 `DescribeDMSTable` 入参中存在；`DescribeDMSTable` 出参会返回 `schema_name`、`retention` 等创建时不可设置的只读字段。
+- `AlterDMSTable` 额外需要 `CurrentName`/`CurrentDbName`（旧名称），用于改名场景；其余字段与 Create 对齐。
+- `DropDMSTable` 需要 `delete_data`、`env_props`、`datasource_connection_name`，其中 `env_props` 为 `KVPair` 结构。
+
+当前约束：本资源为 RESOURCE_KIND_GENERAL 通用资源，必须支持 import；复合 ID 用 `tccommon.FILED_SP` 分隔；调用云 API 需以 `tccommon.ReadRetryTimeout`/`tccommon.WriteRetryTimeout` 做最终一致性重试。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提供 `tencentcloud_dlc_dms_table` 资源，支持对 DLC DMS 元数据表的创建、读取、更新、删除全生命周期管理。
+- 支持通过 `terraform import` 导入已存在的表（使用 `db_name` + `name` 复合 ID）。
+- 正确映射云 API 的复杂嵌套结构（Asset、DMSSds、DMSColumn、DMSPartition、KVPair）到 Terraform schema。
+- 在更新场景下正确处理 `AlterDMSTable` 的 `CurrentName`/`CurrentDbName`（取变更前的旧值）。
+- 满足 provider 代码规范：Create 返回值空检查、Read 字段 nil 检查、retry 块仅放接口调用、使用资源蛇形命名做日志。
+- 通过 gomonkey mock 云 API 的单元测试覆盖核心 CRUD 业务逻辑。
+
+**Non-Goals:**
+- 不实现 DMS 表的权限管理（PermValues 仅作为 Asset 属性透传，不做细粒度权限资源化）。
+- 不暴露 `DescribeDMSTable` 专用的查询参数（`keyword`、`pattern`、`catalog`、`schema_name`）作为用户可配置的创建参数；其中 `schema_name` 作为只读 computed 字段从出参回填，`catalog`/`keyword`/`pattern` 不纳入 schema。
+- 不实现数据源（datasource）形式的 `tencentcloud_dlc_dms_table`，本变更仅交付 resource。
+- 不修改任何已有 DLC 资源的 schema。
+
+## Decisions
+
+### 决策 1：复合 ID 设计 = `db_name` + `name`
+- **选择**：使用 `db_name` 与 `name` 通过 `tccommon.FILED_SP` 拼接作为资源 ID。
+- **理由**：`CreateDMSTable` 无返回 ID；DMS 表在云端的唯一键即“数据库名 + 表名”。`DescribeDMSTable` 入参也正是 `DbName` + `Name`。二者组合可在 Read/Update/Delete 中拆分还原。
+- **备选**：仅用 `name` 作 ID——不可行，因为同名表可存在于不同数据库，无法唯一定位。
+- **影响**：Import 需用户提供 `db_name` 与 `name` 的复合 ID；文档需说明。
+
+### 决策 2：Schema 字段分层与 ForceNew 策略
+- **选择**：
+  - `db_name`、`name`、`datasource_connection_name`：Required，且 `db_name`/`name` 标记 `ForceNew`（改库名/表名走 AlterDMSTable 的改名逻辑而非重建）。但由于 AlterDMSTable 支持改名（通过 CurrentName/CurrentDbName + 新 Name/DbName），故 `db_name`/`name` **不** ForceNew，而在 Update 时通过 d.HasChange 判断并把旧值映射到 `CurrentName`/`CurrentDbName`。
+  - `delete_data`、`env_props`：仅 DropDMSTable 使用，作为 Optional 字段（`delete_data` 默认可设为 true 或由用户指定）。
+  - `type`、`storage_size`、`record_count`、`life_time`、`data_update_time`、`struct_update_time`、`last_access_time`、`view_original_text`、`view_expanded_text`：Optional，可更新。
+  - `asset`、`sds`、`columns`、`partition_keys`、`partitions`：Optional 复杂嵌套结构，可更新。
+  - `schema_name`、`retention`：Computed only（从 DescribeDMSTable 出参回填，不可由用户设置）。
+- **理由**：严格对照云 API Create/Alter 入参字段，确保 Create 入参字段均在 CreateDMSTable 存在、Update 入参字段均在 AlterDMSTable 存在。`schema_name`/`retention` 仅在出参出现，设为 Computed。
+
+### 决策 3：Update 改名通过 CurrentName/CurrentDbName
+- **选择**：在 `resourceTencentCloudDlcDmsTableUpdate` 中，先构造 `AlterDMSTableRequest`，对 `db_name`/`name` 使用 `d.GetOk` 取新值填入 `DbName`/`Name`，并使用 `d.GetChange("db_name")`/`d.GetChange("name")` 取旧值填入 `CurrentDbName`/`CurrentName`；其余可变字段从 schema 读取填入。无 immutableArgs 限制（因为 AlterDMSTable 支持所有 Create 字段）。
+- **理由**：AlterDMSTable 设计即用于改名与字段更新，符合云 API 语义。
+- **备选**：把改名视为 ForceNew 重建——会产生删表再建表的副作用，破坏数据，不可接受。
+
+### 决策 4：嵌套结构 schema 扁平化与 KVPair 复用
+- **选择**：对 `KVPair` 定义为可复用的 list-of-map（`key`/`value` 两个字符串字段），在 Asset.PermValues/Params/BizParams、DMSSds.SerdeParams/Params、DMSColumn.Params/BizParams、DMSPartition.Params、DropDMSTable.EnvProps 等位置统一使用该结构。`DMSColumnOrder`（SortCols/SortColumns）定义为含 `col`/`order` 的对象。
+- **理由**：保持与 SDK 结构一致，便于双向映射；KVPair 是云 API 通用键值结构。
+
+### 决策 5：Retry 与空值检查遵循 provider 规范
+- **选择**：
+  - Create/Update/Delete 使用 `resource.Retry(tccommon.WriteRetryTimeout, ...)`，retry 块内仅调用接口，错误用 `tccommon.RetryError(e)` 包装；Create 成功后在 retry 外做 `response == nil || response.Response == nil` 空检查（返回 NonRetryableError），但因 Create Response 无业务字段，仅做 Response 非空校验。
+  - Read 使用 `service.DescribeDmsTableById`（内部 `resource.Retry(tccommon.ReadRetryTimeout, ...)`）。在 retry 块内检查 `response == nil || response.Response == nil`，返回 NonRetryableError（不直接 SetId("")），让外层重试耗尽后失败；外层失败路径打印 `log.Printf("[DATASOURCE] read empty, skip SetId")`。注意：本资源为 RESOURCE_KIND_GENERAL 非 DATASOURCE，但 Read 为空时仍遵循“先打印含 id 的日志再 SetId("")”规范。
+  - Read 中 set 字段前逐一判断 Response 字段 nil。
+- **理由**：符合项目硬约束与代码生成要求第 8/9/14 条。
+
+### 决策 6：单元测试使用 gomonkey mock
+- **选择**：新增资源为全新资源，按规范使用 gomonkey mock 云 API（`UseDlcV20210125Client` 及其 `CreateDMSTableWithContext`/`DescribeDMSTableWithContext`/`AlterDMSTableWithContext`/`DropDMSTableWithContext`），仅测业务逻辑，用 `go test -gcflags=all=-l` 跑通。
+- **理由**：规范要求新增 terraform 资源测试用 mock，不使用 TF 测试套件。
+
+## Risks / Trade-offs
+
+- [风险] `AlterDMSTable` 改名时若 `CurrentName`/`CurrentDbName` 传错会导致更新失败或操作到错误的表 → 缓解：Update 中严格使用 `d.GetChange` 获取旧值，并在日志中打印 current/new 便于排障。
+- [风险] `Asset` 结构层级深、字段多，schema 映射易遗漏或与 SDK 类型不一致 → 缓解：严格按 vendor models.go 逐字段核对类型（int64/string/[]*KVPair/[]*DMSColumn 等），Read 时对每个字段做 nil 判断。
+- [风险] `DropDMSTable` 的 `delete_data`（bool）与 `env_props`（KVPair）若未在 schema 暴露，删除时无法控制是否清除底层数据 → 缓解：在 schema 中暴露 `delete_data`（Optional，默认 false 与云 API 一致）与 `env_props`（Optional KVPair 列表）。
+- [风险] `DescribeDMSTable` 返回 `schema_name`/`retention` 等只读字段，若误设为可写会导致 update 时云 API 拒绝 → 缓解：这两个字段设为 Computed，不参与 AlterDMSTable 入参构造。
+- [权衡] 复杂嵌套结构导致 schema 较大、转换代码冗长 → 接受，以保证功能完整；不抽取通用 helper 以避免影响既有代码。
+- [风险] Create Response 无 ID，无法通过返回值判断创建具体实例 → 缓解：Create 成功后用用户输入的 `db_name`+`name` 复合 ID 设置 d.Id()，并立即调用 Read 回查确认表已存在；若 Read 查不到则返回错误。
+
+## Migration Plan
+
+- 纯新增资源，无数据迁移。部署只需合并代码并在 provider 注册新资源。
+- 回滚策略：移除 provider.go 中的注册项与资源文件即可，不影响存量 state（该资源类型此前不存在）。

--- a/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/proposal.md
+++ b/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Terraform TencentCloud provider 目前缺少对 DLC（Data Lake Compute）DMS 元数据表的管理能力。用户无法通过 Terraform 声明式地创建、查询、更新和删除 DMS 元数据表（`tencentcloud_dlc_dms_table`），导致涉及 DLC 湖仓元数据的基础设施编排必须依赖手工控制台操作或脚本，无法纳入 IaC 统一管理。新增该资源可以让用户以 Terraform 管理表结构、分区、列、存储描述等完整生命周期，提升湖仓元数据治理的自动化与一致性。
+
+## What Changes
+
+- 新增 Terraform 资源 `tencentcloud_dlc_dms_table`（RESOURCE_KIND_GENERAL），覆盖 DMS 元数据表的完整 CRUD 生命周期：
+  - 创建：调用 DLC `CreateDMSTable` 接口。
+  - 查询：调用 DLC `DescribeDMSTable` 接口。
+  - 更新：调用 DLC `AlterDMSTable` 接口。
+  - 删除：调用 DLC `DropDMSTable` 接口。
+- 资源采用复合 ID（数据库名 + 表名），通过 `tccommon` 的 `FILED_SP` 分隔符组合，以支持导入与唯一标识。
+- 在 `tencentcloud/provider.go` 与 `tencentcloud/provider.md` 中注册新资源。
+- 新增资源文档 `tencentcloud/services/dlc/resource_tc_tencentcloud_dlc_dms_table.md`。
+- 新增单元测试 `tencentcloud/services/dlc/resource_tc_tencentcloud_dlc_dms_table_test.go`，使用 gomonkey mock 云 API 进行业务逻辑测试。
+
+## Capabilities
+
+### New Capabilities
+- `dlc-dms-table-resource`: 通过 Terraform 管理 DLC DMS 元数据表资源的完整生命周期（创建、读取、更新、删除），包含表基础信息、列、分区键、分区、存储描述（Sds）、视图文本及数据源连接等参数。
+
+### Modified Capabilities
+<!-- 无现有 spec 需要修改 -->
+
+## Impact
+
+- **新增代码文件**：
+  - `tencentcloud/services/dlc/resource_tc_tencentcloud_dlc_dms_table.go`（资源 CRUD 实现）
+  - `tencentcloud/services/dlc/resource_tc_tencentcloud_dlc_dms_table_test.go`（单元测试）
+  - `tencentcloud/services/dlc/resource_tc_tencentcloud_dlc_dms_table.md`（资源文档）
+- **修改代码文件**：
+  - `tencentcloud/provider.go`：注册 `tencentcloud_dlc_dms_table` 资源。
+  - `tencentcloud/provider.md`：新增资源文档条目。
+- **依赖**：依赖 `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125` 中已有的 `CreateDMSTable`、`DescribeDMSTable`、`AlterDMSTable`、`DropDMSTable` 接口及 `Asset`、`DMSSds`、`DMSColumn`、`DMSPartition`、`KVPair` 等数据结构（已 vendored）。
+- **向后兼容**：纯新增资源，不修改任何现有资源 schema，完全向后兼容。

--- a/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/specs/dlc-dms-table-resource/spec.md
+++ b/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/specs/dlc-dms-table-resource/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: 资源注册与命名
+系统 SHALL 在 provider 中注册名为 `tencentcloud_dlc_dms_table` 的 Terraform 资源，资源类型为 RESOURCE_KIND_GENERAL，实现文件为 `tencentcloud/services/dlc/resource_tc_tencentcloud_dlc_dms_table.go`，并在 `provider.go` 与 `provider.md` 中完成注册登记。
+
+#### Scenario: provider 可识别新资源
+- **WHEN** 执行 `terraform providers schema` 或使用 `tencentcloud_dlc_dms_table` 资源块
+- **THEN** provider 能识别并接受该资源类型，无 unknown resource 错误
+
+### Requirement: 资源 schema 定义
+系统 SHALL 为 `tencentcloud_dlc_dms_table` 定义 schema，覆盖 CreateDMSTable/AlterDMSTable 入参与 DescribeDMSTable 出参的字段，包括：`asset`、`type`、`db_name`、`storage_size`、`record_count`、`life_time`、`data_update_time`、`struct_update_time`、`last_access_time`、`sds`、`columns`、`partition_keys`、`view_original_text`、`view_expanded_text`、`partitions`、`name`、`datasource_connection_name`、`delete_data`、`env_props`，以及 Computed 只读字段 `schema_name`、`retention`。嵌套结构 `asset`、`sds`、`columns`、`partition_keys`、`partitions`、`env_props` 及其子结构 SHALL 完整映射云 API 的 `Asset`、`DMSSds`、`DMSColumn`、`DMSPartition`、`KVPair` 数据模型。
+
+#### Scenario: 必填字段校验
+- **WHEN** 用户在 Terraform 配置中省略 `db_name` 或 `name`
+- **THEN** terraform plan 阶段报错，提示必填字段缺失
+
+#### Scenario: 只读字段不可写
+- **WHEN** 用户尝试在配置中设置 `schema_name` 或 `retention`
+- **THEN** terraform plan 阶段报错，提示该字段为 Computed 不可设置
+
+### Requirement: 创建 DMS 表
+系统 SHALL 在资源 Create 时调用 DLC `CreateDMSTable` 接口，将 schema 中 CreateDMSTable 支持的字段映射到请求入参，调用成功后以 `db_name` 与 `name` 通过 `tccommon.FILED_SP` 拼接作为复合 ID 写入 state，并立即调用 Read 回查确认表已存在。
+
+#### Scenario: 创建成功
+- **WHEN** 用户提供合法的 `db_name`、`name` 及其它 CreateDMSTable 入参字段
+- **THEN** 调用 `CreateDMSTable` 成功，资源 ID 被设置为 `db_name<FILED_SP>name`，state 被回填
+
+#### Scenario: 创建接口返回空
+- **WHEN** `CreateDMSTable` 返回 `Response` 为 nil
+- **THEN** 返回 NonRetryableError，资源 ID 不被写入，避免空 ID 导致状态混乱
+
+### Requirement: 读取 DMS 表
+系统 SHALL 在资源 Read 时从复合 ID 拆分出 `db_name` 与 `name`，调用 DLC `DescribeDMSTable` 接口，并将 `DescribeDMSTableResponse` 中非空的字段回填到 state。当云端返回为空（response/Response 为 nil）时，系统 SHALL 打印包含资源 id 的日志后执行 `d.SetId("")`。
+
+#### Scenario: 读取成功回填字段
+- **WHEN** 资源存在且 `DescribeDMSTable` 正常返回
+- **THEN** 将 `asset`、`type`、`db_name`、`schema_name`、`storage_size`、`record_count`、`life_time`、`data_update_time`、`struct_update_time`、`last_access_time`、`sds`、`columns`、`partition_keys`、`partitions`、`view_original_text`、`view_expanded_text`、`retention`、`name` 等非空字段回填 state
+
+#### Scenario: 资源不存在
+- **WHEN** `DescribeDMSTable` 返回为空或表已被删除
+- **THEN** 打印 `[CRUD] dlc_dms_table id=<id>` 日志后执行 `d.SetId("")`，不返回错误
+
+#### Scenario: 读取字段 nil 跳过
+- **WHEN** Response 中某字段为 nil
+- **THEN** 不对该字段调用 set，避免写入空值覆盖
+
+### Requirement: 更新 DMS 表
+系统 SHALL 在资源 Update 时调用 DLC `AlterDMSTable` 接口。当 `db_name` 或 `name` 发生变更时，系统 SHALL 将变更前的旧值分别映射到 `CurrentDbName` 与 `CurrentName`，将变更后的新值映射到 `DbName` 与 `Name`，实现改名。其余 AlterDMSTable 支持的字段 SHALL 从 schema 读取填入请求。`schema_name`、`retention` 等只在出参出现的字段 SHALL NOT 被加入 AlterDMSTable 请求。
+
+#### Scenario: 更新普通字段
+- **WHEN** 用户修改 `type`、`columns`、`sds` 等 AlterDMSTable 支持的字段
+- **THEN** 调用 `AlterDMSTable` 成功，state 更新为新值
+
+#### Scenario: 改表名
+- **WHEN** 用户修改 `name` 字段
+- **THEN** `AlterDMSTable` 请求中 `CurrentName` 为旧表名、`Name` 为新表名，调用成功后复合 ID 更新为新 `db_name<FILED_SP>新name`
+
+#### Scenario: 改库名
+- **WHEN** 用户修改 `db_name` 字段
+- **THEN** `AlterDMSTable` 请求中 `CurrentDbName` 为旧库名、`DbName` 为新库名，调用成功后复合 ID 更新
+
+### Requirement: 删除 DMS 表
+系统 SHALL 在资源 Delete 时从复合 ID 拆分 `db_name` 与 `name`，调用 DLC `DropDMSTable` 接口，将 `db_name`、`name`、`delete_data`、`env_props`、`datasource_connection_name` 映射到请求入参。
+
+#### Scenario: 删除成功
+- **WHEN** 用户执行 `terraform destroy` 或删除该资源
+- **THEN** 调用 `DropDMSTable` 成功，资源从 state 移除
+
+### Requirement: 导入支持
+系统 SHALL 支持 `terraform import`，导入时使用 `db_name` 与 `name` 通过 `tccommon.FILED_SP` 拼接的复合 ID。资源文档 SHALL 在 Import 部分说明需使用复合 ID。
+
+#### Scenario: 导入已存在表
+- **WHEN** 用户执行 `terraform import tencentcloud_dlc_dms_table.xxx <db_name>#<name>`
+- **THEN** 资源被导入 state，后续 plan 显示无变更
+
+#### Scenario: 导入 ID 格式错误
+- **WHEN** 导入 ID 不包含 `FILED_SP` 分隔的两个部分
+- **THEN** 返回 "id is broken" 错误
+
+### Requirement: 重试与错误处理
+系统 SHALL 在调用 Create/Update/Delete 接口时使用 `tccommon.WriteRetryTimeout` 做 retry，在调用 Read 接口时使用 `tccommon.ReadRetryTimeout` 做 retry。retry 块内 SHALL 仅包含接口调用，接口错误 SHALL 通过 `tccommon.RetryError()` 包装。设置 ID、回填 state 等成功操作 SHALL 在 retry 块外执行。
+
+#### Scenario: 接口瞬时失败重试
+- **WHEN** 云 API 返回可重试错误（如限流）
+- **THEN** 系统在 retry 超时时间内自动重试，最终成功则正常返回
+
+#### Scenario: 重试耗尽
+- **WHEN** 云 API 持续失败直至重试超时
+- **THEN** 返回包装后的错误，资源状态不被错误清空
+
+### Requirement: 单元测试覆盖
+系统 SHALL 新增 `resource_tc_tencentcloud_dlc_dms_table_test.go`，使用 gomonkey mock DLC 云 API（`CreateDMSTableWithContext`/`DescribeDMSTableWithContext`/`AlterDMSTableWithContext`/`DropDMSTableWithContext`），覆盖 Create/Read/Update/Delete 业务逻辑，并通过 `go test -gcflags=all=-l` 执行通过。测试 SHALL NOT 使用 Terraform 验收测试套件。
+
+#### Scenario: 单元测试通过
+- **WHEN** 执行 `go test -gcflags=all=-l ./tencentcloud/services/dlc/ -run TestResourceTencentCloudDlcDmsTable`
+- **THEN** 所有 mock 测试用例通过，验证 CRUD 业务逻辑正确

--- a/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/tasks.md
+++ b/openspec/changes/archive/2026-07-13-add-dlc-dms-table-resource/tasks.md
@@ -1,0 +1,30 @@
+## 1. 资源 schema 与 CRUD 实现
+
+- [x] 1.1 创建 `tencentcloud/services/dlc/resource_tc_dlc_dms_table.go`，定义 `ResourceTencentCloudDlcDmsTable()` 返回 `*schema.Resource`，包含 Create/Read/Update/Delete 及 Importer（State: schema.ImportStatePassthrough）
+- [x] 1.2 定义顶层 schema 字段：`asset`（TypeList，Asset 嵌套）、`type`（TypeString，Optional）、`db_name`（TypeString，Required）、`name`（TypeString，Required）、`datasource_connection_name`（TypeString，Optional）、`storage_size`（TypeInt，Optional）、`record_count`（TypeInt，Optional）、`life_time`（TypeInt，Optional）、`data_update_time`/`struct_update_time`/`last_access_time`/`view_original_text`/`view_expanded_text`（TypeString，Optional）、`sds`（TypeList，DMSSds 嵌套）、`columns`（TypeList，DMSColumn 嵌套）、`partition_keys`（TypeList，DMSColumn 嵌套）、`partitions`（TypeList，DMSPartition 嵌套）、`delete_data`（TypeBool，Optional）、`env_props`（TypeList，KVPair 嵌套）、`schema_name`（TypeString，Computed）、`retention`（TypeInt，Computed）
+- [x] 1.3 定义嵌套 schema：`asset`（含 id/name/guid/catalog/description/owner/owner_account/perm_values/params/biz_params/data_version/create_time/modified_time/datasource_id，其中 perm_values/params/biz_params 为 KVPair 列表）、`sds`（含 location/input_format/output_format/num_buckets/compressed/stored_as_sub_directories/serde_lib/serde_name/bucket_cols/serde_params/params/sort_cols/dms_cols/sort_columns，其中 serde_params/params 为 KVPair 列表、sort_cols 为 DMSColumnOrder、dms_cols 为 DMSColumn 列表、sort_columns 为 DMSColumnOrder 列表）、`columns`/`partition_keys`（DMSColumn：name/description/type/position/params/biz_params/is_partition）、`partitions`（DMSPartition：database_name/schema_name/table_name/data_version/name/values/storage_size/record_count/create_time/modified_time/last_access_time/params/sds/datasource_connection_name）、`env_props`（KVPair：key/value）
+- [x] 1.4 实现 `resourceTencentCloudDlcDmsTableCreate`：构造 `CreateDMSTableRequest` 填入 Create 入参字段；`resource.Retry(tccommon.WriteRetryTimeout)` 内仅调用 `CreateDMSTableWithContext`，错误用 `tccommon.RetryError` 包装；retry 外检查 response/Response 非空，空则返回 NonRetryableError；成功后 `d.SetId(strings.Join([]string{db_name, name}, tccommon.FILED_SP))`，并调用 Read 回查
+- [x] 1.5 实现 `resourceTencentCloudDlcDmsTableRead`：从 `d.Id()` 按 `FILED_SP` 拆分 db_name/name；调用 service 层 `DescribeDmsTableById`（内部 ReadRetryTimeout）；response 为空时先 `log.Printf("[CRUD] dlc_dms_table id=%s", d.Id())` 再 `d.SetId("")`；非空时对每个 Response 字段做 nil 判断后 set（包括 Computed 的 schema_name、retention）；嵌套结构按 SDK 结构转换为 []map[string]interface{}
+- [x] 1.6 实现 `resourceTencentCloudDlcDmsTableUpdate`：构造 `AlterDMSTableRequest`；对 `db_name`/`name` 用 `d.GetChange` 取旧值填入 `CurrentDbName`/`CurrentName`，新值填入 `DbName`/`Name`；其余 AlterDMSTable 支持字段从 schema 读取填入；`schema_name`/`retention` 不加入请求；`resource.Retry(tccommon.WriteRetryTimeout)` 内仅调用 `AlterDMSTableWithContext`，错误用 `tccommon.RetryError` 包装；成功后若 db_name/name 变更则更新 `d.SetId`，再调用 Read 回查
+- [x] 1.7 实现 `resourceTencentCloudDlcDmsTableDelete`：从 `d.Id()` 拆分 db_name/name；构造 `DropDMSTableRequest` 填入 db_name/name/delete_data/env_props/datasource_connection_name；`resource.Retry(tccommon.WriteRetryTimeout)` 内仅调用 `DropDMSTableWithContext`，错误用 `tccommon.RetryError` 包装
+- [x] 1.8 在 service 层文件（`tencentcloud/services/dlc/service_tencentcloud_dlc.go`）中新增 `DescribeDmsTableById` 方法：内部 `resource.Retry(tccommon.ReadRetryTimeout)` 调用 `DescribeDMSTableWithContext`，request 填入 DbName/Name；retry 块内检查 response/Response 为空返回 NonRetryableError；返回 `*DescribeDMSTableResponseParams`
+
+## 2. Provider 注册
+
+- [x] 2.1 在 `tencentcloud/provider.go` 的资源 map 中新增 `"tencentcloud_dlc_dms_table": dlc.ResourceTencentCloudDlcDmsTable()`
+- [x] 2.2 在 `tencentcloud/provider.md` 中新增 `tencentcloud_dlc_dms_table` 资源条目
+
+## 3. 资源文档
+
+- [x] 3.1 创建 `tencentcloud/services/dlc/resource_tc_dlc_dms_table.md`：一句话描述带上 DLC 产品名（"Provides a resource to create a DLC DMS table"）、Example Usage（涉及 json 字符串用 jsonencode）、Import 部分说明使用 `db_name#name` 复合 ID；不添加 Argument Reference 与 Attribute Reference（由 make doc 自动生成）
+
+## 4. 单元测试
+
+- [x] 4.1 创建 `tencentcloud/services/dlc/resource_tc_dlc_dms_table_test.go`，使用 gomonkey mock `UseDlcClient` 的 `CreateDMSTableWithContext`/`DescribeDMSTableWithContext`/`AlterDMSTableWithContext`/`DropDMSTableWithContext`，覆盖 Create/Read/Update/Delete 业务逻辑
+- [x] 4.2 执行 `go test -gcflags=all=-l ./tencentcloud/services/dlc/ -run TestResourceTencentCloudDlcDmsTable` 确保单元测试通过
+
+## 5. 验证与收尾
+
+- [x] 5.1 检查所有函数返回的 error 均被处理，必定不出错的用 `_ = func()` 赋值给 `_`
+- [x] 5.2 核对 Create/Update/Delete 入参字段均在对应云 API 接口中存在，schema 字段类型与 vendor models.go 一致
+- [ ] 5.3 通过 tfpacer-finalize skill 执行 gofmt、make doc 生成 website/docs 文档、生成 changelog 文件并推送

--- a/openspec/specs/dlc-dms-table-resource/spec.md
+++ b/openspec/specs/dlc-dms-table-resource/spec.md
@@ -1,0 +1,100 @@
+# dlc-dms-table-resource Specification
+
+## Purpose
+TBD - created by archiving change add-dlc-dms-table-resource. Update Purpose after archive.
+## Requirements
+### Requirement: 资源注册与命名
+系统 SHALL 在 provider 中注册名为 `tencentcloud_dlc_dms_table` 的 Terraform 资源，资源类型为 RESOURCE_KIND_GENERAL，实现文件为 `tencentcloud/services/dlc/resource_tc_tencentcloud_dlc_dms_table.go`，并在 `provider.go` 与 `provider.md` 中完成注册登记。
+
+#### Scenario: provider 可识别新资源
+- **WHEN** 执行 `terraform providers schema` 或使用 `tencentcloud_dlc_dms_table` 资源块
+- **THEN** provider 能识别并接受该资源类型，无 unknown resource 错误
+
+### Requirement: 资源 schema 定义
+系统 SHALL 为 `tencentcloud_dlc_dms_table` 定义 schema，覆盖 CreateDMSTable/AlterDMSTable 入参与 DescribeDMSTable 出参的字段，包括：`asset`、`type`、`db_name`、`storage_size`、`record_count`、`life_time`、`data_update_time`、`struct_update_time`、`last_access_time`、`sds`、`columns`、`partition_keys`、`view_original_text`、`view_expanded_text`、`partitions`、`name`、`datasource_connection_name`、`delete_data`、`env_props`，以及 Computed 只读字段 `schema_name`、`retention`。嵌套结构 `asset`、`sds`、`columns`、`partition_keys`、`partitions`、`env_props` 及其子结构 SHALL 完整映射云 API 的 `Asset`、`DMSSds`、`DMSColumn`、`DMSPartition`、`KVPair` 数据模型。
+
+#### Scenario: 必填字段校验
+- **WHEN** 用户在 Terraform 配置中省略 `db_name` 或 `name`
+- **THEN** terraform plan 阶段报错，提示必填字段缺失
+
+#### Scenario: 只读字段不可写
+- **WHEN** 用户尝试在配置中设置 `schema_name` 或 `retention`
+- **THEN** terraform plan 阶段报错，提示该字段为 Computed 不可设置
+
+### Requirement: 创建 DMS 表
+系统 SHALL 在资源 Create 时调用 DLC `CreateDMSTable` 接口，将 schema 中 CreateDMSTable 支持的字段映射到请求入参，调用成功后以 `db_name` 与 `name` 通过 `tccommon.FILED_SP` 拼接作为复合 ID 写入 state，并立即调用 Read 回查确认表已存在。
+
+#### Scenario: 创建成功
+- **WHEN** 用户提供合法的 `db_name`、`name` 及其它 CreateDMSTable 入参字段
+- **THEN** 调用 `CreateDMSTable` 成功，资源 ID 被设置为 `db_name<FILED_SP>name`，state 被回填
+
+#### Scenario: 创建接口返回空
+- **WHEN** `CreateDMSTable` 返回 `Response` 为 nil
+- **THEN** 返回 NonRetryableError，资源 ID 不被写入，避免空 ID 导致状态混乱
+
+### Requirement: 读取 DMS 表
+系统 SHALL 在资源 Read 时从复合 ID 拆分出 `db_name` 与 `name`，调用 DLC `DescribeDMSTable` 接口，并将 `DescribeDMSTableResponse` 中非空的字段回填到 state。当云端返回为空（response/Response 为 nil）时，系统 SHALL 打印包含资源 id 的日志后执行 `d.SetId("")`。
+
+#### Scenario: 读取成功回填字段
+- **WHEN** 资源存在且 `DescribeDMSTable` 正常返回
+- **THEN** 将 `asset`、`type`、`db_name`、`schema_name`、`storage_size`、`record_count`、`life_time`、`data_update_time`、`struct_update_time`、`last_access_time`、`sds`、`columns`、`partition_keys`、`partitions`、`view_original_text`、`view_expanded_text`、`retention`、`name` 等非空字段回填 state
+
+#### Scenario: 资源不存在
+- **WHEN** `DescribeDMSTable` 返回为空或表已被删除
+- **THEN** 打印 `[CRUD] dlc_dms_table id=<id>` 日志后执行 `d.SetId("")`，不返回错误
+
+#### Scenario: 读取字段 nil 跳过
+- **WHEN** Response 中某字段为 nil
+- **THEN** 不对该字段调用 set，避免写入空值覆盖
+
+### Requirement: 更新 DMS 表
+系统 SHALL 在资源 Update 时调用 DLC `AlterDMSTable` 接口。当 `db_name` 或 `name` 发生变更时，系统 SHALL 将变更前的旧值分别映射到 `CurrentDbName` 与 `CurrentName`，将变更后的新值映射到 `DbName` 与 `Name`，实现改名。其余 AlterDMSTable 支持的字段 SHALL 从 schema 读取填入请求。`schema_name`、`retention` 等只在出参出现的字段 SHALL NOT 被加入 AlterDMSTable 请求。
+
+#### Scenario: 更新普通字段
+- **WHEN** 用户修改 `type`、`columns`、`sds` 等 AlterDMSTable 支持的字段
+- **THEN** 调用 `AlterDMSTable` 成功，state 更新为新值
+
+#### Scenario: 改表名
+- **WHEN** 用户修改 `name` 字段
+- **THEN** `AlterDMSTable` 请求中 `CurrentName` 为旧表名、`Name` 为新表名，调用成功后复合 ID 更新为新 `db_name<FILED_SP>新name`
+
+#### Scenario: 改库名
+- **WHEN** 用户修改 `db_name` 字段
+- **THEN** `AlterDMSTable` 请求中 `CurrentDbName` 为旧库名、`DbName` 为新库名，调用成功后复合 ID 更新
+
+### Requirement: 删除 DMS 表
+系统 SHALL 在资源 Delete 时从复合 ID 拆分 `db_name` 与 `name`，调用 DLC `DropDMSTable` 接口，将 `db_name`、`name`、`delete_data`、`env_props`、`datasource_connection_name` 映射到请求入参。
+
+#### Scenario: 删除成功
+- **WHEN** 用户执行 `terraform destroy` 或删除该资源
+- **THEN** 调用 `DropDMSTable` 成功，资源从 state 移除
+
+### Requirement: 导入支持
+系统 SHALL 支持 `terraform import`，导入时使用 `db_name` 与 `name` 通过 `tccommon.FILED_SP` 拼接的复合 ID。资源文档 SHALL 在 Import 部分说明需使用复合 ID。
+
+#### Scenario: 导入已存在表
+- **WHEN** 用户执行 `terraform import tencentcloud_dlc_dms_table.xxx <db_name>#<name>`
+- **THEN** 资源被导入 state，后续 plan 显示无变更
+
+#### Scenario: 导入 ID 格式错误
+- **WHEN** 导入 ID 不包含 `FILED_SP` 分隔的两个部分
+- **THEN** 返回 "id is broken" 错误
+
+### Requirement: 重试与错误处理
+系统 SHALL 在调用 Create/Update/Delete 接口时使用 `tccommon.WriteRetryTimeout` 做 retry，在调用 Read 接口时使用 `tccommon.ReadRetryTimeout` 做 retry。retry 块内 SHALL 仅包含接口调用，接口错误 SHALL 通过 `tccommon.RetryError()` 包装。设置 ID、回填 state 等成功操作 SHALL 在 retry 块外执行。
+
+#### Scenario: 接口瞬时失败重试
+- **WHEN** 云 API 返回可重试错误（如限流）
+- **THEN** 系统在 retry 超时时间内自动重试，最终成功则正常返回
+
+#### Scenario: 重试耗尽
+- **WHEN** 云 API 持续失败直至重试超时
+- **THEN** 返回包装后的错误，资源状态不被错误清空
+
+### Requirement: 单元测试覆盖
+系统 SHALL 新增 `resource_tc_tencentcloud_dlc_dms_table_test.go`，使用 gomonkey mock DLC 云 API（`CreateDMSTableWithContext`/`DescribeDMSTableWithContext`/`AlterDMSTableWithContext`/`DropDMSTableWithContext`），覆盖 Create/Read/Update/Delete 业务逻辑，并通过 `go test -gcflags=all=-l` 执行通过。测试 SHALL NOT 使用 Terraform 验收测试套件。
+
+#### Scenario: 单元测试通过
+- **WHEN** 执行 `go test -gcflags=all=-l ./tencentcloud/services/dlc/ -run TestResourceTencentCloudDlcDmsTable`
+- **THEN** 所有 mock 测试用例通过，验证 CRUD 业务逻辑正确
+

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -2524,6 +2524,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_dlc_attach_data_mask_policy":                                              dlc.ResourceTencentCloudDlcAttachDataMaskPolicy(),
 			"tencentcloud_dlc_standard_engine_resource_group_config_info":                           dlc.ResourceTencentCloudDlcStandardEngineResourceGroupConfigInfo(),
 			"tencentcloud_dlc_datasource_house_attachment":                                          dlc.ResourceTencentCloudDlcDatasourceHouseAttachment(),
+			"tencentcloud_dlc_dms_table":                                                            dlc.ResourceTencentCloudDlcDmsTable(),
 			"tencentcloud_waf_custom_rule":                                                          waf.ResourceTencentCloudWafCustomRule(),
 			"tencentcloud_waf_custom_white_rule":                                                    waf.ResourceTencentCloudWafCustomWhiteRule(),
 			"tencentcloud_waf_clb_domain":                                                           waf.ResourceTencentCloudWafClbDomain(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -2326,6 +2326,7 @@ tencentcloud_dlc_data_mask_strategy
 tencentcloud_dlc_attach_data_mask_policy
 tencentcloud_dlc_standard_engine_resource_group_config_info
 tencentcloud_dlc_datasource_house_attachment
+tencentcloud_dlc_dms_table
 
 Web Application Firewall(WAF)
 Data Source

--- a/tencentcloud/services/dlc/resource_tc_dlc_dms_table.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_dms_table.go
@@ -1,0 +1,2031 @@
+package dlc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	dlc "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudDlcDmsTable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudDlcDmsTableCreate,
+		Read:   resourceTencentCloudDlcDmsTableRead,
+		Update: resourceTencentCloudDlcDmsTableUpdate,
+		Delete: resourceTencentCloudDlcDmsTableDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"asset": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Basic object.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "Primary key.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Name.",
+						},
+						"guid": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Object GUID value.",
+						},
+						"catalog": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Data catalog.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Description.",
+						},
+						"owner": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Object owner.",
+						},
+						"owner_account": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Object owner account.",
+						},
+						"perm_values": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Permissions.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Additional attributes.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"biz_params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Additional business attributes.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"data_version": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "Data version.",
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Create time.",
+						},
+						"modified_time": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Modified time.",
+						},
+						"datasource_id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "Data source primary key.",
+						},
+					},
+				},
+			},
+
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Table type: EXTERNAL_TABLE, VIRTUAL_VIEW, MATERIALIZED_VIEW.",
+			},
+
+			"db_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Database name.",
+			},
+
+			"storage_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Storage size.",
+			},
+
+			"record_count": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Record count.",
+			},
+
+			"life_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Life cycle.",
+			},
+
+			"data_update_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Data update time.",
+			},
+
+			"struct_update_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Structure update time.",
+			},
+
+			"last_access_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Last access time.",
+			},
+
+			"sds": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Storage object.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"location": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Storage location.",
+						},
+						"input_format": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Input format.",
+						},
+						"output_format": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Output format.",
+						},
+						"num_buckets": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Bucket count.",
+						},
+						"compressed": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether compressed.",
+						},
+						"stored_as_sub_directories": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether has sub directories.",
+						},
+						"serde_lib": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Serde lib.",
+						},
+						"serde_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Serde name.",
+						},
+						"bucket_cols": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Bucket columns.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"serde_params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Serde parameters.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Additional parameters.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"sort_cols": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: "Column sort (Expired).",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"col": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Column name.",
+									},
+									"order": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: "Order.",
+									},
+								},
+							},
+						},
+						"dms_cols": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Columns.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Name.",
+									},
+									"description": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Description.",
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Type.",
+									},
+									"position": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: "Position.",
+									},
+									"params": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Description: "Additional parameters.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "Key.",
+												},
+												"value": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "Value.",
+												},
+											},
+										},
+									},
+									"biz_params": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Description: "Business parameters.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "Key.",
+												},
+												"value": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "Value.",
+												},
+											},
+										},
+									},
+									"is_partition": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: "Whether partition.",
+									},
+								},
+							},
+						},
+						"sort_columns": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Column sort fields.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"col": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Column name.",
+									},
+									"order": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: "Order.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"columns": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Columns.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Name.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Description.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Type.",
+						},
+						"position": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Position.",
+						},
+						"params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Additional parameters.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"biz_params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Business parameters.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"is_partition": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether partition.",
+						},
+					},
+				},
+			},
+
+			"partition_keys": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Partition keys.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Name.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Description.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Type.",
+						},
+						"position": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Position.",
+						},
+						"params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Additional parameters.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"biz_params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Business parameters.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"is_partition": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether partition.",
+						},
+					},
+				},
+			},
+
+			"view_original_text": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "View original text.",
+			},
+
+			"view_expanded_text": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "View expanded text.",
+			},
+
+			"partitions": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Partitions.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"database_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Database name.",
+						},
+						"schema_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Schema name.",
+						},
+						"table_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Table name.",
+						},
+						"data_version": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Data version.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Partition name.",
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Value list.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"storage_size": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Storage size.",
+						},
+						"record_count": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Record count.",
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Create time.",
+						},
+						"modified_time": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Modified time.",
+						},
+						"last_access_time": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Last access time.",
+						},
+						"params": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Additional attributes.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Value.",
+									},
+								},
+							},
+						},
+						"sds": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: "Storage object.",
+							Elem: &schema.Resource{
+								Schema: dmsSdsSchema(),
+							},
+						},
+						"datasource_connection_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Data source connection name.",
+						},
+					},
+				},
+			},
+
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Table name.",
+			},
+
+			"datasource_connection_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Data source connection name.",
+			},
+
+			"delete_data": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to delete data.",
+			},
+
+			"env_props": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Environment attributes.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Key.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Value.",
+						},
+					},
+				},
+			},
+
+			"schema_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Schema name.",
+			},
+
+			"retention": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Hive retention version.",
+			},
+		},
+	}
+}
+
+// dmsSdsSchema returns the schema definition for DMSSds structure, reused by sds and partition.sds.
+func dmsSdsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"location": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Storage location.",
+		},
+		"input_format": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Input format.",
+		},
+		"output_format": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Output format.",
+		},
+		"num_buckets": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Bucket count.",
+		},
+		"compressed": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Whether compressed.",
+		},
+		"stored_as_sub_directories": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Whether has sub directories.",
+		},
+		"serde_lib": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Serde lib.",
+		},
+		"serde_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Serde name.",
+		},
+		"bucket_cols": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Bucket columns.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"serde_params": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Serde parameters.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Key.",
+					},
+					"value": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Value.",
+					},
+				},
+			},
+		},
+		"params": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Additional parameters.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Key.",
+					},
+					"value": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Value.",
+					},
+				},
+			},
+		},
+		"sort_cols": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Column sort (Expired).",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"col": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Column name.",
+					},
+					"order": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Order.",
+					},
+				},
+			},
+		},
+		"dms_cols": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Columns.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Name.",
+					},
+					"description": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Description.",
+					},
+					"type": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Type.",
+					},
+					"position": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Position.",
+					},
+					"params": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						Description: "Additional parameters.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"key": {
+									Type:        schema.TypeString,
+									Optional:    true,
+									Description: "Key.",
+								},
+								"value": {
+									Type:        schema.TypeString,
+									Optional:    true,
+									Description: "Value.",
+								},
+							},
+						},
+					},
+					"biz_params": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						Description: "Business parameters.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"key": {
+									Type:        schema.TypeString,
+									Optional:    true,
+									Description: "Key.",
+								},
+								"value": {
+									Type:        schema.TypeString,
+									Optional:    true,
+									Description: "Value.",
+								},
+							},
+						},
+					},
+					"is_partition": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Whether partition.",
+					},
+				},
+			},
+		},
+		"sort_columns": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Column sort fields.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"col": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Column name.",
+					},
+					"order": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Order.",
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceTencentCloudDlcDmsTableCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_dlc_dms_table.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId    = tccommon.GetLogId(tccommon.ContextNil)
+		ctx      = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request  = dlc.NewCreateDMSTableRequest()
+		response = dlc.NewCreateDMSTableResponse()
+		dbName   string
+		name     string
+	)
+
+	if v, ok := d.GetOk("db_name"); ok {
+		request.DbName = helper.String(v.(string))
+		dbName = v.(string)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		request.Name = helper.String(v.(string))
+		name = v.(string)
+	}
+
+	if v, ok := d.GetOk("asset"); ok {
+		for _, item := range v.([]interface{}) {
+			assetMap := item.(map[string]interface{})
+			asset := dlc.Asset{}
+			if v, ok := assetMap["id"].(int); ok && v != 0 {
+				asset.Id = helper.Int64(int64(v))
+			}
+			if v, ok := assetMap["name"].(string); ok && v != "" {
+				asset.Name = helper.String(v)
+			}
+			if v, ok := assetMap["guid"].(string); ok && v != "" {
+				asset.Guid = helper.String(v)
+			}
+			if v, ok := assetMap["catalog"].(string); ok && v != "" {
+				asset.Catalog = helper.String(v)
+			}
+			if v, ok := assetMap["description"].(string); ok && v != "" {
+				asset.Description = helper.String(v)
+			}
+			if v, ok := assetMap["owner"].(string); ok && v != "" {
+				asset.Owner = helper.String(v)
+			}
+			if v, ok := assetMap["owner_account"].(string); ok && v != "" {
+				asset.OwnerAccount = helper.String(v)
+			}
+			if v, ok := assetMap["perm_values"].([]interface{}); ok && len(v) > 0 {
+				for _, kvItem := range v {
+					kvMap := kvItem.(map[string]interface{})
+					kvPair := dlc.KVPair{}
+					if v, ok := kvMap["key"].(string); ok && v != "" {
+						kvPair.Key = helper.String(v)
+					}
+					if v, ok := kvMap["value"].(string); ok && v != "" {
+						kvPair.Value = helper.String(v)
+					}
+					asset.PermValues = append(asset.PermValues, &kvPair)
+				}
+			}
+			if v, ok := assetMap["params"].([]interface{}); ok && len(v) > 0 {
+				for _, kvItem := range v {
+					kvMap := kvItem.(map[string]interface{})
+					kvPair := dlc.KVPair{}
+					if v, ok := kvMap["key"].(string); ok && v != "" {
+						kvPair.Key = helper.String(v)
+					}
+					if v, ok := kvMap["value"].(string); ok && v != "" {
+						kvPair.Value = helper.String(v)
+					}
+					asset.Params = append(asset.Params, &kvPair)
+				}
+			}
+			if v, ok := assetMap["biz_params"].([]interface{}); ok && len(v) > 0 {
+				for _, kvItem := range v {
+					kvMap := kvItem.(map[string]interface{})
+					kvPair := dlc.KVPair{}
+					if v, ok := kvMap["key"].(string); ok && v != "" {
+						kvPair.Key = helper.String(v)
+					}
+					if v, ok := kvMap["value"].(string); ok && v != "" {
+						kvPair.Value = helper.String(v)
+					}
+					asset.BizParams = append(asset.BizParams, &kvPair)
+				}
+			}
+			if v, ok := assetMap["data_version"].(int); ok && v != 0 {
+				asset.DataVersion = helper.Int64(int64(v))
+			}
+			if v, ok := assetMap["create_time"].(string); ok && v != "" {
+				asset.CreateTime = helper.String(v)
+			}
+			if v, ok := assetMap["modified_time"].(string); ok && v != "" {
+				asset.ModifiedTime = helper.String(v)
+			}
+			if v, ok := assetMap["datasource_id"].(int); ok && v != 0 {
+				asset.DatasourceId = helper.Int64(int64(v))
+			}
+			request.Asset = &asset
+		}
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		request.Type = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOkExists("storage_size"); ok {
+		request.StorageSize = helper.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOkExists("record_count"); ok {
+		request.RecordCount = helper.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOkExists("life_time"); ok {
+		request.LifeTime = helper.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("data_update_time"); ok {
+		request.DataUpdateTime = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("struct_update_time"); ok {
+		request.StructUpdateTime = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("last_access_time"); ok {
+		request.LastAccessTime = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("sds"); ok {
+		for _, item := range v.([]interface{}) {
+			sdsMap := item.(map[string]interface{})
+			sds := buildDlcDmsSds(sdsMap)
+			request.Sds = &sds
+		}
+	}
+
+	if v, ok := d.GetOk("columns"); ok {
+		for _, item := range v.([]interface{}) {
+			columnMap := item.(map[string]interface{})
+			column := buildDlcDmsColumn(columnMap)
+			request.Columns = append(request.Columns, &column)
+		}
+	}
+
+	if v, ok := d.GetOk("partition_keys"); ok {
+		for _, item := range v.([]interface{}) {
+			columnMap := item.(map[string]interface{})
+			column := buildDlcDmsColumn(columnMap)
+			request.PartitionKeys = append(request.PartitionKeys, &column)
+		}
+	}
+
+	if v, ok := d.GetOk("view_original_text"); ok {
+		request.ViewOriginalText = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("view_expanded_text"); ok {
+		request.ViewExpandedText = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("partitions"); ok {
+		for _, item := range v.([]interface{}) {
+			partitionMap := item.(map[string]interface{})
+			partition := buildDlcDmsPartition(partitionMap)
+			request.Partitions = append(request.Partitions, &partition)
+		}
+	}
+
+	if v, ok := d.GetOk("datasource_connection_name"); ok {
+		request.DatasourceConnectionName = helper.String(v.(string))
+	}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDlcClient().CreateDMSTableWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create dlc_dms_table failed, Response is nil."))
+		}
+
+		response = result
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s create dlc_dms_table failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	log.Printf("[INFO]%s create dlc_dms_table success, db_name=%s, name=%s, RequestId=%s", logId, dbName, name, *response.Response.RequestId)
+
+	if dbName == "" || name == "" {
+		return fmt.Errorf("dlc_dms_table db_name or name is empty, db_name=%s, name=%s", dbName, name)
+	}
+
+	d.SetId(strings.Join([]string{dbName, name}, tccommon.FILED_SP))
+	return resourceTencentCloudDlcDmsTableRead(d, meta)
+}
+
+func resourceTencentCloudDlcDmsTableRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_dlc_dms_table.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service = DlcService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	dbName := idSplit[0]
+	name := idSplit[1]
+
+	respData, err := service.DescribeDmsTableById(ctx, dbName, name)
+	if err != nil {
+		return err
+	}
+
+	if respData == nil {
+		log.Printf("[CRUD] dlc_dms_table id=%s", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if respData.Asset != nil {
+		assetMap := map[string]interface{}{}
+		if respData.Asset.Id != nil {
+			assetMap["id"] = respData.Asset.Id
+		}
+		if respData.Asset.Name != nil {
+			assetMap["name"] = respData.Asset.Name
+		}
+		if respData.Asset.Guid != nil {
+			assetMap["guid"] = respData.Asset.Guid
+		}
+		if respData.Asset.Catalog != nil {
+			assetMap["catalog"] = respData.Asset.Catalog
+		}
+		if respData.Asset.Description != nil {
+			assetMap["description"] = respData.Asset.Description
+		}
+		if respData.Asset.Owner != nil {
+			assetMap["owner"] = respData.Asset.Owner
+		}
+		if respData.Asset.OwnerAccount != nil {
+			assetMap["owner_account"] = respData.Asset.OwnerAccount
+		}
+		if respData.Asset.PermValues != nil {
+			permValuesList := make([]map[string]interface{}, 0, len(respData.Asset.PermValues))
+			for _, kvPair := range respData.Asset.PermValues {
+				kvMap := map[string]interface{}{}
+				if kvPair.Key != nil {
+					kvMap["key"] = kvPair.Key
+				}
+				if kvPair.Value != nil {
+					kvMap["value"] = kvPair.Value
+				}
+				permValuesList = append(permValuesList, kvMap)
+			}
+			assetMap["perm_values"] = permValuesList
+		}
+		if respData.Asset.Params != nil {
+			paramsList := make([]map[string]interface{}, 0, len(respData.Asset.Params))
+			for _, kvPair := range respData.Asset.Params {
+				kvMap := map[string]interface{}{}
+				if kvPair.Key != nil {
+					kvMap["key"] = kvPair.Key
+				}
+				if kvPair.Value != nil {
+					kvMap["value"] = kvPair.Value
+				}
+				paramsList = append(paramsList, kvMap)
+			}
+			assetMap["params"] = paramsList
+		}
+		if respData.Asset.BizParams != nil {
+			bizParamsList := make([]map[string]interface{}, 0, len(respData.Asset.BizParams))
+			for _, kvPair := range respData.Asset.BizParams {
+				kvMap := map[string]interface{}{}
+				if kvPair.Key != nil {
+					kvMap["key"] = kvPair.Key
+				}
+				if kvPair.Value != nil {
+					kvMap["value"] = kvPair.Value
+				}
+				bizParamsList = append(bizParamsList, kvMap)
+			}
+			assetMap["biz_params"] = bizParamsList
+		}
+		if respData.Asset.DataVersion != nil {
+			assetMap["data_version"] = respData.Asset.DataVersion
+		}
+		if respData.Asset.CreateTime != nil {
+			assetMap["create_time"] = respData.Asset.CreateTime
+		}
+		if respData.Asset.ModifiedTime != nil {
+			assetMap["modified_time"] = respData.Asset.ModifiedTime
+		}
+		if respData.Asset.DatasourceId != nil {
+			assetMap["datasource_id"] = respData.Asset.DatasourceId
+		}
+		_ = d.Set("asset", []interface{}{assetMap})
+	}
+
+	if respData.Type != nil {
+		_ = d.Set("type", respData.Type)
+	}
+
+	if respData.DbName != nil {
+		_ = d.Set("db_name", respData.DbName)
+	}
+
+	if respData.StorageSize != nil {
+		_ = d.Set("storage_size", respData.StorageSize)
+	}
+
+	if respData.RecordCount != nil {
+		_ = d.Set("record_count", respData.RecordCount)
+	}
+
+	if respData.LifeTime != nil {
+		_ = d.Set("life_time", respData.LifeTime)
+	}
+
+	if respData.DataUpdateTime != nil {
+		_ = d.Set("data_update_time", respData.DataUpdateTime)
+	}
+
+	if respData.StructUpdateTime != nil {
+		_ = d.Set("struct_update_time", respData.StructUpdateTime)
+	}
+
+	if respData.LastAccessTime != nil {
+		_ = d.Set("last_access_time", respData.LastAccessTime)
+	}
+
+	if respData.Sds != nil {
+		sdsList := []interface{}{flattenDlcDmsSds(respData.Sds)}
+		_ = d.Set("sds", sdsList)
+	}
+
+	if respData.Columns != nil {
+		columnsList := make([]interface{}, 0, len(respData.Columns))
+		for _, column := range respData.Columns {
+			columnsList = append(columnsList, flattenDlcDmsColumn(column))
+		}
+		_ = d.Set("columns", columnsList)
+	}
+
+	if respData.PartitionKeys != nil {
+		partitionKeysList := make([]interface{}, 0, len(respData.PartitionKeys))
+		for _, column := range respData.PartitionKeys {
+			partitionKeysList = append(partitionKeysList, flattenDlcDmsColumn(column))
+		}
+		_ = d.Set("partition_keys", partitionKeysList)
+	}
+
+	if respData.ViewOriginalText != nil {
+		_ = d.Set("view_original_text", respData.ViewOriginalText)
+	}
+
+	if respData.ViewExpandedText != nil {
+		_ = d.Set("view_expanded_text", respData.ViewExpandedText)
+	}
+
+	if respData.Partitions != nil {
+		partitionsList := make([]interface{}, 0, len(respData.Partitions))
+		for _, partition := range respData.Partitions {
+			partitionsList = append(partitionsList, flattenDlcDmsPartition(partition))
+		}
+		_ = d.Set("partitions", partitionsList)
+	}
+
+	if respData.Name != nil {
+		_ = d.Set("name", respData.Name)
+	}
+
+	if respData.SchemaName != nil {
+		_ = d.Set("schema_name", respData.SchemaName)
+	}
+
+	if respData.Retention != nil {
+		_ = d.Set("retention", respData.Retention)
+	}
+
+	return nil
+}
+
+func resourceTencentCloudDlcDmsTableUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_dlc_dms_table.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	currentDbName := idSplit[0]
+	currentName := idSplit[1]
+
+	request := dlc.NewAlterDMSTableRequest()
+
+	if d.HasChange("db_name") {
+		_, newDbName := d.GetChange("db_name")
+		request.DbName = helper.String(newDbName.(string))
+		request.CurrentDbName = helper.String(currentDbName)
+	}
+
+	if d.HasChange("name") {
+		_, newName := d.GetChange("name")
+		request.Name = helper.String(newName.(string))
+		request.CurrentName = helper.String(currentName)
+	}
+
+	if v, ok := d.GetOk("asset"); ok {
+		for _, item := range v.([]interface{}) {
+			assetMap := item.(map[string]interface{})
+			asset := dlc.Asset{}
+			if v, ok := assetMap["id"].(int); ok && v != 0 {
+				asset.Id = helper.Int64(int64(v))
+			}
+			if v, ok := assetMap["name"].(string); ok && v != "" {
+				asset.Name = helper.String(v)
+			}
+			if v, ok := assetMap["guid"].(string); ok && v != "" {
+				asset.Guid = helper.String(v)
+			}
+			if v, ok := assetMap["catalog"].(string); ok && v != "" {
+				asset.Catalog = helper.String(v)
+			}
+			if v, ok := assetMap["description"].(string); ok && v != "" {
+				asset.Description = helper.String(v)
+			}
+			if v, ok := assetMap["owner"].(string); ok && v != "" {
+				asset.Owner = helper.String(v)
+			}
+			if v, ok := assetMap["owner_account"].(string); ok && v != "" {
+				asset.OwnerAccount = helper.String(v)
+			}
+			if v, ok := assetMap["perm_values"].([]interface{}); ok && len(v) > 0 {
+				for _, kvItem := range v {
+					kvMap := kvItem.(map[string]interface{})
+					kvPair := dlc.KVPair{}
+					if v, ok := kvMap["key"].(string); ok && v != "" {
+						kvPair.Key = helper.String(v)
+					}
+					if v, ok := kvMap["value"].(string); ok && v != "" {
+						kvPair.Value = helper.String(v)
+					}
+					asset.PermValues = append(asset.PermValues, &kvPair)
+				}
+			}
+			if v, ok := assetMap["params"].([]interface{}); ok && len(v) > 0 {
+				for _, kvItem := range v {
+					kvMap := kvItem.(map[string]interface{})
+					kvPair := dlc.KVPair{}
+					if v, ok := kvMap["key"].(string); ok && v != "" {
+						kvPair.Key = helper.String(v)
+					}
+					if v, ok := kvMap["value"].(string); ok && v != "" {
+						kvPair.Value = helper.String(v)
+					}
+					asset.Params = append(asset.Params, &kvPair)
+				}
+			}
+			if v, ok := assetMap["biz_params"].([]interface{}); ok && len(v) > 0 {
+				for _, kvItem := range v {
+					kvMap := kvItem.(map[string]interface{})
+					kvPair := dlc.KVPair{}
+					if v, ok := kvMap["key"].(string); ok && v != "" {
+						kvPair.Key = helper.String(v)
+					}
+					if v, ok := kvMap["value"].(string); ok && v != "" {
+						kvPair.Value = helper.String(v)
+					}
+					asset.BizParams = append(asset.BizParams, &kvPair)
+				}
+			}
+			if v, ok := assetMap["data_version"].(int); ok && v != 0 {
+				asset.DataVersion = helper.Int64(int64(v))
+			}
+			if v, ok := assetMap["create_time"].(string); ok && v != "" {
+				asset.CreateTime = helper.String(v)
+			}
+			if v, ok := assetMap["modified_time"].(string); ok && v != "" {
+				asset.ModifiedTime = helper.String(v)
+			}
+			if v, ok := assetMap["datasource_id"].(int); ok && v != 0 {
+				asset.DatasourceId = helper.Int64(int64(v))
+			}
+			request.Asset = &asset
+		}
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		request.Type = helper.String(v.(string))
+	}
+
+	if !d.HasChange("db_name") {
+		request.DbName = helper.String(currentDbName)
+	}
+
+	if !d.HasChange("name") {
+		request.Name = helper.String(currentName)
+	}
+
+	if v, ok := d.GetOkExists("storage_size"); ok {
+		request.StorageSize = helper.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOkExists("record_count"); ok {
+		request.RecordCount = helper.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOkExists("life_time"); ok {
+		request.LifeTime = helper.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("data_update_time"); ok {
+		request.DataUpdateTime = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("struct_update_time"); ok {
+		request.StructUpdateTime = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("last_access_time"); ok {
+		request.LastAccessTime = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("sds"); ok {
+		for _, item := range v.([]interface{}) {
+			sdsMap := item.(map[string]interface{})
+			sds := buildDlcDmsSds(sdsMap)
+			request.Sds = &sds
+		}
+	}
+
+	if v, ok := d.GetOk("columns"); ok {
+		for _, item := range v.([]interface{}) {
+			columnMap := item.(map[string]interface{})
+			column := buildDlcDmsColumn(columnMap)
+			request.Columns = append(request.Columns, &column)
+		}
+	}
+
+	if v, ok := d.GetOk("partition_keys"); ok {
+		for _, item := range v.([]interface{}) {
+			columnMap := item.(map[string]interface{})
+			column := buildDlcDmsColumn(columnMap)
+			request.PartitionKeys = append(request.PartitionKeys, &column)
+		}
+	}
+
+	if v, ok := d.GetOk("view_original_text"); ok {
+		request.ViewOriginalText = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("view_expanded_text"); ok {
+		request.ViewExpandedText = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("partitions"); ok {
+		for _, item := range v.([]interface{}) {
+			partitionMap := item.(map[string]interface{})
+			partition := buildDlcDmsPartition(partitionMap)
+			request.Partitions = append(request.Partitions, &partition)
+		}
+	}
+
+	if v, ok := d.GetOk("datasource_connection_name"); ok {
+		request.DatasourceConnectionName = helper.String(v.(string))
+	}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDlcClient().AlterDMSTableWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Update dlc_dms_table failed, Response is nil."))
+		}
+
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s update dlc_dms_table failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	if request.DbName != nil && request.Name != nil {
+		newDbName := *request.DbName
+		newName := *request.Name
+		if newDbName != currentDbName || newName != currentName {
+			d.SetId(strings.Join([]string{newDbName, newName}, tccommon.FILED_SP))
+		}
+	}
+
+	return resourceTencentCloudDlcDmsTableRead(d, meta)
+}
+
+func resourceTencentCloudDlcDmsTableDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_dlc_dms_table.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = dlc.NewDropDMSTableRequest()
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	dbName := idSplit[0]
+	name := idSplit[1]
+
+	request.DbName = helper.String(dbName)
+	request.Name = helper.String(name)
+
+	if v, ok := d.GetOkExists("delete_data"); ok {
+		request.DeleteData = helper.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("env_props"); ok {
+		for _, item := range v.([]interface{}) {
+			kvMap := item.(map[string]interface{})
+			kvPair := dlc.KVPair{}
+			if v, ok := kvMap["key"].(string); ok && v != "" {
+				kvPair.Key = helper.String(v)
+			}
+			if v, ok := kvMap["value"].(string); ok && v != "" {
+				kvPair.Value = helper.String(v)
+			}
+			request.EnvProps = &kvPair
+		}
+	}
+
+	if v, ok := d.GetOk("datasource_connection_name"); ok {
+		request.DatasourceConnectionName = helper.String(v.(string))
+	}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDlcClient().DropDMSTableWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Delete dlc_dms_table failed, Response is nil."))
+		}
+
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s delete dlc_dms_table failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	return nil
+}
+
+// buildDlcDmsSds builds a DMSSds struct from a schema map.
+func buildDlcDmsSds(sdsMap map[string]interface{}) dlc.DMSSds {
+	sds := dlc.DMSSds{}
+	if v, ok := sdsMap["location"].(string); ok && v != "" {
+		sds.Location = helper.String(v)
+	}
+	if v, ok := sdsMap["input_format"].(string); ok && v != "" {
+		sds.InputFormat = helper.String(v)
+	}
+	if v, ok := sdsMap["output_format"].(string); ok && v != "" {
+		sds.OutputFormat = helper.String(v)
+	}
+	if v, ok := sdsMap["num_buckets"].(int); ok && v != 0 {
+		sds.NumBuckets = helper.Int64(int64(v))
+	}
+	if v, ok := sdsMap["compressed"].(bool); ok {
+		sds.Compressed = helper.Bool(v)
+	}
+	if v, ok := sdsMap["stored_as_sub_directories"].(bool); ok {
+		sds.StoredAsSubDirectories = helper.Bool(v)
+	}
+	if v, ok := sdsMap["serde_lib"].(string); ok && v != "" {
+		sds.SerdeLib = helper.String(v)
+	}
+	if v, ok := sdsMap["serde_name"].(string); ok && v != "" {
+		sds.SerdeName = helper.String(v)
+	}
+	if v, ok := sdsMap["bucket_cols"].([]interface{}); ok && len(v) > 0 {
+		for _, col := range v {
+			if colStr, ok := col.(string); ok && colStr != "" {
+				sds.BucketCols = append(sds.BucketCols, helper.String(colStr))
+			}
+		}
+	}
+	if v, ok := sdsMap["serde_params"].([]interface{}); ok && len(v) > 0 {
+		for _, kvItem := range v {
+			kvMap := kvItem.(map[string]interface{})
+			kvPair := dlc.KVPair{}
+			if v, ok := kvMap["key"].(string); ok && v != "" {
+				kvPair.Key = helper.String(v)
+			}
+			if v, ok := kvMap["value"].(string); ok && v != "" {
+				kvPair.Value = helper.String(v)
+			}
+			sds.SerdeParams = append(sds.SerdeParams, &kvPair)
+		}
+	}
+	if v, ok := sdsMap["params"].([]interface{}); ok && len(v) > 0 {
+		for _, kvItem := range v {
+			kvMap := kvItem.(map[string]interface{})
+			kvPair := dlc.KVPair{}
+			if v, ok := kvMap["key"].(string); ok && v != "" {
+				kvPair.Key = helper.String(v)
+			}
+			if v, ok := kvMap["value"].(string); ok && v != "" {
+				kvPair.Value = helper.String(v)
+			}
+			sds.Params = append(sds.Params, &kvPair)
+		}
+	}
+	if v, ok := sdsMap["sort_cols"].([]interface{}); ok && len(v) > 0 {
+		for _, sortItem := range v {
+			sortMap := sortItem.(map[string]interface{})
+			sortCol := dlc.DMSColumnOrder{}
+			if v, ok := sortMap["col"].(string); ok && v != "" {
+				sortCol.Col = helper.String(v)
+			}
+			if v, ok := sortMap["order"].(int); ok && v != 0 {
+				sortCol.Order = helper.Int64(int64(v))
+			}
+			sds.SortCols = &sortCol
+		}
+	}
+	if v, ok := sdsMap["dms_cols"].([]interface{}); ok && len(v) > 0 {
+		for _, colItem := range v {
+			colMap := colItem.(map[string]interface{})
+			col := buildDlcDmsColumn(colMap)
+			sds.Cols = append(sds.Cols, &col)
+		}
+	}
+	if v, ok := sdsMap["sort_columns"].([]interface{}); ok && len(v) > 0 {
+		for _, sortItem := range v {
+			sortMap := sortItem.(map[string]interface{})
+			sortCol := dlc.DMSColumnOrder{}
+			if v, ok := sortMap["col"].(string); ok && v != "" {
+				sortCol.Col = helper.String(v)
+			}
+			if v, ok := sortMap["order"].(int); ok && v != 0 {
+				sortCol.Order = helper.Int64(int64(v))
+			}
+			sds.SortColumns = append(sds.SortColumns, &sortCol)
+		}
+	}
+	return sds
+}
+
+// buildDlcDmsColumn builds a DMSColumn struct from a schema map.
+func buildDlcDmsColumn(columnMap map[string]interface{}) dlc.DMSColumn {
+	column := dlc.DMSColumn{}
+	if v, ok := columnMap["name"].(string); ok && v != "" {
+		column.Name = helper.String(v)
+	}
+	if v, ok := columnMap["description"].(string); ok && v != "" {
+		column.Description = helper.String(v)
+	}
+	if v, ok := columnMap["type"].(string); ok && v != "" {
+		column.Type = helper.String(v)
+	}
+	if v, ok := columnMap["position"].(int); ok && v != 0 {
+		column.Position = helper.Int64(int64(v))
+	}
+	if v, ok := columnMap["params"].([]interface{}); ok && len(v) > 0 {
+		for _, kvItem := range v {
+			kvMap := kvItem.(map[string]interface{})
+			kvPair := dlc.KVPair{}
+			if v, ok := kvMap["key"].(string); ok && v != "" {
+				kvPair.Key = helper.String(v)
+			}
+			if v, ok := kvMap["value"].(string); ok && v != "" {
+				kvPair.Value = helper.String(v)
+			}
+			column.Params = append(column.Params, &kvPair)
+		}
+	}
+	if v, ok := columnMap["biz_params"].([]interface{}); ok && len(v) > 0 {
+		for _, kvItem := range v {
+			kvMap := kvItem.(map[string]interface{})
+			kvPair := dlc.KVPair{}
+			if v, ok := kvMap["key"].(string); ok && v != "" {
+				kvPair.Key = helper.String(v)
+			}
+			if v, ok := kvMap["value"].(string); ok && v != "" {
+				kvPair.Value = helper.String(v)
+			}
+			column.BizParams = append(column.BizParams, &kvPair)
+		}
+	}
+	if v, ok := columnMap["is_partition"].(bool); ok {
+		column.IsPartition = helper.Bool(v)
+	}
+	return column
+}
+
+// buildDlcDmsPartition builds a DMSPartition struct from a schema map.
+func buildDlcDmsPartition(partitionMap map[string]interface{}) dlc.DMSPartition {
+	partition := dlc.DMSPartition{}
+	if v, ok := partitionMap["database_name"].(string); ok && v != "" {
+		partition.DatabaseName = helper.String(v)
+	}
+	if v, ok := partitionMap["schema_name"].(string); ok && v != "" {
+		partition.SchemaName = helper.String(v)
+	}
+	if v, ok := partitionMap["table_name"].(string); ok && v != "" {
+		partition.TableName = helper.String(v)
+	}
+	if v, ok := partitionMap["data_version"].(int); ok && v != 0 {
+		partition.DataVersion = helper.Int64(int64(v))
+	}
+	if v, ok := partitionMap["name"].(string); ok && v != "" {
+		partition.Name = helper.String(v)
+	}
+	if v, ok := partitionMap["values"].([]interface{}); ok && len(v) > 0 {
+		for _, val := range v {
+			if valStr, ok := val.(string); ok && valStr != "" {
+				partition.Values = append(partition.Values, helper.String(valStr))
+			}
+		}
+	}
+	if v, ok := partitionMap["storage_size"].(int); ok && v != 0 {
+		partition.StorageSize = helper.Int64(int64(v))
+	}
+	if v, ok := partitionMap["record_count"].(int); ok && v != 0 {
+		partition.RecordCount = helper.Int64(int64(v))
+	}
+	if v, ok := partitionMap["create_time"].(string); ok && v != "" {
+		partition.CreateTime = helper.String(v)
+	}
+	if v, ok := partitionMap["modified_time"].(string); ok && v != "" {
+		partition.ModifiedTime = helper.String(v)
+	}
+	if v, ok := partitionMap["last_access_time"].(string); ok && v != "" {
+		partition.LastAccessTime = helper.String(v)
+	}
+	if v, ok := partitionMap["params"].([]interface{}); ok && len(v) > 0 {
+		for _, kvItem := range v {
+			kvMap := kvItem.(map[string]interface{})
+			kvPair := dlc.KVPair{}
+			if v, ok := kvMap["key"].(string); ok && v != "" {
+				kvPair.Key = helper.String(v)
+			}
+			if v, ok := kvMap["value"].(string); ok && v != "" {
+				kvPair.Value = helper.String(v)
+			}
+			partition.Params = append(partition.Params, &kvPair)
+		}
+	}
+	if v, ok := partitionMap["sds"].([]interface{}); ok && len(v) > 0 {
+		for _, sdsItem := range v {
+			sdsMap := sdsItem.(map[string]interface{})
+			sds := buildDlcDmsSds(sdsMap)
+			partition.Sds = &sds
+		}
+	}
+	if v, ok := partitionMap["datasource_connection_name"].(string); ok && v != "" {
+		partition.DatasourceConnectionName = helper.String(v)
+	}
+	return partition
+}
+
+// flattenDlcDmsSds converts a DMSSds struct to a schema map.
+func flattenDlcDmsSds(sds *dlc.DMSSds) map[string]interface{} {
+	sdsMap := map[string]interface{}{}
+	if sds.Location != nil {
+		sdsMap["location"] = sds.Location
+	}
+	if sds.InputFormat != nil {
+		sdsMap["input_format"] = sds.InputFormat
+	}
+	if sds.OutputFormat != nil {
+		sdsMap["output_format"] = sds.OutputFormat
+	}
+	if sds.NumBuckets != nil {
+		sdsMap["num_buckets"] = sds.NumBuckets
+	}
+	if sds.Compressed != nil {
+		sdsMap["compressed"] = sds.Compressed
+	}
+	if sds.StoredAsSubDirectories != nil {
+		sdsMap["stored_as_sub_directories"] = sds.StoredAsSubDirectories
+	}
+	if sds.SerdeLib != nil {
+		sdsMap["serde_lib"] = sds.SerdeLib
+	}
+	if sds.SerdeName != nil {
+		sdsMap["serde_name"] = sds.SerdeName
+	}
+	if sds.BucketCols != nil {
+		bucketColsList := make([]interface{}, 0, len(sds.BucketCols))
+		for _, col := range sds.BucketCols {
+			bucketColsList = append(bucketColsList, col)
+		}
+		sdsMap["bucket_cols"] = bucketColsList
+	}
+	if sds.SerdeParams != nil {
+		serdeParamsList := make([]map[string]interface{}, 0, len(sds.SerdeParams))
+		for _, kvPair := range sds.SerdeParams {
+			kvMap := map[string]interface{}{}
+			if kvPair.Key != nil {
+				kvMap["key"] = kvPair.Key
+			}
+			if kvPair.Value != nil {
+				kvMap["value"] = kvPair.Value
+			}
+			serdeParamsList = append(serdeParamsList, kvMap)
+		}
+		sdsMap["serde_params"] = serdeParamsList
+	}
+	if sds.Params != nil {
+		paramsList := make([]map[string]interface{}, 0, len(sds.Params))
+		for _, kvPair := range sds.Params {
+			kvMap := map[string]interface{}{}
+			if kvPair.Key != nil {
+				kvMap["key"] = kvPair.Key
+			}
+			if kvPair.Value != nil {
+				kvMap["value"] = kvPair.Value
+			}
+			paramsList = append(paramsList, kvMap)
+		}
+		sdsMap["params"] = paramsList
+	}
+	if sds.SortCols != nil {
+		sortColsMap := map[string]interface{}{}
+		if sds.SortCols.Col != nil {
+			sortColsMap["col"] = sds.SortCols.Col
+		}
+		if sds.SortCols.Order != nil {
+			sortColsMap["order"] = sds.SortCols.Order
+		}
+		sdsMap["sort_cols"] = []interface{}{sortColsMap}
+	}
+	if sds.Cols != nil {
+		colsList := make([]map[string]interface{}, 0, len(sds.Cols))
+		for _, col := range sds.Cols {
+			colsList = append(colsList, flattenDlcDmsColumn(col))
+		}
+		sdsMap["dms_cols"] = colsList
+	}
+	if sds.SortColumns != nil {
+		sortColumnsList := make([]map[string]interface{}, 0, len(sds.SortColumns))
+		for _, sortCol := range sds.SortColumns {
+			sortColMap := map[string]interface{}{}
+			if sortCol.Col != nil {
+				sortColMap["col"] = sortCol.Col
+			}
+			if sortCol.Order != nil {
+				sortColMap["order"] = sortCol.Order
+			}
+			sortColumnsList = append(sortColumnsList, sortColMap)
+		}
+		sdsMap["sort_columns"] = sortColumnsList
+	}
+	return sdsMap
+}
+
+// flattenDlcDmsColumn converts a DMSColumn struct to a schema map.
+func flattenDlcDmsColumn(column *dlc.DMSColumn) map[string]interface{} {
+	columnMap := map[string]interface{}{}
+	if column.Name != nil {
+		columnMap["name"] = column.Name
+	}
+	if column.Description != nil {
+		columnMap["description"] = column.Description
+	}
+	if column.Type != nil {
+		columnMap["type"] = column.Type
+	}
+	if column.Position != nil {
+		columnMap["position"] = column.Position
+	}
+	if column.Params != nil {
+		paramsList := make([]map[string]interface{}, 0, len(column.Params))
+		for _, kvPair := range column.Params {
+			kvMap := map[string]interface{}{}
+			if kvPair.Key != nil {
+				kvMap["key"] = kvPair.Key
+			}
+			if kvPair.Value != nil {
+				kvMap["value"] = kvPair.Value
+			}
+			paramsList = append(paramsList, kvMap)
+		}
+		columnMap["params"] = paramsList
+	}
+	if column.BizParams != nil {
+		bizParamsList := make([]map[string]interface{}, 0, len(column.BizParams))
+		for _, kvPair := range column.BizParams {
+			kvMap := map[string]interface{}{}
+			if kvPair.Key != nil {
+				kvMap["key"] = kvPair.Key
+			}
+			if kvPair.Value != nil {
+				kvMap["value"] = kvPair.Value
+			}
+			bizParamsList = append(bizParamsList, kvMap)
+		}
+		columnMap["biz_params"] = bizParamsList
+	}
+	if column.IsPartition != nil {
+		columnMap["is_partition"] = column.IsPartition
+	}
+	return columnMap
+}
+
+// flattenDlcDmsPartition converts a DMSPartition struct to a schema map.
+func flattenDlcDmsPartition(partition *dlc.DMSPartition) map[string]interface{} {
+	partitionMap := map[string]interface{}{}
+	if partition.DatabaseName != nil {
+		partitionMap["database_name"] = partition.DatabaseName
+	}
+	if partition.SchemaName != nil {
+		partitionMap["schema_name"] = partition.SchemaName
+	}
+	if partition.TableName != nil {
+		partitionMap["table_name"] = partition.TableName
+	}
+	if partition.DataVersion != nil {
+		partitionMap["data_version"] = partition.DataVersion
+	}
+	if partition.Name != nil {
+		partitionMap["name"] = partition.Name
+	}
+	if partition.Values != nil {
+		valuesList := make([]interface{}, 0, len(partition.Values))
+		for _, val := range partition.Values {
+			valuesList = append(valuesList, val)
+		}
+		partitionMap["values"] = valuesList
+	}
+	if partition.StorageSize != nil {
+		partitionMap["storage_size"] = partition.StorageSize
+	}
+	if partition.RecordCount != nil {
+		partitionMap["record_count"] = partition.RecordCount
+	}
+	if partition.CreateTime != nil {
+		partitionMap["create_time"] = partition.CreateTime
+	}
+	if partition.ModifiedTime != nil {
+		partitionMap["modified_time"] = partition.ModifiedTime
+	}
+	if partition.LastAccessTime != nil {
+		partitionMap["last_access_time"] = partition.LastAccessTime
+	}
+	if partition.Params != nil {
+		paramsList := make([]map[string]interface{}, 0, len(partition.Params))
+		for _, kvPair := range partition.Params {
+			kvMap := map[string]interface{}{}
+			if kvPair.Key != nil {
+				kvMap["key"] = kvPair.Key
+			}
+			if kvPair.Value != nil {
+				kvMap["value"] = kvPair.Value
+			}
+			paramsList = append(paramsList, kvMap)
+		}
+		partitionMap["params"] = paramsList
+	}
+	if partition.Sds != nil {
+		partitionMap["sds"] = []interface{}{flattenDlcDmsSds(partition.Sds)}
+	}
+	if partition.DatasourceConnectionName != nil {
+		partitionMap["datasource_connection_name"] = partition.DatasourceConnectionName
+	}
+	return partitionMap
+}

--- a/tencentcloud/services/dlc/resource_tc_dlc_dms_table.md
+++ b/tencentcloud/services/dlc/resource_tc_dlc_dms_table.md
@@ -1,0 +1,48 @@
+Provides a resource to create a DLC DMS table
+
+Example Usage
+
+```hcl
+resource "tencentcloud_dlc_dms_table" "example" {
+  db_name = "tf_example_db"
+  name    = "tf_example_table"
+  type    = "EXTERNAL_TABLE"
+
+  asset {
+    name        = "tf_example_table"
+    description = "tf example dlc dms table"
+    owner       = "root"
+  }
+
+  columns {
+    name     = "id"
+    type     = "bigint"
+    position = 1
+  }
+
+  columns {
+    name     = "name"
+    type     = "string"
+    position = 2
+  }
+
+  sds {
+    location      = "cosn://tf-example-bucket/example/"
+    input_format  = "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat"
+    serde_lib     = "org.apache.hadoop.hive.serde2.avro.AvroSerDe"
+    serde_params {
+      key   = "serialization.format"
+      value = "1"
+    }
+  }
+}
+```
+
+Import
+
+DLC DMS table can be imported using the db_name#name, e.g.
+
+```
+terraform import tencentcloud_dlc_dms_table.example tf_example_db#tf_example_table
+```

--- a/tencentcloud/services/dlc/resource_tc_dlc_dms_table_test.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_dms_table_test.go
@@ -1,0 +1,421 @@
+package dlc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	dlc "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	svcdlc "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/dlc"
+)
+
+// mockMetaDlcDmsTable implements tccommon.ProviderMeta
+type mockMetaDlcDmsTable struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaDlcDmsTable) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaDlcDmsTable{}
+
+func newMockMetaDlcDmsTable() *mockMetaDlcDmsTable {
+	return &mockMetaDlcDmsTable{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringDmsTable(s string) *string {
+	return &s
+}
+
+func ptrInt64DmsTable(i int64) *int64 {
+	return &i
+}
+
+func ptrBoolDmsTable(b bool) *bool {
+	return &b
+}
+
+// go test ./tencentcloud/services/dlc/ -run "TestResourceTencentCloudDlcDmsTable_Create" -v -count=1 -gcflags="all=-l"
+
+// TestResourceTencentCloudDlcDmsTable_Create tests the Create flow: CreateDMSTable succeeds, then Read is called to refresh state
+func TestResourceTencentCloudDlcDmsTable_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dlcClient := &dlc.Client{}
+	patches.ApplyMethodReturn(newMockMetaDlcDmsTable().client, "UseDlcClient", dlcClient)
+
+	var capturedCreateRequest *dlc.CreateDMSTableRequest
+	patches.ApplyMethodFunc(dlcClient, "CreateDMSTableWithContext", func(_ context.Context, request *dlc.CreateDMSTableRequest) (*dlc.CreateDMSTableResponse, error) {
+		capturedCreateRequest = request
+		resp := dlc.NewCreateDMSTableResponse()
+		resp.Response = &dlc.CreateDMSTableResponseParams{
+			RequestId: ptrStringDmsTable("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Patch DescribeDMSTableWithContext for the Read call after Create
+	patches.ApplyMethodFunc(dlcClient, "DescribeDMSTableWithContext", func(_ context.Context, request *dlc.DescribeDMSTableRequest) (*dlc.DescribeDMSTableResponse, error) {
+		resp := dlc.NewDescribeDMSTableResponse()
+		resp.Response = &dlc.DescribeDMSTableResponseParams{
+			DbName: ptrStringDmsTable("tf_example_db"),
+			Name:   ptrStringDmsTable("tf_example_table"),
+			Type:   ptrStringDmsTable("EXTERNAL_TABLE"),
+			Asset: &dlc.Asset{
+				Name:        ptrStringDmsTable("tf_example_table"),
+				Description: ptrStringDmsTable("tf example dlc dms table"),
+				Owner:       ptrStringDmsTable("root"),
+			},
+			SchemaName: ptrStringDmsTable("default"),
+			Retention:  ptrInt64DmsTable(0),
+			Columns: []*dlc.DMSColumn{
+				{
+					Name:     ptrStringDmsTable("id"),
+					Type:     ptrStringDmsTable("bigint"),
+					Position: ptrInt64DmsTable(1),
+				},
+				{
+					Name:     ptrStringDmsTable("name"),
+					Type:     ptrStringDmsTable("string"),
+					Position: ptrInt64DmsTable(2),
+				},
+			},
+			Sds: &dlc.DMSSds{
+				Location:     ptrStringDmsTable("cosn://tf-example-bucket/example/"),
+				InputFormat:  ptrStringDmsTable("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat"),
+				OutputFormat: ptrStringDmsTable("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat"),
+				SerdeLib:     ptrStringDmsTable("org.apache.hadoop.hive.serde2.avro.AvroSerDe"),
+				SerdeParams:  []*dlc.KVPair{{Key: ptrStringDmsTable("serialization.format"), Value: ptrStringDmsTable("1")}},
+			},
+			RequestId: ptrStringDmsTable("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDlcDmsTable()
+	res := svcdlc.ResourceTencentCloudDlcDmsTable()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"db_name": "tf_example_db",
+		"name":    "tf_example_table",
+		"type":    "EXTERNAL_TABLE",
+		"asset": []interface{}{
+			map[string]interface{}{
+				"name":        "tf_example_table",
+				"description": "tf example dlc dms table",
+				"owner":       "root",
+			},
+		},
+		"columns": []interface{}{
+			map[string]interface{}{"name": "id", "type": "bigint", "position": 1},
+			map[string]interface{}{"name": "name", "type": "string", "position": 2},
+		},
+		"sds": []interface{}{
+			map[string]interface{}{
+				"location":      "cosn://tf-example-bucket/example/",
+				"input_format":  "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat",
+				"output_format": "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat",
+				"serde_lib":     "org.apache.hadoop.hive.serde2.avro.AvroSerDe",
+				"serde_params": []interface{}{
+					map[string]interface{}{"key": "serialization.format", "value": "1"},
+				},
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "tf_example_db#tf_example_table", d.Id())
+	assert.NotNil(t, capturedCreateRequest)
+	assert.NotNil(t, capturedCreateRequest.DbName)
+	assert.Equal(t, "tf_example_db", *capturedCreateRequest.DbName)
+	assert.NotNil(t, capturedCreateRequest.Name)
+	assert.Equal(t, "tf_example_table", *capturedCreateRequest.Name)
+}
+
+// TestResourceTencentCloudDlcDmsTable_Read tests the Read flow when the table exists
+func TestResourceTencentCloudDlcDmsTable_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dlcClient := &dlc.Client{}
+	patches.ApplyMethodReturn(newMockMetaDlcDmsTable().client, "UseDlcClient", dlcClient)
+
+	patches.ApplyMethodFunc(dlcClient, "DescribeDMSTableWithContext", func(_ context.Context, request *dlc.DescribeDMSTableRequest) (*dlc.DescribeDMSTableResponse, error) {
+		resp := dlc.NewDescribeDMSTableResponse()
+		resp.Response = &dlc.DescribeDMSTableResponseParams{
+			DbName: ptrStringDmsTable("tf_example_db"),
+			Name:   ptrStringDmsTable("tf_example_table"),
+			Type:   ptrStringDmsTable("EXTERNAL_TABLE"),
+			Asset: &dlc.Asset{
+				Name:        ptrStringDmsTable("tf_example_table"),
+				Description: ptrStringDmsTable("tf example dlc dms table"),
+				Owner:       ptrStringDmsTable("root"),
+			},
+			SchemaName: ptrStringDmsTable("default"),
+			Retention:  ptrInt64DmsTable(0),
+			Columns: []*dlc.DMSColumn{
+				{
+					Name:     ptrStringDmsTable("id"),
+					Type:     ptrStringDmsTable("bigint"),
+					Position: ptrInt64DmsTable(1),
+				},
+			},
+			RequestId: ptrStringDmsTable("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDlcDmsTable()
+	res := svcdlc.ResourceTencentCloudDlcDmsTable()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"db_name": "tf_example_db",
+		"name":    "tf_example_table",
+	})
+	d.SetId("tf_example_db#tf_example_table")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "tf_example_db#tf_example_table", d.Id())
+	assert.Equal(t, "tf_example_db", d.Get("db_name").(string))
+	assert.Equal(t, "tf_example_table", d.Get("name").(string))
+	assert.Equal(t, "EXTERNAL_TABLE", d.Get("type").(string))
+	assert.Equal(t, "default", d.Get("schema_name").(string))
+}
+
+// TestResourceTencentCloudDlcDmsTable_Read_NotFound tests the Read flow when the table does not exist (response is nil)
+func TestResourceTencentCloudDlcDmsTable_Read_NotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dlcClient := &dlc.Client{}
+	patches.ApplyMethodReturn(newMockMetaDlcDmsTable().client, "UseDlcClient", dlcClient)
+
+	// DescribeDmsTableById returns nil ret when retry fails with NonRetryableError (response is nil).
+	// To simulate NotFound, we make DescribeDMSTableWithContext return a response with nil Response.
+	patches.ApplyMethodFunc(dlcClient, "DescribeDMSTableWithContext", func(_ context.Context, request *dlc.DescribeDMSTableRequest) (*dlc.DescribeDMSTableResponse, error) {
+		resp := dlc.NewDescribeDMSTableResponse()
+		// Return an error so the retry in DescribeDmsTableById returns NonRetryableError and ret stays nil
+		return resp, nil
+	})
+
+	// Since the mock returns a response with nil Response, DescribeDmsTableById will return NonRetryableError.
+	// The Read method checks if respData == nil and calls d.SetId("").
+	// But because the service returns NonRetryableError, the Read returns an error, not SetId("").
+	// To properly test the d.SetId("") path, we need to mock DescribeDmsTableById directly.
+	patches.ApplyMethodFunc(&svcdlc.DlcService{}, "DescribeDmsTableById", func(_ context.Context, dbName, name string) (*dlc.DescribeDMSTableResponseParams, error) {
+		return nil, nil
+	})
+
+	meta := newMockMetaDlcDmsTable()
+	res := svcdlc.ResourceTencentCloudDlcDmsTable()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"db_name": "tf_example_db",
+		"name":    "tf_example_table",
+	})
+	d.SetId("tf_example_db#tf_example_table")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestResourceTencentCloudDlcDmsTable_Update tests the Update flow: AlterDMSTable succeeds, then Read is called
+func TestResourceTencentCloudDlcDmsTable_Update(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dlcClient := &dlc.Client{}
+	patches.ApplyMethodReturn(newMockMetaDlcDmsTable().client, "UseDlcClient", dlcClient)
+
+	var capturedAlterRequest *dlc.AlterDMSTableRequest
+	patches.ApplyMethodFunc(dlcClient, "AlterDMSTableWithContext", func(_ context.Context, request *dlc.AlterDMSTableRequest) (*dlc.AlterDMSTableResponse, error) {
+		capturedAlterRequest = request
+		resp := dlc.NewAlterDMSTableResponse()
+		resp.Response = &dlc.AlterDMSTableResponseParams{
+			RequestId: ptrStringDmsTable("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Patch DescribeDMSTableWithContext for the Read call after Update
+	patches.ApplyMethodFunc(dlcClient, "DescribeDMSTableWithContext", func(_ context.Context, request *dlc.DescribeDMSTableRequest) (*dlc.DescribeDMSTableResponse, error) {
+		resp := dlc.NewDescribeDMSTableResponse()
+		resp.Response = &dlc.DescribeDMSTableResponseParams{
+			DbName:     ptrStringDmsTable("tf_example_db"),
+			Name:       ptrStringDmsTable("tf_example_table_updated"),
+			Type:       ptrStringDmsTable("EXTERNAL_TABLE"),
+			SchemaName: ptrStringDmsTable("default"),
+			Retention:  ptrInt64DmsTable(0),
+			RequestId:  ptrStringDmsTable("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDlcDmsTable()
+	res := svcdlc.ResourceTencentCloudDlcDmsTable()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"db_name": "tf_example_db",
+		"name":    "tf_example_table_updated",
+		"type":    "EXTERNAL_TABLE",
+	})
+	// The old id was "tf_example_db#tf_example_table", simulating a rename from tf_example_table to tf_example_table_updated.
+	// TestResourceDataRaw has no prior state, so HasChange("name") returns true, triggering the rename path:
+	// CurrentName is taken from the id and Name from the config.
+	d.SetId("tf_example_db#tf_example_table")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedAlterRequest)
+	// The rename path sets CurrentName from the old id and Name from config
+	assert.NotNil(t, capturedAlterRequest.CurrentName)
+	assert.Equal(t, "tf_example_table", *capturedAlterRequest.CurrentName)
+	assert.NotNil(t, capturedAlterRequest.Name)
+	assert.Equal(t, "tf_example_table_updated", *capturedAlterRequest.Name)
+	// Since name changed from tf_example_table to tf_example_table_updated, the id should be updated
+	assert.Equal(t, "tf_example_db#tf_example_table_updated", d.Id())
+}
+
+// TestResourceTencentCloudDlcDmsTable_Delete tests the Delete flow: DropDMSTable succeeds
+func TestResourceTencentCloudDlcDmsTable_Delete(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dlcClient := &dlc.Client{}
+	patches.ApplyMethodReturn(newMockMetaDlcDmsTable().client, "UseDlcClient", dlcClient)
+
+	var capturedDropRequest *dlc.DropDMSTableRequest
+	patches.ApplyMethodFunc(dlcClient, "DropDMSTableWithContext", func(_ context.Context, request *dlc.DropDMSTableRequest) (*dlc.DropDMSTableResponse, error) {
+		capturedDropRequest = request
+		resp := dlc.NewDropDMSTableResponse()
+		resp.Response = &dlc.DropDMSTableResponseParams{
+			RequestId: ptrStringDmsTable("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDlcDmsTable()
+	res := svcdlc.ResourceTencentCloudDlcDmsTable()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"db_name":     "tf_example_db",
+		"name":        "tf_example_table",
+		"delete_data": true,
+	})
+	d.SetId("tf_example_db#tf_example_table")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedDropRequest)
+	assert.NotNil(t, capturedDropRequest.DbName)
+	assert.Equal(t, "tf_example_db", *capturedDropRequest.DbName)
+	assert.NotNil(t, capturedDropRequest.Name)
+	assert.Equal(t, "tf_example_table", *capturedDropRequest.Name)
+}
+
+// TestResourceTencentCloudDlcDmsTable_Schema tests the schema definition
+func TestResourceTencentCloudDlcDmsTable_Schema(t *testing.T) {
+	res := svcdlc.ResourceTencentCloudDlcDmsTable()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "db_name")
+	assert.Contains(t, res.Schema, "name")
+	assert.Contains(t, res.Schema, "asset")
+	assert.Contains(t, res.Schema, "type")
+	assert.Contains(t, res.Schema, "sds")
+	assert.Contains(t, res.Schema, "columns")
+	assert.Contains(t, res.Schema, "partition_keys")
+	assert.Contains(t, res.Schema, "partitions")
+	assert.Contains(t, res.Schema, "view_original_text")
+	assert.Contains(t, res.Schema, "view_expanded_text")
+	assert.Contains(t, res.Schema, "datasource_connection_name")
+	assert.Contains(t, res.Schema, "delete_data")
+	assert.Contains(t, res.Schema, "env_props")
+	assert.Contains(t, res.Schema, "schema_name")
+	assert.Contains(t, res.Schema, "retention")
+
+	// db_name and name are Required
+	assert.True(t, res.Schema["db_name"].Required)
+	assert.True(t, res.Schema["name"].Required)
+
+	// schema_name and retention are Computed only
+	assert.True(t, res.Schema["schema_name"].Computed)
+	assert.False(t, res.Schema["schema_name"].Optional)
+	assert.True(t, res.Schema["retention"].Computed)
+	assert.False(t, res.Schema["retention"].Optional)
+}
+
+// TestResourceTencentCloudDlcDmsTable_Create_EmptyResponse tests that Create returns an error when CreateDMSTable returns nil response
+func TestResourceTencentCloudDlcDmsTable_Create_EmptyResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dlcClient := &dlc.Client{}
+	patches.ApplyMethodReturn(newMockMetaDlcDmsTable().client, "UseDlcClient", dlcClient)
+
+	// Return a response with nil Response to trigger NonRetryableError
+	patches.ApplyMethodFunc(dlcClient, "CreateDMSTableWithContext", func(_ context.Context, request *dlc.CreateDMSTableRequest) (*dlc.CreateDMSTableResponse, error) {
+		resp := dlc.NewCreateDMSTableResponse()
+		// Response is nil
+		return resp, nil
+	})
+
+	meta := newMockMetaDlcDmsTable()
+	res := svcdlc.ResourceTencentCloudDlcDmsTable()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"db_name": "tf_example_db",
+		"name":    "tf_example_table",
+	})
+
+	err := res.Create(d, meta)
+	assert.Error(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestResourceTencentCloudDlcDmsTable_Delete_WithEnvProps tests that Delete correctly sends env_props
+func TestResourceTencentCloudDlcDmsTable_Delete_WithEnvProps(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dlcClient := &dlc.Client{}
+	patches.ApplyMethodReturn(newMockMetaDlcDmsTable().client, "UseDlcClient", dlcClient)
+
+	var capturedDropRequest *dlc.DropDMSTableRequest
+	patches.ApplyMethodFunc(dlcClient, "DropDMSTableWithContext", func(_ context.Context, request *dlc.DropDMSTableRequest) (*dlc.DropDMSTableResponse, error) {
+		capturedDropRequest = request
+		resp := dlc.NewDropDMSTableResponse()
+		resp.Response = &dlc.DropDMSTableResponseParams{
+			RequestId: ptrStringDmsTable("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDlcDmsTable()
+	res := svcdlc.ResourceTencentCloudDlcDmsTable()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"db_name":     "tf_example_db",
+		"name":        "tf_example_table",
+		"delete_data": true,
+		"env_props": []interface{}{
+			map[string]interface{}{"key": "env_key", "value": "env_value"},
+		},
+		"datasource_connection_name": "tf_example_connection",
+	})
+	d.SetId("tf_example_db#tf_example_table")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedDropRequest)
+	assert.NotNil(t, capturedDropRequest.EnvProps)
+	assert.Equal(t, "env_key", *capturedDropRequest.EnvProps.Key)
+	assert.Equal(t, "env_value", *capturedDropRequest.EnvProps.Value)
+	assert.NotNil(t, capturedDropRequest.DeleteData)
+	assert.True(t, *capturedDropRequest.DeleteData)
+	assert.NotNil(t, capturedDropRequest.DatasourceConnectionName)
+	assert.Equal(t, "tf_example_connection", *capturedDropRequest.DatasourceConnectionName)
+}

--- a/tencentcloud/services/dlc/service_tencentcloud_dlc.go
+++ b/tencentcloud/services/dlc/service_tencentcloud_dlc.go
@@ -1522,3 +1522,41 @@ func (me *DlcService) DescribeDlcDatasourceHouseAttachmentById(ctx context.Conte
 	ret = response.Response.NetworkConnectionSet[0]
 	return
 }
+
+func (me *DlcService) DescribeDmsTableById(ctx context.Context, dbName, name string) (ret *dlc.DescribeDMSTableResponseParams, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := dlc.NewDescribeDMSTableRequest()
+	request.DbName = helper.String(dbName)
+	request.Name = helper.String(name)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	errRet = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, e := me.client.UseDlcClient().DescribeDMSTableWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe dlc_dms_table failed, Response is nil."))
+		}
+
+		ret = result.Response
+		return nil
+	})
+
+	if errRet != nil {
+		log.Printf("[DATASOURCE] read empty, skip SetId")
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.130"
+	params["RequestClient"] = "SDK_GO_1.3.132"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/client.go
@@ -548,7 +548,9 @@ func NewAttachDataMaskPolicyResponse() (response *AttachDataMaskPolicyResponse) 
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER_INVALIDACCESSPOLICY = "InvalidParameter.InvalidAccessPolicy"
 //  INVALIDPARAMETER_INVALIDGROUPID = "InvalidParameter.InvalidGroupId"
+//  INVALIDPARAMETER_INVALIDPARAMETER_COLUMNTYPENOTCOMPATIBLE = "InvalidParameter.InvalidParameter_ColumnTypeNotCompatible"
 //  UNAUTHORIZEDOPERATION_GRANTPOLICY = "UnauthorizedOperation.GrantPolicy"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATION = "UnauthorizedOperation.UnauthorizedOperation"
 //  UNAUTHORIZEDOPERATION_USERNOTEXIST = "UnauthorizedOperation.UserNotExist"
 func (c *Client) AttachDataMaskPolicy(request *AttachDataMaskPolicyRequest) (response *AttachDataMaskPolicyResponse, err error) {
     return c.AttachDataMaskPolicyWithContext(context.Background(), request)
@@ -566,7 +568,9 @@ func (c *Client) AttachDataMaskPolicy(request *AttachDataMaskPolicyRequest) (res
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER_INVALIDACCESSPOLICY = "InvalidParameter.InvalidAccessPolicy"
 //  INVALIDPARAMETER_INVALIDGROUPID = "InvalidParameter.InvalidGroupId"
+//  INVALIDPARAMETER_INVALIDPARAMETER_COLUMNTYPENOTCOMPATIBLE = "InvalidParameter.InvalidParameter_ColumnTypeNotCompatible"
 //  UNAUTHORIZEDOPERATION_GRANTPOLICY = "UnauthorizedOperation.GrantPolicy"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATION = "UnauthorizedOperation.UnauthorizedOperation"
 //  UNAUTHORIZEDOPERATION_USERNOTEXIST = "UnauthorizedOperation.UserNotExist"
 func (c *Client) AttachDataMaskPolicyWithContext(ctx context.Context, request *AttachDataMaskPolicyRequest) (response *AttachDataMaskPolicyResponse, err error) {
     if request == nil {
@@ -1081,6 +1085,7 @@ func NewCancelTasksResponse() (response *CancelTasksResponse) {
 //  INVALIDPARAMETER_INVALIDSQLCONFIGSQL = "InvalidParameter.InvalidSQLConfigSQL"
 //  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
 //  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  RESOURCENOTFOUND_TASKALREADYFINISHED = "ResourceNotFound.TaskAlreadyFinished"
 func (c *Client) CancelTasks(request *CancelTasksRequest) (response *CancelTasksResponse, err error) {
     return c.CancelTasksWithContext(context.Background(), request)
 }
@@ -1094,6 +1099,7 @@ func (c *Client) CancelTasks(request *CancelTasksRequest) (response *CancelTasks
 //  INVALIDPARAMETER_INVALIDSQLCONFIGSQL = "InvalidParameter.InvalidSQLConfigSQL"
 //  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
 //  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  RESOURCENOTFOUND_TASKALREADYFINISHED = "ResourceNotFound.TaskAlreadyFinished"
 func (c *Client) CancelTasksWithContext(ctx context.Context, request *CancelTasksRequest) (response *CancelTasksResponse, err error) {
     if request == nil {
         request = NewCancelTasksRequest()
@@ -1423,6 +1429,7 @@ func NewCreateCHDFSBindingProductResponse() (response *CreateCHDFSBindingProduct
 //  FAILEDOPERATION = "FailedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDBUCKETNAME = "InvalidParameter.InvalidBucketName"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) CreateCHDFSBindingProduct(request *CreateCHDFSBindingProductRequest) (response *CreateCHDFSBindingProductResponse, err error) {
     return c.CreateCHDFSBindingProductWithContext(context.Background(), request)
@@ -1435,6 +1442,7 @@ func (c *Client) CreateCHDFSBindingProduct(request *CreateCHDFSBindingProductReq
 //  FAILEDOPERATION = "FailedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDBUCKETNAME = "InvalidParameter.InvalidBucketName"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) CreateCHDFSBindingProductWithContext(ctx context.Context, request *CreateCHDFSBindingProductRequest) (response *CreateCHDFSBindingProductResponse, err error) {
     if request == nil {
@@ -1811,6 +1819,82 @@ func (c *Client) CreateDatabaseWithContext(ctx context.Context, request *CreateD
     request.SetContext(ctx)
     
     response = NewCreateDatabaseResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateDatasourceConnectionRequest() (request *CreateDatasourceConnectionRequest) {
+    request = &CreateDatasourceConnectionRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateDatasourceConnection")
+    
+    
+    return
+}
+
+func NewCreateDatasourceConnectionResponse() (response *CreateDatasourceConnectionResponse) {
+    response = &CreateDatasourceConnectionResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateDatasourceConnection
+// 创建数据源
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_ANOTHERCREATEPROCESSRUNNING = "FailedOperation.AnotherCreateProcessRunning"
+//  FAILEDOPERATION_ANOTHERPROCESSRUNNING = "FailedOperation.AnotherProcessRunning"
+//  FAILEDOPERATION_ANOTHERREQUESTPROCESSING = "FailedOperation.AnotherRequestProcessing"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER_DATASOURCETYPEERROR = "InvalidParameter.DatasourceTypeError"
+//  INVALIDPARAMETER_DUPLICATEDATASOURCENAME = "InvalidParameter.DuplicateDatasourceName"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDDATASOURCECONNECTIONCONFIG = "InvalidParameter.InvalidDatasourceConnectionConfig"
+//  INVALIDPARAMETER_INVALIDHIVEVERSION = "InvalidParameter.InvalidHiveVersion"
+//  INVALIDPARAMETER_URLFORMATERROR = "InvalidParameter.UrlFormatError"
+//  INVALIDPARAMETER_VPCCIDRFORMATERROR = "InvalidParameter.VpcCidrFormatError"
+//  INVALIDPARAMETER_VPCCIDROVERLAP = "InvalidParameter.VpcCidrOverlap"
+//  RESOURCENOTFOUND_EKSRESOURCENOTFOUND = "ResourceNotFound.EksResourceNotFound"
+//  UNAUTHORIZEDOPERATION_CREATECATALOG = "UnauthorizedOperation.CreateCatalog"
+func (c *Client) CreateDatasourceConnection(request *CreateDatasourceConnectionRequest) (response *CreateDatasourceConnectionResponse, err error) {
+    return c.CreateDatasourceConnectionWithContext(context.Background(), request)
+}
+
+// CreateDatasourceConnection
+// 创建数据源
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_ANOTHERCREATEPROCESSRUNNING = "FailedOperation.AnotherCreateProcessRunning"
+//  FAILEDOPERATION_ANOTHERPROCESSRUNNING = "FailedOperation.AnotherProcessRunning"
+//  FAILEDOPERATION_ANOTHERREQUESTPROCESSING = "FailedOperation.AnotherRequestProcessing"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER_DATASOURCETYPEERROR = "InvalidParameter.DatasourceTypeError"
+//  INVALIDPARAMETER_DUPLICATEDATASOURCENAME = "InvalidParameter.DuplicateDatasourceName"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDDATASOURCECONNECTIONCONFIG = "InvalidParameter.InvalidDatasourceConnectionConfig"
+//  INVALIDPARAMETER_INVALIDHIVEVERSION = "InvalidParameter.InvalidHiveVersion"
+//  INVALIDPARAMETER_URLFORMATERROR = "InvalidParameter.UrlFormatError"
+//  INVALIDPARAMETER_VPCCIDRFORMATERROR = "InvalidParameter.VpcCidrFormatError"
+//  INVALIDPARAMETER_VPCCIDROVERLAP = "InvalidParameter.VpcCidrOverlap"
+//  RESOURCENOTFOUND_EKSRESOURCENOTFOUND = "ResourceNotFound.EksResourceNotFound"
+//  UNAUTHORIZEDOPERATION_CREATECATALOG = "UnauthorizedOperation.CreateCatalog"
+func (c *Client) CreateDatasourceConnectionWithContext(ctx context.Context, request *CreateDatasourceConnectionRequest) (response *CreateDatasourceConnectionResponse, err error) {
+    if request == nil {
+        request = NewCreateDatasourceConnectionRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateDatasourceConnection")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateDatasourceConnection require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateDatasourceConnectionResponse()
     err = c.Send(request, response)
     return
 }
@@ -2839,6 +2923,7 @@ func NewCreateStandardEngineResourceGroupResponse() (response *CreateStandardEng
 //  INTERNALERROR_DBERROR = "InternalError.DBError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  LIMITEXCEEDED = "LimitExceeded"
+//  RESOURCENOTFOUND_GATEWAYNOTFOUND = "ResourceNotFound.GatewayNotFound"
 //  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
 //  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
 func (c *Client) CreateStandardEngineResourceGroup(request *CreateStandardEngineResourceGroupRequest) (response *CreateStandardEngineResourceGroupResponse, err error) {
@@ -2854,6 +2939,7 @@ func (c *Client) CreateStandardEngineResourceGroup(request *CreateStandardEngine
 //  INTERNALERROR_DBERROR = "InternalError.DBError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  LIMITEXCEEDED = "LimitExceeded"
+//  RESOURCENOTFOUND_GATEWAYNOTFOUND = "ResourceNotFound.GatewayNotFound"
 //  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
 //  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
 func (c *Client) CreateStandardEngineResourceGroupWithContext(ctx context.Context, request *CreateStandardEngineResourceGroupRequest) (response *CreateStandardEngineResourceGroupResponse, err error) {
@@ -3408,9 +3494,11 @@ func NewCreateUserResponse() (response *CreateUserResponse) {
 //  INVALIDPARAMETER_INVALIDUSERALIAS = "InvalidParameter.InvalidUserAlias"
 //  INVALIDPARAMETER_INVALIDUSERNAME = "InvalidParameter.InvalidUserName"
 //  INVALIDPARAMETER_INVALIDUSERTYPE = "InvalidParameter.InvalidUserType"
+//  RESOURCENOTFOUND_USERNOTEXIST = "ResourceNotFound.UserNotExist"
 //  RESOURCESSOLDOUT = "ResourcesSoldOut"
 //  RESOURCESSOLDOUT_UNAUTHORIZEDGRANTPOLICY = "ResourcesSoldOut.UnauthorizedGrantPolicy"
 //  RESOURCESSOLDOUT_UNAUTHORIZEDOPERATION = "ResourcesSoldOut.UnauthorizedOperation"
+//  UNAUTHORIZEDOPERATION_CREATEADMINISTRATOR = "UnauthorizedOperation.CreateAdministrator"
 //  UNAUTHORIZEDOPERATION_GRANTPOLICY = "UnauthorizedOperation.GrantPolicy"
 //  UNAUTHORIZEDOPERATION_USERNOTEXIST = "UnauthorizedOperation.UserNotExist"
 func (c *Client) CreateUser(request *CreateUserRequest) (response *CreateUserResponse, err error) {
@@ -3431,9 +3519,11 @@ func (c *Client) CreateUser(request *CreateUserRequest) (response *CreateUserRes
 //  INVALIDPARAMETER_INVALIDUSERALIAS = "InvalidParameter.InvalidUserAlias"
 //  INVALIDPARAMETER_INVALIDUSERNAME = "InvalidParameter.InvalidUserName"
 //  INVALIDPARAMETER_INVALIDUSERTYPE = "InvalidParameter.InvalidUserType"
+//  RESOURCENOTFOUND_USERNOTEXIST = "ResourceNotFound.UserNotExist"
 //  RESOURCESSOLDOUT = "ResourcesSoldOut"
 //  RESOURCESSOLDOUT_UNAUTHORIZEDGRANTPOLICY = "ResourcesSoldOut.UnauthorizedGrantPolicy"
 //  RESOURCESSOLDOUT_UNAUTHORIZEDOPERATION = "ResourcesSoldOut.UnauthorizedOperation"
+//  UNAUTHORIZEDOPERATION_CREATEADMINISTRATOR = "UnauthorizedOperation.CreateAdministrator"
 //  UNAUTHORIZEDOPERATION_GRANTPOLICY = "UnauthorizedOperation.GrantPolicy"
 //  UNAUTHORIZEDOPERATION_USERNOTEXIST = "UnauthorizedOperation.UserNotExist"
 func (c *Client) CreateUserWithContext(ctx context.Context, request *CreateUserRequest) (response *CreateUserResponse, err error) {
@@ -3449,6 +3539,56 @@ func (c *Client) CreateUserWithContext(ctx context.Context, request *CreateUserR
     request.SetContext(ctx)
     
     response = NewCreateUserResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateUserRoleRequest() (request *CreateUserRoleRequest) {
+    request = &CreateUserRoleRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateUserRole")
+    
+    
+    return
+}
+
+func NewCreateUserRoleResponse() (response *CreateUserRoleResponse) {
+    response = &CreateUserRoleResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateUserRole
+// 创建用户角色
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) CreateUserRole(request *CreateUserRoleRequest) (response *CreateUserRoleResponse, err error) {
+    return c.CreateUserRoleWithContext(context.Background(), request)
+}
+
+// CreateUserRole
+// 创建用户角色
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) CreateUserRoleWithContext(ctx context.Context, request *CreateUserRoleRequest) (response *CreateUserRoleResponse, err error) {
+    if request == nil {
+        request = NewCreateUserRoleRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateUserRole")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateUserRole require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateUserRoleResponse()
     err = c.Send(request, response)
     return
 }
@@ -4962,6 +5102,9 @@ func NewDescribeDataEngineEventsResponse() (response *DescribeDataEngineEventsRe
 // 查询数据引擎事件
 //
 // 可能返回的错误码:
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDTIMEFORMAT = "InvalidParameter.InvalidTimeFormat"
+//  INVALIDPARAMETER_INVALIDTIMEPARAMETER = "InvalidParameter.InvalidTimeParameter"
 //  UNAUTHORIZEDOPERATION_MONITORCOMPUTINGENGINE = "UnauthorizedOperation.MonitorComputingEngine"
 //  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
 func (c *Client) DescribeDataEngineEvents(request *DescribeDataEngineEventsRequest) (response *DescribeDataEngineEventsResponse, err error) {
@@ -4972,6 +5115,9 @@ func (c *Client) DescribeDataEngineEvents(request *DescribeDataEngineEventsReque
 // 查询数据引擎事件
 //
 // 可能返回的错误码:
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDTIMEFORMAT = "InvalidParameter.InvalidTimeFormat"
+//  INVALIDPARAMETER_INVALIDTIMEPARAMETER = "InvalidParameter.InvalidTimeParameter"
 //  UNAUTHORIZEDOPERATION_MONITORCOMPUTINGENGINE = "UnauthorizedOperation.MonitorComputingEngine"
 //  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
 func (c *Client) DescribeDataEngineEventsWithContext(ctx context.Context, request *DescribeDataEngineEventsRequest) (response *DescribeDataEngineEventsResponse, err error) {
@@ -6461,6 +6607,62 @@ func (c *Client) DescribeOtherCHDFSBindingListWithContext(ctx context.Context, r
     return
 }
 
+func NewDescribeResourceGroupUsageInfoRequest() (request *DescribeResourceGroupUsageInfoRequest) {
+    request = &DescribeResourceGroupUsageInfoRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeResourceGroupUsageInfo")
+    
+    
+    return
+}
+
+func NewDescribeResourceGroupUsageInfoResponse() (response *DescribeResourceGroupUsageInfoResponse) {
+    response = &DescribeResourceGroupUsageInfoResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeResourceGroupUsageInfo
+// 本接口根据资源组ID查询资源组CU使用情况
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) DescribeResourceGroupUsageInfo(request *DescribeResourceGroupUsageInfoRequest) (response *DescribeResourceGroupUsageInfoResponse, err error) {
+    return c.DescribeResourceGroupUsageInfoWithContext(context.Background(), request)
+}
+
+// DescribeResourceGroupUsageInfo
+// 本接口根据资源组ID查询资源组CU使用情况
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) DescribeResourceGroupUsageInfoWithContext(ctx context.Context, request *DescribeResourceGroupUsageInfoRequest) (response *DescribeResourceGroupUsageInfoResponse, err error) {
+    if request == nil {
+        request = NewDescribeResourceGroupUsageInfoRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeResourceGroupUsageInfo")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeResourceGroupUsageInfo require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeResourceGroupUsageInfoResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeResultDownloadRequest() (request *DescribeResultDownloadRequest) {
     request = &DescribeResultDownloadRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -7229,6 +7431,60 @@ func (c *Client) DescribeSubUserAccessPolicyWithContext(ctx context.Context, req
     return
 }
 
+func NewDescribeTCLakeMetaInstanceRequest() (request *DescribeTCLakeMetaInstanceRequest) {
+    request = &DescribeTCLakeMetaInstanceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeTCLakeMetaInstance")
+    
+    
+    return
+}
+
+func NewDescribeTCLakeMetaInstanceResponse() (response *DescribeTCLakeMetaInstanceResponse) {
+    response = &DescribeTCLakeMetaInstanceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTCLakeMetaInstance
+// 是否成功开通TCLake
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) DescribeTCLakeMetaInstance(request *DescribeTCLakeMetaInstanceRequest) (response *DescribeTCLakeMetaInstanceResponse, err error) {
+    return c.DescribeTCLakeMetaInstanceWithContext(context.Background(), request)
+}
+
+// DescribeTCLakeMetaInstance
+// 是否成功开通TCLake
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) DescribeTCLakeMetaInstanceWithContext(ctx context.Context, request *DescribeTCLakeMetaInstanceRequest) (response *DescribeTCLakeMetaInstanceResponse, err error) {
+    if request == nil {
+        request = NewDescribeTCLakeMetaInstanceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeTCLakeMetaInstance")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTCLakeMetaInstance require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTCLakeMetaInstanceResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeTableRequest() (request *DescribeTableRequest) {
     request = &DescribeTableRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -7481,6 +7737,170 @@ func (c *Client) DescribeTablesNameWithContext(ctx context.Context, request *Des
     request.SetContext(ctx)
     
     response = NewDescribeTablesNameResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeTaskDetailRequest() (request *DescribeTaskDetailRequest) {
+    request = &DescribeTaskDetailRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeTaskDetail")
+    
+    
+    return
+}
+
+func NewDescribeTaskDetailResponse() (response *DescribeTaskDetailResponse) {
+    response = &DescribeTaskDetailResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTaskDetail
+// 该接口（DescribeTaskDetail）用于查询历史任务详情
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_FILTERSVALUESNUMBEROUTOFLIMIT = "InvalidParameter.FiltersValuesNumberOutOfLimit"
+//  INVALIDPARAMETER_INVALIDFILTERLENGTH = "InvalidParameter.InvalidFilterLength"
+//  INVALIDPARAMETER_INVALIDTIMEFORMAT = "InvalidParameter.InvalidTimeFormat"
+//  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  INVALIDPARAMETER_SQLTASKFILTERSKEYTYPENOTMATH = "InvalidParameter.SQLTaskFiltersKeyTypeNotMath"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  INVALIDPARAMETER_SQLTASKSORTBYTYPENOTMATCH = "InvalidParameter.SQLTaskSortByTypeNotMatch"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND_TASKINFONOTFOUND = "ResourceNotFound.TaskInfoNotFound"
+func (c *Client) DescribeTaskDetail(request *DescribeTaskDetailRequest) (response *DescribeTaskDetailResponse, err error) {
+    return c.DescribeTaskDetailWithContext(context.Background(), request)
+}
+
+// DescribeTaskDetail
+// 该接口（DescribeTaskDetail）用于查询历史任务详情
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_FILTERSVALUESNUMBEROUTOFLIMIT = "InvalidParameter.FiltersValuesNumberOutOfLimit"
+//  INVALIDPARAMETER_INVALIDFILTERLENGTH = "InvalidParameter.InvalidFilterLength"
+//  INVALIDPARAMETER_INVALIDTIMEFORMAT = "InvalidParameter.InvalidTimeFormat"
+//  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  INVALIDPARAMETER_SQLTASKFILTERSKEYTYPENOTMATH = "InvalidParameter.SQLTaskFiltersKeyTypeNotMath"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  INVALIDPARAMETER_SQLTASKSORTBYTYPENOTMATCH = "InvalidParameter.SQLTaskSortByTypeNotMatch"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND_TASKINFONOTFOUND = "ResourceNotFound.TaskInfoNotFound"
+func (c *Client) DescribeTaskDetailWithContext(ctx context.Context, request *DescribeTaskDetailRequest) (response *DescribeTaskDetailResponse, err error) {
+    if request == nil {
+        request = NewDescribeTaskDetailRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeTaskDetail")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTaskDetail require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTaskDetailResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeTaskListRequest() (request *DescribeTaskListRequest) {
+    request = &DescribeTaskListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeTaskList")
+    
+    
+    return
+}
+
+func NewDescribeTaskListResponse() (response *DescribeTaskListResponse) {
+    response = &DescribeTaskListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTaskList
+// 该接口（DescribleTasks）用于查询任务列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_FILTERSVALUESNUMBEROUTOFLIMIT = "InvalidParameter.FiltersValuesNumberOutOfLimit"
+//  INVALIDPARAMETER_INVALIDFILTERLENGTH = "InvalidParameter.InvalidFilterLength"
+//  INVALIDPARAMETER_INVALIDTASKSFILTERLENGTH = "InvalidParameter.InvalidTasksFilterLength"
+//  INVALIDPARAMETER_INVALIDTIMEFORMAT = "InvalidParameter.InvalidTimeFormat"
+//  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  INVALIDPARAMETER_SQLTASKFILTERSKEYTYPENOTMATH = "InvalidParameter.SQLTaskFiltersKeyTypeNotMath"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  INVALIDPARAMETER_SQLTASKSORTBYTYPENOTMATCH = "InvalidParameter.SQLTaskSortByTypeNotMatch"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_TASKLISTFILTERSKEYTYPENOTMATH = "InvalidParameter.TaskListFiltersKeyTypeNotMath"
+//  INVALIDPARAMETER_TASKLISTSORTBYTYPENOTMATCH = "InvalidParameter.TaskListSortByTypeNotMatch"
+//  INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeTaskList(request *DescribeTaskListRequest) (response *DescribeTaskListResponse, err error) {
+    return c.DescribeTaskListWithContext(context.Background(), request)
+}
+
+// DescribeTaskList
+// 该接口（DescribleTasks）用于查询任务列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_FILTERSVALUESNUMBEROUTOFLIMIT = "InvalidParameter.FiltersValuesNumberOutOfLimit"
+//  INVALIDPARAMETER_INVALIDFILTERLENGTH = "InvalidParameter.InvalidFilterLength"
+//  INVALIDPARAMETER_INVALIDTASKSFILTERLENGTH = "InvalidParameter.InvalidTasksFilterLength"
+//  INVALIDPARAMETER_INVALIDTIMEFORMAT = "InvalidParameter.InvalidTimeFormat"
+//  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  INVALIDPARAMETER_SQLTASKFILTERSKEYTYPENOTMATH = "InvalidParameter.SQLTaskFiltersKeyTypeNotMath"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  INVALIDPARAMETER_SQLTASKSORTBYTYPENOTMATCH = "InvalidParameter.SQLTaskSortByTypeNotMatch"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_TASKLISTFILTERSKEYTYPENOTMATH = "InvalidParameter.TaskListFiltersKeyTypeNotMath"
+//  INVALIDPARAMETER_TASKLISTSORTBYTYPENOTMATCH = "InvalidParameter.TaskListSortByTypeNotMatch"
+//  INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeTaskListWithContext(ctx context.Context, request *DescribeTaskListRequest) (response *DescribeTaskListResponse, err error) {
+    if request == nil {
+        request = NewDescribeTaskListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeTaskList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTaskList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTaskListResponse()
     err = c.Send(request, response)
     return
 }
@@ -8877,6 +9297,7 @@ func NewDetachUserPolicyResponse() (response *DetachUserPolicyResponse) {
 //  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
 //  INVALIDPARAMETER_INVALIDACCESSPOLICY = "InvalidParameter.InvalidAccessPolicy"
 //  INVALIDPARAMETER_INVALIDUSERNAME = "InvalidParameter.InvalidUserName"
+//  INVALIDPARAMETER_POLICYTYPECONFLICT = "InvalidParameter.PolicyTypeConflict"
 //  UNAUTHORIZEDOPERATION_GRANTPOLICY = "UnauthorizedOperation.GrantPolicy"
 //  UNAUTHORIZEDOPERATION_PROHIBITEDOPERATIONADMIN = "UnauthorizedOperation.ProhibitedOperationAdmin"
 //  UNAUTHORIZEDOPERATION_REVOKEPOLICY = "UnauthorizedOperation.RevokePolicy"
@@ -8899,6 +9320,7 @@ func (c *Client) DetachUserPolicy(request *DetachUserPolicyRequest) (response *D
 //  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
 //  INVALIDPARAMETER_INVALIDACCESSPOLICY = "InvalidParameter.InvalidAccessPolicy"
 //  INVALIDPARAMETER_INVALIDUSERNAME = "InvalidParameter.InvalidUserName"
+//  INVALIDPARAMETER_POLICYTYPECONFLICT = "InvalidParameter.PolicyTypeConflict"
 //  UNAUTHORIZEDOPERATION_GRANTPOLICY = "UnauthorizedOperation.GrantPolicy"
 //  UNAUTHORIZEDOPERATION_PROHIBITEDOPERATIONADMIN = "UnauthorizedOperation.ProhibitedOperationAdmin"
 //  UNAUTHORIZEDOPERATION_REVOKEPOLICY = "UnauthorizedOperation.RevokePolicy"
@@ -9323,6 +9745,56 @@ func (c *Client) GrantDLCCatalogAccessWithContext(ctx context.Context, request *
     request.SetContext(ctx)
     
     response = NewGrantDLCCatalogAccessResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewInitializeTCLakeRequest() (request *InitializeTCLakeRequest) {
+    request = &InitializeTCLakeRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "InitializeTCLake")
+    
+    
+    return
+}
+
+func NewInitializeTCLakeResponse() (response *InitializeTCLakeResponse) {
+    response = &InitializeTCLakeResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// InitializeTCLake
+// 开通TCLake
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) InitializeTCLake(request *InitializeTCLakeRequest) (response *InitializeTCLakeResponse, err error) {
+    return c.InitializeTCLakeWithContext(context.Background(), request)
+}
+
+// InitializeTCLake
+// 开通TCLake
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) InitializeTCLakeWithContext(ctx context.Context, request *InitializeTCLakeRequest) (response *InitializeTCLakeResponse, err error) {
+    if request == nil {
+        request = NewInitializeTCLakeRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "InitializeTCLake")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("InitializeTCLake require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewInitializeTCLakeResponse()
     err = c.Send(request, response)
     return
 }
@@ -10233,6 +10705,7 @@ func NewQueryResultResponse() (response *QueryResultResponse) {
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
 //  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
 func (c *Client) QueryResult(request *QueryResultRequest) (response *QueryResultResponse, err error) {
     return c.QueryResultWithContext(context.Background(), request)
@@ -10243,6 +10716,7 @@ func (c *Client) QueryResult(request *QueryResultRequest) (response *QueryResult
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
 //  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
 func (c *Client) QueryResultWithContext(ctx context.Context, request *QueryResultRequest) (response *QueryResultResponse, err error) {
     if request == nil {
@@ -10729,6 +11203,108 @@ func (c *Client) RollbackDataEngineImageWithContext(ctx context.Context, request
     return
 }
 
+func NewSetOptimizerPolicyRequest() (request *SetOptimizerPolicyRequest) {
+    request = &SetOptimizerPolicyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "SetOptimizerPolicy")
+    
+    
+    return
+}
+
+func NewSetOptimizerPolicyResponse() (response *SetOptimizerPolicyResponse) {
+    response = &SetOptimizerPolicyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// SetOptimizerPolicy
+// 设置优化策略的接口
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_NOPERMISSIONTOUSETHEDATAENGINE = "FailedOperation.NoPermissionToUseTheDataEngine"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_DATAENGINEEXECTYPENOTMATCH = "InvalidParameter.DataEngineExecTypeNotMatch"
+//  INVALIDPARAMETER_DATAENGINEIMAGEOPERATENOTMATCH = "InvalidParameter.DataEngineImageOperateNotMatch"
+//  INVALIDPARAMETER_DATAENGINEPAYMODETYPENOTMATCH = "InvalidParameter.DataEnginePayModeTypeNotMatch"
+//  INVALIDPARAMETER_DATAENGINETYPENOTMATCH = "InvalidParameter.DataEngineTypeNotMatch"
+//  INVALIDPARAMETER_IMAGECLUSTERPARAMETERSFORMATNOTJSON = "InvalidParameter.ImageClusterParametersFormatNotJson"
+//  INVALIDPARAMETER_IMAGEENGINETYPENOTMATCH = "InvalidParameter.ImageEngineTypeNotMatch"
+//  INVALIDPARAMETER_IMAGEISPUBLICNOTMATCH = "InvalidParameter.ImageIsPublicNotMatch"
+//  INVALIDPARAMETER_IMAGEPARAMETERNOTFOUND = "InvalidParameter.ImageParameterNotFound"
+//  INVALIDPARAMETER_IMAGESESSIONPARAMETERSFORMATNOTJSON = "InvalidParameter.ImageSessionParametersFormatNotJson"
+//  INVALIDPARAMETER_IMAGESTATENOTMATCH = "InvalidParameter.ImageStateNotMatch"
+//  INVALIDPARAMETER_IMAGEUSERRECORDSTYPENOTMATCH = "InvalidParameter.ImageUserRecordsTypeNotMatch"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  RESOURCENOTFOUND_DATAENGINECONFIGINSTANCENOTFOUND = "ResourceNotFound.DataEngineConfigInstanceNotFound"
+//  RESOURCENOTFOUND_DATAENGINECONFIGINSTANCENOTUNIQUE = "ResourceNotFound.DataEngineConfigInstanceNotUnique"
+//  RESOURCENOTFOUND_DATAENGINENOTACTIVITY = "ResourceNotFound.DataEngineNotActivity"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTMULTIVERSION = "ResourceNotFound.DataEngineNotMultiVersion"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTFOUND = "ResourceNotFound.ImageSessionConfigNotFound"
+//  RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTUNIQUE = "ResourceNotFound.ImageSessionConfigNotUnique"
+//  RESOURCENOTFOUND_IMAGEVERSIONNOTACTIVITY = "ResourceNotFound.ImageVersionNotActivity"
+//  RESOURCENOTFOUND_IMAGEVERSIONNOTUNIQUE = "ResourceNotFound.ImageVersionNotUnique"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) SetOptimizerPolicy(request *SetOptimizerPolicyRequest) (response *SetOptimizerPolicyResponse, err error) {
+    return c.SetOptimizerPolicyWithContext(context.Background(), request)
+}
+
+// SetOptimizerPolicy
+// 设置优化策略的接口
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_NOPERMISSIONTOUSETHEDATAENGINE = "FailedOperation.NoPermissionToUseTheDataEngine"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_DATAENGINEEXECTYPENOTMATCH = "InvalidParameter.DataEngineExecTypeNotMatch"
+//  INVALIDPARAMETER_DATAENGINEIMAGEOPERATENOTMATCH = "InvalidParameter.DataEngineImageOperateNotMatch"
+//  INVALIDPARAMETER_DATAENGINEPAYMODETYPENOTMATCH = "InvalidParameter.DataEnginePayModeTypeNotMatch"
+//  INVALIDPARAMETER_DATAENGINETYPENOTMATCH = "InvalidParameter.DataEngineTypeNotMatch"
+//  INVALIDPARAMETER_IMAGECLUSTERPARAMETERSFORMATNOTJSON = "InvalidParameter.ImageClusterParametersFormatNotJson"
+//  INVALIDPARAMETER_IMAGEENGINETYPENOTMATCH = "InvalidParameter.ImageEngineTypeNotMatch"
+//  INVALIDPARAMETER_IMAGEISPUBLICNOTMATCH = "InvalidParameter.ImageIsPublicNotMatch"
+//  INVALIDPARAMETER_IMAGEPARAMETERNOTFOUND = "InvalidParameter.ImageParameterNotFound"
+//  INVALIDPARAMETER_IMAGESESSIONPARAMETERSFORMATNOTJSON = "InvalidParameter.ImageSessionParametersFormatNotJson"
+//  INVALIDPARAMETER_IMAGESTATENOTMATCH = "InvalidParameter.ImageStateNotMatch"
+//  INVALIDPARAMETER_IMAGEUSERRECORDSTYPENOTMATCH = "InvalidParameter.ImageUserRecordsTypeNotMatch"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  RESOURCENOTFOUND_DATAENGINECONFIGINSTANCENOTFOUND = "ResourceNotFound.DataEngineConfigInstanceNotFound"
+//  RESOURCENOTFOUND_DATAENGINECONFIGINSTANCENOTUNIQUE = "ResourceNotFound.DataEngineConfigInstanceNotUnique"
+//  RESOURCENOTFOUND_DATAENGINENOTACTIVITY = "ResourceNotFound.DataEngineNotActivity"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTMULTIVERSION = "ResourceNotFound.DataEngineNotMultiVersion"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTFOUND = "ResourceNotFound.ImageSessionConfigNotFound"
+//  RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTUNIQUE = "ResourceNotFound.ImageSessionConfigNotUnique"
+//  RESOURCENOTFOUND_IMAGEVERSIONNOTACTIVITY = "ResourceNotFound.ImageVersionNotActivity"
+//  RESOURCENOTFOUND_IMAGEVERSIONNOTUNIQUE = "ResourceNotFound.ImageVersionNotUnique"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) SetOptimizerPolicyWithContext(ctx context.Context, request *SetOptimizerPolicyRequest) (response *SetOptimizerPolicyResponse, err error) {
+    if request == nil {
+        request = NewSetOptimizerPolicyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "SetOptimizerPolicy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("SetOptimizerPolicy require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewSetOptimizerPolicyResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewSuspendResumeDataEngineRequest() (request *SuspendResumeDataEngineRequest) {
     request = &SuspendResumeDataEngineRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -11016,7 +11592,7 @@ func NewUnboundDatasourceHouseResponse() (response *UnboundDatasourceHouseRespon
 // 解绑数据源与队列
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_FAILEDOPERATIONCODE_NETWORKCONNECTIONINUSED = "FailedOperation.FailedOperationCode_NetworkConnectionInUsed"
+//  FAILEDOPERATION_NETWORKCONNECTIONINUSED = "FailedOperation.NetworkConnectionInUsed"
 //  INTERNALERROR = "InternalError"
 //  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
 //  RESOURCENOTFOUND_EKSRESOURCENOTFOUND = "ResourceNotFound.EksResourceNotFound"
@@ -11029,7 +11605,7 @@ func (c *Client) UnboundDatasourceHouse(request *UnboundDatasourceHouseRequest) 
 // 解绑数据源与队列
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_FAILEDOPERATIONCODE_NETWORKCONNECTIONINUSED = "FailedOperation.FailedOperationCode_NetworkConnectionInUsed"
+//  FAILEDOPERATION_NETWORKCONNECTIONINUSED = "FailedOperation.NetworkConnectionInUsed"
 //  INTERNALERROR = "InternalError"
 //  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
 //  RESOURCENOTFOUND_EKSRESOURCENOTFOUND = "ResourceNotFound.EksResourceNotFound"
@@ -11149,6 +11725,7 @@ func NewUpdateDataEngineResponse() (response *UpdateDataEngineResponse) {
 //  INVALIDPARAMETER_INVALIDDESCRIPTION = "InvalidParameter.InvalidDescription"
 //  INVALIDPARAMETER_INVALIDMINCLUSTERS = "InvalidParameter.InvalidMinClusters"
 //  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSCHEDULEDELASTICITYMINELASTICCLUSTERS = "InvalidParameter.InvalidScheduledElasticityMinElasticClusters"
 //  RESOURCEINUSE_UNFINISHEDSQLS = "ResourceInUse.UnfinishedSQLs"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNAUTHORIZEDOPERATION_MODIFYCOMPUTINGENGINE = "UnauthorizedOperation.ModifyComputingEngine"
@@ -11186,6 +11763,7 @@ func (c *Client) UpdateDataEngine(request *UpdateDataEngineRequest) (response *U
 //  INVALIDPARAMETER_INVALIDDESCRIPTION = "InvalidParameter.InvalidDescription"
 //  INVALIDPARAMETER_INVALIDMINCLUSTERS = "InvalidParameter.InvalidMinClusters"
 //  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSCHEDULEDELASTICITYMINELASTICCLUSTERS = "InvalidParameter.InvalidScheduledElasticityMinElasticClusters"
 //  RESOURCEINUSE_UNFINISHEDSQLS = "ResourceInUse.UnfinishedSQLs"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNAUTHORIZEDOPERATION_MODIFYCOMPUTINGENGINE = "UnauthorizedOperation.ModifyComputingEngine"
@@ -11608,6 +12186,7 @@ func NewUpdateStandardEngineResourceGroupConfigInfoResponse() (response *UpdateS
 //  INVALIDPARAMETER = "InvalidParameter"
 //  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
 //  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
+//  RESOURCEUNAVAILABLE_GATEWAYNOTRUNNING = "ResourceUnavailable.GatewayNotRunning"
 //  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
 func (c *Client) UpdateStandardEngineResourceGroupConfigInfo(request *UpdateStandardEngineResourceGroupConfigInfoRequest) (response *UpdateStandardEngineResourceGroupConfigInfoResponse, err error) {
     return c.UpdateStandardEngineResourceGroupConfigInfoWithContext(context.Background(), request)
@@ -11623,6 +12202,7 @@ func (c *Client) UpdateStandardEngineResourceGroupConfigInfo(request *UpdateStan
 //  INVALIDPARAMETER = "InvalidParameter"
 //  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
 //  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
+//  RESOURCEUNAVAILABLE_GATEWAYNOTRUNNING = "ResourceUnavailable.GatewayNotRunning"
 //  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
 func (c *Client) UpdateStandardEngineResourceGroupConfigInfoWithContext(ctx context.Context, request *UpdateStandardEngineResourceGroupConfigInfoRequest) (response *UpdateStandardEngineResourceGroupConfigInfoResponse, err error) {
     if request == nil {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/errors.go
@@ -56,9 +56,6 @@ const (
 	// 重复的标签键。
 	FAILEDOPERATION_DUPLICATETAGKEY = "FailedOperation.DuplicateTagKey"
 
-	// 当前已有资源组正在使用该配置项，无法一键删除（一键删除会导致引擎重启）您可前往资源组列表页点击详情删除
-	FAILEDOPERATION_FAILEDOPERATIONCODE_NETWORKCONNECTIONINUSED = "FailedOperation.FailedOperationCode_NetworkConnectionInUsed"
-
 	// 扣费失败。
 	FAILEDOPERATION_FEEDEDUCTIONFAILED = "FailedOperation.FeeDeductionFailed"
 
@@ -107,6 +104,9 @@ const (
 	// The  datasource vpc has been bound to the engine
 	FAILEDOPERATION_NETWORKCONNECTIONEXIST = "FailedOperation.NetworkConnectionExist"
 
+	// 当前已有资源组正在使用该配置项，无法一键删除（一键删除会导致引擎重启）您可前往资源组列表页点击详情删除
+	FAILEDOPERATION_NETWORKCONNECTIONINUSED = "FailedOperation.NetworkConnectionInUsed"
+
 	// 没有操作权限。
 	FAILEDOPERATION_NOPERMISSION = "FailedOperation.NoPermission"
 
@@ -145,6 +145,9 @@ const (
 
 	// 标签值长度超过限制。
 	FAILEDOPERATION_TAGVALUETOOLONG = "FailedOperation.TagValueTooLong"
+
+	// 获取结果超时
+	FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
 
 	// 资源数量超出限制。
 	FAILEDOPERATION_TOOMANYRESOURCES = "FailedOperation.TooManyResources"
@@ -221,6 +224,9 @@ const (
 	// 重复的引擎名称。
 	INVALIDPARAMETER_DUPLICATEDATAENGINENAME = "InvalidParameter.DuplicateDataEngineName"
 
+	// 数据源名称重复。
+	INVALIDPARAMETER_DUPLICATEDATASOURCENAME = "InvalidParameter.DuplicateDatasourceName"
+
 	// 重复的工作组名称。
 	INVALIDPARAMETER_DUPLICATEGROUPNAME = "InvalidParameter.DuplicateGroupName"
 
@@ -268,6 +274,9 @@ const (
 
 	// 指定的Spark任务程序包文件格式不匹配，当前仅支持.jar或.py
 	INVALIDPARAMETER_INVALIDAPPFILEFORMAT = "InvalidParameter.InvalidAppFileFormat"
+
+	// 指定的桶不存在
+	INVALIDPARAMETER_INVALIDBUCKETNAME = "InvalidParameter.InvalidBucketName"
 
 	// 字段名称设置错误，字段名称必须小于等于128字节
 	INVALIDPARAMETER_INVALIDCOLUMNNAMELENGTH = "InvalidParameter.InvalidColumnNameLength"
@@ -356,6 +365,9 @@ const (
 	// 无效的工作组Id。
 	INVALIDPARAMETER_INVALIDGROUPID = "InvalidParameter.InvalidGroupId"
 
+	// 不支持的Hive版本。
+	INVALIDPARAMETER_INVALIDHIVEVERSION = "InvalidParameter.InvalidHiveVersion"
+
 	// 请求的消息类型无效。
 	INVALIDPARAMETER_INVALIDINFOTYPE = "InvalidParameter.InvalidInfoType"
 
@@ -370,6 +382,9 @@ const (
 
 	// 无效的Offset值。
 	INVALIDPARAMETER_INVALIDOFFSET = "InvalidParameter.InvalidOffset"
+
+	// 列上执行的操作与该列的数据类型不兼容
+	INVALIDPARAMETER_INVALIDPARAMETER_COLUMNTYPENOTCOMPATIBLE = "InvalidParameter.InvalidParameter_ColumnTypeNotCompatible"
 
 	// 排序列不合法
 	INVALIDPARAMETER_INVALIDPARAMETER_SQLTASKANALYSISSORTBYTYPENOTMATCH = "InvalidParameter.InvalidParameter_SQLTaskAnalysisSortByTypeNotMatch"
@@ -391,6 +406,9 @@ const (
 
 	// 单次获取SQL任务结果数量需大于0条，小于1000条
 	INVALIDPARAMETER_INVALIDSQLTASKMAXRESULTS = "InvalidParameter.InvalidSQLTaskMaxResults"
+
+	// 指定的弹性范围不合规范
+	INVALIDPARAMETER_INVALIDSCHEDULEDELASTICITYMINELASTICCLUSTERS = "InvalidParameter.InvalidScheduledElasticityMinElasticClusters"
 
 	// 当前Session仅支持: spark/pyspark/sparkr/sql类型
 	INVALIDPARAMETER_INVALIDSESSIONKINDTYPE = "InvalidParameter.InvalidSessionKindType"
@@ -479,6 +497,9 @@ const (
 	// 找不到参数或参数为空
 	INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
 
+	// 权限类型冲突。
+	INVALIDPARAMETER_POLICYTYPECONFLICT = "InvalidParameter.PolicyTypeConflict"
+
 	// SQL脚本Base64解析失败
 	INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
 
@@ -521,11 +542,20 @@ const (
 	// 任务已经结束，不能取消。
 	INVALIDPARAMETER_TASKALREADYFINISHED = "InvalidParameter.TaskAlreadyFinished"
 
+	// 筛选参数不匹配
+	INVALIDPARAMETER_TASKLISTFILTERSKEYTYPENOTMATH = "InvalidParameter.TaskListFiltersKeyTypeNotMath"
+
+	// 过滤字段类型不匹配，当前仅支持： task-id/task-sql-keyword/task-kind/task-operator/batch-id/session-id/task-state/task-time-sum/stage-start-time/input-records-sum/output-records-sum/output-bytes-sum/output-files-num/output-small-files-num/shuffle-read-records-sum/shuffle-read-bytes-sum
+	INVALIDPARAMETER_TASKLISTSORTBYTYPENOTMATCH = "InvalidParameter.TaskListSortByTypeNotMatch"
+
 	// 任务不存在。
 	INVALIDPARAMETER_TASKNOTFOUND = "InvalidParameter.TaskNotFound"
 
 	// 指定的任务状态不匹配，当前仅支持: 0:初始化, 1:运行中, 2:成功, 3:数据写入中, 4:排队中, -1:失败, -3:删除
 	INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
+
+	// Url格式错误。
+	INVALIDPARAMETER_URLFORMATERROR = "InvalidParameter.UrlFormatError"
 
 	// Vpc cidr格式错误。
 	INVALIDPARAMETER_VPCCIDRFORMATERROR = "InvalidParameter.VpcCidrFormatError"
@@ -599,6 +629,9 @@ const (
 	// Eks计算集群初始化或迁移中，请稍后再试。
 	RESOURCENOTFOUND_EKSRESOURCENOTFOUND = "ResourceNotFound.EksResourceNotFound"
 
+	// 网关不存在
+	RESOURCENOTFOUND_GATEWAYNOTFOUND = "ResourceNotFound.GatewayNotFound"
+
 	// 指定集群镜像Session配置不存在
 	RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTFOUND = "ResourceNotFound.ImageSessionConfigNotFound"
 
@@ -659,6 +692,12 @@ const (
 	// 任务已经完成
 	RESOURCENOTFOUND_TASKALREADYFINISHED = "ResourceNotFound.TaskAlreadyFinished"
 
+	// 任务详情查询，任务不存在。
+	RESOURCENOTFOUND_TASKINFONOTFOUND = "ResourceNotFound.TaskInfoNotFound"
+
+	// 用户不存在
+	RESOURCENOTFOUND_USERNOTEXIST = "ResourceNotFound.UserNotExist"
+
 	// 找不到Warehouse存储路径，请到控制台->数据探索页面->存储配置中设置
 	RESOURCENOTFOUND_WAREHOUSEDIRNOTFOUND = "ResourceNotFound.WarehouseDirNotFound"
 
@@ -667,6 +706,9 @@ const (
 
 	// 账号余额不足，无法执行SQL任务。
 	RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+
+	// 网关不处于运行中
+	RESOURCEUNAVAILABLE_GATEWAYNOTRUNNING = "ResourceUnavailable.GatewayNotRunning"
 
 	// 网关未运行
 	RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
@@ -694,6 +736,12 @@ const (
 
 	// 子用户不是管理员，无权绑定工作组到用户。
 	UNAUTHORIZEDOPERATION_BINDWORKGROUPSTOUSER = "UnauthorizedOperation.BindWorkgroupsToUser"
+
+	// 用户无权限创建管理员
+	UNAUTHORIZEDOPERATION_CREATEADMINISTRATOR = "UnauthorizedOperation.CreateAdministrator"
+
+	// 子用户无权创建联邦查询数据源。
+	UNAUTHORIZEDOPERATION_CREATECATALOG = "UnauthorizedOperation.CreateCatalog"
 
 	// 子用户不是管理员，无权创建工作组。
 	UNAUTHORIZEDOPERATION_CREATEWORKGROUP = "UnauthorizedOperation.CreateWorkgroup"
@@ -742,6 +790,9 @@ const (
 
 	// 子用户无权取消特定权限。
 	UNAUTHORIZEDOPERATION_REVOKEPOLICY = "UnauthorizedOperation.RevokePolicy"
+
+	// 用户没有操作权限
+	UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATION = "UnauthorizedOperation.UnauthorizedOperation"
 
 	// 无引擎cam权限
 	UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/models.go
@@ -564,57 +564,59 @@ func (r *AlterDMSTableResponse) FromJsonString(s string) error {
 }
 
 type AnalysisTaskResults struct {
-	// 任务Id
+	// <p>任务Id</p>
 	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
 
-	// 任务创建时间，毫秒时间戳
+	// <p>任务创建时间，毫秒时间戳</p>
 	InstanceStartTime *int64 `json:"InstanceStartTime,omitnil,omitempty" name:"InstanceStartTime"`
 
-	// 任务结束时间，毫秒时间戳
+	// <p>任务结束时间，毫秒时间戳</p>
 	InstanceCompleteTime *int64 `json:"InstanceCompleteTime,omitnil,omitempty" name:"InstanceCompleteTime"`
 
-	// 任务状态：0 初始化， 1 执行中， 2 执行成功，3 数据写入中，4 排队中。-1 执行失败，-3 已取消。
+	// <p>任务状态：0 初始化， 1 执行中， 2 执行成功，3 数据写入中，4 排队中。-1 执行失败，-3 已取消。</p>
 	State *int64 `json:"State,omitnil,omitempty" name:"State"`
 
-	// 任务SQL语句
+	// <p>任务SQL语句</p>
 	SQL *string `json:"SQL,omitnil,omitempty" name:"SQL"`
 
-	// 计算资源名字
+	// <p>计算资源名字</p>
 	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
 
-	// 单位毫秒，引擎内执行耗时, 反映真正用于计算所需的耗时，即从  Spark 任务第一个 Task  开始执行到任务结束之间的耗时。
-	// 具体的：会统计任务的每个 Spark Stage 第一个 Task 到最后一个 Task 完成时长之和，不包含任务开始的排队耗时（即剔除从任务提交到 Spark Task 开始执行之间的调度等其他耗时），也不包含任务执行过程中多个 Spark Stage 之间因 executor 资源不足而等待执行 Task 所消耗的时间。
+	// <p>单位毫秒，引擎内执行耗时, 反映真正用于计算所需的耗时，即从  Spark 任务第一个 Task  开始执行到任务结束之间的耗时。<br>具体的：会统计任务的每个 Spark Stage 第一个 Task 到最后一个 Task 完成时长之和，不包含任务开始的排队耗时（即剔除从任务提交到 Spark Task 开始执行之间的调度等其他耗时），也不包含任务执行过程中多个 Spark Stage 之间因 executor 资源不足而等待执行 Task 所消耗的时间。</p>
 	JobTimeSum *int64 `json:"JobTimeSum,omitnil,omitempty" name:"JobTimeSum"`
 
-	// 单位秒，累计 CPU* 秒 ( 累计 CPU * 时 = 累计 CPU* 秒/ 3600)，统计参与计算所用 Spark Executor 每个 core 的 CPU 执行时长总和
+	// <p>单位秒，累计 CPU* 秒 ( 累计 CPU * 时 = 累计 CPU* 秒/ 3600)，统计参与计算所用 Spark Executor 每个 core 的 CPU 执行时长总和</p>
 	TaskTimeSum *int64 `json:"TaskTimeSum,omitnil,omitempty" name:"TaskTimeSum"`
 
-	// 数据扫描总行数
+	// <p>数据扫描总行数</p>
 	InputRecordsSum *int64 `json:"InputRecordsSum,omitnil,omitempty" name:"InputRecordsSum"`
 
-	// 数据扫描总 bytes
+	// <p>数据扫描总 bytes</p>
 	InputBytesSum *int64 `json:"InputBytesSum,omitnil,omitempty" name:"InputBytesSum"`
 
-	// 输出总行数
+	// <p>输出总行数</p>
 	OutputRecordsSum *int64 `json:"OutputRecordsSum,omitnil,omitempty" name:"OutputRecordsSum"`
 
-	// 输出总 bytes
+	// <p>输出总 bytes</p>
 	OutputBytesSum *int64 `json:"OutputBytesSum,omitnil,omitempty" name:"OutputBytesSum"`
 
-	// shuffle read 总 bytes
+	// <p>shuffle read 总 bytes</p>
 	ShuffleReadBytesSum *int64 `json:"ShuffleReadBytesSum,omitnil,omitempty" name:"ShuffleReadBytesSum"`
 
-	// shuffle read 总行数
+	// <p>shuffle read 总行数</p>
 	ShuffleReadRecordsSum *int64 `json:"ShuffleReadRecordsSum,omitnil,omitempty" name:"ShuffleReadRecordsSum"`
 
-	// 洞察结果类型分类，一个 json 数组，有如下几种类型：SPARK-StageScheduleDelay（资源抢占）, SPARK-ShuffleFailure（Shuffle异常）, SPARK-SlowTask（慢task）, SPARK-DataSkew（数据倾斜）, SPARK-InsufficientResource（磁盘或内存不足）
+	// <p>洞察结果类型分类，一个 json 数组，有如下几种类型：SPARK-StageScheduleDelay（资源抢占）, SPARK-ShuffleFailure（Shuffle异常）, SPARK-SlowTask（慢task）, SPARK-DataSkew（数据倾斜）, SPARK-InsufficientResource（磁盘或内存不足）</p>
 	AnalysisStatus *string `json:"AnalysisStatus,omitnil,omitempty" name:"AnalysisStatus"`
 
-	// 任务输出文件总数
+	// <p>任务输出文件总数</p>
 	OutputFilesNum *int64 `json:"OutputFilesNum,omitnil,omitempty" name:"OutputFilesNum"`
 
-	// 任务输出小文件总数
+	// <p>任务输出小文件总数</p>
 	OutputSmallFilesNum *int64 `json:"OutputSmallFilesNum,omitnil,omitempty" name:"OutputSmallFilesNum"`
+
+	// <p>shuffle write 总 Bytes 大小</p><p>单位：Bytes</p><p>默认值：无</p>
+	ShuffleWriteBytesSum *int64 `json:"ShuffleWriteBytesSum,omitnil,omitempty" name:"ShuffleWriteBytesSum"`
 }
 
 type Asset struct {
@@ -895,21 +897,27 @@ func (r *AttachDataMaskPolicyResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachUserPolicyRequestParams struct {
-	// 用户Id，和子用户uin相同，需要先使用CreateUser接口创建用户。可以使用DescribeUsers接口查看。
+	// <p>用户Id，和子用户uin相同，需要先使用CreateUser接口创建用户。可以使用DescribeUsers接口查看。</p>
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
 
-	// 鉴权策略集合
+	// <p>鉴权策略集合</p>
 	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
+
+	// <p>用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）</p>
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 type AttachUserPolicyRequest struct {
 	*tchttp.BaseRequest
 	
-	// 用户Id，和子用户uin相同，需要先使用CreateUser接口创建用户。可以使用DescribeUsers接口查看。
+	// <p>用户Id，和子用户uin相同，需要先使用CreateUser接口创建用户。可以使用DescribeUsers接口查看。</p>
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
 
-	// 鉴权策略集合
+	// <p>鉴权策略集合</p>
 	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
+
+	// <p>用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）</p>
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 func (r *AttachUserPolicyRequest) ToJsonString() string {
@@ -926,6 +934,7 @@ func (r *AttachUserPolicyRequest) FromJsonString(s string) error {
 	}
 	delete(f, "UserId")
 	delete(f, "PolicySet")
+	delete(f, "AccountType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "AttachUserPolicyRequest has unknown keys!", "")
 	}
@@ -934,6 +943,9 @@ func (r *AttachUserPolicyRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachUserPolicyResponseParams struct {
+	// <p>要授权的策略列表</p>
+	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
+
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
@@ -956,20 +968,20 @@ func (r *AttachUserPolicyResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachWorkGroupPolicyRequestParams struct {
-	// 工作组Id
+	// <p>工作组Id</p>
 	WorkGroupId *int64 `json:"WorkGroupId,omitnil,omitempty" name:"WorkGroupId"`
 
-	// 要绑定的策略集合
+	// <p>要绑定的策略集合</p>
 	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
 }
 
 type AttachWorkGroupPolicyRequest struct {
 	*tchttp.BaseRequest
 	
-	// 工作组Id
+	// <p>工作组Id</p>
 	WorkGroupId *int64 `json:"WorkGroupId,omitnil,omitempty" name:"WorkGroupId"`
 
-	// 要绑定的策略集合
+	// <p>要绑定的策略集合</p>
 	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
 }
 
@@ -995,6 +1007,9 @@ func (r *AttachWorkGroupPolicyRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachWorkGroupPolicyResponseParams struct {
+	// <p>要授权的策略列表</p>
+	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
+
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
@@ -1719,40 +1734,43 @@ func (r *CheckLockMetaDataResponse) FromJsonString(s string) error {
 }
 
 type Column struct {
-	// 列名称，不区分大小写，最大支持25个字符。
+	// <p>列名称，不区分大小写，最大支持25个字符。</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// string|tinyint|smallint|int|bigint|boolean|float|double|decimal|timestamp|date|binary|array|map|struct|uniontype
+	// <p>string|tinyint|smallint|int|bigint|boolean|float|double|decimal|timestamp|date|binary|array|map|struct|uniontype</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 对该类的注释。
+	// <p>对该类的注释。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Comment *string `json:"Comment,omitnil,omitempty" name:"Comment"`
 
-	// 表示整个 numeric 的长度
+	// <p>表示整个 numeric 的长度</p>
 	Precision *int64 `json:"Precision,omitnil,omitempty" name:"Precision"`
 
-	// 表示小数部分的长度
+	// <p>表示小数部分的长度</p>
 	Scale *int64 `json:"Scale,omitnil,omitempty" name:"Scale"`
 
-	// 是否为null
+	// <p>是否为null</p>
 	Nullable *string `json:"Nullable,omitnil,omitempty" name:"Nullable"`
 
-	// 字段位置，小的在前
+	// <p>字段位置，小的在前</p>
 	Position *int64 `json:"Position,omitnil,omitempty" name:"Position"`
 
-	// 字段创建时间
+	// <p>字段创建时间</p><p>参数格式：YYYY-MM-DD hh:mm:ss</p>
 	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
-	// 字段修改时间
+	// <p>字段修改时间</p><p>参数格式：YYYY-MM-DD hh:mm:ss</p>
 	ModifiedTime *string `json:"ModifiedTime,omitnil,omitempty" name:"ModifiedTime"`
 
-	// 是否为分区字段
+	// <p>是否为分区字段</p>
 	IsPartition *bool `json:"IsPartition,omitnil,omitempty" name:"IsPartition"`
 
-	// 数据脱敏策略信息
+	// <p>数据脱敏策略信息</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	DataMaskStrategyInfo *DataMaskStrategyInfo `json:"DataMaskStrategyInfo,omitnil,omitempty" name:"DataMaskStrategyInfo"`
+
+	// <p>数据字段说明</p>
+	TypeText *string `json:"TypeText,omitnil,omitempty" name:"TypeText"`
 }
 
 type CommonMetrics struct {
@@ -2553,6 +2571,126 @@ func (r *CreateDatabaseResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateDatabaseResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateDatasourceConnectionRequestParams struct {
+	// 数据连接名称
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
+
+	// 数据连接类型
+	DatasourceConnectionType *string `json:"DatasourceConnectionType,omitnil,omitempty" name:"DatasourceConnectionType"`
+
+	// 数据连接属性
+	DatasourceConnectionConfig *DatasourceConnectionConfig `json:"DatasourceConnectionConfig,omitnil,omitempty" name:"DatasourceConnectionConfig"`
+
+	// 数据连接所属服务
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
+
+	// 数据连接描述
+	DatasourceConnectionDesc *string `json:"DatasourceConnectionDesc,omitnil,omitempty" name:"DatasourceConnectionDesc"`
+
+	// 数据引擎名称数组
+	DataEngineNames []*string `json:"DataEngineNames,omitnil,omitempty" name:"DataEngineNames"`
+
+	// 网络连接名称
+	NetworkConnectionName *string `json:"NetworkConnectionName,omitnil,omitempty" name:"NetworkConnectionName"`
+
+	// 网络连接描述
+	NetworkConnectionDesc *string `json:"NetworkConnectionDesc,omitnil,omitempty" name:"NetworkConnectionDesc"`
+
+	// 网络连接类型 （2-夸源型，4-增强型）
+	NetworkConnectionType *int64 `json:"NetworkConnectionType,omitnil,omitempty" name:"NetworkConnectionType"`
+
+	// 自定义配置
+	CustomConfig []*CustomConfig `json:"CustomConfig,omitnil,omitempty" name:"CustomConfig"`
+}
+
+type CreateDatasourceConnectionRequest struct {
+	*tchttp.BaseRequest
+	
+	// 数据连接名称
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
+
+	// 数据连接类型
+	DatasourceConnectionType *string `json:"DatasourceConnectionType,omitnil,omitempty" name:"DatasourceConnectionType"`
+
+	// 数据连接属性
+	DatasourceConnectionConfig *DatasourceConnectionConfig `json:"DatasourceConnectionConfig,omitnil,omitempty" name:"DatasourceConnectionConfig"`
+
+	// 数据连接所属服务
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
+
+	// 数据连接描述
+	DatasourceConnectionDesc *string `json:"DatasourceConnectionDesc,omitnil,omitempty" name:"DatasourceConnectionDesc"`
+
+	// 数据引擎名称数组
+	DataEngineNames []*string `json:"DataEngineNames,omitnil,omitempty" name:"DataEngineNames"`
+
+	// 网络连接名称
+	NetworkConnectionName *string `json:"NetworkConnectionName,omitnil,omitempty" name:"NetworkConnectionName"`
+
+	// 网络连接描述
+	NetworkConnectionDesc *string `json:"NetworkConnectionDesc,omitnil,omitempty" name:"NetworkConnectionDesc"`
+
+	// 网络连接类型 （2-夸源型，4-增强型）
+	NetworkConnectionType *int64 `json:"NetworkConnectionType,omitnil,omitempty" name:"NetworkConnectionType"`
+
+	// 自定义配置
+	CustomConfig []*CustomConfig `json:"CustomConfig,omitnil,omitempty" name:"CustomConfig"`
+}
+
+func (r *CreateDatasourceConnectionRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateDatasourceConnectionRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DatasourceConnectionName")
+	delete(f, "DatasourceConnectionType")
+	delete(f, "DatasourceConnectionConfig")
+	delete(f, "ServiceType")
+	delete(f, "DatasourceConnectionDesc")
+	delete(f, "DataEngineNames")
+	delete(f, "NetworkConnectionName")
+	delete(f, "NetworkConnectionDesc")
+	delete(f, "NetworkConnectionType")
+	delete(f, "CustomConfig")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDatasourceConnectionRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateDatasourceConnectionResponseParams struct {
+	// 数据连接Id
+	DatasourceConnectionId *string `json:"DatasourceConnectionId,omitnil,omitempty" name:"DatasourceConnectionId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateDatasourceConnectionResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateDatasourceConnectionResponseParams `json:"Response"`
+}
+
+func (r *CreateDatasourceConnectionResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateDatasourceConnectionResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -4650,6 +4788,9 @@ type CreateUserRequestParams struct {
 
 	// 用户别名，字符长度小50
 	UserAlias *string `json:"UserAlias,omitnil,omitempty" name:"UserAlias"`
+
+	// 账号类型，UserAccount：用户账号 RoleAccount：角色账号，默认为用户账号
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 type CreateUserRequest struct {
@@ -4672,6 +4813,9 @@ type CreateUserRequest struct {
 
 	// 用户别名，字符长度小50
 	UserAlias *string `json:"UserAlias,omitnil,omitempty" name:"UserAlias"`
+
+	// 账号类型，UserAccount：用户账号 RoleAccount：角色账号，默认为用户账号
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 func (r *CreateUserRequest) ToJsonString() string {
@@ -4692,6 +4836,7 @@ func (r *CreateUserRequest) FromJsonString(s string) error {
 	delete(f, "UserType")
 	delete(f, "WorkGroupIds")
 	delete(f, "UserAlias")
+	delete(f, "AccountType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateUserRequest has unknown keys!", "")
 	}
@@ -4717,6 +4862,95 @@ func (r *CreateUserResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateUserResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateUserRoleRequestParams struct {
+	// 角色Arn信息
+	Arn *string `json:"Arn,omitnil,omitempty" name:"Arn"`
+
+	// 角色描述信息
+	Desc *string `json:"Desc,omitnil,omitempty" name:"Desc"`
+
+	// 角色名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// cos授权路径列表
+	CosPermissionList []*CosPermission `json:"CosPermissionList,omitnil,omitempty" name:"CosPermissionList"`
+
+	// cam策略json
+	PermissionJson *string `json:"PermissionJson,omitnil,omitempty" name:"PermissionJson"`
+
+	// 是否设置为常驻：1非常驻（默认）、2常驻（仅能设置一个常驻）
+	IsDefault *int64 `json:"IsDefault,omitnil,omitempty" name:"IsDefault"`
+}
+
+type CreateUserRoleRequest struct {
+	*tchttp.BaseRequest
+	
+	// 角色Arn信息
+	Arn *string `json:"Arn,omitnil,omitempty" name:"Arn"`
+
+	// 角色描述信息
+	Desc *string `json:"Desc,omitnil,omitempty" name:"Desc"`
+
+	// 角色名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// cos授权路径列表
+	CosPermissionList []*CosPermission `json:"CosPermissionList,omitnil,omitempty" name:"CosPermissionList"`
+
+	// cam策略json
+	PermissionJson *string `json:"PermissionJson,omitnil,omitempty" name:"PermissionJson"`
+
+	// 是否设置为常驻：1非常驻（默认）、2常驻（仅能设置一个常驻）
+	IsDefault *int64 `json:"IsDefault,omitnil,omitempty" name:"IsDefault"`
+}
+
+func (r *CreateUserRoleRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateUserRoleRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Arn")
+	delete(f, "Desc")
+	delete(f, "Name")
+	delete(f, "CosPermissionList")
+	delete(f, "PermissionJson")
+	delete(f, "IsDefault")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateUserRoleRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateUserRoleResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateUserRoleResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateUserRoleResponseParams `json:"Response"`
+}
+
+func (r *CreateUserRoleResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateUserRoleResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -5493,6 +5727,27 @@ type DataEngineInfo struct {
 
 	// 引擎资源弹性伸缩策略
 	ScheduleElasticityConf *ScheduleElasticityConf `json:"ScheduleElasticityConf,omitnil,omitempty" name:"ScheduleElasticityConf"`
+
+	// GPU 信息
+	GPUInfo *GPUInfo `json:"GPUInfo,omitnil,omitempty" name:"GPUInfo"`
+
+	// GPU 使用量
+	EngineResourceUsedGPU *int64 `json:"EngineResourceUsedGPU,omitnil,omitempty" name:"EngineResourceUsedGPU"`
+
+	// GPU 总规格
+	GPUTotalSize *int64 `json:"GPUTotalSize,omitnil,omitempty" name:"GPUTotalSize"`
+
+	// GPU 机型
+	InstanceModel *string `json:"InstanceModel,omitnil,omitempty" name:"InstanceModel"`
+
+	// 节点数量
+	NodeNum *int64 `json:"NodeNum,omitnil,omitempty" name:"NodeNum"`
+
+	// 引擎规格，包含负载弹性或分时弹性
+	SizeWithElastic *uint64 `json:"SizeWithElastic,omitnil,omitempty" name:"SizeWithElastic"`
+
+	// 最大弹性值，包含负载弹性或分时弹性
+	MaxElasticSize *uint64 `json:"MaxElasticSize,omitnil,omitempty" name:"MaxElasticSize"`
 }
 
 type DataEngineScaleInfo struct {
@@ -5716,6 +5971,18 @@ type DatabaseResponseInfo struct {
 
 	// 数据库ID（无效字段）
 	DatabaseId *string `json:"DatabaseId,omitnil,omitempty" name:"DatabaseId"`
+
+	// 所属catalog名称
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CatalogName *string `json:"CatalogName,omitnil,omitempty" name:"CatalogName"`
+
+	// 所属catalog 类型
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CatalogType *string `json:"CatalogType,omitnil,omitempty" name:"CatalogType"`
+
+	// 是否InformationSchema
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	IsInformationSchema *bool `json:"IsInformationSchema,omitnil,omitempty" name:"IsInformationSchema"`
 }
 
 type DatasourceConnectionConfig struct {
@@ -5761,6 +6028,9 @@ type DatasourceConnectionConfig struct {
 
 	// TccHive数据目录连接信息
 	TccHive *TccHive `json:"TccHive,omitnil,omitempty" name:"TccHive"`
+
+	// MongoDB 数据源
+	MongoDB *DataSourceInfo `json:"MongoDB,omitnil,omitempty" name:"MongoDB"`
 }
 
 type DatasourceConnectionInfo struct {
@@ -5923,14 +6193,14 @@ func (r *DeleteCHDFSBindingProductResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteDataEngineRequestParams struct {
-	// 删除虚拟集群的名称数组
+	// <p>删除虚拟集群的名称数组</p>
 	DataEngineNames []*string `json:"DataEngineNames,omitnil,omitempty" name:"DataEngineNames"`
 }
 
 type DeleteDataEngineRequest struct {
 	*tchttp.BaseRequest
 	
-	// 删除虚拟集群的名称数组
+	// <p>删除虚拟集群的名称数组</p>
 	DataEngineNames []*string `json:"DataEngineNames,omitnil,omitempty" name:"DataEngineNames"`
 }
 
@@ -6425,6 +6695,9 @@ func (r *DeleteThirdPartyAccessUserResponse) FromJsonString(s string) error {
 type DeleteUserRequestParams struct {
 	// 需要删除的用户的Id
 	UserIds []*string `json:"UserIds,omitnil,omitempty" name:"UserIds"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 type DeleteUserRequest struct {
@@ -6432,6 +6705,9 @@ type DeleteUserRequest struct {
 	
 	// 需要删除的用户的Id
 	UserIds []*string `json:"UserIds,omitnil,omitempty" name:"UserIds"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 func (r *DeleteUserRequest) ToJsonString() string {
@@ -6447,6 +6723,7 @@ func (r *DeleteUserRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "UserIds")
+	delete(f, "AccountType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteUserRequest has unknown keys!", "")
 	}
@@ -7441,33 +7718,45 @@ func (r *DescribeDMSTablesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeDataEngineEventsRequestParams struct {
-	// 虚拟集群名称
+	// <p>虚拟集群名称</p>
 	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
 
-	// 返回数量，默认为10，最大为100
+	// <p>返回数量，默认为10，最大为100</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0
+	// <p>偏移量，默认为0</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 资源组id
+	// <p>资源组id</p>
 	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+
+	// <p>查询开始时间，用于筛选资源组启停事件的时间范围，不传则不限制开始时间</p><p>参数格式：YYYY-mm-dd HH:MM:SS</p>
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>查询结束时间，用于筛选资源组启停事件的时间范围，不传则不限制结束时间。需大于等于 StartTime</p><p>参数格式：YYYY-mm-dd HH:MM:SS</p>
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 }
 
 type DescribeDataEngineEventsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 虚拟集群名称
+	// <p>虚拟集群名称</p>
 	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
 
-	// 返回数量，默认为10，最大为100
+	// <p>返回数量，默认为10，最大为100</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0
+	// <p>偏移量，默认为0</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 资源组id
+	// <p>资源组id</p>
 	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+
+	// <p>查询开始时间，用于筛选资源组启停事件的时间范围，不传则不限制开始时间</p><p>参数格式：YYYY-mm-dd HH:MM:SS</p>
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>查询结束时间，用于筛选资源组启停事件的时间范围，不传则不限制结束时间。需大于等于 StartTime</p><p>参数格式：YYYY-mm-dd HH:MM:SS</p>
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 }
 
 func (r *DescribeDataEngineEventsRequest) ToJsonString() string {
@@ -7486,6 +7775,8 @@ func (r *DescribeDataEngineEventsRequest) FromJsonString(s string) error {
 	delete(f, "Limit")
 	delete(f, "Offset")
 	delete(f, "SessionId")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDataEngineEventsRequest has unknown keys!", "")
 	}
@@ -7494,20 +7785,20 @@ func (r *DescribeDataEngineEventsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeDataEngineEventsResponseParams struct {
-	// 事件详细信息
+	// <p>事件详细信息</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Events []*HouseEventsInfo `json:"Events,omitnil,omitempty" name:"Events"`
 
-	// 分页号
+	// <p>分页号</p>
 	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
 
-	// 分页大小
+	// <p>分页大小</p>
 	Size *int64 `json:"Size,omitnil,omitempty" name:"Size"`
 
-	// 总页数
+	// <p>总页数</p>
 	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
 
-	// 总条数
+	// <p>总条数</p>
 	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -8753,6 +9044,12 @@ type DescribeNativeSparkSessionsRequestParams struct {
 
 	// 资源组ID
 	ResourceGroupId *string `json:"ResourceGroupId,omitnil,omitempty" name:"ResourceGroupId"`
+
+	// 项目ID
+	ProjectId *string `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
+
+	// 用户Uin
+	UserUin *string `json:"UserUin,omitnil,omitempty" name:"UserUin"`
 }
 
 type DescribeNativeSparkSessionsRequest struct {
@@ -8763,6 +9060,12 @@ type DescribeNativeSparkSessionsRequest struct {
 
 	// 资源组ID
 	ResourceGroupId *string `json:"ResourceGroupId,omitnil,omitempty" name:"ResourceGroupId"`
+
+	// 项目ID
+	ProjectId *string `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
+
+	// 用户Uin
+	UserUin *string `json:"UserUin,omitnil,omitempty" name:"UserUin"`
 }
 
 func (r *DescribeNativeSparkSessionsRequest) ToJsonString() string {
@@ -8779,6 +9082,8 @@ func (r *DescribeNativeSparkSessionsRequest) FromJsonString(s string) error {
 	}
 	delete(f, "DataEngineId")
 	delete(f, "ResourceGroupId")
+	delete(f, "ProjectId")
+	delete(f, "UserUin")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeNativeSparkSessionsRequest has unknown keys!", "")
 	}
@@ -8789,6 +9094,12 @@ func (r *DescribeNativeSparkSessionsRequest) FromJsonString(s string) error {
 type DescribeNativeSparkSessionsResponseParams struct {
 	// spark session列表
 	SparkSessionsList []*SparkSessionInfo `json:"SparkSessionsList,omitnil,omitempty" name:"SparkSessionsList"`
+
+	// 资源组总规格
+	TotalSpec *int64 `json:"TotalSpec,omitnil,omitempty" name:"TotalSpec"`
+
+	// 资源组当前可用规格
+	TotalAvailable *int64 `json:"TotalAvailable,omitnil,omitempty" name:"TotalAvailable"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -9451,6 +9762,69 @@ func (r *DescribeOtherCHDFSBindingListResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeOtherCHDFSBindingListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeResourceGroupUsageInfoRequestParams struct {
+	// 资源组ID
+	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+}
+
+type DescribeResourceGroupUsageInfoRequest struct {
+	*tchttp.BaseRequest
+	
+	// 资源组ID
+	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+}
+
+func (r *DescribeResourceGroupUsageInfoRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeResourceGroupUsageInfoRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SessionId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeResourceGroupUsageInfoRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeResourceGroupUsageInfoResponseParams struct {
+	// 资源上限
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 已占用资源
+	Used *int64 `json:"Used,omitnil,omitempty" name:"Used"`
+
+	// 剩余可用资源
+	Available *int64 `json:"Available,omitnil,omitempty" name:"Available"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeResourceGroupUsageInfoResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeResourceGroupUsageInfoResponseParams `json:"Response"`
+}
+
+func (r *DescribeResourceGroupUsageInfoResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeResourceGroupUsageInfoResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -10443,6 +10817,60 @@ func (r *DescribeSubUserAccessPolicyResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeTCLakeMetaInstanceRequestParams struct {
+
+}
+
+type DescribeTCLakeMetaInstanceRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *DescribeTCLakeMetaInstanceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTCLakeMetaInstanceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTCLakeMetaInstanceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTCLakeMetaInstanceResponseParams struct {
+	// <p>开通状态</p><p>枚举值：</p><ul><li>Running： 开通成功</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTCLakeMetaInstanceResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTCLakeMetaInstanceResponseParams `json:"Response"`
+}
+
+func (r *DescribeTCLakeMetaInstanceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTCLakeMetaInstanceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeTablePartitionsRequestParams struct {
 	// 数据目录名称
 	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
@@ -10893,6 +11321,196 @@ func (r *DescribeTablesResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeTablesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTaskDetailRequestParams struct {
+	// 任务id
+	TaskInstanceId *string `json:"TaskInstanceId,omitnil,omitempty" name:"TaskInstanceId"`
+}
+
+type DescribeTaskDetailRequest struct {
+	*tchttp.BaseRequest
+	
+	// 任务id
+	TaskInstanceId *string `json:"TaskInstanceId,omitnil,omitempty" name:"TaskInstanceId"`
+}
+
+func (r *DescribeTaskDetailRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTaskDetailRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TaskInstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTaskDetailRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTaskDetailResponseParams struct {
+	// 任务详情信息
+	TaskDetail *TaskFullRespInfo `json:"TaskDetail,omitnil,omitempty" name:"TaskDetail"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTaskDetailResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTaskDetailResponseParams `json:"Response"`
+}
+
+func (r *DescribeTaskDetailResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTaskDetailResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTaskListRequestParams struct {
+	// 返回数量，默认为10，最大值为100。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 偏移量，默认为0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。
+	// task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。
+	// task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。
+	// task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。
+	// task-operator- string （子uin过滤）
+	// task-kind - string （任务类型过滤）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）
+	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
+
+	// 排序方式，desc表示正序，asc表示反序， 默认为asc。
+	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
+
+	// 起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 数据引擎名称，用于筛选
+	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
+
+	// spark引擎资源组名称
+	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
+
+	// 引擎id列表
+	HouseIds []*string `json:"HouseIds,omitnil,omitempty" name:"HouseIds"`
+}
+
+type DescribeTaskListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 返回数量，默认为10，最大值为100。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 偏移量，默认为0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。
+	// task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。
+	// task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。
+	// task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。
+	// task-operator- string （子uin过滤）
+	// task-kind - string （任务类型过滤）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）
+	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
+
+	// 排序方式，desc表示正序，asc表示反序， 默认为asc。
+	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
+
+	// 起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 数据引擎名称，用于筛选
+	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
+
+	// spark引擎资源组名称
+	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
+
+	// 引擎id列表
+	HouseIds []*string `json:"HouseIds,omitnil,omitempty" name:"HouseIds"`
+}
+
+func (r *DescribeTaskListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTaskListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Limit")
+	delete(f, "Offset")
+	delete(f, "Filters")
+	delete(f, "SortBy")
+	delete(f, "Sorting")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "DataEngineName")
+	delete(f, "ResourceGroupName")
+	delete(f, "HouseIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTaskListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTaskListResponseParams struct {
+	// 任务对象列表。
+	TaskList []*TaskFullRespInfo `json:"TaskList,omitnil,omitempty" name:"TaskList"`
+
+	// 实例总数。
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTaskListResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTaskListResponseParams `json:"Response"`
+}
+
+func (r *DescribeTaskListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTaskListResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -11548,72 +12166,62 @@ func (r *DescribeTasksOverviewResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTasksRequestParams struct {
-	// 返回数量，默认为10，最大值为100。
+	// <p>返回数量，默认为10，最大值为100。</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。
-	// task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。
-	// task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。
-	// task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。
-	// task-operator- string （子uin过滤）
-	// task-kind - string （任务类型过滤）
+	// <p>过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。<br>task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。<br>task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。<br>task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。<br>task-operator- string （子uin过滤）<br>task-kind - string （任务类型过滤）</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）
+	// <p>排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）</p>
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
 
-	// 排序方式，desc表示正序，asc表示反序， 默认为asc。
+	// <p>排序方式，desc表示正序，asc表示反序， 默认为asc。</p>
 	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
 
-	// 起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻
+	// <p>起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻</p>
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻
+	// <p>结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 数据引擎名称，用于筛选
+	// <p>数据引擎名称，用于筛选</p>
 	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
 
-	// spark引擎资源组名称
+	// <p>spark引擎资源组名称</p>
 	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
 }
 
 type DescribeTasksRequest struct {
 	*tchttp.BaseRequest
 	
-	// 返回数量，默认为10，最大值为100。
+	// <p>返回数量，默认为10，最大值为100。</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。
-	// task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。
-	// task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。
-	// task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。
-	// task-operator- string （子uin过滤）
-	// task-kind - string （任务类型过滤）
+	// <p>过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。<br>task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。<br>task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。<br>task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。<br>task-operator- string （子uin过滤）<br>task-kind - string （任务类型过滤）</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）
+	// <p>排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）</p>
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
 
-	// 排序方式，desc表示正序，asc表示反序， 默认为asc。
+	// <p>排序方式，desc表示正序，asc表示反序， 默认为asc。</p>
 	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
 
-	// 起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻
+	// <p>起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻</p>
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻
+	// <p>结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 数据引擎名称，用于筛选
+	// <p>数据引擎名称，用于筛选</p>
 	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
 
-	// spark引擎资源组名称
+	// <p>spark引擎资源组名称</p>
 	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
 }
 
@@ -11646,13 +12254,13 @@ func (r *DescribeTasksRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTasksResponseParams struct {
-	// 任务对象列表。
+	// <p>任务对象列表。</p>
 	TaskList []*TaskResponseInfo `json:"TaskList,omitnil,omitempty" name:"TaskList"`
 
-	// 实例总数。
+	// <p>实例总数。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 任务概览信息
+	// <p>任务概览信息</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	TasksOverview *TasksOverview `json:"TasksOverview,omitnil,omitempty" name:"TasksOverview"`
 
@@ -11969,99 +12577,63 @@ func (r *DescribeUserDataEngineConfigResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeUserInfoRequestParams struct {
-	// 用户Id
+	// <p>用户Id</p>
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
 
-	// 必传字段，查询的信息类型，Group：工作组 DataAuth：数据权限 EngineAuth:引擎权限 RowFilter：行级别权限
+	// <p>必传字段，查询的信息类型，Group：工作组 DataAuth：数据权限 EngineAuth:引擎权限 RowFilter：行级别权限</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 查询的过滤条件。
-	// 
-	// 当Type为Group时，支持Key为workgroup-name的模糊搜索；
-	// 
-	// 当Type为DataAuth时，支持key：
-	// 
-	// policy-type：权限类型。
-	// 
-	// policy-source：数据来源。
-	// 
-	// data-name：库表的模糊搜索。
-	// 
-	// 当Type为EngineAuth时，支持key：
-	// 
-	// policy-type：权限类型。
-	// 
-	// policy-source：数据来源。
-	// 
-	// engine-name：库表的模糊搜索。
+	// <p>查询的过滤条件。</p><p>当Type为Group时，支持Key为workgroup-name的模糊搜索；</p><p>当Type为DataAuth时，支持key：</p><p>policy-type：权限类型。</p><p>policy-source：数据来源。</p><p>data-name：库表的模糊搜索。</p><p>当Type为EngineAuth时，支持key：</p><p>policy-type：权限类型。</p><p>policy-source：数据来源。</p><p>engine-name：库表的模糊搜索。</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 排序字段。
-	// 
-	// 当Type为Group时，支持create-time、group-name
-	// 
-	// 当Type为DataAuth时，支持create-time
-	// 
-	// 当Type为EngineAuth时，支持create-time
+	// <p>排序字段。</p><p>当Type为Group时，支持create-time、group-name</p><p>当Type为DataAuth时，支持create-time</p><p>当Type为EngineAuth时，支持create-time</p>
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
 
-	// 排序方式，desc表示正序，asc表示反序， 默认为asc
+	// <p>排序方式，desc表示正序，asc表示反序， 默认为asc</p>
 	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
 
-	// 返回数量，默认20，最大值100
+	// <p>返回数量，默认20，最大值100</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0
+	// <p>偏移量，默认为0</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）</p>
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
+
+	// <p>TF 资源 ID</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
 }
 
 type DescribeUserInfoRequest struct {
 	*tchttp.BaseRequest
 	
-	// 用户Id
+	// <p>用户Id</p>
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
 
-	// 必传字段，查询的信息类型，Group：工作组 DataAuth：数据权限 EngineAuth:引擎权限 RowFilter：行级别权限
+	// <p>必传字段，查询的信息类型，Group：工作组 DataAuth：数据权限 EngineAuth:引擎权限 RowFilter：行级别权限</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 查询的过滤条件。
-	// 
-	// 当Type为Group时，支持Key为workgroup-name的模糊搜索；
-	// 
-	// 当Type为DataAuth时，支持key：
-	// 
-	// policy-type：权限类型。
-	// 
-	// policy-source：数据来源。
-	// 
-	// data-name：库表的模糊搜索。
-	// 
-	// 当Type为EngineAuth时，支持key：
-	// 
-	// policy-type：权限类型。
-	// 
-	// policy-source：数据来源。
-	// 
-	// engine-name：库表的模糊搜索。
+	// <p>查询的过滤条件。</p><p>当Type为Group时，支持Key为workgroup-name的模糊搜索；</p><p>当Type为DataAuth时，支持key：</p><p>policy-type：权限类型。</p><p>policy-source：数据来源。</p><p>data-name：库表的模糊搜索。</p><p>当Type为EngineAuth时，支持key：</p><p>policy-type：权限类型。</p><p>policy-source：数据来源。</p><p>engine-name：库表的模糊搜索。</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 排序字段。
-	// 
-	// 当Type为Group时，支持create-time、group-name
-	// 
-	// 当Type为DataAuth时，支持create-time
-	// 
-	// 当Type为EngineAuth时，支持create-time
+	// <p>排序字段。</p><p>当Type为Group时，支持create-time、group-name</p><p>当Type为DataAuth时，支持create-time</p><p>当Type为EngineAuth时，支持create-time</p>
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
 
-	// 排序方式，desc表示正序，asc表示反序， 默认为asc
+	// <p>排序方式，desc表示正序，asc表示反序， 默认为asc</p>
 	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
 
-	// 返回数量，默认20，最大值100
+	// <p>返回数量，默认20，最大值100</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0
+	// <p>偏移量，默认为0</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）</p>
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
+
+	// <p>TF 资源 ID</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
 }
 
 func (r *DescribeUserInfoRequest) ToJsonString() string {
@@ -12083,6 +12655,8 @@ func (r *DescribeUserInfoRequest) FromJsonString(s string) error {
 	delete(f, "Sorting")
 	delete(f, "Limit")
 	delete(f, "Offset")
+	delete(f, "AccountType")
+	delete(f, "PolicyId")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeUserInfoRequest has unknown keys!", "")
 	}
@@ -12091,7 +12665,7 @@ func (r *DescribeUserInfoRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeUserInfoResponseParams struct {
-	// 用户详细信息
+	// <p>用户详细信息</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	UserInfo *UserDetailInfo `json:"UserInfo,omitnil,omitempty" name:"UserInfo"`
 
@@ -12271,6 +12845,9 @@ func (r *DescribeUserRolesResponse) FromJsonString(s string) error {
 type DescribeUserTypeRequestParams struct {
 	// 用户ID（UIN），如果不填默认为调用方的子UIN
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 type DescribeUserTypeRequest struct {
@@ -12278,6 +12855,9 @@ type DescribeUserTypeRequest struct {
 	
 	// 用户ID（UIN），如果不填默认为调用方的子UIN
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 func (r *DescribeUserTypeRequest) ToJsonString() string {
@@ -12293,6 +12873,7 @@ func (r *DescribeUserTypeRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "UserId")
+	delete(f, "AccountType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeUserTypeRequest has unknown keys!", "")
 	}
@@ -12415,6 +12996,9 @@ type DescribeUsersRequestParams struct {
 
 	// 过滤条件，支持如下字段类型，user-type：根据用户类型过滤。user-keyword：根据用户名称过滤
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 type DescribeUsersRequest struct {
@@ -12437,6 +13021,9 @@ type DescribeUsersRequest struct {
 
 	// 过滤条件，支持如下字段类型，user-type：根据用户类型过滤。user-keyword：根据用户名称过滤
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 func (r *DescribeUsersRequest) ToJsonString() string {
@@ -12457,6 +13044,7 @@ func (r *DescribeUsersRequest) FromJsonString(s string) error {
 	delete(f, "SortBy")
 	delete(f, "Sorting")
 	delete(f, "Filters")
+	delete(f, "AccountType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeUsersRequest has unknown keys!", "")
 	}
@@ -12622,99 +13210,57 @@ func (r *DescribeViewsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeWorkGroupInfoRequestParams struct {
-	// 工作组Id
+	// <p>工作组Id</p>
 	WorkGroupId *int64 `json:"WorkGroupId,omitnil,omitempty" name:"WorkGroupId"`
 
-	// 查询信息类型：User：用户信息 DataAuth：数据权限 EngineAuth：引擎权限
+	// <p>查询信息类型：User：用户信息 DataAuth：数据权限 EngineAuth：引擎权限</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 查询的过滤条件。
-	// 
-	// 当Type为User时，支持Key为user-name的模糊搜索；
-	// 
-	// 当Type为DataAuth时，支持key：
-	// 
-	// policy-type：权限类型。
-	// 
-	// policy-source：数据来源。
-	// 
-	// data-name：库表的模糊搜索。
-	// 
-	// 当Type为EngineAuth时，支持key：
-	// 
-	// policy-type：权限类型。
-	// 
-	// policy-source：数据来源。
-	// 
-	// engine-name：库表的模糊搜索。
+	// <p>查询的过滤条件。</p><p>当Type为User时，支持Key为user-name的模糊搜索；</p><p>当Type为DataAuth时，支持key：</p><p>policy-type：权限类型。</p><p>policy-source：数据来源。</p><p>data-name：库表的模糊搜索。</p><p>当Type为EngineAuth时，支持key：</p><p>policy-type：权限类型。</p><p>policy-source：数据来源。</p><p>engine-name：库表的模糊搜索。</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 排序字段。
-	// 
-	// 当Type为User时，支持create-time、user-name
-	// 
-	// 当Type为DataAuth时，支持create-time
-	// 
-	// 当Type为EngineAuth时，支持create-time
+	// <p>排序字段。</p><p>当Type为User时，支持create-time、user-name</p><p>当Type为DataAuth时，支持create-time</p><p>当Type为EngineAuth时，支持create-time</p>
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
 
-	// 排序方式，desc表示正序，asc表示反序， 默认为asc
+	// <p>排序方式，desc表示正序，asc表示反序， 默认为asc</p>
 	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
 
-	// 返回数量，默认20，最大值100
+	// <p>返回数量，默认20，最大值100</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0
+	// <p>偏移量，默认为0</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>要授权的策略列表</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
 }
 
 type DescribeWorkGroupInfoRequest struct {
 	*tchttp.BaseRequest
 	
-	// 工作组Id
+	// <p>工作组Id</p>
 	WorkGroupId *int64 `json:"WorkGroupId,omitnil,omitempty" name:"WorkGroupId"`
 
-	// 查询信息类型：User：用户信息 DataAuth：数据权限 EngineAuth：引擎权限
+	// <p>查询信息类型：User：用户信息 DataAuth：数据权限 EngineAuth：引擎权限</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 查询的过滤条件。
-	// 
-	// 当Type为User时，支持Key为user-name的模糊搜索；
-	// 
-	// 当Type为DataAuth时，支持key：
-	// 
-	// policy-type：权限类型。
-	// 
-	// policy-source：数据来源。
-	// 
-	// data-name：库表的模糊搜索。
-	// 
-	// 当Type为EngineAuth时，支持key：
-	// 
-	// policy-type：权限类型。
-	// 
-	// policy-source：数据来源。
-	// 
-	// engine-name：库表的模糊搜索。
+	// <p>查询的过滤条件。</p><p>当Type为User时，支持Key为user-name的模糊搜索；</p><p>当Type为DataAuth时，支持key：</p><p>policy-type：权限类型。</p><p>policy-source：数据来源。</p><p>data-name：库表的模糊搜索。</p><p>当Type为EngineAuth时，支持key：</p><p>policy-type：权限类型。</p><p>policy-source：数据来源。</p><p>engine-name：库表的模糊搜索。</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 排序字段。
-	// 
-	// 当Type为User时，支持create-time、user-name
-	// 
-	// 当Type为DataAuth时，支持create-time
-	// 
-	// 当Type为EngineAuth时，支持create-time
+	// <p>排序字段。</p><p>当Type为User时，支持create-time、user-name</p><p>当Type为DataAuth时，支持create-time</p><p>当Type为EngineAuth时，支持create-time</p>
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
 
-	// 排序方式，desc表示正序，asc表示反序， 默认为asc
+	// <p>排序方式，desc表示正序，asc表示反序， 默认为asc</p>
 	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
 
-	// 返回数量，默认20，最大值100
+	// <p>返回数量，默认20，最大值100</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0
+	// <p>偏移量，默认为0</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>要授权的策略列表</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
 }
 
 func (r *DescribeWorkGroupInfoRequest) ToJsonString() string {
@@ -12736,6 +13282,7 @@ func (r *DescribeWorkGroupInfoRequest) FromJsonString(s string) error {
 	delete(f, "Sorting")
 	delete(f, "Limit")
 	delete(f, "Offset")
+	delete(f, "PolicyId")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeWorkGroupInfoRequest has unknown keys!", "")
 	}
@@ -12744,7 +13291,7 @@ func (r *DescribeWorkGroupInfoRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeWorkGroupInfoResponseParams struct {
-	// 工作组详细信息
+	// <p>工作组详细信息</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	WorkGroupInfo *WorkGroupDetailInfo `json:"WorkGroupInfo,omitnil,omitempty" name:"WorkGroupInfo"`
 
@@ -12865,21 +13412,33 @@ func (r *DescribeWorkGroupsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DetachUserPolicyRequestParams struct {
-	// 用户Id，和CAM侧Uin匹配
+	// <p>用户Id，和CAM侧Uin匹配</p>
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
 
-	// 解绑的权限集合
+	// <p>解绑的权限集合</p>
 	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
+
+	// <p>用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）</p>
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
+
+	// <p>要授权的策略列表</p>
+	PolicyIds []*string `json:"PolicyIds,omitnil,omitempty" name:"PolicyIds"`
 }
 
 type DetachUserPolicyRequest struct {
 	*tchttp.BaseRequest
 	
-	// 用户Id，和CAM侧Uin匹配
+	// <p>用户Id，和CAM侧Uin匹配</p>
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
 
-	// 解绑的权限集合
+	// <p>解绑的权限集合</p>
 	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
+
+	// <p>用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）</p>
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
+
+	// <p>要授权的策略列表</p>
+	PolicyIds []*string `json:"PolicyIds,omitnil,omitempty" name:"PolicyIds"`
 }
 
 func (r *DetachUserPolicyRequest) ToJsonString() string {
@@ -12896,6 +13455,8 @@ func (r *DetachUserPolicyRequest) FromJsonString(s string) error {
 	}
 	delete(f, "UserId")
 	delete(f, "PolicySet")
+	delete(f, "AccountType")
+	delete(f, "PolicyIds")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DetachUserPolicyRequest has unknown keys!", "")
 	}
@@ -12926,21 +13487,27 @@ func (r *DetachUserPolicyResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DetachWorkGroupPolicyRequestParams struct {
-	// 工作组Id
+	// <p>工作组Id</p>
 	WorkGroupId *int64 `json:"WorkGroupId,omitnil,omitempty" name:"WorkGroupId"`
 
-	// 解绑的权限集合
+	// <p>解绑的权限集合</p>
 	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
+
+	// <p>要授权的策略列表</p>
+	PolicyIds []*string `json:"PolicyIds,omitnil,omitempty" name:"PolicyIds"`
 }
 
 type DetachWorkGroupPolicyRequest struct {
 	*tchttp.BaseRequest
 	
-	// 工作组Id
+	// <p>工作组Id</p>
 	WorkGroupId *int64 `json:"WorkGroupId,omitnil,omitempty" name:"WorkGroupId"`
 
-	// 解绑的权限集合
+	// <p>解绑的权限集合</p>
 	PolicySet []*Policy `json:"PolicySet,omitnil,omitempty" name:"PolicySet"`
+
+	// <p>要授权的策略列表</p>
+	PolicyIds []*string `json:"PolicyIds,omitnil,omitempty" name:"PolicyIds"`
 }
 
 func (r *DetachWorkGroupPolicyRequest) ToJsonString() string {
@@ -12957,6 +13524,7 @@ func (r *DetachWorkGroupPolicyRequest) FromJsonString(s string) error {
 	}
 	delete(f, "WorkGroupId")
 	delete(f, "PolicySet")
+	delete(f, "PolicyIds")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DetachWorkGroupPolicyRequest has unknown keys!", "")
 	}
@@ -13256,6 +13824,9 @@ type ElasticPlan struct {
 
 	// 结束时间，Once格式：yyyy-MM-dd HH:mm:ss; 非Once格式： HH:mm:ss
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 分时弹性上限
+	ElasticLimit *int64 `json:"ElasticLimit,omitnil,omitempty" name:"ElasticLimit"`
 }
 
 type ElasticsearchInfo struct {
@@ -13375,11 +13946,40 @@ type FavorInfo struct {
 }
 
 type Filter struct {
-	// 属性名称, 若存在多个Filter时，Filter间的关系为逻辑或（OR）关系。
+	// 筛选字段名，对应实体属性名（驼峰命名）
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 属性值, 若同一个Filter存在多个Values，同一Filter下Values间的关系为逻辑或（OR）关系。
+	// 筛选操作符：EQ/NE/GT/GE/LT/LE/LIKE/IN，默认EQ
+	Operator *string `json:"Operator,omitnil,omitempty" name:"Operator"`
+
+	// 筛选值列表，EQ/NE/GT/GE/LT/LE/LIKE取第一个值，IN使用完整列表
 	Values []*string `json:"Values,omitnil,omitempty" name:"Values"`
+}
+
+type GPUInfo struct {
+	// 计费项
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
+
+	// 机型
+	Model *string `json:"Model,omitnil,omitempty" name:"Model"`
+
+	// cu
+	CU *int64 `json:"CU,omitnil,omitempty" name:"CU"`
+
+	// gpu 机型
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// 数量
+	Num *int64 `json:"Num,omitnil,omitempty" name:"Num"`
+
+	// 显存
+	GPUMemory *int64 `json:"GPUMemory,omitnil,omitempty" name:"GPUMemory"`
+
+	// 机型
+	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
+
+	// 售卖情况（1-缺货，2-低库存，3-充足）
+	SaleStatus *int64 `json:"SaleStatus,omitnil,omitempty" name:"SaleStatus"`
 }
 
 type GatewayInfo struct {
@@ -13746,6 +14346,63 @@ type IcebergTablePartition struct {
 	Location *LocationInfo `json:"Location,omitnil,omitempty" name:"Location"`
 }
 
+// Predefined struct for user
+type InitializeTCLakeRequestParams struct {
+
+}
+
+type InitializeTCLakeRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *InitializeTCLakeRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *InitializeTCLakeRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "InitializeTCLakeRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type InitializeTCLakeResponseParams struct {
+	// <p>实例Id</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>是否成功</p>
+	IsSuccess *bool `json:"IsSuccess,omitnil,omitempty" name:"IsSuccess"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type InitializeTCLakeResponse struct {
+	*tchttp.BaseResponse
+	Response *InitializeTCLakeResponseParams `json:"Response"`
+}
+
+func (r *InitializeTCLakeResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *InitializeTCLakeResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type IpPortPair struct {
 	// ip信息
 	// 注意：此字段可能返回 null，表示取不到有效值。
@@ -13779,10 +14436,10 @@ type JobLogResult struct {
 }
 
 type KVPair struct {
-	// 配置的key值
+	// <p>配置的key值</p>
 	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
 
-	// 配置的value值
+	// <p>配置的value值</p>
 	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
 }
 
@@ -13829,7 +14486,7 @@ type LakeFsInfo struct {
 	// 托管存储类型
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 容量
+	// 存储用量
 	SpaceUsedSize *float64 `json:"SpaceUsedSize,omitnil,omitempty" name:"SpaceUsedSize"`
 
 	// 创建时候的时间戳
@@ -13846,6 +14503,9 @@ type LakeFsInfo struct {
 
 	// 托管桶状态，当前取值为：creating、bind、readOnly、isolate
 	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// 托管存储桶标签列表
+	TagList []*TagInfo `json:"TagList,omitnil,omitempty" name:"TagList"`
 }
 
 // Predefined struct for user
@@ -14778,6 +15438,9 @@ type ModifyUserRequestParams struct {
 
 	// 用户描述
 	UserDescription *string `json:"UserDescription,omitnil,omitempty" name:"UserDescription"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 type ModifyUserRequest struct {
@@ -14788,6 +15451,9 @@ type ModifyUserRequest struct {
 
 	// 用户描述
 	UserDescription *string `json:"UserDescription,omitnil,omitempty" name:"UserDescription"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 func (r *ModifyUserRequest) ToJsonString() string {
@@ -14804,6 +15470,7 @@ func (r *ModifyUserRequest) FromJsonString(s string) error {
 	}
 	delete(f, "UserId")
 	delete(f, "UserDescription")
+	delete(f, "AccountType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyUserRequest has unknown keys!", "")
 	}
@@ -14839,6 +15506,9 @@ type ModifyUserTypeRequestParams struct {
 
 	// 用户要修改到的类型，ADMIN：管理员，COMMON：一般用户。
 	UserType *string `json:"UserType,omitnil,omitempty" name:"UserType"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 type ModifyUserTypeRequest struct {
@@ -14849,6 +15519,9 @@ type ModifyUserTypeRequest struct {
 
 	// 用户要修改到的类型，ADMIN：管理员，COMMON：一般用户。
 	UserType *string `json:"UserType,omitnil,omitempty" name:"UserType"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 func (r *ModifyUserTypeRequest) ToJsonString() string {
@@ -14865,6 +15538,7 @@ func (r *ModifyUserTypeRequest) FromJsonString(s string) error {
 	}
 	delete(f, "UserId")
 	delete(f, "UserType")
+	delete(f, "AccountType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyUserTypeRequest has unknown keys!", "")
 	}
@@ -15170,6 +15844,9 @@ type NotebookSessionInfo struct {
 
 	// pod数量
 	PodNumbers *int64 `json:"PodNumbers,omitnil,omitempty" name:"PodNumbers"`
+
+	// spark app名称
+	SparkAppName *string `json:"SparkAppName,omitnil,omitempty" name:"SparkAppName"`
 }
 
 type NotebookSessionStatementBatchInformation struct {
@@ -15263,6 +15940,12 @@ type NotebookSessions struct {
 
 	// 资源组名字
 	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
+
+	// Kernel id
+	KernelId *string `json:"KernelId,omitnil,omitempty" name:"KernelId"`
+
+	// spark app名称
+	SparkAppName *string `json:"SparkAppName,omitnil,omitempty" name:"SparkAppName"`
 }
 
 type OpendThirdAccessUserInfo struct {
@@ -15414,71 +16097,80 @@ func (r *PauseStandardEngineResourceGroupsResponse) FromJsonString(s string) err
 }
 
 type Policy struct {
-	// 需要授权的数据库名，填 * 代表当前Catalog下所有数据库。当授权类型为管理员级别时，只允许填 “*”，当授权类型为数据连接级别时只允许填空，其他类型下可以任意指定数据库。
+	// <p>需要授权的数据库名，填 * 代表当前Catalog下所有数据库。当授权类型为管理员级别时，只允许填 “*”，当授权类型为数据连接级别时只允许填空，其他类型下可以任意指定数据库。</p>
 	Database *string `json:"Database,omitnil,omitempty" name:"Database"`
 
-	// 需要授权的数据源名称，管理员级别下只支持填  * （代表该级别全部资源）；数据源级别和数据库级别鉴权的情况下，只支持填COSDataCatalog或者*；在数据表级别鉴权下可以填写用户自定义数据源。不填情况下默认为DataLakeCatalog。注意：如果是对用户自定义数据源进行鉴权，DLC能够管理的权限是用户接入数据源的时候提供的账户的子集。
+	// <p>需要授权的数据源名称，管理员级别下只支持填  * （代表该级别全部资源）；数据源级别和数据库级别鉴权的情况下，只支持填COSDataCatalog或者*；在数据表级别鉴权下可以填写用户自定义数据源。不填情况下默认为DataLakeCatalog。注意：如果是对用户自定义数据源进行鉴权，DLC能够管理的权限是用户接入数据源的时候提供的账户的子集。</p>
 	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
 
-	// 需要授权的表名，填 * 代表当前Database下所有表。当授权类型为管理员级别时，只允许填“*”，当授权类型为数据连接级别、数据库级别时只允许填空，其他类型下可以任意指定数据表。
+	// <p>需要授权的表名，填 * 代表当前Database下所有表。当授权类型为管理员级别时，只允许填“*”，当授权类型为数据连接级别、数据库级别时只允许填空，其他类型下可以任意指定数据表。</p>
 	Table *string `json:"Table,omitnil,omitempty" name:"Table"`
 
-	// 授权的权限操作，对于不同级别的鉴权提供不同操作。管理员权限：ALL，不填默认为ALL；数据连接级鉴权：CREATE；数据库级别鉴权：ALL、CREATE、ALTER、DROP；数据表权限：ALL、SELECT、INSERT、ALTER、DELETE、DROP、UPDATE。注意：在数据表权限下，指定的数据源不为COSDataCatalog的时候，只支持SELECT操作。
+	// <p>授权的权限操作，对于不同级别的鉴权提供不同操作。管理员权限：ALL，不填默认为ALL；数据连接级鉴权：CREATE；数据库级别鉴权：ALL、CREATE、ALTER、DROP；数据表权限：ALL、SELECT、INSERT、ALTER、DELETE、DROP、UPDATE。注意：在数据表权限下，指定的数据源不为COSDataCatalog的时候，只支持SELECT操作。</p>
 	Operation *string `json:"Operation,omitnil,omitempty" name:"Operation"`
 
-	// 授权类型，现在支持八种授权类型：ADMIN:管理员级别鉴权 DATASOURCE：数据连接级别鉴权 DATABASE：数据库级别鉴权 TABLE：表级别鉴权 VIEW：视图级别鉴权 FUNCTION：函数级别鉴权 COLUMN：列级别鉴权 ENGINE：数据引擎鉴权。不填默认为管理员级别鉴权。
+	// <p>授权类型，现在支持八种授权类型：ADMIN:管理员级别鉴权 DATASOURCE：数据连接级别鉴权 DATABASE：数据库级别鉴权 TABLE：表级别鉴权 VIEW：视图级别鉴权 FUNCTION：函数级别鉴权 COLUMN：列级别鉴权 ENGINE：数据引擎鉴权。不填默认为管理员级别鉴权。</p>
 	PolicyType *string `json:"PolicyType,omitnil,omitempty" name:"PolicyType"`
 
-	// 需要授权的函数名，填 * 代表当前Catalog下所有函数。当授权类型为管理员级别时，只允许填“*”，当授权类型为数据连接级别时只允许填空，其他类型下可以任意指定函数。
+	// <p>需要授权的函数名，填 * 代表当前Catalog下所有函数。当授权类型为管理员级别时，只允许填“*”，当授权类型为数据连接级别时只允许填空，其他类型下可以任意指定函数。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Function *string `json:"Function,omitnil,omitempty" name:"Function"`
 
-	// 需要授权的视图，填 * 代表当前Database下所有视图。当授权类型为管理员级别时，只允许填“*”，当授权类型为数据连接级别、数据库级别时只允许填空，其他类型下可以任意指定视图。
+	// <p>需要授权的视图，填 * 代表当前Database下所有视图。当授权类型为管理员级别时，只允许填“*”，当授权类型为数据连接级别、数据库级别时只允许填空，其他类型下可以任意指定视图。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	View *string `json:"View,omitnil,omitempty" name:"View"`
 
-	// 需要授权的列，填 * 代表当前所有列。当授权类型为管理员级别时，只允许填“*”
+	// <p>需要授权的列，填 * 代表当前所有列。当授权类型为管理员级别时，只允许填“*”</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Column *string `json:"Column,omitnil,omitempty" name:"Column"`
 
-	// 需要授权的数据引擎，填 * 代表当前所有引擎。当授权类型为管理员级别时，只允许填“*”
+	// <p>需要授权的数据引擎，填 * 代表当前所有引擎。当授权类型为管理员级别时，只允许填“*”</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	DataEngine *string `json:"DataEngine,omitnil,omitempty" name:"DataEngine"`
 
-	// 用户是否可以进行二次授权。当为true的时候，被授权的用户可以将本次获取的权限再次授权给其他子用户。默认为false
+	// <p>用户是否可以进行二次授权。当为true的时候，被授权的用户可以将本次获取的权限再次授权给其他子用户。默认为false</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ReAuth *bool `json:"ReAuth,omitnil,omitempty" name:"ReAuth"`
 
-	// 权限来源，入参不填。USER：权限来自用户本身；WORKGROUP：权限来自绑定的工作组
+	// <p>权限来源，入参不填。USER：权限来自用户本身；WORKGROUP：权限来自绑定的工作组</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Source *string `json:"Source,omitnil,omitempty" name:"Source"`
 
-	// 授权模式，入参不填。COMMON：普通模式；SENIOR：高级模式。
+	// <p>授权模式，入参不填。COMMON：普通模式；SENIOR：高级模式。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
 
-	// 操作者，入参不填。
+	// <p>操作者，入参不填。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Operator *string `json:"Operator,omitnil,omitempty" name:"Operator"`
 
-	// 权限创建的时间，入参不填
+	// <p>权限创建的时间，入参不填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
-	// 权限所属工作组的ID，只有当该权限的来源为工作组时才会有值。即仅当Source字段的值为WORKGROUP时该字段才有值。
+	// <p>权限所属工作组的ID，只有当该权限的来源为工作组时才会有值。即仅当Source字段的值为WORKGROUP时该字段才有值。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	SourceId *int64 `json:"SourceId,omitnil,omitempty" name:"SourceId"`
 
-	// 权限所属工作组的名称，只有当该权限的来源为工作组时才会有值。即仅当Source字段的值为WORKGROUP时该字段才有值。
+	// <p>权限所属工作组的名称，只有当该权限的来源为工作组时才会有值。即仅当Source字段的值为WORKGROUP时该字段才有值。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	SourceName *string `json:"SourceName,omitnil,omitempty" name:"SourceName"`
 
-	// 策略ID
+	// <p>策略ID</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
 
-	// 引擎类型
+	// <p>引擎类型</p>
 	EngineGeneration *string `json:"EngineGeneration,omitnil,omitempty" name:"EngineGeneration"`
+
+	// <p>需要授权的Model名，填 * 代表当前Database下所有表。当授权类型为管理员级别时，只允许填“*”，当授权类型为数据连接级别、数据库级别时只允许填空，其他类型下可以任意指定数据表。</p>
+	Model *string `json:"Model,omitnil,omitempty" name:"Model"`
+
+	// <p>权限来源是否为管理员</p>
+	IsAdminPolicy *bool `json:"IsAdminPolicy,omitnil,omitempty" name:"IsAdminPolicy"`
+
+	// <p>user和workgroup对应的确定性字符串PolicyId</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
 }
 
 type Policys struct {
@@ -15535,6 +16227,9 @@ type QueryInternalTableWarehouseRequestParams struct {
 
 	// 表名
 	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// catalog名称
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
 }
 
 type QueryInternalTableWarehouseRequest struct {
@@ -15545,6 +16240,9 @@ type QueryInternalTableWarehouseRequest struct {
 
 	// 表名
 	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// catalog名称
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
 }
 
 func (r *QueryInternalTableWarehouseRequest) ToJsonString() string {
@@ -15561,6 +16259,7 @@ func (r *QueryInternalTableWarehouseRequest) FromJsonString(s string) error {
 	}
 	delete(f, "DatabaseName")
 	delete(f, "TableName")
+	delete(f, "DatasourceConnectionName")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "QueryInternalTableWarehouseRequest has unknown keys!", "")
 	}
@@ -15969,6 +16668,11 @@ func (r *ReportHeartbeatMetaDataResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type ResourceConf struct {
+	// 当为TCLake优化资源时，优化任务的并行度
+	Parallelism *int64 `json:"Parallelism,omitnil,omitempty" name:"Parallelism"`
+}
+
 type ResourceInfo struct {
 	// 归属类型
 	AttributionType *string `json:"AttributionType,omitnil,omitempty" name:"AttributionType"`
@@ -15991,6 +16695,9 @@ type ResourceInfo struct {
 
 	// 标准引擎资源组信息
 	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
+
+	// 资源配置信息
+	ResourceConf *ResourceConf `json:"ResourceConf,omitnil,omitempty" name:"ResourceConf"`
 }
 
 // Predefined struct for user
@@ -16240,6 +16947,60 @@ type SessionResourceTemplate struct {
 	RunningTimeParameters []*DataEngineConfigPair `json:"RunningTimeParameters,omitnil,omitempty" name:"RunningTimeParameters"`
 }
 
+// Predefined struct for user
+type SetOptimizerPolicyRequestParams struct {
+	// 优化策略
+	SmartPolicy *SmartPolicy `json:"SmartPolicy,omitnil,omitempty" name:"SmartPolicy"`
+}
+
+type SetOptimizerPolicyRequest struct {
+	*tchttp.BaseRequest
+	
+	// 优化策略
+	SmartPolicy *SmartPolicy `json:"SmartPolicy,omitnil,omitempty" name:"SmartPolicy"`
+}
+
+func (r *SetOptimizerPolicyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *SetOptimizerPolicyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SmartPolicy")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "SetOptimizerPolicyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type SetOptimizerPolicyResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type SetOptimizerPolicyResponse struct {
+	*tchttp.BaseResponse
+	Response *SetOptimizerPolicyResponseParams `json:"Response"`
+}
+
+func (r *SetOptimizerPolicyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *SetOptimizerPolicyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type SmartOptimizerChangeTablePolicy struct {
 	// change表的数据保存时间，单位为天
 	DataRetentionTime *int64 `json:"DataRetentionTime,omitnil,omitempty" name:"DataRetentionTime"`
@@ -16257,7 +17018,9 @@ type SmartOptimizerLifecyclePolicy struct {
 	// 过期时间
 	Expiration *int64 `json:"Expiration,omitnil,omitempty" name:"Expiration"`
 
-	// 是否删表
+	// 是否删表，该字段废弃已使用，用TableExpiration策略替代
+	//
+	// Deprecated: DropTable is deprecated.
 	DropTable *bool `json:"DropTable,omitnil,omitempty" name:"DropTable"`
 
 	// 过期字段
@@ -16271,15 +17034,15 @@ type SmartOptimizerPolicy struct {
 	// 是否继承
 	Inherit *string `json:"Inherit,omitnil,omitempty" name:"Inherit"`
 
-	// ResourceInfo
+	// 数据治理资源
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Resources []*ResourceInfo `json:"Resources,omitnil,omitempty" name:"Resources"`
 
-	// SmartOptimizerWrittenPolicy
+	// 数据重写策略
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Written *SmartOptimizerWrittenPolicy `json:"Written,omitnil,omitempty" name:"Written"`
 
-	// SmartOptimizerLifecyclePolicy
+	// 数据过期策略
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Lifecycle *SmartOptimizerLifecyclePolicy `json:"Lifecycle,omitnil,omitempty" name:"Lifecycle"`
 
@@ -16290,11 +17053,18 @@ type SmartOptimizerPolicy struct {
 	// SmartOptimizerChangeTablePolicy
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ChangeTable *SmartOptimizerChangeTablePolicy `json:"ChangeTable,omitnil,omitempty" name:"ChangeTable"`
+
+	// 表过期策略
+	TableExpiration *TableExpirationPolicy `json:"TableExpiration,omitnil,omitempty" name:"TableExpiration"`
 }
 
 type SmartOptimizerWrittenPolicy struct {
 	// none/enable/disable/default
 	WrittenEnable *string `json:"WrittenEnable,omitnil,omitempty" name:"WrittenEnable"`
+
+	// 用户自定义高级参数
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AdvancePolicy *WrittenAdvancePolicy `json:"AdvancePolicy,omitnil,omitempty" name:"AdvancePolicy"`
 }
 
 type SmartPolicy struct {
@@ -16333,6 +17103,17 @@ type Sort struct {
 
 	// 是否按照ASC排序，否则DESC排序
 	Asc *bool `json:"Asc,omitnil,omitempty" name:"Asc"`
+}
+
+type SortOrder struct {
+	// sort的数据表列名称
+	Column *string `json:"Column,omitnil,omitempty" name:"Column"`
+
+	// 按照升序或者降序进行排序
+	SortDirection *string `json:"SortDirection,omitnil,omitempty" name:"SortDirection"`
+
+	// null值放在开头或者末尾
+	NullOrder *string `json:"NullOrder,omitnil,omitempty" name:"NullOrder"`
 }
 
 type SparkJobInfo struct {
@@ -16555,6 +17336,9 @@ type SparkSessionInfo struct {
 
 	// 总规格最大
 	TotalSpecMax *int64 `json:"TotalSpecMax,omitnil,omitempty" name:"TotalSpecMax"`
+
+	// 状态，STARTING、RUNNING、TERMINATED
+	State *string `json:"State,omitnil,omitempty" name:"State"`
 }
 
 type SpecInfo struct {
@@ -17119,6 +17903,14 @@ type TableBaseInfo struct {
 	PrimaryKeys []*string `json:"PrimaryKeys,omitnil,omitempty" name:"PrimaryKeys"`
 }
 
+type TableExpirationPolicy struct {
+	// 是否启用策略
+	Enabled *bool `json:"Enabled,omitnil,omitempty" name:"Enabled"`
+
+	// 表过期时间，单位：天
+	Expiration *uint64 `json:"Expiration,omitnil,omitempty" name:"Expiration"`
+}
+
 type TableInfo struct {
 	// 数据表配置信息。
 	TableBaseInfo *TableBaseInfo `json:"TableBaseInfo,omitnil,omitempty" name:"TableBaseInfo"`
@@ -17194,6 +17986,249 @@ type Task struct {
 
 	// Spark SQL查询任务
 	SparkSQLTask *SQLTask `json:"SparkSQLTask,omitnil,omitempty" name:"SparkSQLTask"`
+}
+
+type TaskFullRespInfo struct {
+	// <p>任务所属Database的名称。</p>
+	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
+
+	// <p>任务数据量。</p>
+	DataAmount *int64 `json:"DataAmount,omitnil,omitempty" name:"DataAmount"`
+
+	// <p>任务Id。</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>计算耗时，单位： ms</p>
+	UsedTime *int64 `json:"UsedTime,omitnil,omitempty" name:"UsedTime"`
+
+	// <p>任务输出路径。</p>
+	OutputPath *string `json:"OutputPath,omitnil,omitempty" name:"OutputPath"`
+
+	// <p>任务创建时间。</p>
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>任务状态：0 初始化， 1 执行中， 2 执行成功，3 数据写入中，4 排队中。-1 执行失败，-3 已取消。</p>
+	State *int64 `json:"State,omitnil,omitempty" name:"State"`
+
+	// <p>任务SQL类型，DDL|DML等</p>
+	SQLType *string `json:"SQLType,omitnil,omitempty" name:"SQLType"`
+
+	// <p>任务SQL语句</p>
+	SQL *string `json:"SQL,omitnil,omitempty" name:"SQL"`
+
+	// <p>结果是否过期。</p>
+	ResultExpired *bool `json:"ResultExpired,omitnil,omitempty" name:"ResultExpired"`
+
+	// <p>数据影响统计信息。</p>
+	RowAffectInfo *string `json:"RowAffectInfo,omitnil,omitempty" name:"RowAffectInfo"`
+
+	// <p>任务结果数据表。</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DataSet *string `json:"DataSet,omitnil,omitempty" name:"DataSet"`
+
+	// <p>失败信息, 例如：errorMessage。该字段已废弃。</p>
+	Error *string `json:"Error,omitnil,omitempty" name:"Error"`
+
+	// <p>任务执行进度num/100(%)</p>
+	Percentage *int64 `json:"Percentage,omitnil,omitempty" name:"Percentage"`
+
+	// <p>任务执行输出信息。</p>
+	OutputMessage *string `json:"OutputMessage,omitnil,omitempty" name:"OutputMessage"`
+
+	// <p>执行SQL的引擎类型</p>
+	TaskType *string `json:"TaskType,omitnil,omitempty" name:"TaskType"`
+
+	// <p>任务进度明细</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ProgressDetail *string `json:"ProgressDetail,omitnil,omitempty" name:"ProgressDetail"`
+
+	// <p>任务结束时间</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>计算资源id</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DataEngineId *string `json:"DataEngineId,omitnil,omitempty" name:"DataEngineId"`
+
+	// <p>执行sql的子uin</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	OperateUin *string `json:"OperateUin,omitnil,omitempty" name:"OperateUin"`
+
+	// <p>计算资源名字</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
+
+	// <p>导入类型是本地导入还是cos</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InputType *string `json:"InputType,omitnil,omitempty" name:"InputType"`
+
+	// <p>导入配置</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InputConf *string `json:"InputConf,omitnil,omitempty" name:"InputConf"`
+
+	// <p>数据条数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DataNumber *int64 `json:"DataNumber,omitnil,omitempty" name:"DataNumber"`
+
+	// <p>查询数据能不能下载</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CanDownload *bool `json:"CanDownload,omitnil,omitempty" name:"CanDownload"`
+
+	// <p>用户别名</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UserAlias *string `json:"UserAlias,omitnil,omitempty" name:"UserAlias"`
+
+	// <p>spark应用作业名</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SparkJobName *string `json:"SparkJobName,omitnil,omitempty" name:"SparkJobName"`
+
+	// <p>spark应用作业Id</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SparkJobId *string `json:"SparkJobId,omitnil,omitempty" name:"SparkJobId"`
+
+	// <p>spark应用入口jar文件</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SparkJobFile *string `json:"SparkJobFile,omitnil,omitempty" name:"SparkJobFile"`
+
+	// <p>spark ui url</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UiUrl *string `json:"UiUrl,omitnil,omitempty" name:"UiUrl"`
+
+	// <p>任务耗时，单位： ms</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TotalTime *int64 `json:"TotalTime,omitnil,omitempty" name:"TotalTime"`
+
+	// <p>spark app job执行task的程序入口参数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CmdArgs *string `json:"CmdArgs,omitnil,omitempty" name:"CmdArgs"`
+
+	// <p>集群镜像大版本名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ImageVersion *string `json:"ImageVersion,omitnil,omitempty" name:"ImageVersion"`
+
+	// <p>driver规格：small,medium,large,xlarge；内存型(引擎类型)：m.small,m.medium,m.large,m.xlarge</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DriverSize *string `json:"DriverSize,omitnil,omitempty" name:"DriverSize"`
+
+	// <p>executor规格：small,medium,large,xlarge；内存型(引擎类型)：m.small,m.medium,m.large,m.xlarge</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ExecutorSize *string `json:"ExecutorSize,omitnil,omitempty" name:"ExecutorSize"`
+
+	// <p>指定executor数量，最小值为1，最大值小于集群规格</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ExecutorNums *uint64 `json:"ExecutorNums,omitnil,omitempty" name:"ExecutorNums"`
+
+	// <p>指定executor max数量（动态配置场景下），最小值为1，最大值小于集群规格（当ExecutorMaxNumbers小于ExecutorNums时，改值设定为ExecutorNums）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ExecutorMaxNumbers *uint64 `json:"ExecutorMaxNumbers,omitnil,omitempty" name:"ExecutorMaxNumbers"`
+
+	// <p>任务公共指标数据</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CommonMetrics *CommonMetrics `json:"CommonMetrics,omitnil,omitempty" name:"CommonMetrics"`
+
+	// <p>spark任务指标数据</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SparkMonitorMetrics *SparkMonitorMetrics `json:"SparkMonitorMetrics,omitnil,omitempty" name:"SparkMonitorMetrics"`
+
+	// <p>presto任务指标数据</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PrestoMonitorMetrics *PrestoMonitorMetrics `json:"PrestoMonitorMetrics,omitnil,omitempty" name:"PrestoMonitorMetrics"`
+
+	// <p>结果文件格式：默认为csv</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResultFormat *string `json:"ResultFormat,omitnil,omitempty" name:"ResultFormat"`
+
+	// <p>引擎类型，SparkSQL：SparkSQL 引擎；SparkBatch：Spark作业引擎；PrestoSQL：Presto引擎</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EngineTypeDetail *string `json:"EngineTypeDetail,omitnil,omitempty" name:"EngineTypeDetail"`
+
+	// <p>spark引擎资源组名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
+
+	// <p>任务来源信息,如thirdPartyApi,dataExploration, sparkAppTask等</p>
+	Source *string `json:"Source,omitnil,omitempty" name:"Source"`
+
+	// <p>子渠道信息，一般由第三方调用定义</p>
+	SourceExtra *string `json:"SourceExtra,omitnil,omitempty" name:"SourceExtra"`
+
+	// <p>创建人uin</p>
+	CreatorUin *string `json:"CreatorUin,omitnil,omitempty" name:"CreatorUin"`
+
+	// <p>创建人名字</p>
+	CreatorAlias *string `json:"CreatorAlias,omitnil,omitempty" name:"CreatorAlias"`
+
+	// <p>引擎参数</p>
+	CustomizedConf *string `json:"CustomizedConf,omitnil,omitempty" name:"CustomizedConf"`
+
+	// <p>单位秒，累计 CPU* 秒 ( 累计 CPU * 时 = 累计 CPU* 秒/ 3600)，统计参与计算所用 Spark Executor 每个 core 的 CPU 执行时长总和<br>示例值：4329</p>
+	TaskTimeSum *int64 `json:"TaskTimeSum,omitnil,omitempty" name:"TaskTimeSum"`
+
+	// <p>引擎执行时间</p>
+	StageStartTime *int64 `json:"StageStartTime,omitnil,omitempty" name:"StageStartTime"`
+
+	// <p>数据扫描条数</p>
+	InputRecordsSum *int64 `json:"InputRecordsSum,omitnil,omitempty" name:"InputRecordsSum"`
+
+	// <p>健康状态</p>
+	AnalysisStatusType *int64 `json:"AnalysisStatusType,omitnil,omitempty" name:"AnalysisStatusType"`
+
+	// <p>输出总行数</p>
+	OutputRecordsSum *int64 `json:"OutputRecordsSum,omitnil,omitempty" name:"OutputRecordsSum"`
+
+	// <p>输出总大小</p>
+	OutputBytesSum *int64 `json:"OutputBytesSum,omitnil,omitempty" name:"OutputBytesSum"`
+
+	// <p>输出文件个数</p>
+	OutputFilesNum *int64 `json:"OutputFilesNum,omitnil,omitempty" name:"OutputFilesNum"`
+
+	// <p>输出小文件个数</p>
+	OutputSmallFilesNum *int64 `json:"OutputSmallFilesNum,omitnil,omitempty" name:"OutputSmallFilesNum"`
+
+	// <p>数据shuffle行数</p>
+	ShuffleReadRecordsSum *int64 `json:"ShuffleReadRecordsSum,omitnil,omitempty" name:"ShuffleReadRecordsSum"`
+
+	// <p>数据shuffle大小</p>
+	ShuffleReadBytesSum *int64 `json:"ShuffleReadBytesSum,omitnil,omitempty" name:"ShuffleReadBytesSum"`
+
+	// <p>spark作业id</p>
+	SparkAppId *string `json:"SparkAppId,omitnil,omitempty" name:"SparkAppId"`
+
+	// <p>任务大类，DLC2.0中任务区分为两大类，sql任务和作业任务</p>
+	TaskCategory *string `json:"TaskCategory,omitnil,omitempty" name:"TaskCategory"`
+
+	// <p>任务名称</p>
+	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
+
+	// <p>引擎类型，用做任务详情页跳转引擎tab</p>
+	EngineType *string `json:"EngineType,omitnil,omitempty" name:"EngineType"`
+
+	// <p>引擎是否支持洞察数据采集</p>
+	EngineHasListenerConfig *bool `json:"EngineHasListenerConfig,omitnil,omitempty" name:"EngineHasListenerConfig"`
+
+	// <p>spark引擎资源组id</p>
+	ResourceGroupId *string `json:"ResourceGroupId,omitnil,omitempty" name:"ResourceGroupId"`
+
+	// <p>任务计算耗时</p>
+	JobTimeSum *int64 `json:"JobTimeSum,omitnil,omitempty" name:"JobTimeSum"`
+
+	// <p>任务启动耗时</p>
+	LaunchTime *string `json:"LaunchTime,omitnil,omitempty" name:"LaunchTime"`
+
+	// <p>Gpu Driver 规格</p>
+	GpuDriverSize *int64 `json:"GpuDriverSize,omitnil,omitempty" name:"GpuDriverSize"`
+
+	// <p>Gpu Executor 规格</p>
+	GpuExecutorSize *int64 `json:"GpuExecutorSize,omitnil,omitempty" name:"GpuExecutorSize"`
+
+	// <p>ShuffleWrite数据量</p>
+	ShuffleWriteBytesSum *int64 `json:"ShuffleWriteBytesSum,omitnil,omitempty" name:"ShuffleWriteBytesSum"`
+
+	// <p>活跃core</p>
+	ActiveCore *int64 `json:"ActiveCore,omitnil,omitempty" name:"ActiveCore"`
+
+	// <p>排队时间</p><p>单位：毫秒</p>
+	QueueTime *int64 `json:"QueueTime,omitnil,omitempty" name:"QueueTime"`
 }
 
 type TaskMonitorInfo struct {
@@ -18744,6 +19779,9 @@ type UserDetailInfo struct {
 	// 数据源权限集合
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	CatalogPolicyInfo *Policys `json:"CatalogPolicyInfo,omitnil,omitempty" name:"CatalogPolicyInfo"`
+
+	// 模型权限集合
+	ModelPolicyInfo *Policys `json:"ModelPolicyInfo,omitnil,omitempty" name:"ModelPolicyInfo"`
 }
 
 type UserIdSetOfWorkGroupId struct {
@@ -18804,6 +19842,9 @@ type UserMessage struct {
 
 	// 用户别名
 	UserAlias *string `json:"UserAlias,omitnil,omitempty" name:"UserAlias"`
+
+	// 用户来源类型TencentAccount（普通腾讯云用户） / EntraAccount（微软用户）
+	AccountType *string `json:"AccountType,omitnil,omitempty" name:"AccountType"`
 }
 
 type UserRole struct {
@@ -18955,6 +19996,12 @@ type WorkGroupDetailInfo struct {
 	// 数据目录权限集
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	CatalogPolicyInfo *Policy `json:"CatalogPolicyInfo,omitnil,omitempty" name:"CatalogPolicyInfo"`
+
+	// 数据目录权限
+	DataCatalogPolicyInfo *Policys `json:"DataCatalogPolicyInfo,omitnil,omitempty" name:"DataCatalogPolicyInfo"`
+
+	// 模型权限
+	ModelPolicyInfo *Policys `json:"ModelPolicyInfo,omitnil,omitempty" name:"ModelPolicyInfo"`
 }
 
 type WorkGroupIdSetOfUserId struct {
@@ -19017,4 +20064,40 @@ type WorkGroups struct {
 
 	// 工作组总数
 	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+}
+
+type WrittenAdvancePolicy struct {
+	// 是否启用合并
+	CompactEnable *string `json:"CompactEnable,omitnil,omitempty" name:"CompactEnable"`
+
+	// 是否启用历史数据清理
+	DeleteEnable *string `json:"DeleteEnable,omitnil,omitempty" name:"DeleteEnable"`
+
+	// 合并最新文件数量
+	MinInputFiles *int64 `json:"MinInputFiles,omitnil,omitempty" name:"MinInputFiles"`
+
+	// 合并文件目录文件大小
+	TargetFileSizeBytes *int64 `json:"TargetFileSizeBytes,omitnil,omitempty" name:"TargetFileSizeBytes"`
+
+	// 保留过期时间的快照数量
+	RetainLast *int64 `json:"RetainLast,omitnil,omitempty" name:"RetainLast"`
+
+	// 快照过期时间
+	BeforeDays *int64 `json:"BeforeDays,omitnil,omitempty" name:"BeforeDays"`
+
+	// 快照过期执行周期
+	ExpiredSnapshotsIntervalMin *int64 `json:"ExpiredSnapshotsIntervalMin,omitnil,omitempty" name:"ExpiredSnapshotsIntervalMin"`
+
+	// 移除孤立文件执行周期
+	RemoveOrphanIntervalMin *int64 `json:"RemoveOrphanIntervalMin,omitnil,omitempty" name:"RemoveOrphanIntervalMin"`
+
+	// 是否开启COW表合并
+	CowCompactEnable *string `json:"CowCompactEnable,omitnil,omitempty" name:"CowCompactEnable"`
+
+	// 文件合并策略
+	CompactStrategy *string `json:"CompactStrategy,omitnil,omitempty" name:"CompactStrategy"`
+
+	// sort合并策略的规则定义
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SortOrders []*SortOrder `json:"SortOrders,omitnil,omitempty" name:"SortOrders"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.129
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1306,7 +1306,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc/v20180410
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb/v20180411
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.1.35
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.132
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124

--- a/website/docs/r/dlc_dms_table.html.markdown
+++ b/website/docs/r/dlc_dms_table.html.markdown
@@ -1,0 +1,266 @@
+---
+subcategory: "Data Lake Compute(DLC)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_dlc_dms_table"
+sidebar_current: "docs-tencentcloud-resource-dlc_dms_table"
+description: |-
+  Provides a resource to create a DLC DMS table
+---
+
+# tencentcloud_dlc_dms_table
+
+Provides a resource to create a DLC DMS table
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_dlc_dms_table" "example" {
+  db_name = "tf_example_db"
+  name    = "tf_example_table"
+  type    = "EXTERNAL_TABLE"
+
+  asset {
+    name        = "tf_example_table"
+    description = "tf example dlc dms table"
+    owner       = "root"
+  }
+
+  columns {
+    name     = "id"
+    type     = "bigint"
+    position = 1
+  }
+
+  columns {
+    name     = "name"
+    type     = "string"
+    position = 2
+  }
+
+  sds {
+    location      = "cosn://tf-example-bucket/example/"
+    input_format  = "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat"
+    serde_lib     = "org.apache.hadoop.hive.serde2.avro.AvroSerDe"
+    serde_params {
+      key   = "serialization.format"
+      value = "1"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `db_name` - (Required, String) Database name.
+* `name` - (Required, String) Table name.
+* `asset` - (Optional, List) Basic object.
+* `columns` - (Optional, List) Columns.
+* `data_update_time` - (Optional, String) Data update time.
+* `datasource_connection_name` - (Optional, String) Data source connection name.
+* `delete_data` - (Optional, Bool) Whether to delete data.
+* `env_props` - (Optional, List) Environment attributes.
+* `last_access_time` - (Optional, String) Last access time.
+* `life_time` - (Optional, Int) Life cycle.
+* `partition_keys` - (Optional, List) Partition keys.
+* `partitions` - (Optional, List) Partitions.
+* `record_count` - (Optional, Int) Record count.
+* `sds` - (Optional, List) Storage object.
+* `storage_size` - (Optional, Int) Storage size.
+* `struct_update_time` - (Optional, String) Structure update time.
+* `type` - (Optional, String) Table type: EXTERNAL_TABLE, VIRTUAL_VIEW, MATERIALIZED_VIEW.
+* `view_expanded_text` - (Optional, String) View expanded text.
+* `view_original_text` - (Optional, String) View original text.
+
+The `asset` object supports the following:
+
+* `biz_params` - (Optional, List) Additional business attributes.
+* `catalog` - (Optional, String) Data catalog.
+* `create_time` - (Optional, String) Create time.
+* `data_version` - (Optional, Int) Data version.
+* `datasource_id` - (Optional, Int) Data source primary key.
+* `description` - (Optional, String) Description.
+* `guid` - (Optional, String) Object GUID value.
+* `id` - (Optional, Int) Primary key.
+* `modified_time` - (Optional, String) Modified time.
+* `name` - (Optional, String) Name.
+* `owner_account` - (Optional, String) Object owner account.
+* `owner` - (Optional, String) Object owner.
+* `params` - (Optional, List) Additional attributes.
+* `perm_values` - (Optional, List) Permissions.
+
+The `biz_params` object of `asset` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `biz_params` object of `columns` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `biz_params` object of `dms_cols` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `biz_params` object of `partition_keys` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `columns` object supports the following:
+
+* `biz_params` - (Optional, List) Business parameters.
+* `description` - (Optional, String) Description.
+* `is_partition` - (Optional, Bool) Whether partition.
+* `name` - (Optional, String) Name.
+* `params` - (Optional, List) Additional parameters.
+* `position` - (Optional, Int) Position.
+* `type` - (Optional, String) Type.
+
+The `dms_cols` object of `sds` supports the following:
+
+* `biz_params` - (Optional, List) Business parameters.
+* `description` - (Optional, String) Description.
+* `is_partition` - (Optional, Bool) Whether partition.
+* `name` - (Optional, String) Name.
+* `params` - (Optional, List) Additional parameters.
+* `position` - (Optional, Int) Position.
+* `type` - (Optional, String) Type.
+
+The `env_props` object supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `params` object of `asset` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `params` object of `columns` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `params` object of `dms_cols` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `params` object of `partition_keys` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `params` object of `partitions` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `params` object of `sds` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `partition_keys` object supports the following:
+
+* `biz_params` - (Optional, List) Business parameters.
+* `description` - (Optional, String) Description.
+* `is_partition` - (Optional, Bool) Whether partition.
+* `name` - (Optional, String) Name.
+* `params` - (Optional, List) Additional parameters.
+* `position` - (Optional, Int) Position.
+* `type` - (Optional, String) Type.
+
+The `partitions` object supports the following:
+
+* `create_time` - (Optional, String) Create time.
+* `data_version` - (Optional, Int) Data version.
+* `database_name` - (Optional, String) Database name.
+* `datasource_connection_name` - (Optional, String) Data source connection name.
+* `last_access_time` - (Optional, String) Last access time.
+* `modified_time` - (Optional, String) Modified time.
+* `name` - (Optional, String) Partition name.
+* `params` - (Optional, List) Additional attributes.
+* `record_count` - (Optional, Int) Record count.
+* `schema_name` - (Optional, String) Schema name.
+* `sds` - (Optional, List) Storage object.
+* `storage_size` - (Optional, Int) Storage size.
+* `table_name` - (Optional, String) Table name.
+* `values` - (Optional, List) Value list.
+
+The `perm_values` object of `asset` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `sds` object of `partitions` supports the following:
+
+* `bucket_cols` - (Optional, List) Bucket columns.
+* `compressed` - (Optional, Bool) Whether compressed.
+* `dms_cols` - (Optional, List) Columns.
+* `input_format` - (Optional, String) Input format.
+* `location` - (Optional, String) Storage location.
+* `num_buckets` - (Optional, Int) Bucket count.
+* `output_format` - (Optional, String) Output format.
+* `params` - (Optional, List) Additional parameters.
+* `serde_lib` - (Optional, String) Serde lib.
+* `serde_name` - (Optional, String) Serde name.
+* `serde_params` - (Optional, List) Serde parameters.
+* `sort_cols` - (Optional, List) Column sort (Expired).
+* `sort_columns` - (Optional, List) Column sort fields.
+* `stored_as_sub_directories` - (Optional, Bool) Whether has sub directories.
+
+The `sds` object supports the following:
+
+* `bucket_cols` - (Optional, List) Bucket columns.
+* `compressed` - (Optional, Bool) Whether compressed.
+* `dms_cols` - (Optional, List) Columns.
+* `input_format` - (Optional, String) Input format.
+* `location` - (Optional, String) Storage location.
+* `num_buckets` - (Optional, Int) Bucket count.
+* `output_format` - (Optional, String) Output format.
+* `params` - (Optional, List) Additional parameters.
+* `serde_lib` - (Optional, String) Serde lib.
+* `serde_name` - (Optional, String) Serde name.
+* `serde_params` - (Optional, List) Serde parameters.
+* `sort_cols` - (Optional, List) Column sort (Expired).
+* `sort_columns` - (Optional, List) Column sort fields.
+* `stored_as_sub_directories` - (Optional, Bool) Whether has sub directories.
+
+The `serde_params` object of `sds` supports the following:
+
+* `key` - (Optional, String) Key.
+* `value` - (Optional, String) Value.
+
+The `sort_cols` object of `sds` supports the following:
+
+* `col` - (Optional, String) Column name.
+* `order` - (Optional, Int) Order.
+
+The `sort_columns` object of `sds` supports the following:
+
+* `col` - (Optional, String) Column name.
+* `order` - (Optional, Int) Order.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `retention` - Hive retention version.
+* `schema_name` - Schema name.
+
+
+## Import
+
+DLC DMS table can be imported using the db_name#name, e.g.
+
+```
+terraform import tencentcloud_dlc_dms_table.example tf_example_db#tf_example_table
+```
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -2608,6 +2608,9 @@
                                     <a href="/docs/providers/tencentcloud/r/dlc_datasource_house_attachment.html">tencentcloud_dlc_datasource_house_attachment</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/r/dlc_dms_table.html">tencentcloud_dlc_dms_table</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/r/dlc_modify_data_engine_description_operation.html">tencentcloud_dlc_modify_data_engine_description_operation</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add a new Terraform resource tencentcloud_dlc_dms_table to manage the full CRUD lifecycle of DLC DMS metadata tables, including table info, columns, partition keys, partitions, storage descriptors (Sds), view text, and datasource connection. Uses composite ID (db_name + table_name). Registers the resource in provider.go and provider.md. Includes unit tests with gomonkey mocking.