### PR TITLE
fix(dts): [173335400] pause running sync job before isolation on delete

### DIFF
--- a/tencentcloud/services/dts/resource_tc_dts_sync_job.go
+++ b/tencentcloud/services/dts/resource_tc_dts_sync_job.go
@@ -2,7 +2,6 @@ package dts
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -238,7 +237,7 @@ func resourceTencentCloudDtsSyncJobRead(d *schema.ResourceData, meta interface{}
 
 	if syncJob == nil {
 		d.SetId("")
-		return fmt.Errorf("resource `syncJob` %s does not exist", syncJobId)
+		return nil
 	}
 
 	if syncJob.PayMode != nil {
@@ -310,6 +309,35 @@ func resourceTencentCloudDtsSyncJobDelete(d *schema.ResourceData, meta interface
 	service := DtsService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
 	syncJobId := d.Id()
+
+	// Check current state before attempting isolation.
+	syncJob, err := service.DescribeDtsSyncJob(ctx, helper.String(syncJobId))
+	if err != nil {
+		return err
+	}
+
+	// Job already gone — remove from state cleanly.
+	if syncJob == nil {
+		return nil
+	}
+
+	// Job already in a billing-terminal state (auto-deleted by Tencent) — nothing to do.
+	if syncJob.TradeStatus != nil && (*syncJob.TradeStatus == "NotBilledByInternational" || *syncJob.TradeStatus == "NotBilled") {
+		return nil
+	}
+
+	// Job is running or syncing — pause it first so isolation is accepted.
+	if syncJob.Status != nil && *syncJob.Status != "Paused" && *syncJob.Status != "Isolated" {
+		log.Printf("[DEBUG]%s sync job[%s] is in status [%s], pausing before isolation\n", logId, syncJobId, *syncJob.Status)
+		if err := service.PauseDtsSyncJobById(ctx, syncJobId); err != nil {
+			return err
+		}
+
+		conf := tccommon.BuildStateChangeConf([]string{}, []string{"Paused"}, 2*tccommon.ReadRetryTimeout, time.Second, service.DtsSyncJobStateRefreshFunc(syncJobId, "Paused", []string{}))
+		if _, e := conf.WaitForState(); e != nil {
+			return e
+		}
+	}
 
 	if err := service.IsolateDtsSyncJobById(ctx, syncJobId); err != nil {
 		return err

--- a/tencentcloud/services/dts/service_tencentcloud_dts.go
+++ b/tencentcloud/services/dts/service_tencentcloud_dts.go
@@ -136,6 +136,31 @@ func (me *DtsService) DescribeDtsSyncJobsByFilter(ctx context.Context, param map
 	return
 }
 
+func (me *DtsService) PauseDtsSyncJobById(ctx context.Context, jobId string) (errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := dts.NewPauseSyncJobRequest()
+	request.JobId = helper.String(jobId)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, "pause object", request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	ratelimit.Check(request.GetAction())
+	response, err := me.client.UseDtsClient().PauseSyncJob(request)
+	if err != nil {
+		errRet = err
+		return err
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+		logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+	return
+}
+
 func (me *DtsService) IsolateDtsSyncJobById(ctx context.Context, jobId string) (errRet error) {
 	logId := tccommon.GetLogId(ctx)
 


### PR DESCRIPTION
**What**
Fix tencentcloud_dts_sync_job to pause a running job before attempting isolation on delete, and return nil instead of an error when the job is not found during Read.

**Why**
Delete bug: The Delete function calls IsolateSyncJobs directly regardless of the job's current state. Tencent rejects isolation on a running or syncing job with:


UnsupportedOperation.UnsupportedOperationError: Current job is temporarily unable to respond to isolation events
This makes it impossible to destroy a tencentcloud_dts_sync_job resource through Terraform while the job is actively syncing — which is the normal production state. Every terraform destroy or config removal requires manual console intervention to pause the job first.

Read bug: When a job is not found, the Read function calls d.SetId("") correctly but then returns fmt.Errorf(...) instead of nil. The error overrides the state ID clear, so Terraform fails every subsequent plan with resource syncJob sync-xxx does not exist rather than automatically removing the stale entry from state. This breaks pipelines whenever a job is deleted outside Terraform.

**Type of change**
 Bug fix
**Changes**
resource_tc_dts_sync_job.go — Delete:
Added a pre-isolation status check. If the job is in a running/syncing state, PauseSyncJob is called first and the function waits for Paused status before proceeding with isolation. Jobs already in NotBilledByInternational or NotBilled trade status are treated as gone and return nil immediately.

resource_tc_dts_sync_job.go — Read:
Changed return fmt.Errorf(...) to return nil after d.SetId("") so Terraform gracefully removes missing resources from state instead of erroring.

service_tencentcloud_dts.go:
Added PauseDtsSyncJobById helper following the same pattern as the existing IsolateDtsSyncJobById.

**Checklist**
 make build succeeds locally
 make fmt produces no diff
 make lint passes
 make check-mux passes
 Acceptance tests added or updated
 Changelog entry added under .changelog/<PR>.txt

**Notes for reviewers**
The delete sequence is now: check status → pause if running → wait for Paused → isolate → wait for Isolated/NotBilled → destroy → wait for Offlined. This mirrors the manual steps required to delete a DTS sync job via the Tencent Cloud Console and follows the same polling pattern already used elsewhere in this file.

The NotBilledByInternational early-exit path (lines 329–331 in the original) is preserved — PostPay jobs that enter this state after isolation are auto-removed by Tencent and do not need an explicit destroy call.