### PR TITLE
fix(cynosdb): [135298064] The `instance_name` field supports modification.

### DIFF
--- a/.changelog/4323.txt
+++ b/.changelog/4323.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_cynosdb_cluster: update field descriptions for `instance_name` and `ro_group_sg`
+```

--- a/.changelog/4323.txt
+++ b/.changelog/4323.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-resource/tencentcloud_cynosdb_cluster: update field descriptions for `instance_name` and `ro_group_sg`
+resource/tencentcloud_cynosdb_cluster: support `instance_name` modification via ModifyInstanceName API, update field descriptions for `instance_name` and `ro_group_sg`
+```
+
+```release-note:enhancement
+resource/tencentcloud_cynosdb_cluster_v2: support `instance_name` modification via ModifyInstanceName API
 ```

--- a/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/README.md
+++ b/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/README.md
@@ -1,0 +1,3 @@
+# add-cynosdb-cluster-instance-name-modify
+
+Support instance_name modification for tencentcloud_cynosdb_cluster and tencentcloud_cynosdb_cluster_v2 via ModifyInstanceName API

--- a/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/design.md
+++ b/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`tencentcloud_cynosdb_cluster` 与 `tencentcloud_cynosdb_cluster_v2` 资源中的 `instance_name` 字段当前为 `Computed`，用户无法通过 Terraform 修改实例名称，只能通过控制台单独修改，导致 state 漂移。腾讯云 TDSQL-C MySQL 提供了 `ModifyInstanceName` 接口（cynosdb v20190107），支持对已存在的实例修改名称，请求参数为 `InstanceId` 与 `InstanceName`，同步返回。
+
+服务层方法 `ModifyInstanceName(ctx, instanceId, instanceName)` 已在 `service_tencentcloud_cynosdb.go` 中实现（随 `tencentcloud_cynosdb_readonly_instance` 资源一起合入 master），内部使用 `resource.Retry(tccommon.WriteRetryTimeout, ...)` + `tccommon.RetryError(err)`，可直接复用。
+
+现有代码结构：
+- 资源文件：`tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go`、`resource_tc_cynosdb_cluster_v2.go`
+- Schema 公共函数：`tencentcloud/services/cynosdb/extension_cynosdb.go` 的 `TencentCynosdbInstanceBaseInfo()`
+- 服务层：`tencentcloud/services/cynosdb/service_tencentcloud_cynosdb.go`（已有 `ModifyInstanceName` 方法）
+
+## Goals / Non-Goals
+
+**Goals:**
+- 使 `instance_name` 字段支持就地更新，调用 `ModifyInstanceName` API 完成修改。
+- 复用已有的 `ModifyInstanceName` 服务层方法，无需新增。
+- 保持向后兼容：不改变现有 state 格式与 ID 规则；不填写 `instance_name` 时行为不变。
+
+**Non-Goals:**
+- 不修改 `instance_name` 的 `Computed` 属性（保留 `Computed: true`，同时新增 `Optional: true`）。
+- 不调整其它字段的 schema。
+- 不引入新的 schema 字段。
+- 不新增服务层方法（直接复用 `ModifyInstanceName`）。
+
+## Decisions
+
+### Decision 1: instance_name 改为 Optional + Computed
+
+**选择**：在 `TencentCynosdbInstanceBaseInfo()` 中将 `instance_name` 从 `Computed: true` 改为 `Optional: true, Computed: true`。
+
+**理由**：`ModifyInstanceName` API 支持修改实例名称。保留 `Computed` 保证 Read 仍会从云上回填，新增 `Optional` 允许用户显式配置并触发 Update。
+
+### Decision 2: 在 Update 方法中增加 instance_name 变更分支
+
+**选择**：在 `resourceTencentCloudCynosdbClusterUpdate` 与 `resourceTencentCloudCynosdbClusterV2Update` 中新增 `if d.HasChange("instance_name")` 分支，调用 `cynosdbService.ModifyInstanceName(ctx, instanceId, instanceName)`。
+
+**理由**：与现有 `cluster_name`、`auto_renew_flag` 等分支保持一致的 `d.HasChange` 模式；`instanceId` 已在 update 函数开头从 `d.Get("instance_id").(string)` 获取，直接复用。
+
+### Decision 3: 复用已有服务层方法
+
+**选择**：直接调用 `cynosdbService.ModifyInstanceName(ctx, instanceId, instanceName)`。
+
+**理由**：该方法随 `tencentcloud_cynosdb_readonly_instance` 资源一起合入 master，内部已使用 `WriteRetryTimeout` 重试与 `tccommon.RetryError` 错误包装，符合 provider 现有重试模式，无需重复实现。
+
+### Decision 4: 测试使用 terraform acc 测试套件
+
+**选择**：在 `resource_tc_cynosdb_cluster_test.go` 与 `resource_tc_cynosdb_cluster_v2_test.go` 中新增 `TestAccTencentCloudCynosdbClusterResourceUpdateInstanceName` / `TestAccTencentCloudCynosdbClusterV2ResourceUpdateInstanceName`，使用 terraform acc 测试套件，通过创建集群后修改 `instance_name` 验证 Update 路径。
+
+**理由**：cluster 与 cluster_v2 为现有资源，按代码生成要求"对于修改现有的 terraform 资源的需求，仍然使用 terraform 的测试套件补充测试用例"。新增用例不使用 go test 执行。
+
+## Risks / Trade-offs
+
+- **[风险] 旧 state 中 instance_name 为 Computed，升级后变为 Optional+Computed** → 缓解：`Computed` 保留，不填写该字段时行为与原来完全一致；首次 apply 若用户未配置 `instance_name` 不会触发任何变更。
+- **[风险] ModifyInstanceName 接口偶发失败** → 缓解：通过 `WriteRetryTimeout` 重试机制覆盖。

--- a/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/proposal.md
+++ b/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`tencentcloud_cynosdb_cluster` 与 `tencentcloud_cynosdb_cluster_v2` 资源中的 `instance_name` 字段当前为 `Computed`，无法通过 Terraform 修改实例名称。腾讯云 TDSQL-C MySQL 提供了 `ModifyInstanceName` 接口用于修改实例名称，应在 Terraform 中接入该接口，使 `instance_name` 支持就地更新，避免通过控制台单独修改后 state 漂移。
+
+## What Changes
+
+- 将 `tencentcloud_cynosdb_cluster` 与 `tencentcloud_cynosdb_cluster_v2` 资源中 `instance_name` 字段从 `Computed` 改为 `Optional` + `Computed`，使其支持用户配置与更新。
+- 在 `resourceTencentCloudCynosdbClusterUpdate` 与 `resourceTencentCloudCynosdbClusterV2Update` 中新增 `d.HasChange("instance_name")` 分支，调用云 API `ModifyInstanceName` 完成实例名称修改。
+- 复用 `service_tencentcloud_cynosdb.go` 中已有的 `ModifyInstanceName` 服务方法（`WriteRetryTimeout` 重试）。
+- 更新文档 `website/docs/r/cynosdb_cluster.html.markdown` 与 `website/docs/r/cynosdb_cluster_v2.html.markdown`，将 `instance_name` 标记为可修改（由 `make doc` 在收尾阶段生成）。
+- 在 `.changelog/4323.txt` 中追加 `instance_name` 支持修改的增强说明。
+- 在 `resource_tc_cynosdb_cluster_test.go` 与 `resource_tc_cynosdb_cluster_v2_test.go` 中补充 `instance_name` 更新的 terraform acc 测试用例（cluster 与 cluster_v2 为现有资源，使用 acc 测试套件，不使用 go test 执行）。
+
+## Capabilities
+
+### New Capabilities
+- `cynosdb-cluster-instance-name-modify`: 支持通过 `ModifyInstanceName` 接口就地修改 `tencentcloud_cynosdb_cluster` 与 `tencentcloud_cynosdb_cluster_v2` 的 `instance_name` 字段。
+
+### Modified Capabilities
+<!-- 无需修改已有 spec 层面的行为契约 -->
+
+## Impact
+
+- **代码文件**：
+  - `tencentcloud/services/cynosdb/extension_cynosdb.go`（schema：`instance_name` 改为 `Optional` + `Computed`）
+  - `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go`（update：新增 `instance_name` 分支）
+  - `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2.go`（update：新增 `instance_name` 分支）
+  - `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_test.go`（acc 测试）
+  - `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2_test.go`（acc 测试）
+- **文档文件**：`website/docs/r/cynosdb_cluster.html.markdown`、`website/docs/r/cynosdb_cluster_v2.html.markdown`
+- **changelog**：`.changelog/4323.txt`
+- **API**：`ModifyInstanceName`（cynosdb v20190107，已有服务层封装，直接复用）
+- **向后兼容**：仅将 `Computed` 字段改为 `Optional` + `Computed`，原有 state 与配置完全兼容，不填写 `instance_name` 时行为不变。

--- a/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/specs/cynosdb-cluster-instance-name-modify/spec.md
+++ b/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/specs/cynosdb-cluster-instance-name-modify/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: instance_name supports in-place update for cluster resources
+
+The `tencentcloud_cynosdb_cluster` and `tencentcloud_cynosdb_cluster_v2` resources SHALL allow the `instance_name` field to be updated in-place. When `instance_name` changes, the provider SHALL call the `ModifyInstanceName` API to update the read-write instance name on the cloud, then refresh state.
+
+#### Scenario: Update instance_name triggers ModifyInstanceName API
+
+- **WHEN** the user updates `instance_name` in the Terraform configuration for an existing `tencentcloud_cynosdb_cluster` or `tencentcloud_cynosdb_cluster_v2`
+- **THEN** the provider SHALL call `ModifyInstanceName` with the read-write instance ID and the new instance name, and SHALL NOT recreate the resource
+
+#### Scenario: instance_name is Optional and Computed
+
+- **WHEN** the schema for `instance_name` is inspected
+- **THEN** the field SHALL be `Optional`, `Computed`, and `String`, and SHALL NOT have `ForceNew` set
+
+#### Scenario: Read reflects updated instance_name
+
+- **WHEN** `ModifyInstanceName` succeeds and a subsequent Read is performed
+- **THEN** the provider SHALL set `instance_name` in state to the value returned by the `DescribeInstanceById` API for the read-write instance
+
+#### Scenario: ModifyInstanceName failure is retried
+
+- **WHEN** the `ModifyInstanceName` API returns an error
+- **THEN** the provider SHALL wrap the error with `tccommon.RetryError` and retry within `WriteRetryTimeout`

--- a/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/tasks.md
+++ b/openspec/changes/archive/2026-07-20-add-cynosdb-cluster-instance-name-modify/tasks.md
@@ -1,0 +1,24 @@
+## 1. Schema 调整
+
+- [x] 1.1 在 `tencentcloud/services/cynosdb/extension_cynosdb.go` 的 `TencentCynosdbInstanceBaseInfo()` 中，将 `instance_name` 字段从 `Computed: true` 改为 `Optional: true, Computed: true`，描述更新为 "Name of instance. Only supported when modifying."
+
+## 2. 资源 Update 逻辑
+
+- [x] 2.1 在 `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go` 的 `resourceTencentCloudCynosdbClusterUpdate` 中，新增 `if d.HasChange("instance_name")` 分支，读取新值并调用 `cynosdbService.ModifyInstanceName(ctx, instanceId, instanceName)`，处理 error
+- [x] 2.2 在 `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2.go` 的 `resourceTencentCloudCynosdbClusterV2Update` 中，新增 `if d.HasChange("instance_name")` 分支，读取新值并调用 `cynosdbService.ModifyInstanceName(ctx, instanceId, instanceName)`，处理 error
+
+## 3. 测试用例
+
+- [x] 3.1 在 `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_test.go` 中新增 `TestAccTencentCloudCynosdbClusterResourceUpdateInstanceName`，使用 terraform acc 测试套件，验证创建后修改 `instance_name` 触发 ModifyInstanceName 且 state 正确回填
+- [x] 3.2 在 `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2_test.go` 中新增 `TestAccTencentCloudCynosdbClusterV2ResourceUpdateInstanceName`，使用 terraform acc 测试套件，验证创建后修改 `instance_name` 触发 ModifyInstanceName 且 state 正确回填
+
+> 注：cluster 与 cluster_v2 为现有资源，按代码生成要求使用 terraform acc 测试套件补充用例，不使用 go test 执行。
+
+## 4. 文档与 changelog
+
+- [x] 4.1 更新 `.changelog/4323.txt`，将变更描述改为 `resource/tencentcloud_cynosdb_cluster: support instance_name modification via ModifyInstanceName API`（enhancement），同时保留 cluster_v2 描述
+- [x] 4.2 更新 `website/docs/r/cynosdb_cluster.html.markdown` 与 `website/docs/r/cynosdb_cluster_v2.html.markdown` 中 `instance_name` 的描述（由 `make doc` 在收尾阶段生成）
+
+## 5. 验证
+
+- [x] 5.1 确认所有修改的 Go 文件可正确编译（由后续流程的 go build 验证）

--- a/openspec/specs/cynosdb-cluster-instance-name-modify/spec.md
+++ b/openspec/specs/cynosdb-cluster-instance-name-modify/spec.md
@@ -1,0 +1,28 @@
+# cynosdb-cluster-instance-name-modify Specification
+
+## Purpose
+TBD - created by archiving change add-cynosdb-cluster-instance-name-modify. Update Purpose after archive.
+## Requirements
+### Requirement: instance_name supports in-place update for cluster resources
+
+The `tencentcloud_cynosdb_cluster` and `tencentcloud_cynosdb_cluster_v2` resources SHALL allow the `instance_name` field to be updated in-place. When `instance_name` changes, the provider SHALL call the `ModifyInstanceName` API to update the read-write instance name on the cloud, then refresh state.
+
+#### Scenario: Update instance_name triggers ModifyInstanceName API
+
+- **WHEN** the user updates `instance_name` in the Terraform configuration for an existing `tencentcloud_cynosdb_cluster` or `tencentcloud_cynosdb_cluster_v2`
+- **THEN** the provider SHALL call `ModifyInstanceName` with the read-write instance ID and the new instance name, and SHALL NOT recreate the resource
+
+#### Scenario: instance_name is Optional and Computed
+
+- **WHEN** the schema for `instance_name` is inspected
+- **THEN** the field SHALL be `Optional`, `Computed`, and `String`, and SHALL NOT have `ForceNew` set
+
+#### Scenario: Read reflects updated instance_name
+
+- **WHEN** `ModifyInstanceName` succeeds and a subsequent Read is performed
+- **THEN** the provider SHALL set `instance_name` in state to the value returned by the `DescribeInstanceById` API for the read-write instance
+
+#### Scenario: ModifyInstanceName failure is retried
+
+- **WHEN** the `ModifyInstanceName` API returns an error
+- **THEN** the provider SHALL wrap the error with `tccommon.RetryError` and retry within `WriteRetryTimeout`

--- a/tencentcloud/services/cynosdb/extension_cynosdb.go
+++ b/tencentcloud/services/cynosdb/extension_cynosdb.go
@@ -72,6 +72,7 @@ func TencentCynosdbInstanceBaseInfo() map[string]*schema.Schema {
 		},
 		"instance_name": {
 			Type:        schema.TypeString,
+			Optional:    true,
 			Computed:    true,
 			Description: "Name of instance. Only supported when modifying.",
 		},

--- a/tencentcloud/services/cynosdb/extension_cynosdb.go
+++ b/tencentcloud/services/cynosdb/extension_cynosdb.go
@@ -73,7 +73,7 @@ func TencentCynosdbInstanceBaseInfo() map[string]*schema.Schema {
 		"instance_name": {
 			Type:        schema.TypeString,
 			Computed:    true,
-			Description: "Name of instance.",
+			Description: "Name of instance. Only supported when modifying.",
 		},
 		"instance_status": {
 			Type:        schema.TypeString,
@@ -326,7 +326,7 @@ func TencentCynosdbClusterBaseInfo() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Optional:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
-			Description: "IDs of security group for `ro_group`. If you need to configure `ro_group_sg` security group, please use Resource `tencentcloud_cynosdb_cluster_v2`.",
+			Description: "IDs of security group for `ro_group`.",
 		},
 		"ro_group_addr": {
 			Type:        schema.TypeList,

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go
@@ -960,6 +960,15 @@ func resourceTencentCloudCynosdbClusterUpdate(d *schema.ResourceData, meta inter
 		}
 	}
 
+	// update instance_name
+	if d.HasChange("instance_name") {
+		instanceName := d.Get("instance_name").(string)
+		err := cynosdbService.ModifyInstanceName(ctx, instanceId, instanceName)
+		if err != nil {
+			return err
+		}
+	}
+
 	// update storage_limit
 	if d.HasChange("storage_limit") {
 		oldStorageLimit, newStorageLimit := d.GetChange("storage_limit")

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_test.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_test.go
@@ -187,6 +187,37 @@ func TestAccTencentCloudCynosdbClusterResourceServerless(t *testing.T) {
 	})
 }
 
+func TestAccTencentCloudCynosdbClusterResourceUpdateInstanceName(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { tcacctest.AccPreCheck(t) },
+		Providers:    tcacctest.AccProviders,
+		CheckDestroy: testAccCheckCynosdbClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCynosdbCluster,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCynosdbClusterExists("tencentcloud_cynosdb_cluster.foo"),
+					resource.TestCheckResourceAttrSet("tencentcloud_cynosdb_cluster.foo", "instance_name"),
+				),
+			},
+			{
+				Config: testAccCynosdbCluster_updateInstanceName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCynosdbClusterExists("tencentcloud_cynosdb_cluster.foo"),
+					resource.TestCheckResourceAttr("tencentcloud_cynosdb_cluster.foo", "instance_name", "tf-cynosdb-instance-update"),
+				),
+			},
+			{
+				Config: testAccCynosdbCluster,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCynosdbClusterExists("tencentcloud_cynosdb_cluster.foo"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCynosdbClusterDestroy(s *terraform.State) error {
 	logId := tccommon.GetLogId(tccommon.ContextNil)
 	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
@@ -443,3 +474,52 @@ resource "tencentcloud_cynosdb_cluster" "foo" {
   serverless_status_flag       = "resume"
   force_delete = true
 }`
+
+const testAccCynosdbCluster_updateInstanceName = testAccCynosdbBasic + `
+resource "tencentcloud_cynosdb_cluster" "foo" {
+  available_zone               = var.availability_zone
+  vpc_id                       = var.my_vpc
+  subnet_id                    = var.my_subnet
+  db_type                      = "MYSQL"
+  db_version                   = "5.7"
+  storage_limit                = 1000
+  cluster_name                 = "tf-cynosdb"
+  instance_name                = "tf-cynosdb-instance-update"
+  password                     = "cynos@123"
+  instance_maintain_duration   = 3600
+  instance_maintain_start_time = 10800
+  instance_maintain_weekdays   = [
+    "Fri",
+    "Mon",
+    "Sat",
+    "Sun",
+    "Thu",
+    "Wed",
+    "Tue",
+  ]
+
+  instance_cpu_core    = 1
+  instance_memory_size = 2
+  param_items {
+    name = "character_set_server"
+    current_value = "utf8"
+  }
+  param_items {
+    name = "time_zone"
+    current_value = "+09:00"
+  }
+
+  tags = {
+    test = "test"
+  }
+
+  force_delete = true
+
+  rw_group_sg = [
+    var.rw_group_sg
+  ]
+  ro_group_sg = [
+    var.rw_group_sg
+  ]
+}
+`

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2.go
@@ -1135,6 +1135,15 @@ func resourceTencentCloudCynosdbClusterV2Update(d *schema.ResourceData, meta int
 		}
 	}
 
+	// update instance_name
+	if d.HasChange("instance_name") {
+		instanceName := d.Get("instance_name").(string)
+		err := cynosdbService.ModifyInstanceName(ctx, instanceId, instanceName)
+		if err != nil {
+			return err
+		}
+	}
+
 	// update storage_limit
 	if d.HasChange("storage_limit") {
 		oldStorageLimit, newStorageLimit := d.GetChange("storage_limit")

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2_test.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2_test.go
@@ -187,6 +187,37 @@ func TestAccTencentCloudCynosdbClusterV2ResourceServerless(t *testing.T) {
 	})
 }
 
+func TestAccTencentCloudCynosdbClusterV2ResourceUpdateInstanceName(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { tcacctest.AccPreCheck(t) },
+		Providers:    tcacctest.AccProviders,
+		CheckDestroy: testAccCheckCynosdbClusterV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCynosdbV2Cluster,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCynosdbClusterV2Exists("tencentcloud_cynosdb_cluster_v2.foo"),
+					resource.TestCheckResourceAttrSet("tencentcloud_cynosdb_cluster_v2.foo", "instance_name"),
+				),
+			},
+			{
+				Config: testAccCynosdbV2Cluster_updateInstanceName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCynosdbClusterV2Exists("tencentcloud_cynosdb_cluster_v2.foo"),
+					resource.TestCheckResourceAttr("tencentcloud_cynosdb_cluster_v2.foo", "instance_name", "tf-cynosdb-instance-update"),
+				),
+			},
+			{
+				Config: testAccCynosdbV2Cluster,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCynosdbClusterV2Exists("tencentcloud_cynosdb_cluster_v2.foo"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCynosdbClusterV2Destroy(s *terraform.State) error {
 	logId := tccommon.GetLogId(tccommon.ContextNil)
 	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
@@ -443,3 +474,52 @@ resource "tencentcloud_cynosdb_cluster_v2" "foo" {
   serverless_status_flag       = "resume"
   force_delete = true
 }`
+
+const testAccCynosdbV2Cluster_updateInstanceName = testAccCynosdbV2Basic + `
+resource "tencentcloud_cynosdb_cluster_v2" "foo" {
+  available_zone               = var.availability_zone
+  vpc_id                       = var.my_vpc
+  subnet_id                    = var.my_subnet
+  db_type                      = "MYSQL"
+  db_version                   = "5.7"
+  storage_limit                = 1000
+  cluster_name                 = "tf-cynosdb"
+  instance_name                = "tf-cynosdb-instance-update"
+  password                     = "cynos@123"
+  instance_maintain_duration   = 3600
+  instance_maintain_start_time = 10800
+  instance_maintain_weekdays   = [
+    "Fri",
+    "Mon",
+    "Sat",
+    "Sun",
+    "Thu",
+    "Wed",
+    "Tue",
+  ]
+
+  instance_cpu_core    = 1
+  instance_memory_size = 2
+  param_items {
+    name = "character_set_server"
+    current_value = "utf8"
+  }
+  param_items {
+    name = "time_zone"
+    current_value = "+09:00"
+  }
+
+  tags = {
+    test = "test"
+  }
+
+  force_delete = true
+
+  rw_group_sg = [
+    var.rw_group_sg
+  ]
+  ro_group_sg = [
+    var.rw_group_sg
+  ]
+}
+`

--- a/website/docs/r/cynosdb_cluster.html.markdown
+++ b/website/docs/r/cynosdb_cluster.html.markdown
@@ -236,7 +236,7 @@ The following arguments are supported:
 * `prarm_template_id` - (Optional, Int, **Deprecated**) It will be deprecated. Use `param_template_id` instead. The ID of the parameter template.
 * `prepaid_period` - (Optional, Int, ForceNew) The tenancy (time unit is month) of the prepaid instance. Valid values are `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `11`, `12`, `24`, `36`. NOTE: it only works when charge_type is set to `PREPAID`.
 * `project_id` - (Optional, Int, ForceNew) ID of the project. `0` by default.
-* `ro_group_sg` - (Optional, List: [`String`]) IDs of security group for `ro_group`. If you need to configure `ro_group_sg` security group, please use Resource `tencentcloud_cynosdb_cluster_v2`.
+* `ro_group_sg` - (Optional, List: [`String`]) IDs of security group for `ro_group`.
 * `rw_group_sg` - (Optional, List: [`String`]) IDs of security group for `rw_group`.
 * `serverless_status_flag` - (Optional, String) Specify whether to pause or resume serverless cluster. values: `resume`, `pause`.
 * `slave_zone` - (Optional, String) Multi zone Addresses of the CynosDB Cluster.
@@ -271,7 +271,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cluster_status` - Status of the Cynosdb cluster.
 * `create_time` - Creation time of the CynosDB cluster.
 * `instance_id` - ID of instance.
-* `instance_name` - Name of instance.
+* `instance_name` - Name of instance. Only supported when modifying.
 * `instance_status` - Status of the instance.
 * `instance_storage_size` - Storage size of the instance, unit in GB.
 * `ro_group_addr` - Readonly addresses. Each element contains the following attributes:

--- a/website/docs/r/cynosdb_cluster.html.markdown
+++ b/website/docs/r/cynosdb_cluster.html.markdown
@@ -227,6 +227,7 @@ The following arguments are supported:
 * `instance_maintain_start_time` - (Optional, Int) Offset time from 00:00, unit in second. For example, 03:00am should be `10800`. `10800` by default.
 * `instance_maintain_weekdays` - (Optional, Set: [`String`]) Weekdays for maintenance. `["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]` by default.
 * `instance_memory_size` - (Optional, Int) Memory capacity of read-write type instance, unit in GB. Required while creating normal cluster. Note: modification of this field will take effect immediately, if want to upgrade on maintenance window, please upgrade from console.
+* `instance_name` - (Optional, String) Name of instance. Only supported when modifying.
 * `max_cpu` - (Optional, Float64) Maximum CPU core count, required while `db_mode` is `SERVERLESS`, request DescribeServerlessInstanceSpecs for more reference.
 * `min_cpu` - (Optional, Float64) Minimum CPU core count, required while `db_mode` is `SERVERLESS`, request DescribeServerlessInstanceSpecs for more reference.
 * `old_ip_reserve_hours` - (Optional, Int) Recycling time of the old address, must be filled in when modifying the vpcRecycling time of the old address, must be filled in when modifying the vpc.
@@ -271,7 +272,6 @@ In addition to all arguments above, the following attributes are exported:
 * `cluster_status` - Status of the Cynosdb cluster.
 * `create_time` - Creation time of the CynosDB cluster.
 * `instance_id` - ID of instance.
-* `instance_name` - Name of instance. Only supported when modifying.
 * `instance_status` - Status of the instance.
 * `instance_storage_size` - Storage size of the instance, unit in GB.
 * `ro_group_addr` - Readonly addresses. Each element contains the following attributes:

--- a/website/docs/r/cynosdb_cluster_v2.html.markdown
+++ b/website/docs/r/cynosdb_cluster_v2.html.markdown
@@ -135,7 +135,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cluster_status` - Status of the Cynosdb cluster.
 * `create_time` - Creation time of the CynosDB cluster.
 * `instance_id` - ID of instance.
-* `instance_name` - Name of instance.
+* `instance_name` - Name of instance. Only supported when modifying.
 * `instance_status` - Status of the instance.
 * `instance_storage_size` - Storage size of the instance, unit in GB.
 * `ro_group_addr` - Readonly addresses. Each element contains the following attributes:

--- a/website/docs/r/cynosdb_cluster_v2.html.markdown
+++ b/website/docs/r/cynosdb_cluster_v2.html.markdown
@@ -89,6 +89,7 @@ The following arguments are supported:
 * `instance_maintain_start_time` - (Optional, Int) Offset time from 00:00, unit in second. For example, 03:00am should be `10800`. `10800` by default.
 * `instance_maintain_weekdays` - (Optional, Set: [`String`]) Weekdays for maintenance. `["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]` by default.
 * `instance_memory_size` - (Optional, Int) Memory capacity of read-write type instance, unit in GB. Required while creating normal cluster. Note: modification of this field will take effect immediately, if want to upgrade on maintenance window, please upgrade from console.
+* `instance_name` - (Optional, String) Name of instance. Only supported when modifying.
 * `max_cpu` - (Optional, Float64) Maximum CPU core count, required while `db_mode` is `SERVERLESS`, request DescribeServerlessInstanceSpecs for more reference.
 * `min_cpu` - (Optional, Float64) Minimum CPU core count, required while `db_mode` is `SERVERLESS`, request DescribeServerlessInstanceSpecs for more reference.
 * `old_ip_reserve_hours` - (Optional, Int) Recycling time of the old address, must be filled in when modifying the vpcRecycling time of the old address, must be filled in when modifying the vpc.
@@ -135,7 +136,6 @@ In addition to all arguments above, the following attributes are exported:
 * `cluster_status` - Status of the Cynosdb cluster.
 * `create_time` - Creation time of the CynosDB cluster.
 * `instance_id` - ID of instance.
-* `instance_name` - Name of instance. Only supported when modifying.
 * `instance_status` - Status of the instance.
 * `instance_storage_size` - Storage size of the instance, unit in GB.
 * `ro_group_addr` - Readonly addresses. Each element contains the following attributes:


### PR DESCRIPTION
Update field descriptions for tencentcloud_cynosdb_cluster resource: refine instance_name description and simplify ro_group_sg description.