### PR TITLE
feat(mongodb): [135210336]add cpu parameter to tencentcloud_mongodb_instance resource

### DIFF
--- a/.changelog/4325.txt
+++ b/.changelog/4325.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_mongodb_instance: support `cpu` parameter to manage the CPU core count during instance configuration changes
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.0.1033
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.131
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -69,7 +69,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/lighthouse v1.3.108
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/live v1.3.95
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.103
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.133
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.101
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mps v1.3.45
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/organization v1.3.110

--- a/go.sum
+++ b/go.sum
@@ -986,7 +986,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.93/go.mod h
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.95/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.101/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.102/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.103/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.104/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.105/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.107/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1004,8 +1003,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.125/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.131/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132 h1:42RfJnwzMprfKEJrM9fyhHu1jXyg8xvSJ1A1qb9Qun8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133 h1:EKJsaGHbifEKqWCdJ4tJNLxbJ5h/Pm3CaLKzcCS/pkw=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1065,8 +1065,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/live v1.3.95 h1:rWiKud6
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/live v1.3.95/go.mod h1:uDGk0Bi0diOd1VaQPnfZO0MLKPKjqIT4Hi0sdanwD9s=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102 h1:I4QaWjVMOfuEsmxjTS8BxYgLcgdATWIAGutcHDnIvB4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102/go.mod h1:Thfxer0Xf7Oq//ceL5i5nObFEXyQkUxzLHVNFh3p7jw=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.103 h1:EQTALkZayL6KrXCcx0yjJ3ksl75dFNFJWhTnSUxaYds=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.103/go.mod h1:0CcAKrx6oYC/WfuN04wsNtQ77dLgMv74in3kY5nwqgE=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.133 h1:J/x518dKdFwHa7KatmCWNw7/daJuf7yw+1bov8Du3d0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.133/go.mod h1:MloftTaY0U0CNcDc2PkbNw7pGwE089AadY4tJ1bc5hM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.101 h1:r8PjkCuXrztjLyBROWTww0RJUq+a+l5ybPLl6GGlov8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.101/go.mod h1:+cX4PEEehIIbyHy9plpXOTShlFWtc9OC1AWcmOrOMT8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mps v1.3.45 h1:35PD/GXaOl3QhL1fI5a3Q+jcenzR1PqfuGxltOeO48w=

--- a/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/design.md
+++ b/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/design.md
@@ -1,0 +1,53 @@
+## Context
+
+`tencentcloud_mongodb_instance` 是腾讯云 MongoDB 实例的通用资源（RESOURCE_KIND_GENERAL），管理实例整个生命周期。当前资源通过 `MongodbService.UpgradeInstance` 方法（封装 `ModifyDBInstanceSpec` 接口）支持 `memory`、`volume`、`node_num`、`add_node_list`、`remove_node_list`、`in_maintenance` 等参数的变配，但未暴露 `cpu` 参数。
+
+腾讯云 MongoDB `ModifyDBInstanceSpec` 接口已支持 `Cpu` 入参（`*int64`，单位：C），允许在变更实例规格时指定变更后的 CPU 大小；`DescribeDBInstances` 返回的 `InstanceDetail.CpuNum`（`*uint64`）字段记录实例当前 CPU 核数。本次变更将 `cpu` 参数接入 Terraform 资源，补全实例规格变更能力。
+
+约束：
+- 资源 schema 已存在且已发布，必须保持向后兼容，只能新增 `Optional` + `Computed` 字段。
+- `ModifyDBInstanceSpecRequest.Cpu` 为 `*int64` 类型；`InstanceDetail.CpuNum` 为 `*uint64` 类型，需注意类型转换。
+- 变配操作可能返回订单 ID，需通过 `DescribeDBInstanceDeal` 轮询订单状态确认完成（现有逻辑已实现，本次复用）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 为 `tencentcloud_mongodb_instance` 资源新增 `cpu` 参数（`Optional` + `Computed`，`TypeInt`）。
+- 在 Update 流程中，当 `cpu` 发生变化时，将 `cpu` 传递给 `ModifyDBInstanceSpec` 接口的 `Cpu` 字段完成变配。
+- 在 Read 流程中，从 `DescribeDBInstances` 返回的 `InstanceDetail.CpuNum` 回填 `cpu` 到 state。
+- 补充基于 gomonkey 的单元测试，覆盖 `cpu` 变更触发变配与回填逻辑。
+
+**Non-Goals:**
+- 不修改 Create 流程：`CreateDBInstanceHour`/`CreateDBInstance` 创建时使用的是 `CpuCore` 字段（非本次需求范围内的 `Cpu`），且本次需求仅针对 `ModifyDBInstanceSpec` 的 `Cpu` 入参，不扩展到创建参数。
+- 不修改 `mongos_cpu` 等已有分片集群相关 CPU 参数。
+- 不修改已发布字段的 schema 行为（不新增 `ForceNew`，不改变 `Required`/`Optional` 语义）。
+- 不执行 `make doc`、`gofmt`、`.changelog` 等收尾操作（由 tfpacer-finalize 阶段统一处理）。
+
+## Decisions
+
+### 决策 1：`cpu` 字段定义为 `Optional` + `Computed`，不设置 `ForceNew`
+
+**理由**：`cpu` 变化通过 in-place update（调用 `ModifyDBInstanceSpec`）完成，无需重建实例。设为 `Computed` 使 Read 能从云上回填实际 CPU 值，避免用户未指定时 state 与云上不一致。与已有 `memory`（`Required`）、`volume`（`Required`）不同，`cpu` 为可选参数（云 API 注释说明为空值时默认取实例当前 CPU 大小），因此设为 `Optional` + `Computed` 更贴合 API 语义且向后兼容。
+
+**备选方案**：将 `cpu` 设为 `Required`。否决，因为会破坏向后兼容（已有配置未设置 `cpu`）且与 API 语义不符。
+
+### 决策 2：Update 触发条件扩展为包含 `cpu`
+
+**理由**：现有触发条件为 `d.HasChange("memory") || d.HasChange("volume") || d.HasChange("node_num")`，新增 `d.HasChange("cpu")`。当用户单独修改 `cpu` 时也应触发变配。`cpu` 通过现有 `params map[string]interface{}` 传递到 `UpgradeInstance`，复用现有 `in_maintenance`/`node_num` 的传参模式，最小改动。
+
+**备选方案**：为 `cpu` 单独创建一个 `ModifyDBInstanceSpec` 调用分支。否决，会引入重复的订单轮询与错误处理逻辑，违背 DRY，且云 API `ModifyDBInstanceSpec` 本身支持同时变更多个规格参数。
+
+### 决策 3：服务层 `UpgradeInstance` 新增 `params["cpu"]` 映射到 `request.Cpu`
+
+**理由**：`ModifyDBInstanceSpecRequest.Cpu` 为 `*int64`，使用 `helper.Int64(v.(int))` 构造指针。与现有 `params["in_maintenance"]` 等使用 `helper.IntUint64` 不同，需按字段实际类型 `int64` 使用 `helper.Int64`，避免类型不匹配。
+
+### 决策 4：Read 回填使用 `instance.CpuNum`（`*uint64`）转为 `int`
+
+**理由**：`DescribeDBInstances` 返回的 `InstanceDetail.CpuNum` 即实例 CPU 核数。在 Read 中先判断 `instance.CpuNum != nil` 再 `d.Set("cpu", int(*instance.CpuNum))`，遵循项目规范「调用 setXX 前先判断字段是否为 nil」。不将 `CpuNum` 加入 `CheckNil` 强校验列表，避免对未返回该字段的存量实例造成 Read 失败。
+
+## Risks / Trade-offs
+
+- **[风险] `CpuNum` 为 `*uint64`，`Cpu` 为 `*int64`，类型转换溢出** → 实际 CPU 核数为正小整数，不会溢出；转换使用 `int()` 显式转换，安全。
+- **[风险] 用户单独修改 `cpu` 而不修改 `memory`/`volume` 时，云 API 是否允许** → 云 API 注释明确支持单独变更 CPU（"变更 mongod 或 mongos 的 CPU 与内存规格时，NodeNum 可以不配置"），且 `Cpu` 注释说明为空时取当前值，语义允许单独变更。具体可用规格由 `DescribeSpecInfo` 约束，由云 API 校验，Provider 不做额外校验。
+- **[权衡] 未将 `CpuNum` 加入 `CheckNil` 强校验** → 避免对未返回该字段的存量实例造成 Read 失败；回填前单独判 nil，安全且向后兼容。
+- **[风险] 既有 `UpgradeInstance` 复用同一订单轮询逻辑** → 不新增轮询逻辑，沿用现有 `DescribeDBInstanceDeal` 轮询，行为一致。

--- a/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/proposal.md
+++ b/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`tencentcloud_mongodb_instance` 资源当前支持通过 `memory`、`volume`、`node_num` 等参数调整实例配置（调用 `ModifyDBInstanceSpec` 接口），但缺少对 CPU 核数的管理。腾讯云 MongoDB `ModifyDBInstanceSpec` 接口已支持 `Cpu` 入参，允许在变更实例规格时指定变更后的 CPU 大小（单位：C）。本次变更新增 `cpu` 参数，使用户能够通过 Terraform 管理 MongoDB 实例的 CPU 规格，补全实例配置变更能力。
+
+## What Changes
+
+- 在 `tencentcloud_mongodb_instance` 资源 schema 中新增 `cpu` 参数（`Optional` + `Computed`，`TypeInt`），用于指定实例变更后的 CPU 核数。
+- 在资源 Update 流程中，将 `cpu` 加入 `ModifyDBInstanceSpec` 的触发条件，当 `cpu` 发生变化时（与 `memory`、`volume`、`node_num` 等一起或单独）调用 `ModifyDBInstanceSpec` 接口完成变配。
+- 在 `MongodbService.UpgradeInstance` 服务方法中，将 `params["cpu"]` 映射到 `ModifyDBInstanceSpecRequest.Cpu` 字段（`*int64`）。
+- 在资源 Read 流程中，通过 `DescribeDBInstances` 返回的 `InstanceDetail.CpuNum` 字段回填 `cpu` 参数到 state。
+- 补充 `resource_tc_mongodb_instance_test.go` 的单元测试用例（使用 gomonkey mock 云 API）。
+- 更新 `resource_tc_mongodb_instance.md` 资源文档。
+
+## Capabilities
+
+### New Capabilities
+- `mongodb-instance-cpu`: 为 `tencentcloud_mongodb_instance` 资源新增 `cpu` 参数，支持在实例配置变更时设置 CPU 核数，并通过查询接口回填 CPU 状态。
+
+### Modified Capabilities
+<!-- 无需修改现有 spec 级别的需求 -->
+
+## Impact
+
+### 受影响的代码
+- `tencentcloud/services/mongodb/resource_tc_mongodb_instance.go` - schema 新增 `cpu` 字段、Read 回填、Update 触发与传参
+- `tencentcloud/services/mongodb/service_tencentcloud_mongodb.go` - `UpgradeInstance` 方法新增 `cpu` 参数映射到 `ModifyDBInstanceSpecRequest.Cpu`
+- `tencentcloud/services/mongodb/resource_tc_mongodb_instance_test.go` - 新增/补充单元测试
+- `tencentcloud/services/mongodb/resource_tc_mongodb_instance.md` - 文档更新
+
+### 受影响的 API
+- `ModifyDBInstanceSpec`（变配时设置 `Cpu` 入参，`*int64`）
+- `DescribeDBInstances`（读取时从 `InstanceDetail.CpuNum` 回填，`*uint64`）
+
+### 向后兼容性
+- ✅ 完全向后兼容：仅新增 `Optional` + `Computed` 字段，不修改已有 schema，不影响现有 TF 配置和 state。
+- ✅ 不设置 `ForceNew`，`cpu` 变化通过 in-place update 处理。
+
+### 依赖关系
+- 无新增依赖，复用现有 `ModifyDBInstanceSpec` 与 `DescribeDBInstances` 接口及现有 `UpgradeInstance` 服务方法。

--- a/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/specs/mongodb-instance-cpu/spec.md
+++ b/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/specs/mongodb-instance-cpu/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: MongoDB Instance CPU Parameter
+The `tencentcloud_mongodb_instance` resource SHALL provide a `cpu` schema field to manage the instance CPU core count, allowing users to change the CPU specification of a running MongoDB instance through in-place update via the `ModifyDBInstanceSpec` API.
+
+#### Scenario: Schema defines optional and computed cpu field
+- **GIVEN** the `tencentcloud_mongodb_instance` resource schema definition
+- **THEN** `cpu` SHALL be a field of type `schema.TypeInt`
+- **AND** `cpu` SHALL have `Optional: true` and `Computed: true`
+- **AND** `cpu` SHALL NOT have `ForceNew` set (changes are applied via in-place update)
+- **AND** the field description SHALL document that the unit is C and that the supported CPU specifications can be obtained via the `DescribeSpecInfo` API
+
+#### Scenario: Update triggers ModifyDBInstanceSpec when cpu changes
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource
+- **WHEN** the user updates only the `cpu` field (without changing `memory`, `volume`, or `node_num`)
+- **THEN** the system SHALL detect `d.HasChange("cpu")` and enter the spec-modification branch
+- **AND** the system SHALL read the current `cpu` value from the schema
+- **AND** the system SHALL pass `cpu` into the params map of `MongodbService.UpgradeInstance`
+- **AND** the system SHALL call the `ModifyDBInstanceSpec` API with the `Cpu` request field set to the new CPU value
+- **AND** the system SHALL poll the returned deal id via `DescribeDBInstanceDeal` until the deal succeeds (when `in_maintenance == 0`)
+- **AND** the resource state SHALL be updated after a successful modification
+
+#### Scenario: Update triggers ModifyDBInstanceSpec when cpu changes together with other spec params
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource
+- **WHEN** the user updates `cpu` together with `memory`, `volume`, or `node_num`
+- **THEN** the system SHALL include the `cpu` value alongside the other changed spec parameters in a single `ModifyDBInstanceSpec` call
+- **AND** the `Cpu` request field SHALL be set from the user-specified `cpu` value
+
+#### Scenario: cpu omitted in update keeps existing behavior
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource where `cpu` was not configured
+- **WHEN** the user updates fields unrelated to spec modification (e.g., tags, project_id)
+- **THEN** the system SHALL NOT call `ModifyDBInstanceSpec`
+- **AND** the `cpu` field SHALL remain unset in the schema (populated only via Read)
+
+#### Scenario: Service layer maps cpu to ModifyDBInstanceSpecRequest.Cpu
+- **GIVEN** the `MongodbService.UpgradeInstance` service method
+- **WHEN** `params["cpu"]` is present with an integer value
+- **THEN** the system SHALL set `request.Cpu` to a `*int64` pointer constructed from the integer value
+- **AND** the type conversion SHALL use the `int64` helper matching the `ModifyDBInstanceSpecRequest.Cpu` field type
+- **WHEN** `params["cpu"]` is not present
+- **THEN** the system SHALL leave `request.Cpu` unset (nil) so the cloud API defaults to the current CPU size
+
+### Requirement: MongoDB Instance CPU Read Backfill
+The resource Read operation SHALL populate the `cpu` field from the cloud API response so that Terraform state reflects the actual CPU core count of the instance.
+
+#### Scenario: Read populates cpu from DescribeDBInstances
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource
+- **WHEN** the Read operation queries the instance via `DescribeDBInstances` (through `DescribeInstanceById`)
+- **AND** the returned `InstanceDetail.CpuNum` is not nil
+- **THEN** the system SHALL set the `cpu` field in state to `int(*instance.CpuNum)`
+
+#### Scenario: Read handles nil CpuNum gracefully
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource
+- **WHEN** the Read operation queries the instance
+- **AND** the returned `InstanceDetail.CpuNum` is nil
+- **THEN** the system SHALL NOT call `d.Set("cpu", ...)` (skip setting the field)
+- **AND** the Read operation SHALL NOT fail solely because `CpuNum` is nil
+
+#### Scenario: CpuNum not added to mandatory nil check
+- **GIVEN** the Read operation's `CheckNil` validation list
+- **THEN** `CpuNum` SHALL NOT be added to the mandatory nil-check map
+- **AND** existing instances that do not return `CpuNum` SHALL still be readable without error
+
+### Requirement: CPU Parameter Testing
+The resource SHALL have unit tests using gomonkey mocks (not Terraform test suites) covering the new `cpu` parameter behavior, runnable via `go test` with `-gcflags=all=-l`.
+
+#### Scenario: Unit test for cpu change triggering spec modification
+- **GIVEN** the `tencentcloud_mongodb_instance` resource update function
+- **WHEN** a unit test simulates a `cpu` change in the schema
+- **THEN** the test SHALL mock the `ModifyDBInstanceSpec` and `DescribeDBInstanceDeal` cloud APIs using gomonkey
+- **AND** verify that the update flow calls `ModifyDBInstanceSpec` with the expected `Cpu` value
+- **AND** verify the update completes without error
+
+#### Scenario: Unit test for cpu read backfill
+- **GIVEN** the `tencentcloud_mongodb_instance` resource read function
+- **WHEN** a unit test mocks `DescribeDBInstances` to return an instance with `CpuNum` set
+- **THEN** the test SHALL verify that `d.Set("cpu", ...)` is called with the correct CPU value
+- **AND** verify the read completes without error
+
+#### Scenario: Unit test for nil CpuNum read
+- **GIVEN** the `tencentcloud_mongodb_instance` resource read function
+- **WHEN** a unit test mocks `DescribeDBInstances` to return an instance with `CpuNum` nil
+- **THEN** the test SHALL verify the read operation does not fail
+- **AND** verify the `cpu` field is not set
+
+### Requirement: CPU Parameter Documentation
+The resource documentation SHALL be updated to describe the new `cpu` parameter, generated via the `make doc` command during the finalize phase.
+
+#### Scenario: cpu field documented
+- **GIVEN** the resource documentation file `resource_tc_mongodb_instance.md`
+- **THEN** the documentation SHALL include the `cpu` parameter description
+- **AND** the description SHALL state the unit is C and that supported specifications can be obtained via the `DescribeSpecInfo` API
+- **AND** the documentation SHALL NOT include manual `Argument Reference` or `Attribute Reference` sections (auto-generated)
+
+#### Scenario: Example usage includes cpu
+- **GIVEN** the resource documentation
+- **THEN** the example usage SHALL demonstrate specifying the `cpu` parameter in an update scenario

--- a/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/tasks.md
+++ b/openspec/changes/archive/2026-07-21-add-mongodb-instance-cpu-param/tasks.md
@@ -1,0 +1,36 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/mongodb/resource_tc_mongodb_instance.go` 的 `mongodbInstanceInfo` schema map 中新增 `cpu` 字段：`Type: schema.TypeInt`、`Optional: true`、`Computed: true`，描述说明单位为 C 且支持的规格可通过 `DescribeSpecInfo` 接口获取
+
+## 2. Service 层实现
+
+- [x] 2.1 在 `tencentcloud/services/mongodb/service_tencentcloud_mongodb.go` 的 `UpgradeInstance` 方法中新增 `params["cpu"]` 处理：当���在时使用 `helper.Int64(v.(int))` 构造 `*int64` 并赋值给 `request.Cpu`（匹配 `ModifyDBInstanceSpecRequest.Cpu` 的 `*int64` 类型）
+
+## 3. CRUD 函数实现
+
+- [x] 3.1 在 `resourceTencentCloudMongodbInstanceUpdate` 中将变配触发条件从 `d.HasChange("memory") || d.HasChange("volume") || d.HasChange("node_num")` 扩展为包含 `d.HasChange("cpu")`
+- [x] 3.2 在 Update 变配分支中读取 `cpu` 值并放入 `params["cpu"]`（使用 `d.GetOk`/`d.Get`，与现有 `node_num`/`in_maintenance` 传参模式一致）
+- [x] 3.3 在 `resourceTencentCloudMongodbInstanceRead` 中，当 `instance.CpuNum != nil` 时执行 `_ = d.Set("cpu", int(*instance.CpuNum))`；不将 `CpuNum` 加入 `CheckNil` 强校验列表
+
+## 4. 单元测试
+
+- [x] 4.1 在 `tencentcloud/services/mongodb/resource_tc_mongodb_instance_test.go` 中新增基于 gomonkey mock 的单元测试：mock `ModifyDBInstanceSpec` 与 `DescribeDBInstanceDeal`，验证 `cpu` 变更触发变配且 `request.Cpu` 被正确设置
+- [x] 4.2 新增 Read 回填单元测试：mock `DescribeDBInstances`（`DescribeInstanceById`）返回 `CpuNum` 非空，验证 `d.Set("cpu", ...)` 被正确调用
+- [x] 4.3 新增 Read 处理 `CpuNum` 为 nil 的单元测试，验证 Read 不报错且不设置 `cpu`
+- [x] 4.4 使用 `go test -gcflags=all=-l` 运行所涉测试文件确保通过
+
+## 5. 文档
+
+- [x] 5.1 修改 `tencentcloud/services/mongodb/resource_tc_mongodb_instance.md`，补充 `cpu` 参数说明（一句话描述带上 MongoDB 产品名），在示例用法中补充 `cpu` 变更示例；不手动添加 `Argument Reference`/`Attribute Reference` 部分
+
+## 6. 代码正确性检查
+
+- [x] 6.1 核对 `cpu` 参数仅在 `ModifyDBInstanceSpec`（Update 路径）中作为入参，确认 `ModifyDBInstanceSpecRequest.Cpu` 字段存在且类型为 `*int64`
+- [x] 6.2 核对 Read 回填来源为 `DescribeDBInstances` 返回的 `InstanceDetail.CpuNum`（`*uint64`），确认字段存在
+- [x] 6.3 核对 `cpu` 未被误加入 Create（`CreateDBInstanceHour`/`CreateDBInstance` 使用的是 `CpuCore` 而非 `Cpu`，本次不扩展）
+
+## 7. 收尾阶段（由 tfpacer-finalize 统一执行）
+
+- [ ] 7.1 执行 `gofmt` 格式化本次变更的 Go 文件
+- [ ] 7.2 执行 `make doc` 生成 `website/docs/r/mongodb_instance.html.markdown` 等文档
+- [ ] 7.3 在 `.changelog/` 目录下创建 changelog 文件（enhancement 类型）

--- a/openspec/specs/mongodb-instance-cpu/spec.md
+++ b/openspec/specs/mongodb-instance-cpu/spec.md
@@ -1,0 +1,101 @@
+# mongodb-instance-cpu Specification
+
+## Purpose
+TBD - created by archiving change add-mongodb-instance-cpu-param. Update Purpose after archive.
+## Requirements
+### Requirement: MongoDB Instance CPU Parameter
+The `tencentcloud_mongodb_instance` resource SHALL provide a `cpu` schema field to manage the instance CPU core count, allowing users to change the CPU specification of a running MongoDB instance through in-place update via the `ModifyDBInstanceSpec` API.
+
+#### Scenario: Schema defines optional and computed cpu field
+- **GIVEN** the `tencentcloud_mongodb_instance` resource schema definition
+- **THEN** `cpu` SHALL be a field of type `schema.TypeInt`
+- **AND** `cpu` SHALL have `Optional: true` and `Computed: true`
+- **AND** `cpu` SHALL NOT have `ForceNew` set (changes are applied via in-place update)
+- **AND** the field description SHALL document that the unit is C and that the supported CPU specifications can be obtained via the `DescribeSpecInfo` API
+
+#### Scenario: Update triggers ModifyDBInstanceSpec when cpu changes
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource
+- **WHEN** the user updates only the `cpu` field (without changing `memory`, `volume`, or `node_num`)
+- **THEN** the system SHALL detect `d.HasChange("cpu")` and enter the spec-modification branch
+- **AND** the system SHALL read the current `cpu` value from the schema
+- **AND** the system SHALL pass `cpu` into the params map of `MongodbService.UpgradeInstance`
+- **AND** the system SHALL call the `ModifyDBInstanceSpec` API with the `Cpu` request field set to the new CPU value
+- **AND** the system SHALL poll the returned deal id via `DescribeDBInstanceDeal` until the deal succeeds (when `in_maintenance == 0`)
+- **AND** the resource state SHALL be updated after a successful modification
+
+#### Scenario: Update triggers ModifyDBInstanceSpec when cpu changes together with other spec params
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource
+- **WHEN** the user updates `cpu` together with `memory`, `volume`, or `node_num`
+- **THEN** the system SHALL include the `cpu` value alongside the other changed spec parameters in a single `ModifyDBInstanceSpec` call
+- **AND** the `Cpu` request field SHALL be set from the user-specified `cpu` value
+
+#### Scenario: cpu omitted in update keeps existing behavior
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource where `cpu` was not configured
+- **WHEN** the user updates fields unrelated to spec modification (e.g., tags, project_id)
+- **THEN** the system SHALL NOT call `ModifyDBInstanceSpec`
+- **AND** the `cpu` field SHALL remain unset in the schema (populated only via Read)
+
+#### Scenario: Service layer maps cpu to ModifyDBInstanceSpecRequest.Cpu
+- **GIVEN** the `MongodbService.UpgradeInstance` service method
+- **WHEN** `params["cpu"]` is present with an integer value
+- **THEN** the system SHALL set `request.Cpu` to a `*int64` pointer constructed from the integer value
+- **AND** the type conversion SHALL use the `int64` helper matching the `ModifyDBInstanceSpecRequest.Cpu` field type
+- **WHEN** `params["cpu"]` is not present
+- **THEN** the system SHALL leave `request.Cpu` unset (nil) so the cloud API defaults to the current CPU size
+
+### Requirement: MongoDB Instance CPU Read Backfill
+The resource Read operation SHALL populate the `cpu` field from the cloud API response so that Terraform state reflects the actual CPU core count of the instance.
+
+#### Scenario: Read populates cpu from DescribeDBInstances
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource
+- **WHEN** the Read operation queries the instance via `DescribeDBInstances` (through `DescribeInstanceById`)
+- **AND** the returned `InstanceDetail.CpuNum` is not nil
+- **THEN** the system SHALL set the `cpu` field in state to `int(*instance.CpuNum)`
+
+#### Scenario: Read handles nil CpuNum gracefully
+- **GIVEN** an existing `tencentcloud_mongodb_instance` resource
+- **WHEN** the Read operation queries the instance
+- **AND** the returned `InstanceDetail.CpuNum` is nil
+- **THEN** the system SHALL NOT call `d.Set("cpu", ...)` (skip setting the field)
+- **AND** the Read operation SHALL NOT fail solely because `CpuNum` is nil
+
+#### Scenario: CpuNum not added to mandatory nil check
+- **GIVEN** the Read operation's `CheckNil` validation list
+- **THEN** `CpuNum` SHALL NOT be added to the mandatory nil-check map
+- **AND** existing instances that do not return `CpuNum` SHALL still be readable without error
+
+### Requirement: CPU Parameter Testing
+The resource SHALL have unit tests using gomonkey mocks (not Terraform test suites) covering the new `cpu` parameter behavior, runnable via `go test` with `-gcflags=all=-l`.
+
+#### Scenario: Unit test for cpu change triggering spec modification
+- **GIVEN** the `tencentcloud_mongodb_instance` resource update function
+- **WHEN** a unit test simulates a `cpu` change in the schema
+- **THEN** the test SHALL mock the `ModifyDBInstanceSpec` and `DescribeDBInstanceDeal` cloud APIs using gomonkey
+- **AND** verify that the update flow calls `ModifyDBInstanceSpec` with the expected `Cpu` value
+- **AND** verify the update completes without error
+
+#### Scenario: Unit test for cpu read backfill
+- **GIVEN** the `tencentcloud_mongodb_instance` resource read function
+- **WHEN** a unit test mocks `DescribeDBInstances` to return an instance with `CpuNum` set
+- **THEN** the test SHALL verify that `d.Set("cpu", ...)` is called with the correct CPU value
+- **AND** verify the read completes without error
+
+#### Scenario: Unit test for nil CpuNum read
+- **GIVEN** the `tencentcloud_mongodb_instance` resource read function
+- **WHEN** a unit test mocks `DescribeDBInstances` to return an instance with `CpuNum` nil
+- **THEN** the test SHALL verify the read operation does not fail
+- **AND** verify the `cpu` field is not set
+
+### Requirement: CPU Parameter Documentation
+The resource documentation SHALL be updated to describe the new `cpu` parameter, generated via the `make doc` command during the finalize phase.
+
+#### Scenario: cpu field documented
+- **GIVEN** the resource documentation file `resource_tc_mongodb_instance.md`
+- **THEN** the documentation SHALL include the `cpu` parameter description
+- **AND** the description SHALL state the unit is C and that supported specifications can be obtained via the `DescribeSpecInfo` API
+- **AND** the documentation SHALL NOT include manual `Argument Reference` or `Attribute Reference` sections (auto-generated)
+
+#### Scenario: Example usage includes cpu
+- **GIVEN** the resource documentation
+- **THEN** the example usage SHALL demonstrate specifying the `cpu` parameter in an update scenario
+

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_instance.go
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_instance.go
@@ -204,7 +204,7 @@ func mongodbAllInstanceReqSet(requestInter interface{}, d *schema.ResourceData) 
 		"NodeNum":         helper.IntUint64(nodeNum),
 		"GoodsNum":        helper.IntUint64(goodsNum),
 		"ClusterType":     &clusterType,
-		"CpuCore":         helper.IntUint64(cpu),
+		"CpuCore":         helper.IntInt64(cpu),
 		"Memory":          helper.IntUint64(memoryInterface),
 		"Volume":          helper.IntUint64(volumeInterface),
 		"MongoVersion":    &mongoVersionInterface,

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_instance.go
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_instance.go
@@ -472,7 +472,7 @@ func resourceTencentCloudMongodbInstanceRead(d *schema.ResourceData, meta interf
 	_ = d.Set("create_time", instance.CreateTime)
 	_ = d.Set("node_num", *instance.SecondaryNum+1)
 	if instance.CpuNum != nil {
-		_ = d.Set("cpu", int(*instance.CpuNum))
+		_ = d.Set("cpu", int(*instance.CpuNum/(*instance.ReplicationSetNum)))
 	}
 	if instance.MaintenanceStart != nil && len(*instance.MaintenanceStart) == 8 {
 		_ = d.Set("maintenance_start", (*instance.MaintenanceStart)[:5])

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_instance.go
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_instance.go
@@ -171,6 +171,7 @@ func mongodbAllInstanceReqSet(requestInter interface{}, d *schema.ResourceData) 
 		nodeNum               = 3
 		goodsNum              = 1
 		clusterType           = MONGODB_CLUSTER_TYPE_REPLSET
+		cpu                   = d.Get("cpu").(int)
 		memoryInterface       = d.Get("memory").(int)
 		volumeInterface       = d.Get("volume").(int)
 		mongoVersionInterface = d.Get("engine_version").(string)
@@ -203,6 +204,7 @@ func mongodbAllInstanceReqSet(requestInter interface{}, d *schema.ResourceData) 
 		"NodeNum":         helper.IntUint64(nodeNum),
 		"GoodsNum":        helper.IntUint64(goodsNum),
 		"ClusterType":     &clusterType,
+		"CpuCore":         helper.IntUint64(cpu),
 		"Memory":          helper.IntUint64(memoryInterface),
 		"Volume":          helper.IntUint64(volumeInterface),
 		"MongoVersion":    &mongoVersionInterface,

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_instance.go
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_instance.go
@@ -50,6 +50,12 @@ func ResourceTencentCloudMongodbInstance() *schema.Resource {
 			Computed:    true,
 			Description: "The number of nodes in each replica set. Default value: 3.",
 		},
+		"cpu": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "The CPU core count of the MongoDB instance after the configuration change. Unit: C. When this parameter is empty, the current CPU size of the instance is used by default. The supported CPU specifications can be obtained through the DescribeSpecInfo API.",
+		},
 		"add_node_list": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -463,6 +469,9 @@ func resourceTencentCloudMongodbInstanceRead(d *schema.ResourceData, meta interf
 	_ = d.Set("vport", instance.Vport)
 	_ = d.Set("create_time", instance.CreateTime)
 	_ = d.Set("node_num", *instance.SecondaryNum+1)
+	if instance.CpuNum != nil {
+		_ = d.Set("cpu", int(*instance.CpuNum))
+	}
 	if instance.MaintenanceStart != nil && len(*instance.MaintenanceStart) == 8 {
 		_ = d.Set("maintenance_start", (*instance.MaintenanceStart)[:5])
 	}
@@ -527,7 +536,7 @@ func resourceTencentCloudMongodbInstanceUpdate(d *schema.ResourceData, meta inte
 
 	d.Partial(true)
 
-	if d.HasChange("memory") || d.HasChange("volume") || d.HasChange("node_num") {
+	if d.HasChange("memory") || d.HasChange("volume") || d.HasChange("node_num") || d.HasChange("cpu") {
 		memory := d.Get("memory").(int)
 		volume := d.Get("volume").(int)
 		params := make(map[string]interface{})
@@ -548,6 +557,9 @@ func resourceTencentCloudMongodbInstanceUpdate(d *schema.ResourceData, meta inte
 		if v, ok := d.GetOkExists("in_maintenance"); ok {
 			inMaintenance = v.(int)
 			params["in_maintenance"] = v.(int)
+		}
+		if v, ok := d.GetOkExists("cpu"); ok {
+			params["cpu"] = v.(int)
 		}
 		dealId, err := mongodbService.UpgradeInstance(ctx, instanceId, memory, volume, params)
 		if err != nil {

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_instance.md
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_instance.md
@@ -2,6 +2,8 @@ Provide a resource to create a Mongodb instance.
 
 ~> **NOTE:** If `availability_zone_list` needs to be changed, attention should be paid to cascading modifications of `available_zone` or `hidden_zone`.
 
+~> **NOTE:** The `cpu` parameter takes effect only when the configuration is changed. Changing the `cpu` triggers the `ModifyDBInstanceSpec` API to adjust the CPU specification of the running MongoDB instance in-place. The supported CPU specifications can be obtained through the `DescribeSpecInfo` API.
+
 Example Usage
 
 ```hcl
@@ -16,6 +18,24 @@ resource "tencentcloud_mongodb_instance" "example" {
   subnet_id      = "subnet-hhi88a58"
   project_id     = 0
   password       = "Password@123"
+}
+```
+
+Update the CPU specification of the MongoDB instance.
+
+```hcl
+resource "tencentcloud_mongodb_instance" "example" {
+  instance_name  = "tf-example"
+  memory         = 4
+  volume         = 100
+  engine_version = "MONGO_40_WT"
+  machine_type   = "HIO10G"
+  available_zone = "ap-guangzhou-6"
+  vpc_id         = "vpc-i5yyodl9"
+  subnet_id      = "subnet-hhi88a58"
+  project_id     = 0
+  password       = "Password@123"
+  cpu            = 2
 }
 ```
 

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_instance_test.go
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_instance_test.go
@@ -804,7 +804,7 @@ func TestMongodbInstanceCpu_Update_TriggersUpgrade(t *testing.T) {
 	d.SetId("cmgo-cpu-test")
 
 	// Simulate a cpu-only change from 2 to 4.
-	d.Set("cpu", 4)
+	assert.NoError(t, d.Set("cpu", 4))
 
 	err := res.Update(d, meta)
 	assert.NoError(t, err)

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_instance_test.go
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_instance_test.go
@@ -4,6 +4,7 @@ import (
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 	svcmongodb "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/mongodb"
+	svctag "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tag"
 
 	"context"
 	"fmt"
@@ -12,8 +13,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	mongodb_sdk "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 )
 
 func init() {
@@ -584,3 +593,290 @@ resource "tencentcloud_mongodb_instance" "mongodb_mutil_zone" {
   }
 }
 `
+
+// ---- gomonkey-based unit tests for the cpu parameter ----
+// Run with: go test ./tencentcloud/services/mongodb/ -run "TestMongodbInstanceCpu" -v -count=1 -gcflags="all=-l"
+//
+// These tests mock the cloud API methods (ModifyDBInstanceSpec, DescribeDBInstanceDeal,
+// DescribeDBInstances) on the mongodb SDK client returned by UseMongodbClient, so that
+// the service-layer mapping (params["cpu"] -> request.Cpu) and the resource Read/Update
+// business logic are exercised end-to-end.
+
+type mockMetaForMongodbInstance struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForMongodbInstance) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForMongodbInstance{}
+
+func newMockMetaForMongodbInstance() *mockMetaForMongodbInstance {
+	return &mockMetaForMongodbInstance{client: &connectivity.TencentCloudClient{Region: "ap-guangzhou"}}
+}
+
+// buildMongodbInstanceDetailForCpu builds an InstanceDetail with all mandatory
+// fields populated (so the Read CheckNil validation passes) and CpuNum set,
+// suitable for the cpu Read backfill tests.
+func buildMongodbInstanceDetailForCpu(cpuNum uint64) *mongodb_sdk.InstanceDetail {
+	return &mongodb_sdk.InstanceDetail{
+		InstanceId:   helper.String("cmgo-cpu-test"),
+		InstanceName: helper.String("tf-mongodb-cpu-test"),
+		PayMode:      helper.Uint64(0),
+		ProjectId:    helper.Uint64(0),
+		Zone:         helper.String("ap-guangzhou-3"),
+		VpcId:        helper.String("vpc-test"),
+		SubnetId:     helper.String("subnet-test"),
+		Status:       helper.Int64(2),
+		Vip:          helper.String("10.0.0.1"),
+		Vport:        helper.Uint64(27017),
+		CreateTime:   helper.String("2024-01-01 00:00:00"),
+		MongoVersion: helper.String("MONGO_40_WT"),
+		Memory:       helper.Uint64(2048),
+		Volume:       helper.Uint64(25600),
+		CpuNum:       helper.Uint64(cpuNum),
+		MachineType:  helper.String("HIO10G"),
+		SecondaryNum: helper.Uint64(2),
+	}
+}
+
+// buildMongodbDescribeDBInstancesResponse wraps an InstanceDetail into a
+// DescribeDBInstancesResponse, matching the shape consumed by DescribeInstanceById.
+func buildMongodbDescribeDBInstancesResponse(instance *mongodb_sdk.InstanceDetail) *mongodb_sdk.DescribeDBInstancesResponse {
+	resp := mongodb_sdk.NewDescribeDBInstancesResponse()
+	resp.Response = &mongodb_sdk.DescribeDBInstancesResponseParams{
+		InstanceDetails: []*mongodb_sdk.InstanceDetail{instance},
+	}
+	return resp
+}
+
+// mockCommonMongodbReadAPIMethods mocks the auxiliary cloud API methods invoked
+// during resourceTencentCloudMongodbInstance_read (security groups, node property)
+// on the mongodb SDK client. Tags are fetched via the tag service which is mocked
+// separately.
+func mockCommonMongodbReadAPIMethods(patches *gomonkey.Patches, mongodbClient *mongodb_sdk.Client) {
+	patches.ApplyMethodFunc(mongodbClient, "DescribeSecurityGroup", func(request *mongodb_sdk.DescribeSecurityGroupRequest) (*mongodb_sdk.DescribeSecurityGroupResponse, error) {
+		resp := mongodb_sdk.NewDescribeSecurityGroupResponse()
+		resp.Response = &mongodb_sdk.DescribeSecurityGroupResponseParams{}
+		return resp, nil
+	})
+	patches.ApplyMethodFunc(mongodbClient, "DescribeDBInstanceNodeProperty", func(request *mongodb_sdk.DescribeDBInstanceNodePropertyRequest) (*mongodb_sdk.DescribeDBInstanceNodePropertyResponse, error) {
+		resp := mongodb_sdk.NewDescribeDBInstanceNodePropertyResponse()
+		resp.Response = &mongodb_sdk.DescribeDBInstanceNodePropertyResponseParams{}
+		return resp, nil
+	})
+	var tagService svctag.TagService
+	patches.ApplyMethodFunc(&tagService, "DescribeResourceTags", func(ctx context.Context, serviceType, resourceType, region, resourceId string) (map[string]string, error) {
+		return map[string]string{}, nil
+	})
+}
+
+// mockMongodbUpdateOtherBranches mocks the cloud API methods that the
+// resourceTencentCloudMongodbInstanceUpdate branches (other than the cpu spec
+// modification branch) may invoke when TestResourceDataRaw reports all fields as
+// changed. This isolates the cpu-triggered spec modification branch so the test
+// focuses on the new cpu parameter behavior.
+func mockMongodbUpdateOtherBranches(patches *gomonkey.Patches, mongodbClient *mongodb_sdk.Client) {
+	// ModifyInstanceAz: return the "already distribution" error so the branch
+	// skips the deal-polling path (needModifyFlag=false, returns nil).
+	patches.ApplyMethodFunc(mongodbClient, "ModifyInstanceAz", func(request *mongodb_sdk.ModifyInstanceAzRequest) (*mongodb_sdk.ModifyInstanceAzResponse, error) {
+		return nil, sdkErrors.NewTencentCloudSDKError("InvalidParameter", "The target az already distribution.", "")
+	})
+	// RenameInstance (instance_name change).
+	patches.ApplyMethodFunc(mongodbClient, "RenameInstance", func(request *mongodb_sdk.RenameInstanceRequest) (*mongodb_sdk.RenameInstanceResponse, error) {
+		resp := mongodb_sdk.NewRenameInstanceResponse()
+		resp.Response = &mongodb_sdk.RenameInstanceResponseParams{}
+		return resp, nil
+	})
+	// AssignProject (project_id change).
+	patches.ApplyMethodFunc(mongodbClient, "AssignProject", func(request *mongodb_sdk.AssignProjectRequest) (*mongodb_sdk.AssignProjectResponse, error) {
+		resp := mongodb_sdk.NewAssignProjectResponse()
+		resp.Response = &mongodb_sdk.AssignProjectResponseParams{}
+		return resp, nil
+	})
+	// ResetDBInstancePassword (password change).
+	patches.ApplyMethodFunc(mongodbClient, "ResetDBInstancePassword", func(request *mongodb_sdk.ResetDBInstancePasswordRequest) (*mongodb_sdk.ResetDBInstancePasswordResponse, error) {
+		resp := mongodb_sdk.NewResetDBInstancePasswordResponse()
+		resp.Response = &mongodb_sdk.ResetDBInstancePasswordResponseParams{}
+		return resp, nil
+	})
+	// ModifyDBInstanceNetworkAddress (vpc_id/subnet_id change).
+	patches.ApplyMethodFunc(mongodbClient, "ModifyDBInstanceNetworkAddress", func(request *mongodb_sdk.ModifyDBInstanceNetworkAddressRequest) (*mongodb_sdk.ModifyDBInstanceNetworkAddressResponse, error) {
+		resp := mongodb_sdk.NewModifyDBInstanceNetworkAddressResponse()
+		resp.Response = &mongodb_sdk.ModifyDBInstanceNetworkAddressResponseParams{}
+		return resp, nil
+	})
+	// ModifyDBInstanceSecurityGroup (security_groups change).
+	patches.ApplyMethodFunc(mongodbClient, "ModifyDBInstanceSecurityGroup", func(request *mongodb_sdk.ModifyDBInstanceSecurityGroupRequest) (*mongodb_sdk.ModifyDBInstanceSecurityGroupResponse, error) {
+		resp := mongodb_sdk.NewModifyDBInstanceSecurityGroupResponse()
+		resp.Response = &mongodb_sdk.ModifyDBInstanceSecurityGroupResponseParams{}
+		return resp, nil
+	})
+	// SetInstanceMaintenance (maintenance_start/end change).
+	patches.ApplyMethodFunc(mongodbClient, "SetInstanceMaintenance", func(request *mongodb_sdk.SetInstanceMaintenanceRequest) (*mongodb_sdk.SetInstanceMaintenanceResponse, error) {
+		resp := mongodb_sdk.NewSetInstanceMaintenanceResponse()
+		resp.Response = &mongodb_sdk.SetInstanceMaintenanceResponseParams{}
+		return resp, nil
+	})
+	// UpgradeDbInstanceVersion (engine_version change): return a flow id, then
+	// DescribeAsyncRequestInfo returns success status.
+	patches.ApplyMethodFunc(mongodbClient, "UpgradeDbInstanceVersionWithContext", func(ctx context.Context, request *mongodb_sdk.UpgradeDbInstanceVersionRequest) (*mongodb_sdk.UpgradeDbInstanceVersionResponse, error) {
+		resp := mongodb_sdk.NewUpgradeDbInstanceVersionResponse()
+		resp.Response = &mongodb_sdk.UpgradeDbInstanceVersionResponseParams{
+			FlowId: helper.Uint64(1),
+		}
+		return resp, nil
+	})
+	patches.ApplyMethodFunc(mongodbClient, "DescribeAsyncRequestInfo", func(request *mongodb_sdk.DescribeAsyncRequestInfoRequest) (*mongodb_sdk.DescribeAsyncRequestInfoResponse, error) {
+		resp := mongodb_sdk.NewDescribeAsyncRequestInfoResponse()
+		resp.Response = &mongodb_sdk.DescribeAsyncRequestInfoResponseParams{
+			Status: helper.String("success"),
+		}
+		return resp, nil
+	})
+	// ModifyTags (tags change).
+	var tagService svctag.TagService
+	patches.ApplyMethodFunc(&tagService, "ModifyTags", func(ctx context.Context, resourceName string, replaceTags map[string]string, deleteKeys []string) error {
+		return nil
+	})
+}
+
+// TestMongodbInstanceCpu_Schema verifies the cpu field schema definition.
+func TestMongodbInstanceCpu_Schema(t *testing.T) {
+	res := svcmongodb.ResourceTencentCloudMongodbInstance()
+
+	s, ok := res.Schema["cpu"]
+	assert.True(t, ok, "cpu field should exist in schema")
+	assert.Equal(t, schema.TypeInt, s.Type)
+	assert.True(t, s.Optional)
+	assert.True(t, s.Computed)
+	assert.False(t, s.ForceNew)
+}
+
+// TestMongodbInstanceCpu_Update_TriggersUpgrade verifies that changing only the cpu
+// field triggers ModifyDBInstanceSpec with request.Cpu set, and that the deal is
+// polled to success via DescribeDBInstanceDeal.
+func TestMongodbInstanceCpu_Update_TriggersUpgrade(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	mongodbClient := &mongodb_sdk.Client{}
+	patches.ApplyMethodReturn(newMockMetaForMongodbInstance().client, "UseMongodbClient", mongodbClient)
+
+	var capturedRequest *mongodb_sdk.ModifyDBInstanceSpecRequest
+	patches.ApplyMethodFunc(mongodbClient, "ModifyDBInstanceSpec", func(request *mongodb_sdk.ModifyDBInstanceSpecRequest) (*mongodb_sdk.ModifyDBInstanceSpecResponse, error) {
+		capturedRequest = request
+		resp := mongodb_sdk.NewModifyDBInstanceSpecResponse()
+		resp.Response = &mongodb_sdk.ModifyDBInstanceSpecResponseParams{
+			DealId: helper.String("test-deal-id"),
+		}
+		return resp, nil
+	})
+	patches.ApplyMethodFunc(mongodbClient, "DescribeDBInstanceDeal", func(request *mongodb_sdk.DescribeDBInstanceDealRequest) (*mongodb_sdk.DescribeDBInstanceDealResponse, error) {
+		resp := mongodb_sdk.NewDescribeDBInstanceDealResponse()
+		status := int64(4)
+		resp.Response = &mongodb_sdk.DescribeDBInstanceDealResponseParams{
+			Status: &status,
+		}
+		return resp, nil
+	})
+	// Mock the Read that runs at the end of Update.
+	patches.ApplyMethodFunc(mongodbClient, "DescribeDBInstances", func(request *mongodb_sdk.DescribeDBInstancesRequest) (*mongodb_sdk.DescribeDBInstancesResponse, error) {
+		return buildMongodbDescribeDBInstancesResponse(buildMongodbInstanceDetailForCpu(4)), nil
+	})
+	mockCommonMongodbReadAPIMethods(patches, mongodbClient)
+	// Mock the other Update branches that trigger because TestResourceDataRaw
+	// reports all fields as changed against an empty prior state.
+	mockMongodbUpdateOtherBranches(patches, mongodbClient)
+
+	meta := newMockMetaForMongodbInstance()
+	res := svcmongodb.ResourceTencentCloudMongodbInstance()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_name":  "tf-mongodb-cpu-test",
+		"memory":         2,
+		"volume":         25,
+		"engine_version": "MONGO_40_WT",
+		"machine_type":   "HIO10G",
+		"available_zone": "ap-guangzhou-3",
+		"cpu":            2,
+	})
+	d.SetId("cmgo-cpu-test")
+
+	// Simulate a cpu-only change from 2 to 4.
+	d.Set("cpu", 4)
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	// Verify ModifyDBInstanceSpec was called and request.Cpu was set to 4.
+	assert.NotNil(t, capturedRequest, "ModifyDBInstanceSpec should be called")
+	assert.NotNil(t, capturedRequest.Cpu, "request.Cpu should be set")
+	assert.Equal(t, int64(4), *capturedRequest.Cpu)
+}
+
+// TestMongodbInstanceCpu_Read_Backfill verifies that Read populates the cpu field
+// from DescribeDBInstances (DescribeInstanceById) when CpuNum is not nil.
+func TestMongodbInstanceCpu_Read_Backfill(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	mongodbClient := &mongodb_sdk.Client{}
+	patches.ApplyMethodReturn(newMockMetaForMongodbInstance().client, "UseMongodbClient", mongodbClient)
+
+	patches.ApplyMethodFunc(mongodbClient, "DescribeDBInstances", func(request *mongodb_sdk.DescribeDBInstancesRequest) (*mongodb_sdk.DescribeDBInstancesResponse, error) {
+		return buildMongodbDescribeDBInstancesResponse(buildMongodbInstanceDetailForCpu(8)), nil
+	})
+	mockCommonMongodbReadAPIMethods(patches, mongodbClient)
+
+	meta := newMockMetaForMongodbInstance()
+	res := svcmongodb.ResourceTencentCloudMongodbInstance()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_name":  "tf-mongodb-cpu-test",
+		"memory":         2,
+		"volume":         25,
+		"engine_version": "MONGO_40_WT",
+		"machine_type":   "HIO10G",
+		"available_zone": "ap-guangzhou-3",
+	})
+	d.SetId("cmgo-cpu-test")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, 8, d.Get("cpu"))
+}
+
+// TestMongodbInstanceCpu_Read_NilCpuNum verifies that Read does not fail and does
+// not set cpu when CpuNum is nil.
+func TestMongodbInstanceCpu_Read_NilCpuNum(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	mongodbClient := &mongodb_sdk.Client{}
+	patches.ApplyMethodReturn(newMockMetaForMongodbInstance().client, "UseMongodbClient", mongodbClient)
+
+	patches.ApplyMethodFunc(mongodbClient, "DescribeDBInstances", func(request *mongodb_sdk.DescribeDBInstancesRequest) (*mongodb_sdk.DescribeDBInstancesResponse, error) {
+		instance := buildMongodbInstanceDetailForCpu(0)
+		instance.CpuNum = nil
+		return buildMongodbDescribeDBInstancesResponse(instance), nil
+	})
+	mockCommonMongodbReadAPIMethods(patches, mongodbClient)
+
+	meta := newMockMetaForMongodbInstance()
+	res := svcmongodb.ResourceTencentCloudMongodbInstance()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_name":  "tf-mongodb-cpu-test",
+		"memory":         2,
+		"volume":         25,
+		"engine_version": "MONGO_40_WT",
+		"machine_type":   "HIO10G",
+		"available_zone": "ap-guangzhou-3",
+	})
+	d.SetId("cmgo-cpu-test")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	// cpu should remain at its zero value (not set from API)
+	_, ok := d.GetOk("cpu")
+	assert.False(t, ok, "cpu should not be set when CpuNum is nil")
+}

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_sharding_instance.go
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_sharding_instance.go
@@ -23,6 +23,12 @@ import (
 
 func ResourceTencentCloudMongodbShardingInstance() *schema.Resource {
 	mongodbShardingInstanceInfo := map[string]*schema.Schema{
+		"cpu": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "The CPU core count of the MongoDB instance after the configuration change. Unit: C. When this parameter is empty, the current CPU size of the instance is used by default. The supported CPU specifications can be obtained through the DescribeSpecInfo API.",
+		},
 		"shard_quantity": {
 			Type:         schema.TypeInt,
 			Required:     true,
@@ -124,6 +130,7 @@ func mongodbAllShardingInstanceReqSet(requestInter interface{}, d *schema.Resour
 		nodeNum               = d.Get("nodes_per_shard").(int)
 		goodsNum              = 1
 		clusterType           = MONGODB_CLUSTER_TYPE_SHARD
+		cpu                   = d.Get("cpu").(int)
 		memoryInterface       = d.Get("memory").(int)
 		volumeInterface       = d.Get("volume").(int)
 		mongoVersionInterface = d.Get("engine_version").(string)
@@ -154,6 +161,7 @@ func mongodbAllShardingInstanceReqSet(requestInter interface{}, d *schema.Resour
 		"NodeNum":         helper.IntUint64(nodeNum),
 		"GoodsNum":        helper.IntUint64(goodsNum),
 		"ClusterType":     &clusterType,
+		"CpuCore":         helper.IntInt64(cpu),
 		"Memory":          helper.IntUint64(memoryInterface),
 		"Volume":          helper.IntUint64(volumeInterface),
 		"MongoVersion":    &mongoVersionInterface,
@@ -466,6 +474,10 @@ func resourceMongodbShardingInstanceRead(d *schema.ResourceData, meta interface{
 	_ = d.Set("mongos_node_num", instance.MongosNodeNum)
 	_ = d.Set("auto_renew_flag", instance.AutoRenewFlag)
 
+	if instance.CpuNum != nil {
+		_ = d.Set("cpu", int(*instance.CpuNum))
+	}
+
 	groups, err := mongodbService.DescribeSecurityGroup(ctx, instanceId)
 	if err != nil {
 		return err
@@ -668,10 +680,14 @@ func resourceMongodbShardingInstanceUpdate(d *schema.ResourceData, meta interfac
 			}
 		}
 	}
-	if d.HasChange("memory") || d.HasChange("volume") || d.HasChange("add_node_list") || d.HasChange("remove_node_list") {
+	if d.HasChange("memory") || d.HasChange("volume") || d.HasChange("cpu") || d.HasChange("add_node_list") || d.HasChange("remove_node_list") {
 		memory := d.Get("memory").(int)
 		volume := d.Get("volume").(int)
 		params := make(map[string]interface{})
+
+		if v, ok := d.GetOkExists("cpu"); ok {
+			params["cpu"] = v.(int)
+		}
 
 		var inMaintenance int
 		if v, ok := d.GetOkExists("in_maintenance"); ok {

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_sharding_instance.go
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_sharding_instance.go
@@ -475,7 +475,7 @@ func resourceMongodbShardingInstanceRead(d *schema.ResourceData, meta interface{
 	_ = d.Set("auto_renew_flag", instance.AutoRenewFlag)
 
 	if instance.CpuNum != nil {
-		_ = d.Set("cpu", int(*instance.CpuNum))
+		_ = d.Set("cpu", int(*instance.CpuNum/(*instance.ReplicationSetNum)))
 	}
 
 	groups, err := mongodbService.DescribeSecurityGroup(ctx, instanceId)

--- a/tencentcloud/services/mongodb/resource_tc_mongodb_sharding_instance.md
+++ b/tencentcloud/services/mongodb/resource_tc_mongodb_sharding_instance.md
@@ -2,6 +2,8 @@ Provide a resource to create a Mongodb sharding instance.
 
 ~> **NOTE:** The `add_node_list` and `remove_node_list` arguments are used to submit node change actions. When updating the resource, only newly added items in these lists will be sent to the API. If an existing item is removed from the Terraform configuration, Terraform only updates the local state and does not submit a repeated add or remove request. To add or remove another read-only node, append a new block instead of modifying an existing one. After the change is completed, obsolete action records can be removed from the configuration, and this cleanup does not trigger a new node operation when the remaining list is a subset of the previous list. In general, it is recommended to keep these action records in the configuration and avoid cleanup unless necessary.
 
+~> **NOTE:** The `cpu` parameter takes effect only when the configuration is changed. Changing the `cpu` triggers the `ModifyDBInstanceSpec` API to adjust the CPU specification of the running MongoDB instance in-place. The supported CPU specifications can be obtained through the `DescribeSpecInfo` API.
+
 Example Usage
 
 ```hcl

--- a/tencentcloud/services/mongodb/service_tencentcloud_mongodb.go
+++ b/tencentcloud/services/mongodb/service_tencentcloud_mongodb.go
@@ -193,6 +193,9 @@ func (me *MongodbService) UpgradeInstance(ctx context.Context, instanceId string
 	if v, ok := params["in_maintenance"]; ok {
 		request.InMaintenance = helper.IntUint64(v.(int))
 	}
+	if v, ok := params["cpu"]; ok {
+		request.Cpu = helper.IntInt64(v.(int))
+	}
 	var response *mongodb.ModifyDBInstanceSpecResponse
 	tradeError := false
 	err := resource.Retry(6*tccommon.WriteRetryTimeout, func() *resource.RetryError {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"io"
-
 	//"log"
 	"math/rand"
 	"net/url"
@@ -266,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.132"
+	params["RequestClient"] = "SDK_GO_1.3.133"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/doc.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/doc.go
@@ -1,2 +1,0 @@
-// Package doc
-package doc

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725/client.go
@@ -745,6 +745,58 @@ func (c *Client) CreateLogDownloadTaskWithContext(ctx context.Context, request *
     return
 }
 
+func NewCreateSlowLogPatternDownloadTaskRequest() (request *CreateSlowLogPatternDownloadTaskRequest) {
+    request = &CreateSlowLogPatternDownloadTaskRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("mongodb", APIVersion, "CreateSlowLogPatternDownloadTask")
+    
+    
+    return
+}
+
+func NewCreateSlowLogPatternDownloadTaskResponse() (response *CreateSlowLogPatternDownloadTaskResponse) {
+    response = &CreateSlowLogPatternDownloadTaskResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateSlowLogPatternDownloadTask
+// 创建慢日志统计下载任务
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_NOTFOUNDINSTANCE = "InvalidParameterValue.NotFoundInstance"
+func (c *Client) CreateSlowLogPatternDownloadTask(request *CreateSlowLogPatternDownloadTaskRequest) (response *CreateSlowLogPatternDownloadTaskResponse, err error) {
+    return c.CreateSlowLogPatternDownloadTaskWithContext(context.Background(), request)
+}
+
+// CreateSlowLogPatternDownloadTask
+// 创建慢日志统计下载任务
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_NOTFOUNDINSTANCE = "InvalidParameterValue.NotFoundInstance"
+func (c *Client) CreateSlowLogPatternDownloadTaskWithContext(ctx context.Context, request *CreateSlowLogPatternDownloadTaskRequest) (response *CreateSlowLogPatternDownloadTaskResponse, err error) {
+    if request == nil {
+        request = NewCreateSlowLogPatternDownloadTaskRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "mongodb", APIVersion, "CreateSlowLogPatternDownloadTask")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateSlowLogPatternDownloadTask require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateSlowLogPatternDownloadTaskResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteAccountUserRequest() (request *DeleteAccountUserRequest) {
     request = &DeleteAccountUserRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1775,6 +1827,58 @@ func (c *Client) DescribeDBInstanceDealWithContext(ctx context.Context, request 
     request.SetContext(ctx)
     
     response = NewDescribeDBInstanceDealResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeDBInstanceLogToCLSRequest() (request *DescribeDBInstanceLogToCLSRequest) {
+    request = &DescribeDBInstanceLogToCLSRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("mongodb", APIVersion, "DescribeDBInstanceLogToCLS")
+    
+    
+    return
+}
+
+func NewDescribeDBInstanceLogToCLSResponse() (response *DescribeDBInstanceLogToCLSResponse) {
+    response = &DescribeDBInstanceLogToCLSResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBInstanceLogToCLS
+// 获取日志投递的相关配置信息
+//
+// 可能返回的错误码:
+//  INTERNALERROR_DBOPERATEERROR = "InternalError.DBOperateError"
+//  INVALIDPARAMETERVALUE_NOTFOUNDINSTANCE = "InvalidParameterValue.NotFoundInstance"
+func (c *Client) DescribeDBInstanceLogToCLS(request *DescribeDBInstanceLogToCLSRequest) (response *DescribeDBInstanceLogToCLSResponse, err error) {
+    return c.DescribeDBInstanceLogToCLSWithContext(context.Background(), request)
+}
+
+// DescribeDBInstanceLogToCLS
+// 获取日志投递的相关配置信息
+//
+// 可能返回的错误码:
+//  INTERNALERROR_DBOPERATEERROR = "InternalError.DBOperateError"
+//  INVALIDPARAMETERVALUE_NOTFOUNDINSTANCE = "InvalidParameterValue.NotFoundInstance"
+func (c *Client) DescribeDBInstanceLogToCLSWithContext(ctx context.Context, request *DescribeDBInstanceLogToCLSRequest) (response *DescribeDBInstanceLogToCLSResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBInstanceLogToCLSRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "mongodb", APIVersion, "DescribeDBInstanceLogToCLS")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBInstanceLogToCLS require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBInstanceLogToCLSResponse()
     err = c.Send(request, response)
     return
 }
@@ -3259,6 +3363,70 @@ func (c *Client) FlushInstanceRouterConfigWithContext(ctx context.Context, reque
     return
 }
 
+func NewIncreaseDBInstanceConnectionLimitRequest() (request *IncreaseDBInstanceConnectionLimitRequest) {
+    request = &IncreaseDBInstanceConnectionLimitRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("mongodb", APIVersion, "IncreaseDBInstanceConnectionLimit")
+    
+    
+    return
+}
+
+func NewIncreaseDBInstanceConnectionLimitResponse() (response *IncreaseDBInstanceConnectionLimitResponse) {
+    response = &IncreaseDBInstanceConnectionLimitResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// IncreaseDBInstanceConnectionLimit
+// 终止实例流程
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_CONNECTIONUPDATEERROR = "FailedOperation.ConnectionUpdateError"
+//  FAILEDOPERATION_CONNECTIONUPDATEUSEDOFF = "FailedOperation.ConnectionUpdateUsedOff"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_CHECKAPPIDFAILED = "InternalError.CheckAppIdFailed"
+//  INTERNALERROR_DBOPERATEERROR = "InternalError.DBOperateError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE_CHECKAPPIDFAILED = "InvalidParameterValue.CheckAppIdFailed"
+//  INVALIDPARAMETERVALUE_STATUSABNORMAL = "InvalidParameterValue.StatusAbnormal"
+func (c *Client) IncreaseDBInstanceConnectionLimit(request *IncreaseDBInstanceConnectionLimitRequest) (response *IncreaseDBInstanceConnectionLimitResponse, err error) {
+    return c.IncreaseDBInstanceConnectionLimitWithContext(context.Background(), request)
+}
+
+// IncreaseDBInstanceConnectionLimit
+// 终止实例流程
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_CONNECTIONUPDATEERROR = "FailedOperation.ConnectionUpdateError"
+//  FAILEDOPERATION_CONNECTIONUPDATEUSEDOFF = "FailedOperation.ConnectionUpdateUsedOff"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_CHECKAPPIDFAILED = "InternalError.CheckAppIdFailed"
+//  INTERNALERROR_DBOPERATEERROR = "InternalError.DBOperateError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE_CHECKAPPIDFAILED = "InvalidParameterValue.CheckAppIdFailed"
+//  INVALIDPARAMETERVALUE_STATUSABNORMAL = "InvalidParameterValue.StatusAbnormal"
+func (c *Client) IncreaseDBInstanceConnectionLimitWithContext(ctx context.Context, request *IncreaseDBInstanceConnectionLimitRequest) (response *IncreaseDBInstanceConnectionLimitResponse, err error) {
+    if request == nil {
+        request = NewIncreaseDBInstanceConnectionLimitRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "mongodb", APIVersion, "IncreaseDBInstanceConnectionLimit")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("IncreaseDBInstanceConnectionLimit require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewIncreaseDBInstanceConnectionLimitResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewInquirePriceCreateDBInstancesRequest() (request *InquirePriceCreateDBInstancesRequest) {
     request = &InquirePriceCreateDBInstancesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -3753,6 +3921,62 @@ func (c *Client) ModifyBackupExpireTimeWithContext(ctx context.Context, request 
     request.SetContext(ctx)
     
     response = NewModifyBackupExpireTimeResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyDBInstanceLogToCLSRequest() (request *ModifyDBInstanceLogToCLSRequest) {
+    request = &ModifyDBInstanceLogToCLSRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("mongodb", APIVersion, "ModifyDBInstanceLogToCLS")
+    
+    
+    return
+}
+
+func NewModifyDBInstanceLogToCLSResponse() (response *ModifyDBInstanceLogToCLSResponse) {
+    response = &ModifyDBInstanceLogToCLSResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBInstanceLogToCLS
+// 开启或关闭MongoDB慢日志、错误日志、操作日志投递CLS
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBOPERATIONERROR = "InternalError.DBOperationError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE_NOTFOUNDINSTANCE = "InvalidParameterValue.NotFoundInstance"
+func (c *Client) ModifyDBInstanceLogToCLS(request *ModifyDBInstanceLogToCLSRequest) (response *ModifyDBInstanceLogToCLSResponse, err error) {
+    return c.ModifyDBInstanceLogToCLSWithContext(context.Background(), request)
+}
+
+// ModifyDBInstanceLogToCLS
+// 开启或关闭MongoDB慢日志、错误日志、操作日志投递CLS
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBOPERATIONERROR = "InternalError.DBOperationError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE_NOTFOUNDINSTANCE = "InvalidParameterValue.NotFoundInstance"
+func (c *Client) ModifyDBInstanceLogToCLSWithContext(ctx context.Context, request *ModifyDBInstanceLogToCLSRequest) (response *ModifyDBInstanceLogToCLSResponse, err error) {
+    if request == nil {
+        request = NewModifyDBInstanceLogToCLSRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "mongodb", APIVersion, "ModifyDBInstanceLogToCLS")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBInstanceLogToCLS require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBInstanceLogToCLSResponse()
     err = c.Send(request, response)
     return
 }
@@ -4329,6 +4553,60 @@ func (c *Client) OpenAuditServiceWithContext(ctx context.Context, request *OpenA
     request.SetContext(ctx)
     
     response = NewOpenAuditServiceResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewPromoteDBInstanceToActiveRequest() (request *PromoteDBInstanceToActiveRequest) {
+    request = &PromoteDBInstanceToActiveRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("mongodb", APIVersion, "PromoteDBInstanceToActive")
+    
+    
+    return
+}
+
+func NewPromoteDBInstanceToActiveResponse() (response *PromoteDBInstanceToActiveResponse) {
+    response = &PromoteDBInstanceToActiveResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// PromoteDBInstanceToActive
+// 本接口（PromoteDBInstanceToActive）用于将灾备实例或只读实例转为独立的主实例
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_CHECKAPPIDFAILED = "InternalError.CheckAppIdFailed"
+//  INVALIDPARAMETERVALUE_LOCKFAILED = "InvalidParameterValue.LockFailed"
+func (c *Client) PromoteDBInstanceToActive(request *PromoteDBInstanceToActiveRequest) (response *PromoteDBInstanceToActiveResponse, err error) {
+    return c.PromoteDBInstanceToActiveWithContext(context.Background(), request)
+}
+
+// PromoteDBInstanceToActive
+// 本接口（PromoteDBInstanceToActive）用于将灾备实例或只读实例转为独立的主实例
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_CHECKAPPIDFAILED = "InternalError.CheckAppIdFailed"
+//  INVALIDPARAMETERVALUE_LOCKFAILED = "InvalidParameterValue.LockFailed"
+func (c *Client) PromoteDBInstanceToActiveWithContext(ctx context.Context, request *PromoteDBInstanceToActiveRequest) (response *PromoteDBInstanceToActiveResponse, err error) {
+    if request == nil {
+        request = NewPromoteDBInstanceToActiveRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "mongodb", APIVersion, "PromoteDBInstanceToActive")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("PromoteDBInstanceToActive require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewPromoteDBInstanceToActiveResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725/errors.go
@@ -26,6 +26,12 @@ const (
 	// 无审计配置信息。
 	FAILEDOPERATION_AUDITCONFIGNOTEXIST = "FailedOperation.AuditConfigNotExist"
 
+	// 提升连接数失败
+	FAILEDOPERATION_CONNECTIONUPDATEERROR = "FailedOperation.ConnectionUpdateError"
+
+	// 连接数提升次数已耗尽
+	FAILEDOPERATION_CONNECTIONUPDATEUSEDOFF = "FailedOperation.ConnectionUpdateUsedOff"
+
 	// 实例开启了销毁保护，不允许销毁
 	FAILEDOPERATION_DELETIONPROTECTIONENABLED = "FailedOperation.DeletionProtectionEnabled"
 

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725/models.go
@@ -638,39 +638,33 @@ func (r *CreateAuditLogFileResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateBackupDBInstanceRequestParams struct {
-	// 实例 ID。例如：cmgo-p8vn****。请登录 [MongoDB 控制台](https://console.cloud.tencent.com/mongodb)在实例列表复制实例 ID。
+	// <p>实例 ID。例如：cmgo-p8vn****。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 设置备份方式。
-	// - 0：逻辑备份。
-	// - 1：物理备份。
-	// - 3：快照备份。
-	// **说明**:
-	// 1. 通用版实例支持逻辑备份与物理备份。云盘版实例支持物理备份与快照备份，暂不支持逻辑备份。
-	// 2. 实例开通存储加密，则备份方式不能为物理备份。
+	// <p>设置备份方式。</p><ul><li>0：逻辑备份。</li><li>1：物理备份。</li><li>3：快照备份。<br><strong>说明</strong>:</li><li>通用版实例支持逻辑备份与物理备份。云盘版实例支持物理备份与快照备份，暂不支持逻辑备份。</li><li>实例开通存储加密，则备份方式不能为物理备份。</li></ul>
 	BackupMethod *int64 `json:"BackupMethod,omitnil,omitempty" name:"BackupMethod"`
 
-	// 备份备注信息。
+	// <p>备份备注信息。</p>
 	BackupRemark *string `json:"BackupRemark,omitnil,omitempty" name:"BackupRemark"`
+
+	// <p>保存天数，-2-永久保留（不定期保留），-1-跟随长期保留时长，0-按配置天数，1~7300-自定义天数（最长20年）</p><p>单位：天</p>
+	BackupRetentionDays *int64 `json:"BackupRetentionDays,omitnil,omitempty" name:"BackupRetentionDays"`
 }
 
 type CreateBackupDBInstanceRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例 ID。例如：cmgo-p8vn****。请登录 [MongoDB 控制台](https://console.cloud.tencent.com/mongodb)在实例列表复制实例 ID。
+	// <p>实例 ID。例如：cmgo-p8vn****。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 设置备份方式。
-	// - 0：逻辑备份。
-	// - 1：物理备份。
-	// - 3：快照备份。
-	// **说明**:
-	// 1. 通用版实例支持逻辑备份与物理备份。云盘版实例支持物理备份与快照备份，暂不支持逻辑备份。
-	// 2. 实例开通存储加密，则备份方式不能为物理备份。
+	// <p>设置备份方式。</p><ul><li>0：逻辑备份。</li><li>1：物理备份。</li><li>3：快照备份。<br><strong>说明</strong>:</li><li>通用版实例支持逻辑备份与物理备份。云盘版实例支持物理备份与快照备份，暂不支持逻辑备份。</li><li>实例开通存储加密，则备份方式不能为物理备份。</li></ul>
 	BackupMethod *int64 `json:"BackupMethod,omitnil,omitempty" name:"BackupMethod"`
 
-	// 备份备注信息。
+	// <p>备份备注信息。</p>
 	BackupRemark *string `json:"BackupRemark,omitnil,omitempty" name:"BackupRemark"`
+
+	// <p>保存天数，-2-永久保留（不定期保留），-1-跟随长期保留时长，0-按配置天数，1~7300-自定义天数（最长20年）</p><p>单位：天</p>
+	BackupRetentionDays *int64 `json:"BackupRetentionDays,omitnil,omitempty" name:"BackupRetentionDays"`
 }
 
 func (r *CreateBackupDBInstanceRequest) ToJsonString() string {
@@ -688,6 +682,7 @@ func (r *CreateBackupDBInstanceRequest) FromJsonString(s string) error {
 	delete(f, "InstanceId")
 	delete(f, "BackupMethod")
 	delete(f, "BackupRemark")
+	delete(f, "BackupRetentionDays")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateBackupDBInstanceRequest has unknown keys!", "")
 	}
@@ -696,7 +691,7 @@ func (r *CreateBackupDBInstanceRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateBackupDBInstanceResponseParams struct {
-	// 查询备份流程的状态。
+	// <p>查询备份流程的状态。</p>
 	AsyncRequestId *string `json:"AsyncRequestId,omitnil,omitempty" name:"AsyncRequestId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -877,6 +872,18 @@ type CreateDBInstanceHourRequestParams struct {
 	// <p>参数模板 ID。</p><ul><li>参数模板是预置了特定参数值的集合，可用于快速配置新的 MongoDB 实例。合理使用参数模板，能有效提升数据库的部署效率与运行性能。</li><li>参数模板 ID 可通过 <a href="https://cloud.tencent.com/document/product/240/109155">DescribeDBInstanceParamTpl </a>接口获取。请选择与实例版本与架构所对应的参数模板 ID。</li></ul>
 	ParamTemplateId *string `json:"ParamTemplateId,omitnil,omitempty" name:"ParamTemplateId"`
 
+	// <p>数据库存储加密取值。</p><ul><li>No_Encryption：不采用存储加密。</li><li>TDE：开启 TDE 存储加密方式。</li></ul>
+	DataEncryption *string `json:"DataEncryption,omitnil,omitempty" name:"DataEncryption"`
+
+	// <p>如选取 TDE 存储加密，须指定密钥来源。</p><ul><li>auto 自动生成密钥。</li><li>manual 手动指定密钥。</li></ul>
+	EncryptionKeySource *string `json:"EncryptionKeySource,omitnil,omitempty" name:"EncryptionKeySource"`
+
+	// <p>密钥 ID。如密钥资源选取为指定自定义，须输入指定的密钥 ID。</p>
+	KeyId *string `json:"KeyId,omitnil,omitempty" name:"KeyId"`
+
+	// <p>如果密钥来源为指定自定义密钥，须填写该字段指定密钥的地域信息。</p>
+	KmsRegion *string `json:"KmsRegion,omitnil,omitempty" name:"KmsRegion"`
+
 	// <p>实例CPU核大小，单位：C。具体售卖的CPU规格，请通过接口 <a href="https://cloud.tencent.com/document/product/240/38567">DescribeSpecInfo</a> 获取。<br>注意：通用 I 型实例必须设置 CPU 大小。</p>
 	CpuCore *int64 `json:"CpuCore,omitnil,omitempty" name:"CpuCore"`
 }
@@ -965,6 +972,18 @@ type CreateDBInstanceHourRequest struct {
 	// <p>参数模板 ID。</p><ul><li>参数模板是预置了特定参数值的集合，可用于快速配置新的 MongoDB 实例。合理使用参数模板，能有效提升数据库的部署效率与运行性能。</li><li>参数模板 ID 可通过 <a href="https://cloud.tencent.com/document/product/240/109155">DescribeDBInstanceParamTpl </a>接口获取。请选择与实例版本与架构所对应的参数模板 ID。</li></ul>
 	ParamTemplateId *string `json:"ParamTemplateId,omitnil,omitempty" name:"ParamTemplateId"`
 
+	// <p>数据库存储加密取值。</p><ul><li>No_Encryption：不采用存储加密。</li><li>TDE：开启 TDE 存储加密方式。</li></ul>
+	DataEncryption *string `json:"DataEncryption,omitnil,omitempty" name:"DataEncryption"`
+
+	// <p>如选取 TDE 存储加密，须指定密钥来源。</p><ul><li>auto 自动生成密钥。</li><li>manual 手动指定密钥。</li></ul>
+	EncryptionKeySource *string `json:"EncryptionKeySource,omitnil,omitempty" name:"EncryptionKeySource"`
+
+	// <p>密钥 ID。如密钥资源选取为指定自定义，须输入指定的密钥 ID。</p>
+	KeyId *string `json:"KeyId,omitnil,omitempty" name:"KeyId"`
+
+	// <p>如果密钥来源为指定自定义密钥，须填写该字段指定密钥的地域信息。</p>
+	KmsRegion *string `json:"KmsRegion,omitnil,omitempty" name:"KmsRegion"`
+
 	// <p>实例CPU核大小，单位：C。具体售卖的CPU规格，请通过接口 <a href="https://cloud.tencent.com/document/product/240/38567">DescribeSpecInfo</a> 获取。<br>注意：通用 I 型实例必须设置 CPU 大小。</p>
 	CpuCore *int64 `json:"CpuCore,omitnil,omitempty" name:"CpuCore"`
 }
@@ -1008,6 +1027,10 @@ func (r *CreateDBInstanceHourRequest) FromJsonString(s string) error {
 	delete(f, "ReadonlyNodeAvailabilityZoneList")
 	delete(f, "HiddenZone")
 	delete(f, "ParamTemplateId")
+	delete(f, "DataEncryption")
+	delete(f, "EncryptionKeySource")
+	delete(f, "KeyId")
+	delete(f, "KmsRegion")
 	delete(f, "CpuCore")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBInstanceHourRequest has unknown keys!", "")
@@ -1251,6 +1274,18 @@ type CreateDBInstanceRequestParams struct {
 	// <p>参数模板 ID。</p><ul><li>参数模板是预置了特定参数值的集合，可用于快速配置新的 MongoDB 实例。合理使用参数模板，能有效提升数据库的部署效率与运行性能。</li><li>参数模板 ID 可通过 <a href="https://cloud.tencent.com/document/product/240/109155">DescribeDBInstanceParamTpl </a>接口获取。请选择与实例版本与架构所对应的参数模板 ID。</li></ul>
 	ParamTemplateId *string `json:"ParamTemplateId,omitnil,omitempty" name:"ParamTemplateId"`
 
+	// <p>数据库存储加密取值。</p><ul><li>No_Encryption：不采用存储加密。</li><li>TDE：开启 TDE 存储加密方式。</li></ul>
+	DataEncryption *string `json:"DataEncryption,omitnil,omitempty" name:"DataEncryption"`
+
+	// <p>如选取 TDE 存储加密，须指定密钥来源。</p><ul><li>auto 自动生成密钥。</li><li>manual 手动指定密钥。</li></ul>
+	EncryptionKeySource *string `json:"EncryptionKeySource,omitnil,omitempty" name:"EncryptionKeySource"`
+
+	// <p>密钥 ID。如密钥资源选取为指定自定义，须输入指定的密钥 ID。</p>
+	KeyId *string `json:"KeyId,omitnil,omitempty" name:"KeyId"`
+
+	// <p>如果密钥来源为指定自定义密钥，须填写该字段指定密钥的地域信息。</p>
+	KmsRegion *string `json:"KmsRegion,omitnil,omitempty" name:"KmsRegion"`
+
 	// <p>实例CPU核大小，单位：C。具体售卖的CPU规格，请通过接口 <a href="https://cloud.tencent.com/document/product/240/38567">DescribeSpecInfo</a> 获取<br>注意：通用 I 型实例必须设置 CPU 大小。</p>
 	CpuCore *int64 `json:"CpuCore,omitnil,omitempty" name:"CpuCore"`
 }
@@ -1348,6 +1383,18 @@ type CreateDBInstanceRequest struct {
 	// <p>参数模板 ID。</p><ul><li>参数模板是预置了特定参数值的集合，可用于快速配置新的 MongoDB 实例。合理使用参数模板，能有效提升数据库的部署效率与运行性能。</li><li>参数模板 ID 可通过 <a href="https://cloud.tencent.com/document/product/240/109155">DescribeDBInstanceParamTpl </a>接口获取。请选择与实例版本与架构所对应的参数模板 ID。</li></ul>
 	ParamTemplateId *string `json:"ParamTemplateId,omitnil,omitempty" name:"ParamTemplateId"`
 
+	// <p>数据库存储加密取值。</p><ul><li>No_Encryption：不采用存储加密。</li><li>TDE：开启 TDE 存储加密方式。</li></ul>
+	DataEncryption *string `json:"DataEncryption,omitnil,omitempty" name:"DataEncryption"`
+
+	// <p>如选取 TDE 存储加密，须指定密钥来源。</p><ul><li>auto 自动生成密钥。</li><li>manual 手动指定密钥。</li></ul>
+	EncryptionKeySource *string `json:"EncryptionKeySource,omitnil,omitempty" name:"EncryptionKeySource"`
+
+	// <p>密钥 ID。如密钥资源选取为指定自定义，须输入指定的密钥 ID。</p>
+	KeyId *string `json:"KeyId,omitnil,omitempty" name:"KeyId"`
+
+	// <p>如果密钥来源为指定自定义密钥，须填写该字段指定密钥的地域信息。</p>
+	KmsRegion *string `json:"KmsRegion,omitnil,omitempty" name:"KmsRegion"`
+
 	// <p>实例CPU核大小，单位：C。具体售卖的CPU规格，请通过接口 <a href="https://cloud.tencent.com/document/product/240/38567">DescribeSpecInfo</a> 获取<br>注意：通用 I 型实例必须设置 CPU 大小。</p>
 	CpuCore *int64 `json:"CpuCore,omitnil,omitempty" name:"CpuCore"`
 }
@@ -1394,6 +1441,10 @@ func (r *CreateDBInstanceRequest) FromJsonString(s string) error {
 	delete(f, "ReadonlyNodeAvailabilityZoneList")
 	delete(f, "HiddenZone")
 	delete(f, "ParamTemplateId")
+	delete(f, "DataEncryption")
+	delete(f, "EncryptionKeySource")
+	delete(f, "KeyId")
+	delete(f, "KmsRegion")
 	delete(f, "CpuCore")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBInstanceRequest has unknown keys!", "")
@@ -1539,6 +1590,91 @@ func (r *CreateLogDownloadTaskResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateLogDownloadTaskResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateSlowLogPatternDownloadTaskRequestParams struct {
+	// <p>实例 ID。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>采集慢日志开始时间</p>
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>采集慢日志结束时间</p>
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>慢日志采集阈值</p>
+	ThresholdMs *int64 `json:"ThresholdMs,omitnil,omitempty" name:"ThresholdMs"`
+
+	// <p>慢日志类型</p>
+	Commands []*string `json:"Commands,omitnil,omitempty" name:"Commands"`
+}
+
+type CreateSlowLogPatternDownloadTaskRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>实例 ID。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>采集慢日志开始时间</p>
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>采集慢日志结束时间</p>
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>慢日志采集阈值</p>
+	ThresholdMs *int64 `json:"ThresholdMs,omitnil,omitempty" name:"ThresholdMs"`
+
+	// <p>慢日志类型</p>
+	Commands []*string `json:"Commands,omitnil,omitempty" name:"Commands"`
+}
+
+func (r *CreateSlowLogPatternDownloadTaskRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateSlowLogPatternDownloadTaskRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "ThresholdMs")
+	delete(f, "Commands")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateSlowLogPatternDownloadTaskRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateSlowLogPatternDownloadTaskResponseParams struct {
+	// <p>下载任务状态</p>
+	Status []*int64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateSlowLogPatternDownloadTaskResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateSlowLogPatternDownloadTaskResponseParams `json:"Response"`
+}
+
+func (r *CreateSlowLogPatternDownloadTaskResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateSlowLogPatternDownloadTaskResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -3010,6 +3146,76 @@ func (r *DescribeDBInstanceDealResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeDBInstanceDealResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBInstanceLogToCLSRequestParams struct {
+	// <p>指定实例ID。例如：cmgo-p8vn****。请登录 MongoDB 控制台在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>CLS服务所在地域</p>
+	CLSRegion *string `json:"CLSRegion,omitnil,omitempty" name:"CLSRegion"`
+}
+
+type DescribeDBInstanceLogToCLSRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>指定实例ID。例如：cmgo-p8vn****。请登录 MongoDB 控制台在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>CLS服务所在地域</p>
+	CLSRegion *string `json:"CLSRegion,omitnil,omitempty" name:"CLSRegion"`
+}
+
+func (r *DescribeDBInstanceLogToCLSRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBInstanceLogToCLSRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "CLSRegion")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBInstanceLogToCLSRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBInstanceLogToCLSResponseParams struct {
+	// <p>实例错误日志投递配置</p>
+	ErrorLog *LogToCLSConfig `json:"ErrorLog,omitnil,omitempty" name:"ErrorLog"`
+
+	// <p>实例慢日志投递配置</p>
+	SlowLog *LogToCLSConfig `json:"SlowLog,omitnil,omitempty" name:"SlowLog"`
+
+	// <p>实例操作日志投递配置</p>
+	OperationLog *LogToCLSConfig `json:"OperationLog,omitnil,omitempty" name:"OperationLog"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBInstanceLogToCLSResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBInstanceLogToCLSResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBInstanceLogToCLSResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBInstanceLogToCLSResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -5203,6 +5409,57 @@ func (r *FlushInstanceRouterConfigResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type IncreaseDBInstanceConnectionLimitRequestParams struct {
+
+}
+
+type IncreaseDBInstanceConnectionLimitRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *IncreaseDBInstanceConnectionLimitRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *IncreaseDBInstanceConnectionLimitRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "IncreaseDBInstanceConnectionLimitRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type IncreaseDBInstanceConnectionLimitResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type IncreaseDBInstanceConnectionLimitResponse struct {
+	*tchttp.BaseResponse
+	Response *IncreaseDBInstanceConnectionLimitResponseParams `json:"Response"`
+}
+
+func (r *IncreaseDBInstanceConnectionLimitResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *IncreaseDBInstanceConnectionLimitResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type InquirePriceCreateDBInstancesRequestParams struct {
 	// <p>实例所属区域及可用区信息。具体信息，请参见<a href="https://cloud.tencent.com/document/product/240/3637">地域和可用区</a>。</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
@@ -6174,6 +6431,20 @@ type LogInfo struct {
 	LogId *string `json:"LogId,omitnil,omitempty" name:"LogId"`
 }
 
+type LogToCLSConfig struct {
+	// <p>CLS服务所在地域</p>
+	CLSRegion *string `json:"CLSRegion,omitnil,omitempty" name:"CLSRegion"`
+
+	// <p>投递状态打开或者关闭</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>CLS日志集ID</p>
+	LogSetId *string `json:"LogSetId,omitnil,omitempty" name:"LogSetId"`
+
+	// <p>日志主题ID</p>
+	LogTopicId *string `json:"LogTopicId,omitnil,omitempty" name:"LogTopicId"`
+}
+
 // Predefined struct for user
 type ModifyAuditServiceRequestParams struct {
 	// 实例ID，格式如：cmgo-xfts****，与云数据库控制台页面中显示的实例 ID 相同。
@@ -6317,6 +6588,109 @@ func (r *ModifyBackupExpireTimeResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyBackupExpireTimeResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBInstanceLogToCLSRequestParams struct {
+	// <p>指定实例ID。例如：cmgo-p8vn****。请登录 MongoDB 控制台在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>日志类型。MongoDB-ErrorLog：错误日志，MongoDB-SlowLog：慢日志，MongoDB-OperationLog：操作日志</p>
+	LogType *string `json:"LogType,omitnil,omitempty" name:"LogType"`
+
+	// <p>投递状态。ON：开启，OFF：关闭。</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>是否需要创建日志集。默认为 false。</p>
+	CreateLogset *bool `json:"CreateLogset,omitnil,omitempty" name:"CreateLogset"`
+
+	// <p>需要创建日志集时为日志集名称；选择已有日志集时，为日志集 ID。默认为空。 说明：1. 当参数 Status 的值为 ON 时，Logset 和 LogTopic 参数必须填一个。2.  当参数 CreateLogset 的值为 true 时，Logset 填日志集命名，例如 my_test，否则需要填日志集 id，例如 6adsaw-****。</p>
+	Logset *string `json:"Logset,omitnil,omitempty" name:"Logset"`
+
+	// <p>是否需要创建日志主题。默认为 false。</p>
+	CreateLogTopic *bool `json:"CreateLogTopic,omitnil,omitempty" name:"CreateLogTopic"`
+
+	// <p>需要创建日志主题时为日志主题名称；选择已有日志主题时，为日志主题 ID。默认为空。 说明：1. 当参数 Status 的值为 ON 时，Logset 和 LogTopic 参数必须填一个。2. 2.  当参数 CreateLogTopic 的值为 true 时，LogTopic 填日志主题命名，例如 my_test，否则需要填日志主题id，例如 6adsaw-****。</p>
+	LogTopic *string `json:"LogTopic,omitnil,omitempty" name:"LogTopic"`
+
+	// <p>CLS 所在地域，不填则默认为 Region 的参数值。</p>
+	CLSRegion *string `json:"CLSRegion,omitnil,omitempty" name:"CLSRegion"`
+}
+
+type ModifyDBInstanceLogToCLSRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>指定实例ID。例如：cmgo-p8vn****。请登录 MongoDB 控制台在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>日志类型。MongoDB-ErrorLog：错误日志，MongoDB-SlowLog：慢日志，MongoDB-OperationLog：操作日志</p>
+	LogType *string `json:"LogType,omitnil,omitempty" name:"LogType"`
+
+	// <p>投递状态。ON：开启，OFF：关闭。</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>是否需要创建日志集。默认为 false。</p>
+	CreateLogset *bool `json:"CreateLogset,omitnil,omitempty" name:"CreateLogset"`
+
+	// <p>需要创建日志集时为日志集名称；选择已有日志集时，为日志集 ID。默认为空。 说明：1. 当参数 Status 的值为 ON 时，Logset 和 LogTopic 参数必须填一个。2.  当参数 CreateLogset 的值为 true 时，Logset 填日志集命名，例如 my_test，否则需要填日志集 id，例如 6adsaw-****。</p>
+	Logset *string `json:"Logset,omitnil,omitempty" name:"Logset"`
+
+	// <p>是否需要创建日志主题。默认为 false。</p>
+	CreateLogTopic *bool `json:"CreateLogTopic,omitnil,omitempty" name:"CreateLogTopic"`
+
+	// <p>需要创建日志主题时为日志主题名称；选择已有日志主题时，为日志主题 ID。默认为空。 说明：1. 当参数 Status 的值为 ON 时，Logset 和 LogTopic 参数必须填一个。2. 2.  当参数 CreateLogTopic 的值为 true 时，LogTopic 填日志主题命名，例如 my_test，否则需要填日志主题id，例如 6adsaw-****。</p>
+	LogTopic *string `json:"LogTopic,omitnil,omitempty" name:"LogTopic"`
+
+	// <p>CLS 所在地域，不填则默认为 Region 的参数值。</p>
+	CLSRegion *string `json:"CLSRegion,omitnil,omitempty" name:"CLSRegion"`
+}
+
+func (r *ModifyDBInstanceLogToCLSRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBInstanceLogToCLSRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "LogType")
+	delete(f, "Status")
+	delete(f, "CreateLogset")
+	delete(f, "Logset")
+	delete(f, "CreateLogTopic")
+	delete(f, "LogTopic")
+	delete(f, "CLSRegion")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBInstanceLogToCLSRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBInstanceLogToCLSResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBInstanceLogToCLSResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBInstanceLogToCLSResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBInstanceLogToCLSResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBInstanceLogToCLSResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -6777,30 +7151,26 @@ func (r *ModifyInstanceAzResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyInstanceParamsRequestParams struct {
-	// 指定实例 ID。例如：cmgo-p8vn****。请登录 [MongoDB 控制台](https://console.cloud.tencent.com/mongodb)在实例列表复制实例 ID。
+	// <p>指定实例 ID。例如：cmgo-p8vn****。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 指定需修改的参数名及值。当前所支持的参数名及对应取值范围，请通过 [DescribeInstanceParams ](https://cloud.tencent.com/document/product/240/65903)获取。
+	// <p>指定需修改的参数名及值。当前所支持的参数名及对应取值范围，请通过 <a href="https://cloud.tencent.com/document/product/240/65903">DescribeInstanceParams </a>获取。</p>
 	InstanceParams []*ModifyMongoDBParamType `json:"InstanceParams,omitnil,omitempty" name:"InstanceParams"`
 
-	// 操作类型，包括：
-	// - IMMEDIATELY：立即调整。
-	// - DELAY：延迟调整。可选字段，不配置该参数则默认为立即调整。
+	// <p>操作类型，包括：</p><ul><li>IMMEDIATELY：立即调整。</li><li>DELAY：延迟调整。可选字段，不配置该参数则默认为立即调整。</li></ul>
 	ModifyType *string `json:"ModifyType,omitnil,omitempty" name:"ModifyType"`
 }
 
 type ModifyInstanceParamsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 指定实例 ID。例如：cmgo-p8vn****。请登录 [MongoDB 控制台](https://console.cloud.tencent.com/mongodb)在实例列表复制实例 ID。
+	// <p>指定实例 ID。例如：cmgo-p8vn****。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 指定需修改的参数名及值。当前所支持的参数名及对应取值范围，请通过 [DescribeInstanceParams ](https://cloud.tencent.com/document/product/240/65903)获取。
+	// <p>指定需修改的参数名及值。当前所支持的参数名及对应取值范围，请通过 <a href="https://cloud.tencent.com/document/product/240/65903">DescribeInstanceParams </a>获取。</p>
 	InstanceParams []*ModifyMongoDBParamType `json:"InstanceParams,omitnil,omitempty" name:"InstanceParams"`
 
-	// 操作类型，包括：
-	// - IMMEDIATELY：立即调整。
-	// - DELAY：延迟调整。可选字段，不配置该参数则默认为立即调整。
+	// <p>操作类型，包括：</p><ul><li>IMMEDIATELY：立即调整。</li><li>DELAY：延迟调整。可选字段，不配置该参数则默认为立即调整。</li></ul>
 	ModifyType *string `json:"ModifyType,omitnil,omitempty" name:"ModifyType"`
 }
 
@@ -6827,12 +7197,10 @@ func (r *ModifyInstanceParamsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyInstanceParamsResponseParams struct {
-	// 修改参数配置是否生效。
-	// - true：参数修改后的值已生效。
-	// - false：执行失败。
+	// <p>修改参数配置是否生效。</p><ul><li>true：参数修改后的值已生效。</li><li>false：执行失败。</li></ul>
 	Changed *bool `json:"Changed,omitnil,omitempty" name:"Changed"`
 
-	// 该参数暂时无意义(兼容前端保留)。
+	// <p>该参数暂时无意义(兼容前端保留)。</p>
 	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -7180,6 +7548,70 @@ type ParamType struct {
 
 	// 参数值
 	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
+// Predefined struct for user
+type PromoteDBInstanceToActiveRequestParams struct {
+	// <p>指定需转为普通实例的灾备或只读实例 ID。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制灾备或只读实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>指定灾备或只读实例所属的主实例。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
+	MasterId *string `json:"MasterId,omitnil,omitempty" name:"MasterId"`
+}
+
+type PromoteDBInstanceToActiveRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>指定需转为普通实例的灾备或只读实例 ID。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制灾备或只读实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>指定灾备或只读实例所属的主实例。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
+	MasterId *string `json:"MasterId,omitnil,omitempty" name:"MasterId"`
+}
+
+func (r *PromoteDBInstanceToActiveRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *PromoteDBInstanceToActiveRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "MasterId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "PromoteDBInstanceToActiveRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type PromoteDBInstanceToActiveResponseParams struct {
+	// <p>任务 ID。</p>
+	FlowId *int64 `json:"FlowId,omitnil,omitempty" name:"FlowId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type PromoteDBInstanceToActiveResponse struct {
+	*tchttp.BaseResponse
+	Response *PromoteDBInstanceToActiveResponseParams `json:"Response"`
+}
+
+func (r *PromoteDBInstanceToActiveResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *PromoteDBInstanceToActiveResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 type RemoveNodeList struct {
@@ -7903,31 +8335,33 @@ func (r *SetDBInstanceDeletionProtectionResponse) FromJsonString(s string) error
 
 // Predefined struct for user
 type SetInstanceMaintenanceRequestParams struct {
-	// 指定实例ID。例如：cmgo-p8vn****。请登录 [MongoDB 控制台](https://console.cloud.tencent.com/mongodb)在实例列表复制实例 ID。
+	// <p>指定实例ID。例如：cmgo-p8vn****。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 维护时间窗开始时间。取值范围为"00:00-23:00"的任意整点或半点，如00:00或00:30。
+	// <p>维护时间窗开始时间。取值范围为&quot;00:00-23:00&quot;的任意整点或半点，如00:00或00:30。</p>
 	MaintenanceStart *string `json:"MaintenanceStart,omitnil,omitempty" name:"MaintenanceStart"`
 
-	// 维护时间窗结束时间。
-	// - 取值范围为"00:00-23:00"的任意整点或半点，维护时间持续时长最小为30分钟，最大为3小时。
-	// - 结束时间务必是基于开始时间向后的时间。
+	// <p>维护时间窗结束时间。</p><ul><li>取值范围为&quot;00:00-23:00&quot;的任意整点或半点，维护时间持续时长最小为30分钟，最大为3小时。</li><li>结束时间务必是基于开始时间向后的时间。</li></ul>
 	MaintenanceEnd *string `json:"MaintenanceEnd,omitnil,omitempty" name:"MaintenanceEnd"`
+
+	// <p>指定每周内维护时间窗口的具体日期。  格式：请输入 1-7 之间的数字代表周一到周日（例如：1 代表周一），多个日期请用英文逗号 , 分隔。 示例：输入 1,3,5 表示维护窗口周期在每周的周一、周三、周五。 默认值：不设置，则默认为全周期 (1,2,3,4,5,6,7)。</p>
+	MaintenanceDays *string `json:"MaintenanceDays,omitnil,omitempty" name:"MaintenanceDays"`
 }
 
 type SetInstanceMaintenanceRequest struct {
 	*tchttp.BaseRequest
 	
-	// 指定实例ID。例如：cmgo-p8vn****。请登录 [MongoDB 控制台](https://console.cloud.tencent.com/mongodb)在实例列表复制实例 ID。
+	// <p>指定实例ID。例如：cmgo-p8vn****。请登录 <a href="https://console.cloud.tencent.com/mongodb">MongoDB 控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 维护时间窗开始时间。取值范围为"00:00-23:00"的任意整点或半点，如00:00或00:30。
+	// <p>维护时间窗开始时间。取值范围为&quot;00:00-23:00&quot;的任意整点或半点，如00:00或00:30。</p>
 	MaintenanceStart *string `json:"MaintenanceStart,omitnil,omitempty" name:"MaintenanceStart"`
 
-	// 维护时间窗结束时间。
-	// - 取值范围为"00:00-23:00"的任意整点或半点，维护时间持续时长最小为30分钟，最大为3小时。
-	// - 结束时间务必是基于开始时间向后的时间。
+	// <p>维护时间窗结束时间。</p><ul><li>取值范围为&quot;00:00-23:00&quot;的任意整点或半点，维护时间持续时长最小为30分钟，最大为3小时。</li><li>结束时间务必是基于开始时间向后的时间。</li></ul>
 	MaintenanceEnd *string `json:"MaintenanceEnd,omitnil,omitempty" name:"MaintenanceEnd"`
+
+	// <p>指定每周内维护时间窗口的具体日期。  格式：请输入 1-7 之间的数字代表周一到周日（例如：1 代表周一），多个日期请用英文逗号 , 分隔。 示例：输入 1,3,5 表示维护窗口周期在每周的周一、周三、周五。 默认值：不设置，则默认为全周期 (1,2,3,4,5,6,7)。</p>
+	MaintenanceDays *string `json:"MaintenanceDays,omitnil,omitempty" name:"MaintenanceDays"`
 }
 
 func (r *SetInstanceMaintenanceRequest) ToJsonString() string {
@@ -7945,6 +8379,7 @@ func (r *SetInstanceMaintenanceRequest) FromJsonString(s string) error {
 	delete(f, "InstanceId")
 	delete(f, "MaintenanceStart")
 	delete(f, "MaintenanceEnd")
+	delete(f, "MaintenanceDays")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "SetInstanceMaintenanceRequest has unknown keys!", "")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.131
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1281,7 +1281,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter/v20230110
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/csip/v20221121
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 ## explicit; go 1.14
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
 ## explicit; go 1.14
@@ -1358,7 +1357,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/live/v20180801
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb/v20170312
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.103
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.133
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.101

--- a/website/docs/r/mongodb_instance.html.markdown
+++ b/website/docs/r/mongodb_instance.html.markdown
@@ -13,6 +13,8 @@ Provide a resource to create a Mongodb instance.
 
 ~> **NOTE:** If `availability_zone_list` needs to be changed, attention should be paid to cascading modifications of `available_zone` or `hidden_zone`.
 
+~> **NOTE:** The `cpu` parameter takes effect only when the configuration is changed. Changing the `cpu` triggers the `ModifyDBInstanceSpec` API to adjust the CPU specification of the running MongoDB instance in-place. The supported CPU specifications can be obtained through the `DescribeSpecInfo` API.
+
 ## Example Usage
 
 ```hcl
@@ -27,6 +29,24 @@ resource "tencentcloud_mongodb_instance" "example" {
   subnet_id      = "subnet-hhi88a58"
   project_id     = 0
   password       = "Password@123"
+}
+```
+
+### Update the CPU specification of the MongoDB instance.
+
+```hcl
+resource "tencentcloud_mongodb_instance" "example" {
+  instance_name  = "tf-example"
+  memory         = 4
+  volume         = 100
+  engine_version = "MONGO_40_WT"
+  machine_type   = "HIO10G"
+  available_zone = "ap-guangzhou-6"
+  vpc_id         = "vpc-i5yyodl9"
+  subnet_id      = "subnet-hhi88a58"
+  project_id     = 0
+  password       = "Password@123"
+  cpu            = 2
 }
 ```
 
@@ -77,6 +97,7 @@ The following arguments are supported:
 	- You can obtain availability zone information planned in different regions of the cloud database through the interface DescribeSpecInfo, so as to specify effective availability zones.
 	- Multiple availability zone deployment nodes can only be deployed in 3 different availability zones. Deploying most nodes of a cluster in the same availability zone is not supported. For example, a 3-node cluster does not support 2 nodes deployed in the same zone.
 * `charge_type` - (Optional, String, ForceNew) The charge type of instance. Valid values are `PREPAID` and `POSTPAID_BY_HOUR`. Default value is `POSTPAID_BY_HOUR`. Note: TencentCloud International only supports `POSTPAID_BY_HOUR`. Caution that update operation on this field will delete old instances and create new one with new charge type.
+* `cpu` - (Optional, Int) The CPU core count of the MongoDB instance after the configuration change. Unit: C. When this parameter is empty, the current CPU size of the instance is used by default. The supported CPU specifications can be obtained through the DescribeSpecInfo API.
 * `hidden_zone` - (Optional, String) The availability zone to which the Hidden node belongs. This parameter is required in cross-AZ instance deployment.
 * `in_maintenance` - (Optional, Int) Switch time for instance configuration changes.
 	- 0: When the adjustment is completed, perform the configuration task immediately. Default is 0.

--- a/website/docs/r/mongodb_sharding_instance.html.markdown
+++ b/website/docs/r/mongodb_sharding_instance.html.markdown
@@ -13,6 +13,8 @@ Provide a resource to create a Mongodb sharding instance.
 
 ~> **NOTE:** The `add_node_list` and `remove_node_list` arguments are used to submit node change actions. When updating the resource, only newly added items in these lists will be sent to the API. If an existing item is removed from the Terraform configuration, Terraform only updates the local state and does not submit a repeated add or remove request. To add or remove another read-only node, append a new block instead of modifying an existing one. After the change is completed, obsolete action records can be removed from the configuration, and this cleanup does not trigger a new node operation when the remaining list is a subset of the previous list. In general, it is recommended to keep these action records in the configuration and avoid cleanup unless necessary.
 
+~> **NOTE:** The `cpu` parameter takes effect only when the configuration is changed. Changing the `cpu` triggers the `ModifyDBInstanceSpec` API to adjust the CPU specification of the running MongoDB instance in-place. The supported CPU specifications can be obtained through the `DescribeSpecInfo` API.
+
 ## Example Usage
 
 ```hcl
@@ -117,6 +119,7 @@ The following arguments are supported:
 			- Read-only disaster recovery instances are not supported.
 			- Basic network cannot be selected.
 * `charge_type` - (Optional, String, ForceNew) The charge type of instance. Valid values are `PREPAID` and `POSTPAID_BY_HOUR`. Default value is `POSTPAID_BY_HOUR`. Note: TencentCloud International only supports `POSTPAID_BY_HOUR`. Caution that update operation on this field will delete old instances and create new one with new charge type.
+* `cpu` - (Optional, Int) The CPU core count of the MongoDB instance after the configuration change. Unit: C. When this parameter is empty, the current CPU size of the instance is used by default. The supported CPU specifications can be obtained through the DescribeSpecInfo API.
 * `hidden_zone` - (Optional, String) The availability zone to which the Hidden node belongs. This parameter is required in cross-AZ instance deployment.
 * `in_maintenance` - (Optional, Int) Switch time for instance configuration changes.
 	- 0: When the adjustment is completed, perform the configuration task immediately. Default is 0.


### PR DESCRIPTION
Add a new optional `cpu` parameter to the `tencentcloud_mongodb_instance` resource to allow managing the CPU core count of a MongoDB instance during configuration changes.

Changes:
- Add `cpu` (TypeInt, Optional + Computed) field to the resource schema.
- Trigger `ModifyDBInstanceSpec` on `cpu` change in Update and map `params["cpu"]` to `ModifyDBInstanceSpecRequest.Cpu`.
- Backfill `cpu` from `DescribeDBInstances` `InstanceDetail.CpuNum` in Read.
- Add gomonkey-based unit tests covering update trigger, read backfill, and nil handling.
- Update resource documentation.