### PR TITLE
feat(dnspod): [136087766] tencentcloud_dnspod_record modify the update logic for the  ⁠remark⁠  field

### DIFF
--- a/.changelog/4302.txt
+++ b/.changelog/4302.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_dnspod_record: modify the update logic for the `⁠remark`⁠ field
+```

--- a/tencentcloud/services/dnspod/resource_tc_dnspod_record.go
+++ b/tencentcloud/services/dnspod/resource_tc_dnspod_record.go
@@ -120,7 +120,6 @@ func resourceTencentCloudDnspodRecordCreate(d *schema.ResourceData, meta interfa
 		recordId uint64
 	)
 	request := dnspod.NewCreateRecordRequest()
-	requestRemark := dnspod.NewModifyRecordRemarkRequest()
 
 	domain := d.Get("domain").(string)
 	recordType := d.Get("record_type").(string)
@@ -143,6 +142,10 @@ func resourceTencentCloudDnspodRecordCreate(d *schema.ResourceData, meta interfa
 	}
 	request.Status = &status
 
+	if v, ok := d.GetOk("remark"); ok {
+		request.Remark = helper.String(v.(string))
+	}
+
 	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
 		response, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDnsPodClient().CreateRecord(request)
 		if e != nil {
@@ -156,23 +159,6 @@ func resourceTencentCloudDnspodRecordCreate(d *schema.ResourceData, meta interfa
 	if err != nil {
 		log.Printf("[CRITAL]%s create DnsPod record failed, reason:%s\n", logId, err.Error())
 		return err
-	}
-
-	if v, ok := d.GetOk("remark"); ok {
-		requestRemark.Domain = helper.String(domain)
-		requestRemark.RecordId = helper.Uint64(recordId)
-		requestRemark.Remark = helper.String(v.(string))
-		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			_, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDnsPodClient().ModifyRecordRemark(requestRemark)
-			if e != nil {
-				return tccommon.RetryError(e)
-			}
-			return nil
-		})
-		if err != nil {
-			log.Printf("[CRITAL]%s create DnsPod record, modify remark failed, reason:%s\n", logId, err.Error())
-			return err
-		}
 	}
 
 	return resourceTencentCloudDnspodRecordRead(d, meta)
@@ -259,7 +245,6 @@ func resourceTencentCloudDnspodRecordRead(d *schema.ResourceData, meta interface
 func resourceTencentCloudDnspodRecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	defer tccommon.LogElapsed("resource.tencentcloud_dnspod_record.update")()
 
-	logId := tccommon.GetLogId(tccommon.ContextNil)
 	id := d.Id()
 	items := strings.Split(id, tccommon.FILED_SP)
 	if len(items) < 2 {
@@ -271,7 +256,6 @@ func resourceTencentCloudDnspodRecordUpdate(d *schema.ResourceData, meta interfa
 		return err
 	}
 	request := dnspod.NewModifyRecordRequest()
-	requestRemark := dnspod.NewModifyRecordRemarkRequest()
 	request.Domain = &domain
 	request.RecordId = helper.IntUint64(recordId)
 	recordType := d.Get("record_type").(string)
@@ -298,6 +282,10 @@ func resourceTencentCloudDnspodRecordUpdate(d *schema.ResourceData, meta interfa
 		weight := v.(int)
 		request.Weight = helper.IntUint64(weight)
 	}
+	if v, ok := d.GetOk("remark"); ok {
+		remark := v.(string)
+		request.Remark = &remark
+	}
 	d.Partial(true)
 	err = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
 		_, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDnsPodClient().ModifyRecord(request)
@@ -309,24 +297,6 @@ func resourceTencentCloudDnspodRecordUpdate(d *schema.ResourceData, meta interfa
 
 	if err != nil {
 		return err
-	}
-
-	if d.HasChange("remark") {
-		remark := d.Get("remark").(string)
-		requestRemark.Domain = helper.String(domain)
-		requestRemark.Remark = helper.String(remark)
-		requestRemark.RecordId = helper.IntUint64(recordId)
-		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			_, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDnsPodClient().ModifyRecordRemark(requestRemark)
-			if e != nil {
-				return tccommon.RetryError(e)
-			}
-			return nil
-		})
-		if err != nil {
-			log.Printf("[CRITAL]%s mdofify DnsPod record remark failed, reason:%s\n", logId, err.Error())
-			return err
-		}
 	}
 
 	d.Partial(false)


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
