### PR TITLE
fix(tke): [136031033] `tencentcloud_kubernetes_native_node_pool` update code logic

### DIFF
--- a/.changelog/4307.txt
+++ b/.changelog/4307.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_kubernetes_native_node_pool: update code logic
+```

--- a/tencentcloud/services/tke/resource_tc_kubernetes_native_node_pool.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_native_node_pool.go
@@ -1014,8 +1014,8 @@ func resourceTencentCloudKubernetesNativeNodePoolRead(d *schema.ResourceData, me
 	}
 
 	if respData == nil {
+		log.Printf("[WARN]%s resource `tencentcloud_kubernetes_native_node_pool` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
-		log.Printf("[WARN]%s resource `kubernetes_native_node_pool` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		return nil
 	}
 
@@ -1830,7 +1830,9 @@ func resourceTencentCloudKubernetesNativeNodePoolDelete(d *schema.ResourceData, 
 		return err
 	}
 
-	// wait for delete ok
+	_ = response
+
+	// wait node pool for delete ok
 	service := TkeService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 	err = resource.Retry(5*tccommon.ReadRetryTimeout, func() *resource.RetryError {
 		respData, errRet := service.DescribeKubernetesNativeNodePoolById(ctx, clusterId, nodePoolId)
@@ -1848,6 +1850,33 @@ func resourceTencentCloudKubernetesNativeNodePoolDelete(d *schema.ResourceData, 
 		return nil
 	})
 
-	_ = response
+	if err != nil {
+		log.Printf("[CRITAL]%s delete kubernetes native node pool failed, reason:%+v", logId, err)
+		return err
+	}
+
+	// wait node pool instances for delete ok
+	err = resource.Retry(5*tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		respData, errRet := service.DescribeKubernetesClusteInstancesById(ctx, clusterId, nodePoolId)
+		if errRet != nil {
+			errCode := errRet.(*sdkErrors.TencentCloudSDKError).Code
+			if strings.Contains(errCode, "InternalError") {
+				return nil
+			}
+			return tccommon.RetryError(errRet, tccommon.InternalError)
+		}
+
+		if len(respData.InstanceSet) == 0 {
+			return nil
+		}
+
+		return resource.NonRetryableError(fmt.Errorf("native node pool instances still deleteing"))
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s delete kubernetes native node pool failed, reason:%+v", logId, err)
+		return err
+	}
+
 	return nil
 }

--- a/tencentcloud/services/tke/service_tencentcloud_tke.go
+++ b/tencentcloud/services/tke/service_tencentcloud_tke.go
@@ -3948,6 +3948,37 @@ func (me *TkeService) DescribeKubernetesClusterMasterAttachmentByIds(ctx context
 	return
 }
 
+func (me *TkeService) DescribeKubernetesClusteInstancesById(ctx context.Context, clusterId, nodePoolId string) (ret *tke.DescribeClusterInstancesResponseParams, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := tke.NewDescribeClusterInstancesRequest()
+	request.ClusterId = helper.String(clusterId)
+	request.Filters = []*tke.Filter{
+		{
+			Name:   common.StringPtr("nodepool-id"),
+			Values: common.StringPtrs([]string{nodePoolId}),
+		},
+	}
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	ratelimit.Check(request.GetAction())
+	response, err := me.client.UseTkeV20180525Client().DescribeClusterInstances(request)
+	if err != nil {
+		errRet = err
+		return
+	}
+
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+	ret = response.Response
+	return
+}
+
 func (me *TkeService) DescribeKubernetesClusterPendingReleaseById(ctx context.Context, clusterId, clusterReleaseId string) (ret *tke.PendingRelease, errRet error) {
 	logId := tccommon.GetLogId(ctx)
 


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
