### PR TITLE
feat(tcaplusdb): [136195827] add table_group_id parameter for tencentcloud_tcaplus_tablegroup resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.0.199
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcm v1.0.547
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcr v1.3.89
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdcpg v1.0.533

--- a/go.sum
+++ b/go.sum
@@ -1107,8 +1107,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860 h1:epSPxNq
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860/go.mod h1:6hzZuAz+UAG4nWudMqk+6hHwRWXZrFrpP8P7yEsEqY0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634 h1:GJDzXxKloZeM8fN+qlIspPnZbUw1lOZGe7jGqfFbQMM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634/go.mod h1:yX1elLeYvjmtPvgBVCOyYxyy1u2XEKfXaEiZXIWRCKw=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.0.199 h1:i17zUWDw6iN7EMkQMGDXIXpur73vwUvbZrX4M5S0xhQ=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.0.199/go.mod h1:PUgbrkzA9IaKBj1urk+W4L6Jr5TuBhQ4xB/96QvLf/U=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105 h1:6OndfnRdCLh3OTKvLaRA9OTOZbmsyB3uO8r4Hi8H/X4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105/go.mod h1:FR3HD44YAbGbfiDbMUA5IHxSk9j8MZ2Wdl8zKf/Z8rw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcm v1.0.547 h1:6bukohygmfu4riewOMCuYYZSkg3vTad8PCjpGyWD0Gs=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcm v1.0.547/go.mod h1:C7b++Lr8Xh+2KtTUMBjbb+/BrBhfFhAxDMjXzT2GLhY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcr v1.3.89 h1:GXI1UyC8GVPYOPDtsAzefG1Mc6L738UOblk0CB92ztE=

--- a/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/design.md
+++ b/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The `tencentcloud_tcaplus_tablegroup` resource currently supports creating TcaplusDB table groups with `cluster_id` and `tablegroup_name` parameters. The TcaplusDB `CreateTableGroup` API also accepts an optional `TableGroupId` parameter that lets users specify a custom table group ID at creation time (when not specified, the API auto-increments the ID), and the response returns the created `TableGroupId`.
+
+**Current state:**
+- Resource file: `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.go`
+- Service layer: `tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go` (`CreateGroup` function at line 277)
+- SDK: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823`
+
+**API behavior analysis:**
+
+| API | TableGroupId in Request | TableGroupId in Response | Notes |
+|-----|-------------------------|--------------------------|-------|
+| `CreateTableGroup` | Yes (`TableGroupId *string`, optional — user-specified or auto-increment) | Yes (`TableGroupId *string` — created id) | Writable at creation only |
+| `DescribeTableGroups` | N/A | Yes (`TableGroupInfo.TableGroupId`) | Readable for state refresh |
+| `ModifyTableGroupName` | Yes (as locator — "待修改名称的表格组ID") | N/A | `TableGroupId` identifies the target, not a writable attribute |
+| `DeleteTableGroup` | Yes (as locator) | N/A | `TableGroupId` identifies the target |
+
+**Key constraint:** `TableGroupId` is only writable through `CreateTableGroup`. The `ModifyTableGroupName` API uses `TableGroupId` solely to locate the table group whose name is being changed — it cannot change the id itself. Therefore `table_group_id` is immutable after creation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `table_group_id` (Optional, immutable after creation) parameter to `tencentcloud_tcaplus_tablegroup`
+- Pass `TableGroupId` to the `CreateTableGroup` API request when the user specifies `table_group_id`
+- Read `TableGroupId` from the `DescribeTableGroups` API response (`TableGroupInfo.TableGroupId`) to support state refresh and import
+- Implement immutable args check in the Update function so changes to `table_group_id` return a clear error (not ForceNew, to avoid silent resource destruction)
+- Maintain full backward compatibility — existing configurations that omit `table_group_id` continue to use API auto-increment behavior unchanged
+
+**Non-Goals:**
+- Making `table_group_id` updatable (the `ModifyTableGroupName` API does not support changing the id)
+- Adding `table_group_id` to the `tencentcloud_tcaplus_tablegroups` data source (out of scope for this single-parameter change)
+
+## Decisions
+
+### Decision 1: `table_group_id` is immutable (not ForceNew)
+
+**Rationale:** The `ModifyTableGroupName` API only accepts `TableGroupName` as a writable attribute; `TableGroupId` is used only to locate the target table group. Instead of using `ForceNew: true` (which would silently destroy and recreate the resource, risking data loss on the table group), we use an `immutableArgs` array pattern in the Update function that returns a clear error when `table_group_id` changes. This gives users a better error message than silent destruction.
+
+### Decision 2: Optional (not Computed) for `table_group_id`
+
+**Rationale:** The API auto-increments the id when `TableGroupId` is not supplied in the create request. Since the value is always echoed back in the `CreateTableGroup` response and in `DescribeTableGroups`, the Read function sets it into state. Marking the field `Optional` (without `Computed`) is acceptable because the field is always populated by the Read path after creation. This keeps the schema simple and consistent with the existing resource style.
+
+### Decision 3: Read `TableGroupId` from Describe API response
+
+**Rationale:** The `DescribeTableGroups` response's `TableGroupInfo` struct includes `TableGroupId`. Reading this value enables proper state refresh and supports imported resources where the user did not specify the id at create time.
+
+### Decision 4: Preserve existing resource ID format
+
+**Rationale:** The existing resource ID format is `clusterId:tableGroupId` (set via `d.SetId(fmt.Sprintf("%s:%s", clusterId, groupId))`). The `table_group_id` schema field is the human-facing mirror of the group id portion already embedded in `d.Id()`. We keep `d.Id()` unchanged to preserve backward compatibility with existing state files.
+
+### Decision 5: Update `CreateGroup` service function signature
+
+**Rationale:** The `CreateGroup` service function (line 277) currently accepts `(ctx, id, groupName)` and returns `(groupId string, errRet error)`. We extend its signature to accept an optional `tableGroupId string` parameter, passing it to `request.TableGroupId` when non-empty. This is the minimal change needed and keeps the function returning the created `groupId` (which already comes from `response.Response.TableGroupId`).
+
+## Risks / Trade-offs
+
+- **[Risk] Changing `table_group_id` after creation**: Using the immutable args pattern (not ForceNew) means users receive a clear error rather than silent destruction.
+  - **Mitigation:** The Update function returns a formatted error explaining the field cannot be changed.
+
+- **[Risk] User-specified id collision**: If a user specifies a `table_group_id` that already exists within the cluster, the `CreateTableGroup` API will return an error.
+  - **Mitigation:** No provider-side workaround; the API error is surfaced to the user directly, which is the expected behavior.

--- a/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/proposal.md
+++ b/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The TcaplusDB `CreateTableGroup` API supports an optional `TableGroupId` parameter that allows users to specify a custom table group ID at creation time (when not specified, the API auto-increments the ID). However, the Terraform resource `tencentcloud_tcaplus_tablegroup` does not expose this parameter, so users cannot set a fixed table group ID through Terraform. Users who need a deterministic, pre-known table group ID (e.g., for cross-environment consistency or downstream automation referencing the ID) are forced to use the console or API directly.
+
+## What Changes
+
+- Add `table_group_id` (Optional, immutable after creation) parameter to the `tencentcloud_tcaplus_tablegroup` resource. When set, it is passed to the `CreateTableGroup` API request as `TableGroupId`. When not set, the API defaults to auto-increment mode.
+- The `CreateTableGroup` API response returns the created `TableGroupId` (both for user-specified and auto-incremented cases), which is read back into state.
+- Treat `table_group_id` as immutable after creation: the `ModifyTableGroupName` API only accepts `TableGroupName` (not `TableGroupId`), so changes to `table_group_id` after creation SHALL be rejected via the `immutableArgs` check in the Update function.
+- The existing resource ID format (`clusterId:tableGroupId`) is preserved; the `table_group_id` schema field is the human-facing mirror of the group id portion already embedded in `d.Id()`.
+
+## Capabilities
+
+### New Capabilities
+- `tcaplus-tablegroup-id`: Enable the optional `table_group_id` parameter on the `tencentcloud_tcaplus_tablegroup` resource to allow users to specify a custom table group ID when creating a TcaplusDB table group.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.go` — add `table_group_id` schema field (Optional, immutable), wire through Create flow, add immutable args check in Update, set the field in Read
+  - `tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go` — update `CreateGroup` service function to accept and pass the optional `TableGroupId` to the `CreateTableGroup` API request
+  - `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.md` — update documentation with `table_group_id` usage example
+- **SDK dependency:** `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823` — `CreateTableGroupRequest` already includes the optional `TableGroupId *string` field, and `CreateTableGroupResponse` returns `TableGroupId *string`. No SDK update required.
+- **Backward compatibility:** fully backward compatible — the new parameter is Optional; existing configurations that do not set `table_group_id` continue to use API auto-increment behavior unchanged.
+- **API constraints:** `TableGroupId` is only accepted by `CreateTableGroup` (the `ModifyTableGroupName` and `DeleteTableGroup` APIs do not accept it as a writable attribute), so this parameter is immutable after creation.

--- a/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/specs/tcaplus-tablegroup-id/spec.md
+++ b/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/specs/tcaplus-tablegroup-id/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Table group ID on table group creation
+The `tencentcloud_tcaplus_tablegroup` resource SHALL support an optional `table_group_id` parameter (TypeString, immutable after creation) that is passed to the `CreateTableGroup` API as `TableGroupId`. When not specified, the API defaults to auto-increment mode. Changes to `table_group_id` after creation SHALL be rejected with an error via the immutable args check in the Update function.
+
+#### Scenario: Create table group with a user-specified table group id
+- **WHEN** a user specifies `table_group_id = "101"` in the `tencentcloud_tcaplus_tablegroup` resource configuration
+- **THEN** the provider SHALL pass `TableGroupId=101` in the `CreateTableGroup` API request
+
+#### Scenario: Create table group without a table group id
+- **WHEN** a user does NOT specify `table_group_id` in the `tencentcloud_tcaplus_tablegroup` resource configuration
+- **THEN** the provider SHALL NOT set `TableGroupId` in the `CreateTableGroup` API request (API defaults to auto-increment)
+
+#### Scenario: Read existing table group
+- **WHEN** the provider reads an existing `tencentcloud_tcaplus_tablegroup` resource
+- **THEN** `table_group_id` SHALL be refreshed from the `DescribeTableGroups` API response (`TableGroupInfo.TableGroupId`)
+
+#### Scenario: Update table group id triggers immutable error
+- **WHEN** a user changes `table_group_id` after creation
+- **THEN** the provider SHALL return an error indicating `table_group_id` cannot be changed
+
+### Requirement: CreateGroup service function passes optional table group id
+The `CreateGroup` service function SHALL accept an optional `tableGroupId string` parameter and pass it to the `CreateTableGroup` API request as `TableGroupId` when the value is non-empty.
+
+#### Scenario: CreateGroup passes table group id when provided
+- **WHEN** `CreateGroup` is called with a non-empty `tableGroupId`
+- **THEN** the service function SHALL set `request.TableGroupId` to the provided value before calling the `CreateTableGroup` API
+
+#### Scenario: CreateGroup omits table group id when empty
+- **WHEN** `CreateGroup` is called with an empty `tableGroupId`
+- **THEN** the service function SHALL NOT set `request.TableGroupId` before calling the `CreateTableGroup` API (API auto-increments)
+
+#### Scenario: CreateGroup returns the created table group id
+- **WHEN** the `CreateTableGroup` API succeeds
+- **THEN** the service function SHALL return the `TableGroupId` from the API response (`response.Response.TableGroupId`)
+
+### Requirement: Immutable args check in Update function
+The `tencentcloud_tcaplus_tablegroup` Update function SHALL use an `immutableArgs` array to validate that the `table_group_id` field is not changed, because the `ModifyTableGroupName` API does not support modifying the table group id.
+
+#### Scenario: table_group_id in immutable args
+- **WHEN** defining the immutable args for the Update function
+- **THEN** the array SHALL contain `table_group_id`
+
+#### Scenario: Immutable arg change returns error
+- **WHEN** `table_group_id` changes in the Update function
+- **THEN** the provider SHALL return a formatted error indicating the argument cannot be changed

--- a/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/tasks.md
+++ b/openspec/changes/archive/2026-07-22-add-tcaplus-tablegroup-id/tasks.md
@@ -1,0 +1,39 @@
+## 1. Service Layer Changes
+
+- [x] 1.1 Update `CreateGroup` function signature in `tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go` (line 277) to accept an additional `tableGroupId string` parameter
+- [x] 1.2 Pass `tableGroupId` to the `CreateTableGroup` API request as `request.TableGroupId` when the value is non-empty (leave unset when empty so the API auto-increments)
+- [x] 1.3 Keep returning the created `groupId` from `response.Response.TableGroupId` (existing behavior, no change to return value)
+
+## 2. Resource Schema Changes
+
+- [x] 2.1 Add `table_group_id` schema field (TypeString, Optional, immutable after creation, description explaining it is user-specified or auto-incremented) to `ResourceTencentCloudTcaplusTableGroup()` in `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.go`
+
+## 3. Create Function Changes
+
+- [x] 3.1 Read `table_group_id` from schema data in `resourceTencentCloudTcaplusTableGroupCreate`
+- [x] 3.2 Pass `table_group_id` to the updated `CreateGroup` service function
+- [x] 3.3 Preserve existing resource ID format (`clusterId:tableGroupId`) via `d.SetId()`
+
+## 4. Read Function Changes
+
+- [x] 4.1 Set `table_group_id` into state from `DescribeTableGroups` API response (`info.TableGroupId`) in `resourceTencentCloudTcaplusTableGroupRead`, with a nil check before calling `d.Set()`
+
+## 5. Update Function Changes
+
+- [x] 5.1 Add `immutableArgs` array containing `table_group_id` in `resourceTencentCloudTcaplusTableGroupUpdate`
+- [x] 5.2 Iterate `immutableArgs` and return a formatted error if `table_group_id` has changed (reject changes with a clear message instead of ForceNew)
+- [x] 5.3 Keep existing `tablegroup_name` change handling unchanged
+
+## 6. Documentation
+
+- [x] 6.1 Update `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.md` with `table_group_id` usage example
+- [x] 6.2 Run `make doc` during finalize phase to regenerate `website/docs/r/tcaplus_tablegroup.html.markdown`
+
+## 7. Tests
+
+- [x] 7.1 Update `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup_test.go` to add test cases covering `table_group_id` (create with user-specified id, and immutable-update error scenario), using the existing terraform test suite pattern
+
+## 8. Validation
+
+- [x] 8.1 Verify the code compiles successfully
+- [x] 8.2 Run gofmt during the finalize phase

--- a/openspec/specs/tcaplus-tablegroup-id/spec.md
+++ b/openspec/specs/tcaplus-tablegroup-id/spec.md
@@ -1,0 +1,49 @@
+# tcaplus-tablegroup-id Specification
+
+## Purpose
+TBD - created by syncing change add-tcaplus-tablegroup-id. Update Purpose after archive.
+## Requirements
+### Requirement: Table group ID on table group creation
+The `tencentcloud_tcaplus_tablegroup` resource SHALL support an optional `table_group_id` parameter (TypeString, immutable after creation) that is passed to the `CreateTableGroup` API as `TableGroupId`. When not specified, the API defaults to auto-increment mode. Changes to `table_group_id` after creation SHALL be rejected with an error via the immutable args check in the Update function.
+
+#### Scenario: Create table group with a user-specified table group id
+- **WHEN** a user specifies `table_group_id = "101"` in the `tencentcloud_tcaplus_tablegroup` resource configuration
+- **THEN** the provider SHALL pass `TableGroupId=101` in the `CreateTableGroup` API request
+
+#### Scenario: Create table group without a table group id
+- **WHEN** a user does NOT specify `table_group_id` in the `tencentcloud_tcaplus_tablegroup` resource configuration
+- **THEN** the provider SHALL NOT set `TableGroupId` in the `CreateTableGroup` API request (API defaults to auto-increment)
+
+#### Scenario: Read existing table group
+- **WHEN** the provider reads an existing `tencentcloud_tcaplus_tablegroup` resource
+- **THEN** `table_group_id` SHALL be refreshed from the `DescribeTableGroups` API response (`TableGroupInfo.TableGroupId`)
+
+#### Scenario: Update table group id triggers immutable error
+- **WHEN** a user changes `table_group_id` after creation
+- **THEN** the provider SHALL return an error indicating `table_group_id` cannot be changed
+
+### Requirement: CreateGroup service function passes optional table group id
+The `CreateGroup` service function SHALL accept an optional `tableGroupId string` parameter and pass it to the `CreateTableGroup` API request as `TableGroupId` when the value is non-empty.
+
+#### Scenario: CreateGroup passes table group id when provided
+- **WHEN** `CreateGroup` is called with a non-empty `tableGroupId`
+- **THEN** the service function SHALL set `request.TableGroupId` to the provided value before calling the `CreateTableGroup` API
+
+#### Scenario: CreateGroup omits table group id when empty
+- **WHEN** `CreateGroup` is called with an empty `tableGroupId`
+- **THEN** the service function SHALL NOT set `request.TableGroupId` before calling the `CreateTableGroup` API (API auto-increments)
+
+#### Scenario: CreateGroup returns the created table group id
+- **WHEN** the `CreateTableGroup` API succeeds
+- **THEN** the service function SHALL return the `TableGroupId` from the API response (`response.Response.TableGroupId`)
+
+### Requirement: Immutable args check in Update function
+The `tencentcloud_tcaplus_tablegroup` Update function SHALL use an `immutableArgs` array to validate that the `table_group_id` field is not changed, because the `ModifyTableGroupName` API does not support modifying the table group id.
+
+#### Scenario: table_group_id in immutable args
+- **WHEN** defining the immutable args for the Update function
+- **THEN** the array SHALL contain `table_group_id`
+
+#### Scenario: Immutable arg change returns error
+- **WHEN** `table_group_id` changes in the Update function
+- **THEN** the provider SHALL return a formatted error indicating the argument cannot be changed

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.go
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
+	tcaplusdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823"
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -18,24 +21,47 @@ func ResourceTencentCloudTcaplusTableGroup() *schema.Resource {
 		Read:   resourceTencentCloudTcaplusTableGroupRead,
 		Update: resourceTencentCloudTcaplusTableGroupUpdate,
 		Delete: resourceTencentCloudTcaplusTableGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
-		"cluster_id": {
-			Type:        schema.TypeString,
-			Required:    true,
-			ForceNew:    true,
-			Description: "ID of the TcaplusDB cluster to which the table group belongs.",
-		},
-		"tablegroup_name": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: tccommon.ValidateStringLengthInRange(1, 30),
-			Description:  "Name of the TcaplusDB table group. Name length should be between 1 and 30.",
-		},
-		"table_group_id": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "ID of the TcaplusDB table group, can be user-specified (must be unique within the cluster) or auto-incremented by the API when not set. Immutable after creation.",
-		},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ID of the TcaplusDB cluster to which the table group belongs.",
+			},
+			"tablegroup_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Table group name; may consist of Chinese characters, English letters, or numeric characters, with a maximum length of 32 characters.",
+			},
+			"table_group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: "ID of the TcaplusDB table group, can be user-specified (must be unique within the cluster) or auto-incremented by the API when not set. Immutable after creation.",
+			},
+			"resource_tags": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Set of table group tags.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag key.",
+						},
+						"tag_value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag value.",
+						},
+					},
+				},
+			},
 			// Computed values.
 			"table_count": {
 				Type:        schema.TypeInt,
@@ -68,12 +94,31 @@ func resourceTencentCloudTcaplusTableGroupCreate(d *schema.ResourceData, meta in
 		clusterId    = d.Get("cluster_id").(string)
 		groupName    = d.Get("tablegroup_name").(string)
 		tableGroupId = d.Get("table_group_id").(string)
+		resourceTags []*tcaplusdb.TagInfoUnit
 	)
-	groupId, err := tcaplusService.CreateGroup(ctx, clusterId, groupName, tableGroupId)
+
+	if v, ok := d.GetOk("resource_tags"); ok {
+		for _, item := range v.(*schema.Set).List() {
+			dMap := item.(map[string]interface{})
+			resourceTag := tcaplusdb.TagInfoUnit{}
+			if v, ok := dMap["tag_key"]; ok {
+				resourceTag.TagKey = helper.String(v.(string))
+			}
+
+			if v, ok := dMap["tag_value"]; ok {
+				resourceTag.TagValue = helper.String(v.(string))
+			}
+
+			resourceTags = append(resourceTags, &resourceTag)
+		}
+	}
+
+	groupId, err := tcaplusService.CreateGroup(ctx, clusterId, groupName, tableGroupId, resourceTags)
 	if err != nil {
 		return err
 	}
-	log.Printf("[CRUD] tcaplus_tablegroup create success, logId=%s, d.Id()=%s", logId, fmt.Sprintf("%s:%s", clusterId, groupId))
+
+	log.Printf("[CRUD] tencentcloud_tcaplus_tablegroup create success, logId=%s, d.Id()=%s", logId, fmt.Sprintf("%s:%s", clusterId, groupId))
 	d.SetId(fmt.Sprintf("%s:%s", clusterId, groupId))
 	return resourceTencentCloudTcaplusTableGroupRead(d, meta)
 }
@@ -87,13 +132,18 @@ func resourceTencentCloudTcaplusTableGroupRead(d *schema.ResourceData, meta inte
 
 	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
-	clusterId := d.Get("cluster_id").(string)
-	groupId := d.Id()
+	idSplit := strings.Split(d.Id(), ":")
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
 
-	info, has, err := tcaplusService.DescribeGroup(ctx, clusterId, groupId)
+	clusterId := idSplit[0]
+	tableGroupId := idSplit[1]
+
+	info, has, err := tcaplusService.DescribeGroup(ctx, clusterId, tableGroupId)
 	if err != nil {
 		err = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			info, has, err = tcaplusService.DescribeGroup(ctx, clusterId, groupId)
+			info, has, err = tcaplusService.DescribeGroup(ctx, clusterId, tableGroupId)
 			if err != nil {
 				return tccommon.RetryError(err)
 			}
@@ -104,18 +154,55 @@ func resourceTencentCloudTcaplusTableGroupRead(d *schema.ResourceData, meta inte
 		return err
 	}
 	if !has {
-		log.Printf("[CRUD] tcaplus_tablegroup id=%s", d.Id())
+		log.Printf("[CRUD] tencentcloud_tcaplus_tablegroup id=%s", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	_ = d.Set("cluster_id", clusterId)
+
+	if info.TableGroupName != nil {
+		_ = d.Set("tablegroup_name", info.TableGroupName)
 	}
 
 	if info.TableGroupId != nil {
 		_ = d.Set("table_group_id", info.TableGroupId)
 	}
-	_ = d.Set("tablegroup_name", info.TableGroupName)
-	_ = d.Set("table_count", int(*info.TableCount))
-	_ = d.Set("total_size", int(*info.TotalSize))
-	_ = d.Set("create_time", info.CreatedTime)
+
+	if info.TableCount != nil {
+		_ = d.Set("table_count", info.TableCount)
+	}
+
+	if info.TotalSize != nil {
+		_ = d.Set("total_size", info.TotalSize)
+	}
+
+	if info.CreatedTime != nil {
+		_ = d.Set("create_time", info.CreatedTime)
+	}
+
+	tags, err := tcaplusService.DescribeTableGroupTags(ctx, clusterId, tableGroupId)
+	if err != nil {
+		return err
+	}
+
+	if len(tags) > 0 {
+		tagsList := make([]map[string]interface{}, 0, len(tags))
+		for _, tag := range tags {
+			tagMap := map[string]interface{}{}
+			if tag.TagKey != nil {
+				tagMap["tag_key"] = *tag.TagKey
+			}
+			if tag.TagValue != nil {
+				tagMap["tag_value"] = *tag.TagValue
+			}
+			tagsList = append(tagsList, tagMap)
+		}
+
+		_ = d.Set("resource_tags", tagsList)
+	} else {
+		_ = d.Set("resource_tags", nil)
+	}
 
 	return nil
 }
@@ -128,28 +215,111 @@ func resourceTencentCloudTcaplusTableGroupUpdate(d *schema.ResourceData, meta in
 
 	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
-	clusterId := d.Get("cluster_id").(string)
-	groupId := d.Id()
-
-	immutableArgs := []string{"table_group_id"}
-	for _, arg := range immutableArgs {
-		if d.HasChange(arg) {
-			return fmt.Errorf("tcaplus_tablegroup argument `%s` cannot be changed, it is immutable after creation. Please recreate the resource if you need a different value.", arg)
-		}
+	idSplit := strings.Split(d.Id(), ":")
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
 	}
 
+	clusterId := idSplit[0]
+	tableGroupId := idSplit[1]
+
 	if d.HasChange("tablegroup_name") {
-		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			err := tcaplusService.ModifyGroupName(ctx, clusterId, groupId, d.Get("tablegroup_name").(string))
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			err := tcaplusService.ModifyGroupName(ctx, clusterId, tableGroupId, d.Get("tablegroup_name").(string))
 			if err != nil {
 				return tccommon.RetryError(err)
 			}
 			return nil
 		})
+
 		if err != nil {
 			return err
 		}
 	}
+
+	if d.HasChange("resource_tags") {
+		o, n := d.GetChange("resource_tags")
+		oldTags := o.(*schema.Set).List()
+		newTags := n.(*schema.Set).List()
+
+		oldMap := make(map[string]string)
+		for _, item := range oldTags {
+			m := item.(map[string]interface{})
+			oldMap[m["tag_key"].(string)] = m["tag_value"].(string)
+		}
+
+		newMap := make(map[string]string)
+		for _, item := range newTags {
+			m := item.(map[string]interface{})
+			newMap[m["tag_key"].(string)] = m["tag_value"].(string)
+		}
+
+		var replaceTags []*tcaplusdb.TagInfoUnit
+		var deleteTags []*tcaplusdb.TagInfoUnit
+
+		for key, value := range newMap {
+			if oldValue, ok := oldMap[key]; !ok || oldValue != value {
+				replaceTags = append(replaceTags, &tcaplusdb.TagInfoUnit{
+					TagKey:   helper.String(key),
+					TagValue: helper.String(value),
+				})
+			}
+		}
+
+		for key := range oldMap {
+			if _, ok := newMap[key]; !ok {
+				deleteTags = append(deleteTags, &tcaplusdb.TagInfoUnit{
+					TagKey: helper.String(key),
+				})
+			}
+		}
+
+		if len(replaceTags) > 0 || len(deleteTags) > 0 {
+			var taskId string
+			err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+				resp, err := tcaplusService.ModifyTableGroupTags(ctx, clusterId, tableGroupId, replaceTags, deleteTags)
+				if err != nil {
+					return tccommon.RetryError(err)
+				}
+
+				taskId = resp
+				return nil
+			})
+
+			if err != nil {
+				return err
+			}
+
+			// wait
+			err = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+				info, has, err := tcaplusService.DescribeTask(ctx, clusterId, taskId)
+				if err != nil {
+					return tccommon.RetryError(err)
+				}
+				if !has {
+					return resource.NonRetryableError(fmt.Errorf("Modify table group tags task has been deleted"))
+				}
+
+				if *info.Progress == 100 {
+					return nil
+				}
+
+				if *info.Progress >= 0 {
+					return resource.RetryableError(fmt.Errorf("the table group tags modify is in progress, and our wait has timed out"))
+				}
+				if *info.Progress < 0 {
+					return resource.NonRetryableError(fmt.Errorf("TencentCloud SDK return %d task status, modify table group tags task failed", *info.Progress))
+				}
+
+				return nil
+			})
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return resourceTencentCloudTcaplusTableGroupRead(d, meta)
 }
 
@@ -161,13 +331,18 @@ func resourceTencentCloudTcaplusTableGroupDelete(d *schema.ResourceData, meta in
 
 	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
-	clusterId := d.Get("cluster_id").(string)
-	groupId := d.Id()
+	idSplit := strings.Split(d.Id(), ":")
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
 
-	err := tcaplusService.DeleteGroup(ctx, clusterId, groupId)
+	clusterId := idSplit[0]
+	tableGroupId := idSplit[1]
+
+	err := tcaplusService.DeleteGroup(ctx, clusterId, tableGroupId)
 	if err != nil {
 		err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-			err = tcaplusService.DeleteGroup(ctx, clusterId, groupId)
+			err = tcaplusService.DeleteGroup(ctx, clusterId, tableGroupId)
 			if err != nil {
 				return tccommon.RetryError(err)
 			}
@@ -179,10 +354,10 @@ func resourceTencentCloudTcaplusTableGroupDelete(d *schema.ResourceData, meta in
 		return err
 	}
 
-	_, has, err := tcaplusService.DescribeGroup(ctx, clusterId, groupId)
+	_, has, err := tcaplusService.DescribeGroup(ctx, clusterId, tableGroupId)
 	if err != nil || has {
 		err = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			_, has, err = tcaplusService.DescribeGroup(ctx, clusterId, groupId)
+			_, has, err = tcaplusService.DescribeGroup(ctx, clusterId, tableGroupId)
 			if err != nil {
 				return tccommon.RetryError(err)
 			}

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.go
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 
@@ -18,18 +19,23 @@ func ResourceTencentCloudTcaplusTableGroup() *schema.Resource {
 		Update: resourceTencentCloudTcaplusTableGroupUpdate,
 		Delete: resourceTencentCloudTcaplusTableGroupDelete,
 		Schema: map[string]*schema.Schema{
-			"cluster_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "ID of the TcaplusDB cluster to which the table group belongs.",
-			},
-			"tablegroup_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: tccommon.ValidateStringLengthInRange(1, 30),
-				Description:  "Name of the TcaplusDB table group. Name length should be between 1 and 30.",
-			},
+		"cluster_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "ID of the TcaplusDB cluster to which the table group belongs.",
+		},
+		"tablegroup_name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: tccommon.ValidateStringLengthInRange(1, 30),
+			Description:  "Name of the TcaplusDB table group. Name length should be between 1 and 30.",
+		},
+		"table_group_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "ID of the TcaplusDB table group, can be user-specified (must be unique within the cluster) or auto-incremented by the API when not set. Immutable after creation.",
+		},
 			// Computed values.
 			"table_count": {
 				Type:        schema.TypeInt,
@@ -59,13 +65,15 @@ func resourceTencentCloudTcaplusTableGroupCreate(d *schema.ResourceData, meta in
 	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
 	var (
-		clusterId = d.Get("cluster_id").(string)
-		groupName = d.Get("tablegroup_name").(string)
+		clusterId    = d.Get("cluster_id").(string)
+		groupName    = d.Get("tablegroup_name").(string)
+		tableGroupId = d.Get("table_group_id").(string)
 	)
-	groupId, err := tcaplusService.CreateGroup(ctx, clusterId, groupName)
+	groupId, err := tcaplusService.CreateGroup(ctx, clusterId, groupName, tableGroupId)
 	if err != nil {
 		return err
 	}
+	log.Printf("[CRUD] tcaplus_tablegroup create success, logId=%s, d.Id()=%s", logId, fmt.Sprintf("%s:%s", clusterId, groupId))
 	d.SetId(fmt.Sprintf("%s:%s", clusterId, groupId))
 	return resourceTencentCloudTcaplusTableGroupRead(d, meta)
 }
@@ -96,10 +104,14 @@ func resourceTencentCloudTcaplusTableGroupRead(d *schema.ResourceData, meta inte
 		return err
 	}
 	if !has {
+		log.Printf("[CRUD] tcaplus_tablegroup id=%s", d.Id())
 		d.SetId("")
 		return nil
 	}
 
+	if info.TableGroupId != nil {
+		_ = d.Set("table_group_id", info.TableGroupId)
+	}
 	_ = d.Set("tablegroup_name", info.TableGroupName)
 	_ = d.Set("table_count", int(*info.TableCount))
 	_ = d.Set("total_size", int(*info.TotalSize))
@@ -118,6 +130,13 @@ func resourceTencentCloudTcaplusTableGroupUpdate(d *schema.ResourceData, meta in
 
 	clusterId := d.Get("cluster_id").(string)
 	groupId := d.Id()
+
+	immutableArgs := []string{"table_group_id"}
+	for _, arg := range immutableArgs {
+		if d.HasChange(arg) {
+			return fmt.Errorf("tcaplus_tablegroup argument `%s` cannot be changed, it is immutable after creation. Please recreate the resource if you need a different value.", arg)
+		}
+	}
 
 	if d.HasChange("tablegroup_name") {
 		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.md
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.md
@@ -33,3 +33,36 @@ resource "tencentcloud_tcaplus_tablegroup" "example" {
   tablegroup_name = "tf_example_group_name"
 }
 ```
+
+Create a tcaplusdb table group with user-specified table group id
+
+```hcl
+locals {
+  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
+  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
+}
+
+variable "availability_zone" {
+  default = "ap-guangzhou-3"
+}
+
+data "tencentcloud_vpc_subnets" "vpc" {
+  is_default        = true
+  availability_zone = var.availability_zone
+}
+
+resource "tencentcloud_tcaplus_cluster" "example" {
+  idl_type                 = "PROTO"
+  cluster_name             = "tf_example_tcaplus_cluster"
+  vpc_id                   = local.vpc_id
+  subnet_id                = local.subnet_id
+  password                 = "your_pw_123111"
+  old_password_expire_last = 3600
+}
+
+resource "tencentcloud_tcaplus_tablegroup" "example" {
+  cluster_id      = tencentcloud_tcaplus_cluster.example.id
+  tablegroup_name = "tf_example_group_name"
+  table_group_id  = "101"
+}
+```

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.md
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup.md
@@ -5,64 +5,52 @@ Example Usage
 Create a tcaplusdb table group
 
 ```hcl
-locals {
-  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
-  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
-}
-
-variable "availability_zone" {
-  default = "ap-guangzhou-3"
-}
-
-data "tencentcloud_vpc_subnets" "vpc" {
-  is_default        = true
-  availability_zone = var.availability_zone
-}
-
 resource "tencentcloud_tcaplus_cluster" "example" {
   idl_type                 = "PROTO"
   cluster_name             = "tf_example_tcaplus_cluster"
-  vpc_id                   = local.vpc_id
-  subnet_id                = local.subnet_id
-  password                 = "your_pw_123111"
+  vpc_id                   = "vpc-i5yyodl9"
+  subnet_id                = "subnet-hhi88a58"
+  password                 = "Password@2026"
   old_password_expire_last = 3600
 }
 
 resource "tencentcloud_tcaplus_tablegroup" "example" {
   cluster_id      = tencentcloud_tcaplus_cluster.example.id
   tablegroup_name = "tf_example_group_name"
+  resource_tags {
+    tag_key   = "CreatedBy"
+    tag_value = "Terraform"
+  }
 }
 ```
 
 Create a tcaplusdb table group with user-specified table group id
 
 ```hcl
-locals {
-  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
-  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
-}
-
-variable "availability_zone" {
-  default = "ap-guangzhou-3"
-}
-
-data "tencentcloud_vpc_subnets" "vpc" {
-  is_default        = true
-  availability_zone = var.availability_zone
-}
-
 resource "tencentcloud_tcaplus_cluster" "example" {
   idl_type                 = "PROTO"
   cluster_name             = "tf_example_tcaplus_cluster"
-  vpc_id                   = local.vpc_id
-  subnet_id                = local.subnet_id
-  password                 = "your_pw_123111"
+  vpc_id                   = "vpc-i5yyodl9"
+  subnet_id                = "subnet-hhi88a58"
+  password                 = "Password@2026"
   old_password_expire_last = 3600
 }
 
 resource "tencentcloud_tcaplus_tablegroup" "example" {
   cluster_id      = tencentcloud_tcaplus_cluster.example.id
   tablegroup_name = "tf_example_group_name"
-  table_group_id  = "101"
+  table_group_id  = "109"
+  resource_tags {
+    tag_key   = "CreatedBy"
+    tag_value = "Terraform"
+  }
 }
+```
+
+Import
+
+TcaplusDB table group can be imported using the clusterId:tableGroupId, e.g.
+
+```
+terraform import tencentcloud_tcaplus_tablegroup.example 5516511420:52
 ```

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup_test.go
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_tablegroup_test.go
@@ -3,6 +3,7 @@ package tcaplusdb_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
@@ -42,6 +43,32 @@ func TestAccTencentCloudTcaplusGroupResource(t *testing.T) {
 					resource.TestCheckResourceAttr(testTcaplusGroupResourceNameResourceKey, "tablegroup_name", "tf_test_group_name_guagua_2"),
 					resource.TestCheckResourceAttr(testTcaplusGroupResourceNameResourceKey, "table_count", "0"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccTencentCloudTcaplusGroupResourceWithTableGroupId(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { tcacctest.AccPreCheck(t) },
+		Providers:    tcacctest.AccProviders,
+		CheckDestroy: testAccCheckTcaplusGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTcaplusGroupWithId,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTcaplusGroupExists(testTcaplusGroupResourceNameResourceKey),
+					resource.TestCheckResourceAttrSet(testTcaplusGroupResourceNameResourceKey, "total_size"),
+					resource.TestCheckResourceAttrSet(testTcaplusGroupResourceNameResourceKey, "create_time"),
+					resource.TestCheckResourceAttr(testTcaplusGroupResourceNameResourceKey, "tablegroup_name", "tf_test_group_name_with_id"),
+					resource.TestCheckResourceAttr(testTcaplusGroupResourceNameResourceKey, "table_group_id", "10101"),
+					resource.TestCheckResourceAttr(testTcaplusGroupResourceNameResourceKey, "table_count", "0"),
+				),
+			},
+			{
+				Config:      testAccTcaplusGroupWithIdUpdate,
+				ExpectError: regexp.MustCompile(`argument.*table_group_id.*cannot be changed`),
 			},
 		},
 	})
@@ -108,5 +135,19 @@ const testAccTcaplusGroupUpdate = tcacctest.DefaultTcaPlusData + `
 resource "tencentcloud_tcaplus_tablegroup" "test_group" {
   cluster_id         = local.tcaplus_id
   tablegroup_name    = "tf_test_group_name_guagua_2"
+}
+`
+const testAccTcaplusGroupWithId = tcacctest.DefaultTcaPlusData + `
+resource "tencentcloud_tcaplus_tablegroup" "test_group" {
+  cluster_id      = local.tcaplus_id
+  tablegroup_name = "tf_test_group_name_with_id"
+  table_group_id  = "10101"
+}
+`
+const testAccTcaplusGroupWithIdUpdate = tcacctest.DefaultTcaPlusData + `
+resource "tencentcloud_tcaplus_tablegroup" "test_group" {
+  cluster_id      = local.tcaplus_id
+  tablegroup_name = "tf_test_group_name_with_id"
+  table_group_id  = "10102"
 }
 `

--- a/tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go
+++ b/tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go
@@ -11,6 +11,7 @@ import (
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/pkg/errors"
 	sdkError "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 	tcaplusdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823"
@@ -274,7 +275,7 @@ func (me *TcaplusService) DescribeTask(ctx context.Context, clusterId string, ta
 	return
 }
 
-func (me *TcaplusService) CreateGroup(ctx context.Context, id string, groupName string, tableGroupId string) (groupId string, errRet error) {
+func (me *TcaplusService) CreateGroup(ctx context.Context, id string, groupName string, tableGroupId string, resourceTags []*tcaplusdb.TagInfoUnit) (groupId string, errRet error) {
 	logId := tccommon.GetLogId(ctx)
 	request := tcaplusdb.NewCreateTableGroupRequest()
 	defer func() {
@@ -287,8 +288,41 @@ func (me *TcaplusService) CreateGroup(ctx context.Context, id string, groupName 
 	if tableGroupId != "" {
 		request.TableGroupId = &tableGroupId
 	}
+
+	if len(resourceTags) > 0 {
+		request.ResourceTags = resourceTags
+	}
+
+	errRet = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		response, err := me.client.UseTcaplusClient().CreateTableGroup(request)
+		if err != nil {
+			return tccommon.RetryError(err)
+		}
+		if response == nil || response.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("TencentCloud SDK return nil response,%s", request.GetAction()))
+		}
+		if response.Response.TableGroupId == nil || *response.Response.TableGroupId == "" {
+			return resource.NonRetryableError(errors.New("TencentCloud SDK  return empty table group id"))
+		}
+		groupId = *response.Response.TableGroupId
+		return nil
+	})
+	return
+}
+
+func (me *TcaplusService) DescribeTableGroupTags(ctx context.Context, clusterId string, tableGroupId string) (tags []*tcaplusdb.TagInfoUnit, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+	request := tcaplusdb.NewDescribeTableGroupTagsRequest()
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail,reason[%s]", logId, request.GetAction(), errRet.Error())
+		}
+	}()
+	request.ClusterId = &clusterId
+	request.TableGroupIds = []*string{&tableGroupId}
 	ratelimit.Check(request.GetAction())
-	response, err := me.client.UseTcaplusClient().CreateTableGroup(request)
+	response, err := me.client.UseTcaplusClient().DescribeTableGroupTagsWithContext(ctx, request)
 	if err != nil {
 		errRet = err
 		return
@@ -297,11 +331,42 @@ func (me *TcaplusService) CreateGroup(ctx context.Context, id string, groupName 
 		errRet = fmt.Errorf("TencentCloud SDK return nil response,%s", request.GetAction())
 		return
 	}
-	if response.Response.TableGroupId == nil || *response.Response.TableGroupId == "" {
-		errRet = errors.New("TencentCloud SDK  return empty table group id")
+	if len(response.Response.Rows) == 0 {
 		return
 	}
-	groupId = *response.Response.TableGroupId
+	tags = response.Response.Rows[0].Tags
+	return
+}
+
+func (me *TcaplusService) ModifyTableGroupTags(ctx context.Context, clusterId string, tableGroupId string, replaceTags []*tcaplusdb.TagInfoUnit, deleteTags []*tcaplusdb.TagInfoUnit) (taskId string, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+	request := tcaplusdb.NewModifyTableGroupTagsRequest()
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail,reason[%s]", logId, request.GetAction(), errRet.Error())
+		}
+	}()
+	request.ClusterId = &clusterId
+	request.TableGroupId = &tableGroupId
+	if len(replaceTags) > 0 {
+		request.ReplaceTags = replaceTags
+	}
+	if len(deleteTags) > 0 {
+		request.DeleteTags = deleteTags
+	}
+	ratelimit.Check(request.GetAction())
+	response, err := me.client.UseTcaplusClient().ModifyTableGroupTagsWithContext(ctx, request)
+	if err != nil {
+		errRet = err
+		return
+	}
+	if response == nil || response.Response == nil {
+		errRet = fmt.Errorf("TencentCloud SDK return nil response,%s", request.GetAction())
+		return
+	}
+	if response.Response.TaskId != nil {
+		taskId = *response.Response.TaskId
+	}
 	return
 }
 
@@ -379,13 +444,6 @@ func (me *TcaplusService) DescribeGroup(ctx context.Context, id string, groupId 
 		}
 	}()
 
-	items := strings.Split(groupId, ":")
-	if len(items) != 2 {
-		errRet = fmt.Errorf("group id is broken,%s", groupId)
-		return
-	}
-	groupId = items[1]
-
 	request.ClusterId = &id
 	request.TableGroupIds = []*string{&groupId}
 	ratelimit.Check(request.GetAction())
@@ -428,13 +486,6 @@ func (me *TcaplusService) DeleteGroup(ctx context.Context, clusterId string, gro
 		}
 	}()
 
-	items := strings.Split(groupId, ":")
-	if len(items) != 2 {
-		errRet = fmt.Errorf("group id is broken,%s", groupId)
-		return
-	}
-	groupId = items[1]
-
 	request.ClusterId = &clusterId
 	request.TableGroupId = &groupId
 	ratelimit.Check(request.GetAction())
@@ -458,12 +509,6 @@ func (me *TcaplusService) ModifyGroupName(ctx context.Context, id string, groupI
 			log.Printf("[CRITAL]%s api[%s] fail,reason[%s]", logId, request.GetAction(), errRet.Error())
 		}
 	}()
-	items := strings.Split(groupId, ":")
-	if len(items) != 2 {
-		errRet = fmt.Errorf("group id is broken,%s", groupId)
-		return
-	}
-	groupId = items[1]
 
 	request.ClusterId = &id
 	request.TableGroupId = &groupId

--- a/tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go
+++ b/tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go
@@ -274,7 +274,7 @@ func (me *TcaplusService) DescribeTask(ctx context.Context, clusterId string, ta
 	return
 }
 
-func (me *TcaplusService) CreateGroup(ctx context.Context, id string, groupName string) (groupId string, errRet error) {
+func (me *TcaplusService) CreateGroup(ctx context.Context, id string, groupName string, tableGroupId string) (groupId string, errRet error) {
 	logId := tccommon.GetLogId(ctx)
 	request := tcaplusdb.NewCreateTableGroupRequest()
 	defer func() {
@@ -284,6 +284,9 @@ func (me *TcaplusService) CreateGroup(ctx context.Context, id string, groupName 
 	}()
 	request.TableGroupName = &groupName
 	request.ClusterId = &id
+	if tableGroupId != "" {
+		request.TableGroupId = &tableGroupId
+	}
 	ratelimit.Check(request.GetAction())
 	response, err := me.client.UseTcaplusClient().CreateTableGroup(request)
 	if err != nil {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"io"
-
 	//"log"
 	"math/rand"
 	"net/url"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/doc.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/doc.go
@@ -1,2 +1,0 @@
-// Package doc
-package doc

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 package v20190823
 
 import (
+    "context"
+    "errors"
     "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
     tchttp "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http"
     "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
@@ -34,7 +36,7 @@ func NewClientWithSecretId(secretId, secretKey, region string) (client *Client, 
     return
 }
 
-func NewClient(credential *common.Credential, region string, clientProfile *profile.ClientProfile) (client *Client, err error) {
+func NewClient(credential common.CredentialIface, region string, clientProfile *profile.ClientProfile) (client *Client, err error) {
     client = &Client{}
     client.Init(region).
         WithCredential(credential).
@@ -47,15 +49,19 @@ func NewClearTablesRequest() (request *ClearTablesRequest) {
     request = &ClearTablesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ClearTables")
+    
+    
     return
 }
 
 func NewClearTablesResponse() (response *ClearTablesResponse) {
     response = &ClearTablesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ClearTables
@@ -69,9 +75,31 @@ func NewClearTablesResponse() (response *ClearTablesResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ClearTables(request *ClearTablesRequest) (response *ClearTablesResponse, err error) {
+    return c.ClearTablesWithContext(context.Background(), request)
+}
+
+// ClearTables
+// 根据给定的表信息，清除表数据。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ClearTablesWithContext(ctx context.Context, request *ClearTablesRequest) (response *ClearTablesResponse, err error) {
     if request == nil {
         request = NewClearTablesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ClearTables")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ClearTables require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewClearTablesResponse()
     err = c.Send(request, response)
     return
@@ -81,15 +109,19 @@ func NewCompareIdlFilesRequest() (request *CompareIdlFilesRequest) {
     request = &CompareIdlFilesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "CompareIdlFiles")
+    
+    
     return
 }
 
 func NewCompareIdlFilesResponse() (response *CompareIdlFilesResponse) {
     response = &CompareIdlFilesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CompareIdlFiles
@@ -102,9 +134,30 @@ func NewCompareIdlFilesResponse() (response *CompareIdlFilesResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) CompareIdlFiles(request *CompareIdlFilesRequest) (response *CompareIdlFilesResponse, err error) {
+    return c.CompareIdlFilesWithContext(context.Background(), request)
+}
+
+// CompareIdlFiles
+// 选中目标表格，上传并校验改表文件，返回是否允许修改表格结构的结果。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) CompareIdlFilesWithContext(ctx context.Context, request *CompareIdlFilesRequest) (response *CompareIdlFilesResponse, err error) {
     if request == nil {
         request = NewCompareIdlFilesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "CompareIdlFiles")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CompareIdlFiles require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewCompareIdlFilesResponse()
     err = c.Send(request, response)
     return
@@ -114,15 +167,19 @@ func NewCreateBackupRequest() (request *CreateBackupRequest) {
     request = &CreateBackupRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "CreateBackup")
+    
+    
     return
 }
 
 func NewCreateBackupResponse() (response *CreateBackupResponse) {
     response = &CreateBackupResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateBackup
@@ -135,9 +192,30 @@ func NewCreateBackupResponse() (response *CreateBackupResponse) {
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) CreateBackup(request *CreateBackupRequest) (response *CreateBackupResponse, err error) {
+    return c.CreateBackupWithContext(context.Background(), request)
+}
+
+// CreateBackup
+// 用户创建备份任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) CreateBackupWithContext(ctx context.Context, request *CreateBackupRequest) (response *CreateBackupResponse, err error) {
     if request == nil {
         request = NewCreateBackupRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "CreateBackup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateBackup require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewCreateBackupResponse()
     err = c.Send(request, response)
     return
@@ -147,15 +225,19 @@ func NewCreateClusterRequest() (request *CreateClusterRequest) {
     request = &CreateClusterRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "CreateCluster")
+    
+    
     return
 }
 
 func NewCreateClusterResponse() (response *CreateClusterResponse) {
     response = &CreateClusterResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateCluster
@@ -172,9 +254,34 @@ func NewCreateClusterResponse() (response *CreateClusterResponse) {
 //  RESOURCEUNAVAILABLE = "ResourceUnavailable"
 //  RESOURCEUNAVAILABLE_DUPLICATECLUSTERNAME = "ResourceUnavailable.DuplicateClusterName"
 func (c *Client) CreateCluster(request *CreateClusterRequest) (response *CreateClusterResponse, err error) {
+    return c.CreateClusterWithContext(context.Background(), request)
+}
+
+// CreateCluster
+// 本接口用于创建TcaplusDB集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_INVALIDCLUSTERNAME = "InvalidParameterValue.InvalidClusterName"
+//  INVALIDPARAMETERVALUE_UNSUPPORTIDLTYPE = "InvalidParameterValue.UnsupportIdlType"
+//  RESOURCEINSUFFICIENT_BALANCEERROR = "ResourceInsufficient.BalanceError"
+//  RESOURCEINSUFFICIENT_NOAVAILABLECLUSTER = "ResourceInsufficient.NoAvailableCluster"
+//  RESOURCEINSUFFICIENT_NOENOUGHVIPINVPC = "ResourceInsufficient.NoEnoughVipInVPC"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+//  RESOURCEUNAVAILABLE_DUPLICATECLUSTERNAME = "ResourceUnavailable.DuplicateClusterName"
+func (c *Client) CreateClusterWithContext(ctx context.Context, request *CreateClusterRequest) (response *CreateClusterResponse, err error) {
     if request == nil {
         request = NewCreateClusterRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "CreateCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewCreateClusterResponse()
     err = c.Send(request, response)
     return
@@ -184,15 +291,19 @@ func NewCreateSnapshotsRequest() (request *CreateSnapshotsRequest) {
     request = &CreateSnapshotsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "CreateSnapshots")
+    
+    
     return
 }
 
 func NewCreateSnapshotsResponse() (response *CreateSnapshotsResponse) {
     response = &CreateSnapshotsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateSnapshots
@@ -209,9 +320,34 @@ func NewCreateSnapshotsResponse() (response *CreateSnapshotsResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) CreateSnapshots(request *CreateSnapshotsRequest) (response *CreateSnapshotsResponse, err error) {
+    return c.CreateSnapshotsWithContext(context.Background(), request)
+}
+
+// CreateSnapshots
+// 构造表格过去时间点的快照
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) CreateSnapshotsWithContext(ctx context.Context, request *CreateSnapshotsRequest) (response *CreateSnapshotsResponse, err error) {
     if request == nil {
         request = NewCreateSnapshotsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "CreateSnapshots")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateSnapshots require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewCreateSnapshotsResponse()
     err = c.Send(request, response)
     return
@@ -221,15 +357,19 @@ func NewCreateTableGroupRequest() (request *CreateTableGroupRequest) {
     request = &CreateTableGroupRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "CreateTableGroup")
+    
+    
     return
 }
 
 func NewCreateTableGroupResponse() (response *CreateTableGroupResponse) {
     response = &CreateTableGroupResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateTableGroup
@@ -244,9 +384,32 @@ func NewCreateTableGroupResponse() (response *CreateTableGroupResponse) {
 //  RESOURCEUNAVAILABLE_DUPLICATETABLEGROUPNAME = "ResourceUnavailable.DuplicateTableGroupName"
 //  RESOURCEUNAVAILABLE_NOAVAILABLETABLEGROUP = "ResourceUnavailable.NoAvailableTableGroup"
 func (c *Client) CreateTableGroup(request *CreateTableGroupRequest) (response *CreateTableGroupResponse, err error) {
+    return c.CreateTableGroupWithContext(context.Background(), request)
+}
+
+// CreateTableGroup
+// 在TcaplusDB集群下创建表格组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_INVALIDTABLEGROUPNAME = "InvalidParameterValue.InvalidTableGroupName"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCEUNAVAILABLE_DUPLICATETABLEGROUPINFO = "ResourceUnavailable.DuplicateTableGroupInfo"
+//  RESOURCEUNAVAILABLE_DUPLICATETABLEGROUPNAME = "ResourceUnavailable.DuplicateTableGroupName"
+//  RESOURCEUNAVAILABLE_NOAVAILABLETABLEGROUP = "ResourceUnavailable.NoAvailableTableGroup"
+func (c *Client) CreateTableGroupWithContext(ctx context.Context, request *CreateTableGroupRequest) (response *CreateTableGroupResponse, err error) {
     if request == nil {
         request = NewCreateTableGroupRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "CreateTableGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateTableGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewCreateTableGroupResponse()
     err = c.Send(request, response)
     return
@@ -256,15 +419,19 @@ func NewCreateTablesRequest() (request *CreateTablesRequest) {
     request = &CreateTablesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "CreateTables")
+    
+    
     return
 }
 
 func NewCreateTablesResponse() (response *CreateTablesResponse) {
     response = &CreateTablesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateTables
@@ -281,10 +448,95 @@ func NewCreateTablesResponse() (response *CreateTablesResponse) {
 //  RESOURCEINSUFFICIENT_BALANCEERROR = "ResourceInsufficient.BalanceError"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) CreateTables(request *CreateTablesRequest) (response *CreateTablesResponse, err error) {
+    return c.CreateTablesWithContext(context.Background(), request)
+}
+
+// CreateTables
+// 根据选择的IDL文件列表，批量创建表格
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCEINSUFFICIENT_BALANCEERROR = "ResourceInsufficient.BalanceError"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) CreateTablesWithContext(ctx context.Context, request *CreateTablesRequest) (response *CreateTablesResponse, err error) {
     if request == nil {
         request = NewCreateTablesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "CreateTables")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateTables require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewCreateTablesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteBackupRecordsRequest() (request *DeleteBackupRecordsRequest) {
+    request = &DeleteBackupRecordsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("tcaplusdb", APIVersion, "DeleteBackupRecords")
+    
+    
+    return
+}
+
+func NewDeleteBackupRecordsResponse() (response *DeleteBackupRecordsResponse) {
+    response = &DeleteBackupRecordsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteBackupRecords
+// 删除手工备份
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteBackupRecords(request *DeleteBackupRecordsRequest) (response *DeleteBackupRecordsResponse, err error) {
+    return c.DeleteBackupRecordsWithContext(context.Background(), request)
+}
+
+// DeleteBackupRecords
+// 删除手工备份
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteBackupRecordsWithContext(ctx context.Context, request *DeleteBackupRecordsRequest) (response *DeleteBackupRecordsResponse, err error) {
+    if request == nil {
+        request = NewDeleteBackupRecordsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DeleteBackupRecords")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteBackupRecords require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteBackupRecordsResponse()
     err = c.Send(request, response)
     return
 }
@@ -293,15 +545,19 @@ func NewDeleteClusterRequest() (request *DeleteClusterRequest) {
     request = &DeleteClusterRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DeleteCluster")
+    
+    
     return
 }
 
 func NewDeleteClusterResponse() (response *DeleteClusterResponse) {
     response = &DeleteClusterResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteCluster
@@ -313,9 +569,29 @@ func NewDeleteClusterResponse() (response *DeleteClusterResponse) {
 //  RESOURCEINUSE = "ResourceInUse"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DeleteCluster(request *DeleteClusterRequest) (response *DeleteClusterResponse, err error) {
+    return c.DeleteClusterWithContext(context.Background(), request)
+}
+
+// DeleteCluster
+// 删除TcaplusDB集群，必须在集群所属所有资源（包括表格组，表）都已经释放的情况下才会成功。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  RESOURCEINUSE = "ResourceInUse"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteClusterWithContext(ctx context.Context, request *DeleteClusterRequest) (response *DeleteClusterResponse, err error) {
     if request == nil {
         request = NewDeleteClusterRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DeleteCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDeleteClusterResponse()
     err = c.Send(request, response)
     return
@@ -325,15 +601,19 @@ func NewDeleteIdlFilesRequest() (request *DeleteIdlFilesRequest) {
     request = &DeleteIdlFilesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DeleteIdlFiles")
+    
+    
     return
 }
 
 func NewDeleteIdlFilesResponse() (response *DeleteIdlFilesResponse) {
     response = &DeleteIdlFilesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteIdlFiles
@@ -348,9 +628,32 @@ func NewDeleteIdlFilesResponse() (response *DeleteIdlFilesResponse) {
 //  RESOURCEINUSE = "ResourceInUse"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DeleteIdlFiles(request *DeleteIdlFilesRequest) (response *DeleteIdlFilesResponse, err error) {
+    return c.DeleteIdlFilesWithContext(context.Background(), request)
+}
+
+// DeleteIdlFiles
+// 指定集群ID和待删除IDL文件的信息，删除目标文件，如果文件正在被表关联则删除失败。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCEINUSE = "ResourceInUse"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteIdlFilesWithContext(ctx context.Context, request *DeleteIdlFilesRequest) (response *DeleteIdlFilesResponse, err error) {
     if request == nil {
         request = NewDeleteIdlFilesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DeleteIdlFiles")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteIdlFiles require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDeleteIdlFilesResponse()
     err = c.Send(request, response)
     return
@@ -360,15 +663,19 @@ func NewDeleteSnapshotsRequest() (request *DeleteSnapshotsRequest) {
     request = &DeleteSnapshotsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DeleteSnapshots")
+    
+    
     return
 }
 
 func NewDeleteSnapshotsResponse() (response *DeleteSnapshotsResponse) {
     response = &DeleteSnapshotsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteSnapshots
@@ -385,10 +692,95 @@ func NewDeleteSnapshotsResponse() (response *DeleteSnapshotsResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DeleteSnapshots(request *DeleteSnapshotsRequest) (response *DeleteSnapshotsResponse, err error) {
+    return c.DeleteSnapshotsWithContext(context.Background(), request)
+}
+
+// DeleteSnapshots
+// 删除表格的快照
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteSnapshotsWithContext(ctx context.Context, request *DeleteSnapshotsRequest) (response *DeleteSnapshotsResponse, err error) {
     if request == nil {
         request = NewDeleteSnapshotsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DeleteSnapshots")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteSnapshots require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDeleteSnapshotsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteTableDataFlowRequest() (request *DeleteTableDataFlowRequest) {
+    request = &DeleteTableDataFlowRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("tcaplusdb", APIVersion, "DeleteTableDataFlow")
+    
+    
+    return
+}
+
+func NewDeleteTableDataFlowResponse() (response *DeleteTableDataFlowResponse) {
+    response = &DeleteTableDataFlowResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteTableDataFlow
+// 删除表格的数据订阅
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteTableDataFlow(request *DeleteTableDataFlowRequest) (response *DeleteTableDataFlowResponse, err error) {
+    return c.DeleteTableDataFlowWithContext(context.Background(), request)
+}
+
+// DeleteTableDataFlow
+// 删除表格的数据订阅
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteTableDataFlowWithContext(ctx context.Context, request *DeleteTableDataFlowRequest) (response *DeleteTableDataFlowResponse, err error) {
+    if request == nil {
+        request = NewDeleteTableDataFlowRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DeleteTableDataFlow")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteTableDataFlow require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteTableDataFlowResponse()
     err = c.Send(request, response)
     return
 }
@@ -397,28 +789,53 @@ func NewDeleteTableGroupRequest() (request *DeleteTableGroupRequest) {
     request = &DeleteTableGroupRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DeleteTableGroup")
+    
+    
     return
 }
 
 func NewDeleteTableGroupResponse() (response *DeleteTableGroupResponse) {
     response = &DeleteTableGroupResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteTableGroup
 // 删除表格组
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
 //  INTERNALERROR = "InternalError"
 //  RESOURCEINUSE = "ResourceInUse"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DeleteTableGroup(request *DeleteTableGroupRequest) (response *DeleteTableGroupResponse, err error) {
+    return c.DeleteTableGroupWithContext(context.Background(), request)
+}
+
+// DeleteTableGroup
+// 删除表格组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  RESOURCEINUSE = "ResourceInUse"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteTableGroupWithContext(ctx context.Context, request *DeleteTableGroupRequest) (response *DeleteTableGroupResponse, err error) {
     if request == nil {
         request = NewDeleteTableGroupRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DeleteTableGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteTableGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDeleteTableGroupResponse()
     err = c.Send(request, response)
     return
@@ -428,15 +845,19 @@ func NewDeleteTableIndexRequest() (request *DeleteTableIndexRequest) {
     request = &DeleteTableIndexRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DeleteTableIndex")
+    
+    
     return
 }
 
 func NewDeleteTableIndexResponse() (response *DeleteTableIndexResponse) {
     response = &DeleteTableIndexResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteTableIndex
@@ -450,9 +871,31 @@ func NewDeleteTableIndexResponse() (response *DeleteTableIndexResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DeleteTableIndex(request *DeleteTableIndexRequest) (response *DeleteTableIndexResponse, err error) {
+    return c.DeleteTableIndexWithContext(context.Background(), request)
+}
+
+// DeleteTableIndex
+// 删除表格的分布式索引
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteTableIndexWithContext(ctx context.Context, request *DeleteTableIndexRequest) (response *DeleteTableIndexResponse, err error) {
     if request == nil {
         request = NewDeleteTableIndexRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DeleteTableIndex")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteTableIndex require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDeleteTableIndexResponse()
     err = c.Send(request, response)
     return
@@ -462,15 +905,19 @@ func NewDeleteTablesRequest() (request *DeleteTablesRequest) {
     request = &DeleteTablesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DeleteTables")
+    
+    
     return
 }
 
 func NewDeleteTablesResponse() (response *DeleteTablesResponse) {
     response = &DeleteTablesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteTables
@@ -484,9 +931,31 @@ func NewDeleteTablesResponse() (response *DeleteTablesResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DeleteTables(request *DeleteTablesRequest) (response *DeleteTablesResponse, err error) {
+    return c.DeleteTablesWithContext(context.Background(), request)
+}
+
+// DeleteTables
+// 删除指定的表,第一次调用此接口代表将表移动至回收站，再次调用代表将此表格从回收站中彻底删除。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteTablesWithContext(ctx context.Context, request *DeleteTablesRequest) (response *DeleteTablesResponse, err error) {
     if request == nil {
         request = NewDeleteTablesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DeleteTables")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteTables require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDeleteTablesResponse()
     err = c.Send(request, response)
     return
@@ -496,15 +965,19 @@ func NewDescribeApplicationsRequest() (request *DescribeApplicationsRequest) {
     request = &DescribeApplicationsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeApplications")
+    
+    
     return
 }
 
 func NewDescribeApplicationsResponse() (response *DescribeApplicationsResponse) {
     response = &DescribeApplicationsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeApplications
@@ -518,10 +991,108 @@ func NewDescribeApplicationsResponse() (response *DescribeApplicationsResponse) 
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeApplications(request *DescribeApplicationsRequest) (response *DescribeApplicationsResponse, err error) {
+    return c.DescribeApplicationsWithContext(context.Background(), request)
+}
+
+// DescribeApplications
+// 获取审批管理的申请单
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeApplicationsWithContext(ctx context.Context, request *DescribeApplicationsRequest) (response *DescribeApplicationsResponse, err error) {
     if request == nil {
         request = NewDescribeApplicationsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeApplications")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeApplications require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeApplicationsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeBackupRecordsRequest() (request *DescribeBackupRecordsRequest) {
+    request = &DescribeBackupRecordsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeBackupRecords")
+    
+    
+    return
+}
+
+func NewDescribeBackupRecordsResponse() (response *DescribeBackupRecordsResponse) {
+    response = &DescribeBackupRecordsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeBackupRecords
+// 查询备份记录
+//
+// 
+//
+// 查询集群级别时， 将TableGroupId设置为"-1", 将TableName设置为"-1"
+//
+// 查询集群+表格组级别时， 将TableName设置为"-1"
+//
+// 查询集群+表格组+表格级别时， 都不能设置为“-1”
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeBackupRecords(request *DescribeBackupRecordsRequest) (response *DescribeBackupRecordsResponse, err error) {
+    return c.DescribeBackupRecordsWithContext(context.Background(), request)
+}
+
+// DescribeBackupRecords
+// 查询备份记录
+//
+// 
+//
+// 查询集群级别时， 将TableGroupId设置为"-1", 将TableName设置为"-1"
+//
+// 查询集群+表格组级别时， 将TableName设置为"-1"
+//
+// 查询集群+表格组+表格级别时， 都不能设置为“-1”
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeBackupRecordsWithContext(ctx context.Context, request *DescribeBackupRecordsRequest) (response *DescribeBackupRecordsResponse, err error) {
+    if request == nil {
+        request = NewDescribeBackupRecordsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeBackupRecords")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeBackupRecords require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeBackupRecordsResponse()
     err = c.Send(request, response)
     return
 }
@@ -530,15 +1101,19 @@ func NewDescribeClusterTagsRequest() (request *DescribeClusterTagsRequest) {
     request = &DescribeClusterTagsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeClusterTags")
+    
+    
     return
 }
 
 func NewDescribeClusterTagsResponse() (response *DescribeClusterTagsResponse) {
     response = &DescribeClusterTagsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeClusterTags
@@ -551,9 +1126,30 @@ func NewDescribeClusterTagsResponse() (response *DescribeClusterTagsResponse) {
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeClusterTags(request *DescribeClusterTagsRequest) (response *DescribeClusterTagsResponse, err error) {
+    return c.DescribeClusterTagsWithContext(context.Background(), request)
+}
+
+// DescribeClusterTags
+// 获取集群关联的标签列表
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeClusterTagsWithContext(ctx context.Context, request *DescribeClusterTagsRequest) (response *DescribeClusterTagsResponse, err error) {
     if request == nil {
         request = NewDescribeClusterTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeClusterTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClusterTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeClusterTagsResponse()
     err = c.Send(request, response)
     return
@@ -563,15 +1159,19 @@ func NewDescribeClustersRequest() (request *DescribeClustersRequest) {
     request = &DescribeClustersRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeClusters")
+    
+    
     return
 }
 
 func NewDescribeClustersResponse() (response *DescribeClustersResponse) {
     response = &DescribeClustersResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeClusters
@@ -583,9 +1183,29 @@ func NewDescribeClustersResponse() (response *DescribeClustersResponse) {
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 func (c *Client) DescribeClusters(request *DescribeClustersRequest) (response *DescribeClustersResponse, err error) {
+    return c.DescribeClustersWithContext(context.Background(), request)
+}
+
+// DescribeClusters
+// 查询TcaplusDB集群列表，包含集群详细信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeClustersWithContext(ctx context.Context, request *DescribeClustersRequest) (response *DescribeClustersResponse, err error) {
     if request == nil {
         request = NewDescribeClustersRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeClusters")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClusters require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeClustersResponse()
     err = c.Send(request, response)
     return
@@ -595,15 +1215,19 @@ func NewDescribeIdlFileInfosRequest() (request *DescribeIdlFileInfosRequest) {
     request = &DescribeIdlFileInfosRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeIdlFileInfos")
+    
+    
     return
 }
 
 func NewDescribeIdlFileInfosResponse() (response *DescribeIdlFileInfosResponse) {
     response = &DescribeIdlFileInfosResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeIdlFileInfos
@@ -615,9 +1239,29 @@ func NewDescribeIdlFileInfosResponse() (response *DescribeIdlFileInfosResponse) 
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeIdlFileInfos(request *DescribeIdlFileInfosRequest) (response *DescribeIdlFileInfosResponse, err error) {
+    return c.DescribeIdlFileInfosWithContext(context.Background(), request)
+}
+
+// DescribeIdlFileInfos
+// 查询表描述文件详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeIdlFileInfosWithContext(ctx context.Context, request *DescribeIdlFileInfosRequest) (response *DescribeIdlFileInfosResponse, err error) {
     if request == nil {
         request = NewDescribeIdlFileInfosRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeIdlFileInfos")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeIdlFileInfos require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeIdlFileInfosResponse()
     err = c.Send(request, response)
     return
@@ -627,15 +1271,19 @@ func NewDescribeMachineRequest() (request *DescribeMachineRequest) {
     request = &DescribeMachineRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeMachine")
+    
+    
     return
 }
 
 func NewDescribeMachineResponse() (response *DescribeMachineResponse) {
     response = &DescribeMachineResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeMachine
@@ -646,10 +1294,32 @@ func NewDescribeMachineResponse() (response *DescribeMachineResponse) {
 //  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
 func (c *Client) DescribeMachine(request *DescribeMachineRequest) (response *DescribeMachineResponse, err error) {
+    return c.DescribeMachineWithContext(context.Background(), request)
+}
+
+// DescribeMachine
+// 查询独占集群可以申请的剩余机器
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+func (c *Client) DescribeMachineWithContext(ctx context.Context, request *DescribeMachineRequest) (response *DescribeMachineResponse, err error) {
     if request == nil {
         request = NewDescribeMachineRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeMachine")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeMachine require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeMachineResponse()
     err = c.Send(request, response)
     return
@@ -659,15 +1329,19 @@ func NewDescribeRegionsRequest() (request *DescribeRegionsRequest) {
     request = &DescribeRegionsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeRegions")
+    
+    
     return
 }
 
 func NewDescribeRegionsResponse() (response *DescribeRegionsResponse) {
     response = &DescribeRegionsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeRegions
@@ -676,9 +1350,26 @@ func NewDescribeRegionsResponse() (response *DescribeRegionsResponse) {
 // 可能返回的错误码:
 //  INTERNALERROR = "InternalError"
 func (c *Client) DescribeRegions(request *DescribeRegionsRequest) (response *DescribeRegionsResponse, err error) {
+    return c.DescribeRegionsWithContext(context.Background(), request)
+}
+
+// DescribeRegions
+// 查询TcaplusDB服务支持的地域列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribeRegionsWithContext(ctx context.Context, request *DescribeRegionsRequest) (response *DescribeRegionsResponse, err error) {
     if request == nil {
         request = NewDescribeRegionsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeRegions")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeRegions require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeRegionsResponse()
     err = c.Send(request, response)
     return
@@ -688,15 +1379,19 @@ func NewDescribeSnapshotsRequest() (request *DescribeSnapshotsRequest) {
     request = &DescribeSnapshotsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeSnapshots")
+    
+    
     return
 }
 
 func NewDescribeSnapshotsResponse() (response *DescribeSnapshotsResponse) {
     response = &DescribeSnapshotsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeSnapshots
@@ -711,10 +1406,36 @@ func NewDescribeSnapshotsResponse() (response *DescribeSnapshotsResponse) {
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  INVALIDPARAMETERVALUE_INVALIDAPPNAME = "InvalidParameterValue.InvalidAppName"
 //  RESOURCEINSUFFICIENT = "ResourceInsufficient"
+//  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeSnapshots(request *DescribeSnapshotsRequest) (response *DescribeSnapshotsResponse, err error) {
+    return c.DescribeSnapshotsWithContext(context.Background(), request)
+}
+
+// DescribeSnapshots
+// 查询快照列表
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_INVALIDAPPNAME = "InvalidParameterValue.InvalidAppName"
+//  RESOURCEINSUFFICIENT = "ResourceInsufficient"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeSnapshotsWithContext(ctx context.Context, request *DescribeSnapshotsRequest) (response *DescribeSnapshotsResponse, err error) {
     if request == nil {
         request = NewDescribeSnapshotsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeSnapshots")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeSnapshots require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeSnapshotsResponse()
     err = c.Send(request, response)
     return
@@ -724,15 +1445,19 @@ func NewDescribeTableGroupTagsRequest() (request *DescribeTableGroupTagsRequest)
     request = &DescribeTableGroupTagsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeTableGroupTags")
+    
+    
     return
 }
 
 func NewDescribeTableGroupTagsResponse() (response *DescribeTableGroupTagsResponse) {
     response = &DescribeTableGroupTagsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeTableGroupTags
@@ -745,9 +1470,30 @@ func NewDescribeTableGroupTagsResponse() (response *DescribeTableGroupTagsRespon
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeTableGroupTags(request *DescribeTableGroupTagsRequest) (response *DescribeTableGroupTagsResponse, err error) {
+    return c.DescribeTableGroupTagsWithContext(context.Background(), request)
+}
+
+// DescribeTableGroupTags
+// 获取表格组关联的标签列表
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTableGroupTagsWithContext(ctx context.Context, request *DescribeTableGroupTagsRequest) (response *DescribeTableGroupTagsResponse, err error) {
     if request == nil {
         request = NewDescribeTableGroupTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeTableGroupTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTableGroupTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeTableGroupTagsResponse()
     err = c.Send(request, response)
     return
@@ -757,15 +1503,19 @@ func NewDescribeTableGroupsRequest() (request *DescribeTableGroupsRequest) {
     request = &DescribeTableGroupsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeTableGroups")
+    
+    
     return
 }
 
 func NewDescribeTableGroupsResponse() (response *DescribeTableGroupsResponse) {
     response = &DescribeTableGroupsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeTableGroups
@@ -779,9 +1529,31 @@ func NewDescribeTableGroupsResponse() (response *DescribeTableGroupsResponse) {
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeTableGroups(request *DescribeTableGroupsRequest) (response *DescribeTableGroupsResponse, err error) {
+    return c.DescribeTableGroupsWithContext(context.Background(), request)
+}
+
+// DescribeTableGroups
+// 查询表格组列表
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTableGroupsWithContext(ctx context.Context, request *DescribeTableGroupsRequest) (response *DescribeTableGroupsResponse, err error) {
     if request == nil {
         request = NewDescribeTableGroupsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeTableGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTableGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeTableGroupsResponse()
     err = c.Send(request, response)
     return
@@ -791,15 +1563,19 @@ func NewDescribeTableTagsRequest() (request *DescribeTableTagsRequest) {
     request = &DescribeTableTagsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeTableTags")
+    
+    
     return
 }
 
 func NewDescribeTableTagsResponse() (response *DescribeTableTagsResponse) {
     response = &DescribeTableTagsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeTableTags
@@ -812,9 +1588,30 @@ func NewDescribeTableTagsResponse() (response *DescribeTableTagsResponse) {
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeTableTags(request *DescribeTableTagsRequest) (response *DescribeTableTagsResponse, err error) {
+    return c.DescribeTableTagsWithContext(context.Background(), request)
+}
+
+// DescribeTableTags
+// 获取表格标签
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTableTagsWithContext(ctx context.Context, request *DescribeTableTagsRequest) (response *DescribeTableTagsResponse, err error) {
     if request == nil {
         request = NewDescribeTableTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeTableTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTableTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeTableTagsResponse()
     err = c.Send(request, response)
     return
@@ -824,15 +1621,19 @@ func NewDescribeTablesRequest() (request *DescribeTablesRequest) {
     request = &DescribeTablesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeTables")
+    
+    
     return
 }
 
 func NewDescribeTablesResponse() (response *DescribeTablesResponse) {
     response = &DescribeTablesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeTables
@@ -846,9 +1647,31 @@ func NewDescribeTablesResponse() (response *DescribeTablesResponse) {
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeTables(request *DescribeTablesRequest) (response *DescribeTablesResponse, err error) {
+    return c.DescribeTablesWithContext(context.Background(), request)
+}
+
+// DescribeTables
+// 查询表详情
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTablesWithContext(ctx context.Context, request *DescribeTablesRequest) (response *DescribeTablesResponse, err error) {
     if request == nil {
         request = NewDescribeTablesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeTables")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTables require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeTablesResponse()
     err = c.Send(request, response)
     return
@@ -858,15 +1681,19 @@ func NewDescribeTablesInRecycleRequest() (request *DescribeTablesInRecycleReques
     request = &DescribeTablesInRecycleRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeTablesInRecycle")
+    
+    
     return
 }
 
 func NewDescribeTablesInRecycleResponse() (response *DescribeTablesInRecycleResponse) {
     response = &DescribeTablesInRecycleResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeTablesInRecycle
@@ -879,9 +1706,30 @@ func NewDescribeTablesInRecycleResponse() (response *DescribeTablesInRecycleResp
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DescribeTablesInRecycle(request *DescribeTablesInRecycleRequest) (response *DescribeTablesInRecycleResponse, err error) {
+    return c.DescribeTablesInRecycleWithContext(context.Background(), request)
+}
+
+// DescribeTablesInRecycle
+// 查询回收站中的表详情
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTablesInRecycleWithContext(ctx context.Context, request *DescribeTablesInRecycleRequest) (response *DescribeTablesInRecycleResponse, err error) {
     if request == nil {
         request = NewDescribeTablesInRecycleRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeTablesInRecycle")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTablesInRecycle require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeTablesInRecycleResponse()
     err = c.Send(request, response)
     return
@@ -891,15 +1739,19 @@ func NewDescribeTasksRequest() (request *DescribeTasksRequest) {
     request = &DescribeTasksRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeTasks")
+    
+    
     return
 }
 
 func NewDescribeTasksResponse() (response *DescribeTasksResponse) {
     response = &DescribeTasksResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeTasks
@@ -909,9 +1761,27 @@ func NewDescribeTasksResponse() (response *DescribeTasksResponse) {
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 func (c *Client) DescribeTasks(request *DescribeTasksRequest) (response *DescribeTasksResponse, err error) {
+    return c.DescribeTasksWithContext(context.Background(), request)
+}
+
+// DescribeTasks
+// 查询任务列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeTasksWithContext(ctx context.Context, request *DescribeTasksRequest) (response *DescribeTasksResponse, err error) {
     if request == nil {
         request = NewDescribeTasksRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeTasks")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTasks require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeTasksResponse()
     err = c.Send(request, response)
     return
@@ -921,15 +1791,19 @@ func NewDescribeUinInWhitelistRequest() (request *DescribeUinInWhitelistRequest)
     request = &DescribeUinInWhitelistRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DescribeUinInWhitelist")
+    
+    
     return
 }
 
 func NewDescribeUinInWhitelistResponse() (response *DescribeUinInWhitelistResponse) {
     response = &DescribeUinInWhitelistResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DescribeUinInWhitelist
@@ -938,9 +1812,26 @@ func NewDescribeUinInWhitelistResponse() (response *DescribeUinInWhitelistRespon
 // 可能返回的错误码:
 //  INTERNALERROR = "InternalError"
 func (c *Client) DescribeUinInWhitelist(request *DescribeUinInWhitelistRequest) (response *DescribeUinInWhitelistResponse, err error) {
+    return c.DescribeUinInWhitelistWithContext(context.Background(), request)
+}
+
+// DescribeUinInWhitelist
+// 查询本用户是否在白名单中，控制是否能创建TDR类型的APP或表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribeUinInWhitelistWithContext(ctx context.Context, request *DescribeUinInWhitelistRequest) (response *DescribeUinInWhitelistResponse, err error) {
     if request == nil {
         request = NewDescribeUinInWhitelistRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DescribeUinInWhitelist")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeUinInWhitelist require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDescribeUinInWhitelistResponse()
     err = c.Send(request, response)
     return
@@ -950,15 +1841,19 @@ func NewDisableRestProxyRequest() (request *DisableRestProxyRequest) {
     request = &DisableRestProxyRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "DisableRestProxy")
+    
+    
     return
 }
 
 func NewDisableRestProxyResponse() (response *DisableRestProxyResponse) {
     response = &DisableRestProxyResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DisableRestProxy
@@ -971,9 +1866,30 @@ func NewDisableRestProxyResponse() (response *DisableRestProxyResponse) {
 //  INTERNALERROR = "InternalError"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) DisableRestProxy(request *DisableRestProxyRequest) (response *DisableRestProxyResponse, err error) {
+    return c.DisableRestProxyWithContext(context.Background(), request)
+}
+
+// DisableRestProxy
+// 当restful api为关闭状态时，可以通过此接口关闭restful api
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DisableRestProxyWithContext(ctx context.Context, request *DisableRestProxyRequest) (response *DisableRestProxyResponse, err error) {
     if request == nil {
         request = NewDisableRestProxyRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "DisableRestProxy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DisableRestProxy require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewDisableRestProxyResponse()
     err = c.Send(request, response)
     return
@@ -983,30 +1899,73 @@ func NewEnableRestProxyRequest() (request *EnableRestProxyRequest) {
     request = &EnableRestProxyRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "EnableRestProxy")
+    
+    
     return
 }
 
 func NewEnableRestProxyResponse() (response *EnableRestProxyResponse) {
     response = &EnableRestProxyResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // EnableRestProxy
-// 当restful api为关闭状态时，可以通过此接口开启restful apu
+// 当restful api为关闭状态时，可以通过此接口开启restful api。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
 //  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  FAILEDOPERATION = "FailedOperation"
 //  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_INVALIDAPPNAME = "InvalidParameterValue.InvalidAppName"
+//  INVALIDPARAMETERVALUE_INVALIDCLUSTERNAME = "InvalidParameterValue.InvalidClusterName"
+//  INVALIDPARAMETERVALUE_INVALIDTABLEGROUPNAME = "InvalidParameterValue.InvalidTableGroupName"
+//  INVALIDPARAMETERVALUE_INVALIDTIMEVALUE = "InvalidParameterValue.InvalidTimeValue"
+//  INVALIDPARAMETERVALUE_INVALIDZONENAME = "InvalidParameterValue.InvalidZoneName"
+//  INVALIDPARAMETERVALUE_UNSUPPORTIDLTYPE = "InvalidParameterValue.UnsupportIdlType"
 //  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) EnableRestProxy(request *EnableRestProxyRequest) (response *EnableRestProxyResponse, err error) {
+    return c.EnableRestProxyWithContext(context.Background(), request)
+}
+
+// EnableRestProxy
+// 当restful api为关闭状态时，可以通过此接口开启restful api。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_INVALIDAPPNAME = "InvalidParameterValue.InvalidAppName"
+//  INVALIDPARAMETERVALUE_INVALIDCLUSTERNAME = "InvalidParameterValue.InvalidClusterName"
+//  INVALIDPARAMETERVALUE_INVALIDTABLEGROUPNAME = "InvalidParameterValue.InvalidTableGroupName"
+//  INVALIDPARAMETERVALUE_INVALIDTIMEVALUE = "InvalidParameterValue.InvalidTimeValue"
+//  INVALIDPARAMETERVALUE_INVALIDZONENAME = "InvalidParameterValue.InvalidZoneName"
+//  INVALIDPARAMETERVALUE_UNSUPPORTIDLTYPE = "InvalidParameterValue.UnsupportIdlType"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) EnableRestProxyWithContext(ctx context.Context, request *EnableRestProxyRequest) (response *EnableRestProxyResponse, err error) {
     if request == nil {
         request = NewEnableRestProxyRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "EnableRestProxy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("EnableRestProxy require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewEnableRestProxyResponse()
     err = c.Send(request, response)
     return
@@ -1016,15 +1975,19 @@ func NewImportSnapshotsRequest() (request *ImportSnapshotsRequest) {
     request = &ImportSnapshotsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ImportSnapshots")
+    
+    
     return
 }
 
 func NewImportSnapshotsResponse() (response *ImportSnapshotsResponse) {
     response = &ImportSnapshotsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ImportSnapshots
@@ -1042,9 +2005,35 @@ func NewImportSnapshotsResponse() (response *ImportSnapshotsResponse) {
 //  RESOURCEINSUFFICIENT_BALANCEERROR = "ResourceInsufficient.BalanceError"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ImportSnapshots(request *ImportSnapshotsRequest) (response *ImportSnapshotsResponse, err error) {
+    return c.ImportSnapshotsWithContext(context.Background(), request)
+}
+
+// ImportSnapshots
+// 将快照数据导入到新表或当前表
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCEINSUFFICIENT_BALANCEERROR = "ResourceInsufficient.BalanceError"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ImportSnapshotsWithContext(ctx context.Context, request *ImportSnapshotsRequest) (response *ImportSnapshotsResponse, err error) {
     if request == nil {
         request = NewImportSnapshotsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ImportSnapshots")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ImportSnapshots require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewImportSnapshotsResponse()
     err = c.Send(request, response)
     return
@@ -1054,15 +2043,19 @@ func NewMergeTablesDataRequest() (request *MergeTablesDataRequest) {
     request = &MergeTablesDataRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "MergeTablesData")
+    
+    
     return
 }
 
 func NewMergeTablesDataResponse() (response *MergeTablesDataResponse) {
     response = &MergeTablesDataResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // MergeTablesData
@@ -1079,9 +2072,34 @@ func NewMergeTablesDataResponse() (response *MergeTablesDataResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) MergeTablesData(request *MergeTablesDataRequest) (response *MergeTablesDataResponse, err error) {
+    return c.MergeTablesDataWithContext(context.Background(), request)
+}
+
+// MergeTablesData
+// 合并指定表格
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) MergeTablesDataWithContext(ctx context.Context, request *MergeTablesDataRequest) (response *MergeTablesDataResponse, err error) {
     if request == nil {
         request = NewMergeTablesDataRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "MergeTablesData")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("MergeTablesData require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewMergeTablesDataResponse()
     err = c.Send(request, response)
     return
@@ -1091,15 +2109,19 @@ func NewModifyCensorshipRequest() (request *ModifyCensorshipRequest) {
     request = &ModifyCensorshipRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyCensorship")
+    
+    
     return
 }
 
 func NewModifyCensorshipResponse() (response *ModifyCensorshipResponse) {
     response = &ModifyCensorshipResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyCensorship
@@ -1116,9 +2138,34 @@ func NewModifyCensorshipResponse() (response *ModifyCensorshipResponse) {
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
 func (c *Client) ModifyCensorship(request *ModifyCensorshipRequest) (response *ModifyCensorshipResponse, err error) {
+    return c.ModifyCensorshipWithContext(context.Background(), request)
+}
+
+// ModifyCensorship
+// 修改集群审批状态
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_INVALIDCLUSTERNAME = "InvalidParameterValue.InvalidClusterName"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+func (c *Client) ModifyCensorshipWithContext(ctx context.Context, request *ModifyCensorshipRequest) (response *ModifyCensorshipResponse, err error) {
     if request == nil {
         request = NewModifyCensorshipRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyCensorship")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyCensorship require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyCensorshipResponse()
     err = c.Send(request, response)
     return
@@ -1128,15 +2175,19 @@ func NewModifyClusterMachineRequest() (request *ModifyClusterMachineRequest) {
     request = &ModifyClusterMachineRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyClusterMachine")
+    
+    
     return
 }
 
 func NewModifyClusterMachineResponse() (response *ModifyClusterMachineResponse) {
     response = &ModifyClusterMachineResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyClusterMachine
@@ -1150,9 +2201,31 @@ func NewModifyClusterMachineResponse() (response *ModifyClusterMachineResponse) 
 //  RESOURCEINSUFFICIENT_NOAVAILABLEAPP = "ResourceInsufficient.NoAvailableApp"
 //  RESOURCEINSUFFICIENT_NOAVAILABLECLUSTER = "ResourceInsufficient.NoAvailableCluster"
 func (c *Client) ModifyClusterMachine(request *ModifyClusterMachineRequest) (response *ModifyClusterMachineResponse, err error) {
+    return c.ModifyClusterMachineWithContext(context.Background(), request)
+}
+
+// ModifyClusterMachine
+// 修改独占集群机器
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  RESOURCEINUSE = "ResourceInUse"
+//  RESOURCEINSUFFICIENT = "ResourceInsufficient"
+//  RESOURCEINSUFFICIENT_NOAVAILABLEAPP = "ResourceInsufficient.NoAvailableApp"
+//  RESOURCEINSUFFICIENT_NOAVAILABLECLUSTER = "ResourceInsufficient.NoAvailableCluster"
+func (c *Client) ModifyClusterMachineWithContext(ctx context.Context, request *ModifyClusterMachineRequest) (response *ModifyClusterMachineResponse, err error) {
     if request == nil {
         request = NewModifyClusterMachineRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyClusterMachine")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyClusterMachine require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyClusterMachineResponse()
     err = c.Send(request, response)
     return
@@ -1162,15 +2235,19 @@ func NewModifyClusterNameRequest() (request *ModifyClusterNameRequest) {
     request = &ModifyClusterNameRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyClusterName")
+    
+    
     return
 }
 
 func NewModifyClusterNameResponse() (response *ModifyClusterNameResponse) {
     response = &ModifyClusterNameResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyClusterName
@@ -1185,9 +2262,32 @@ func NewModifyClusterNameResponse() (response *ModifyClusterNameResponse) {
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  RESOURCEUNAVAILABLE_DUPLICATECLUSTERNAME = "ResourceUnavailable.DuplicateClusterName"
 func (c *Client) ModifyClusterName(request *ModifyClusterNameRequest) (response *ModifyClusterNameResponse, err error) {
+    return c.ModifyClusterNameWithContext(context.Background(), request)
+}
+
+// ModifyClusterName
+// 修改指定的集群名称
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_REGIONMISMATCH = "FailedOperation.RegionMismatch"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_INVALIDCLUSTERNAME = "InvalidParameterValue.InvalidClusterName"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCEUNAVAILABLE_DUPLICATECLUSTERNAME = "ResourceUnavailable.DuplicateClusterName"
+func (c *Client) ModifyClusterNameWithContext(ctx context.Context, request *ModifyClusterNameRequest) (response *ModifyClusterNameResponse, err error) {
     if request == nil {
         request = NewModifyClusterNameRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyClusterName")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyClusterName require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyClusterNameResponse()
     err = c.Send(request, response)
     return
@@ -1197,15 +2297,19 @@ func NewModifyClusterPasswordRequest() (request *ModifyClusterPasswordRequest) {
     request = &ModifyClusterPasswordRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyClusterPassword")
+    
+    
     return
 }
 
 func NewModifyClusterPasswordResponse() (response *ModifyClusterPasswordResponse) {
     response = &ModifyClusterPasswordResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyClusterPassword
@@ -1222,9 +2326,34 @@ func NewModifyClusterPasswordResponse() (response *ModifyClusterPasswordResponse
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) ModifyClusterPassword(request *ModifyClusterPasswordRequest) (response *ModifyClusterPasswordResponse, err error) {
+    return c.ModifyClusterPasswordWithContext(context.Background(), request)
+}
+
+// ModifyClusterPassword
+// 修改指定集群的密码，后台将在旧密码失效之前同时支持TcaplusDB SDK使用旧密码和新密码访问数据库。在旧密码失效之前不能提交新的密码修改请求，在旧密码失效之后不能提交修改旧密码过期时间的请求。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_OLDPASSWORDHASEXPIRED = "FailedOperation.OldPasswordHasExpired"
+//  FAILEDOPERATION_OLDPASSWORDINUSE = "FailedOperation.OldPasswordInUse"
+//  FAILEDOPERATION_PASSWORDFAILURE = "FailedOperation.PasswordFailure"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_INVALIDTIMEVALUE = "InvalidParameterValue.InvalidTimeValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) ModifyClusterPasswordWithContext(ctx context.Context, request *ModifyClusterPasswordRequest) (response *ModifyClusterPasswordResponse, err error) {
     if request == nil {
         request = NewModifyClusterPasswordRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyClusterPassword")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyClusterPassword require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyClusterPasswordResponse()
     err = c.Send(request, response)
     return
@@ -1234,15 +2363,19 @@ func NewModifyClusterTagsRequest() (request *ModifyClusterTagsRequest) {
     request = &ModifyClusterTagsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyClusterTags")
+    
+    
     return
 }
 
 func NewModifyClusterTagsResponse() (response *ModifyClusterTagsResponse) {
     response = &ModifyClusterTagsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyClusterTags
@@ -1256,9 +2389,31 @@ func NewModifyClusterTagsResponse() (response *ModifyClusterTagsResponse) {
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ModifyClusterTags(request *ModifyClusterTagsRequest) (response *ModifyClusterTagsResponse, err error) {
+    return c.ModifyClusterTagsWithContext(context.Background(), request)
+}
+
+// ModifyClusterTags
+// 修改集群标签
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifyClusterTagsWithContext(ctx context.Context, request *ModifyClusterTagsRequest) (response *ModifyClusterTagsResponse, err error) {
     if request == nil {
         request = NewModifyClusterTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyClusterTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyClusterTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyClusterTagsResponse()
     err = c.Send(request, response)
     return
@@ -1268,15 +2423,19 @@ func NewModifySnapshotsRequest() (request *ModifySnapshotsRequest) {
     request = &ModifySnapshotsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifySnapshots")
+    
+    
     return
 }
 
 func NewModifySnapshotsResponse() (response *ModifySnapshotsResponse) {
     response = &ModifySnapshotsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifySnapshots
@@ -1293,9 +2452,34 @@ func NewModifySnapshotsResponse() (response *ModifySnapshotsResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ModifySnapshots(request *ModifySnapshotsRequest) (response *ModifySnapshotsResponse, err error) {
+    return c.ModifySnapshotsWithContext(context.Background(), request)
+}
+
+// ModifySnapshots
+// 修改表格快照的过期时间
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifySnapshotsWithContext(ctx context.Context, request *ModifySnapshotsRequest) (response *ModifySnapshotsResponse, err error) {
     if request == nil {
         request = NewModifySnapshotsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifySnapshots")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifySnapshots require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifySnapshotsResponse()
     err = c.Send(request, response)
     return
@@ -1305,15 +2489,19 @@ func NewModifyTableGroupNameRequest() (request *ModifyTableGroupNameRequest) {
     request = &ModifyTableGroupNameRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyTableGroupName")
+    
+    
     return
 }
 
 func NewModifyTableGroupNameResponse() (response *ModifyTableGroupNameResponse) {
     response = &ModifyTableGroupNameResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyTableGroupName
@@ -1326,9 +2514,30 @@ func NewModifyTableGroupNameResponse() (response *ModifyTableGroupNameResponse) 
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  RESOURCEUNAVAILABLE_DUPLICATETABLEGROUPNAME = "ResourceUnavailable.DuplicateTableGroupName"
 func (c *Client) ModifyTableGroupName(request *ModifyTableGroupNameRequest) (response *ModifyTableGroupNameResponse, err error) {
+    return c.ModifyTableGroupNameWithContext(context.Background(), request)
+}
+
+// ModifyTableGroupName
+// 修改TcaplusDB表格组名称
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_INVALIDTABLEGROUPNAME = "InvalidParameterValue.InvalidTableGroupName"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCEUNAVAILABLE_DUPLICATETABLEGROUPNAME = "ResourceUnavailable.DuplicateTableGroupName"
+func (c *Client) ModifyTableGroupNameWithContext(ctx context.Context, request *ModifyTableGroupNameRequest) (response *ModifyTableGroupNameResponse, err error) {
     if request == nil {
         request = NewModifyTableGroupNameRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyTableGroupName")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyTableGroupName require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyTableGroupNameResponse()
     err = c.Send(request, response)
     return
@@ -1338,15 +2547,19 @@ func NewModifyTableGroupTagsRequest() (request *ModifyTableGroupTagsRequest) {
     request = &ModifyTableGroupTagsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyTableGroupTags")
+    
+    
     return
 }
 
 func NewModifyTableGroupTagsResponse() (response *ModifyTableGroupTagsResponse) {
     response = &ModifyTableGroupTagsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyTableGroupTags
@@ -1360,9 +2573,31 @@ func NewModifyTableGroupTagsResponse() (response *ModifyTableGroupTagsResponse) 
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ModifyTableGroupTags(request *ModifyTableGroupTagsRequest) (response *ModifyTableGroupTagsResponse, err error) {
+    return c.ModifyTableGroupTagsWithContext(context.Background(), request)
+}
+
+// ModifyTableGroupTags
+// 修改表格组标签
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifyTableGroupTagsWithContext(ctx context.Context, request *ModifyTableGroupTagsRequest) (response *ModifyTableGroupTagsResponse, err error) {
     if request == nil {
         request = NewModifyTableGroupTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyTableGroupTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyTableGroupTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyTableGroupTagsResponse()
     err = c.Send(request, response)
     return
@@ -1372,15 +2607,19 @@ func NewModifyTableMemosRequest() (request *ModifyTableMemosRequest) {
     request = &ModifyTableMemosRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyTableMemos")
+    
+    
     return
 }
 
 func NewModifyTableMemosResponse() (response *ModifyTableMemosResponse) {
     response = &ModifyTableMemosResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyTableMemos
@@ -1394,9 +2633,31 @@ func NewModifyTableMemosResponse() (response *ModifyTableMemosResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ModifyTableMemos(request *ModifyTableMemosRequest) (response *ModifyTableMemosResponse, err error) {
+    return c.ModifyTableMemosWithContext(context.Background(), request)
+}
+
+// ModifyTableMemos
+// 修改表备注信息
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifyTableMemosWithContext(ctx context.Context, request *ModifyTableMemosRequest) (response *ModifyTableMemosResponse, err error) {
     if request == nil {
         request = NewModifyTableMemosRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyTableMemos")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyTableMemos require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyTableMemosResponse()
     err = c.Send(request, response)
     return
@@ -1406,15 +2667,19 @@ func NewModifyTableQuotasRequest() (request *ModifyTableQuotasRequest) {
     request = &ModifyTableQuotasRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyTableQuotas")
+    
+    
     return
 }
 
 func NewModifyTableQuotasResponse() (response *ModifyTableQuotasResponse) {
     response = &ModifyTableQuotasResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyTableQuotas
@@ -1429,9 +2694,32 @@ func NewModifyTableQuotasResponse() (response *ModifyTableQuotasResponse) {
 //  RESOURCEINSUFFICIENT_BALANCEERROR = "ResourceInsufficient.BalanceError"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ModifyTableQuotas(request *ModifyTableQuotasRequest) (response *ModifyTableQuotasResponse, err error) {
+    return c.ModifyTableQuotasWithContext(context.Background(), request)
+}
+
+// ModifyTableQuotas
+// 表格扩缩容
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCEINSUFFICIENT_BALANCEERROR = "ResourceInsufficient.BalanceError"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifyTableQuotasWithContext(ctx context.Context, request *ModifyTableQuotasRequest) (response *ModifyTableQuotasResponse, err error) {
     if request == nil {
         request = NewModifyTableQuotasRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyTableQuotas")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyTableQuotas require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyTableQuotasResponse()
     err = c.Send(request, response)
     return
@@ -1441,15 +2729,19 @@ func NewModifyTableTagsRequest() (request *ModifyTableTagsRequest) {
     request = &ModifyTableTagsRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyTableTags")
+    
+    
     return
 }
 
 func NewModifyTableTagsResponse() (response *ModifyTableTagsResponse) {
     response = &ModifyTableTagsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyTableTags
@@ -1464,9 +2756,32 @@ func NewModifyTableTagsResponse() (response *ModifyTableTagsResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ModifyTableTags(request *ModifyTableTagsRequest) (response *ModifyTableTagsResponse, err error) {
+    return c.ModifyTableTagsWithContext(context.Background(), request)
+}
+
+// ModifyTableTags
+// 修改表格标签
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifyTableTagsWithContext(ctx context.Context, request *ModifyTableTagsRequest) (response *ModifyTableTagsResponse, err error) {
     if request == nil {
         request = NewModifyTableTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyTableTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyTableTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyTableTagsResponse()
     err = c.Send(request, response)
     return
@@ -1476,15 +2791,19 @@ func NewModifyTablesRequest() (request *ModifyTablesRequest) {
     request = &ModifyTablesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "ModifyTables")
+    
+    
     return
 }
 
 func NewModifyTablesResponse() (response *ModifyTablesResponse) {
     response = &ModifyTablesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ModifyTables
@@ -1499,9 +2818,32 @@ func NewModifyTablesResponse() (response *ModifyTablesResponse) {
 //  LIMITEXCEEDED = "LimitExceeded"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) ModifyTables(request *ModifyTablesRequest) (response *ModifyTablesResponse, err error) {
+    return c.ModifyTablesWithContext(context.Background(), request)
+}
+
+// ModifyTables
+// 根据用户选定的表定义IDL文件，批量修改指定的表
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifyTablesWithContext(ctx context.Context, request *ModifyTablesRequest) (response *ModifyTablesResponse, err error) {
     if request == nil {
         request = NewModifyTablesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "ModifyTables")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyTables require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewModifyTablesResponse()
     err = c.Send(request, response)
     return
@@ -1511,15 +2853,19 @@ func NewRecoverRecycleTablesRequest() (request *RecoverRecycleTablesRequest) {
     request = &RecoverRecycleTablesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "RecoverRecycleTables")
+    
+    
     return
 }
 
 func NewRecoverRecycleTablesResponse() (response *RecoverRecycleTablesResponse) {
     response = &RecoverRecycleTablesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // RecoverRecycleTables
@@ -1533,45 +2879,160 @@ func NewRecoverRecycleTablesResponse() (response *RecoverRecycleTablesResponse) 
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) RecoverRecycleTables(request *RecoverRecycleTablesRequest) (response *RecoverRecycleTablesResponse, err error) {
+    return c.RecoverRecycleTablesWithContext(context.Background(), request)
+}
+
+// RecoverRecycleTables
+// 恢复回收站中，用户自行删除的表。对欠费待释放的表无效。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) RecoverRecycleTablesWithContext(ctx context.Context, request *RecoverRecycleTablesRequest) (response *RecoverRecycleTablesResponse, err error) {
     if request == nil {
         request = NewRecoverRecycleTablesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "RecoverRecycleTables")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("RecoverRecycleTables require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewRecoverRecycleTablesResponse()
     err = c.Send(request, response)
     return
 }
 
-func NewRollbackTablesRequest() (request *RollbackTablesRequest) {
-    request = &RollbackTablesRequest{
+func NewSetBackupExpireRuleRequest() (request *SetBackupExpireRuleRequest) {
+    request = &SetBackupExpireRuleRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
-    request.Init().WithApiInfo("tcaplusdb", APIVersion, "RollbackTables")
+    
+    request.Init().WithApiInfo("tcaplusdb", APIVersion, "SetBackupExpireRule")
+    
+    
     return
 }
 
-func NewRollbackTablesResponse() (response *RollbackTablesResponse) {
-    response = &RollbackTablesResponse{
+func NewSetBackupExpireRuleResponse() (response *SetBackupExpireRuleResponse) {
+    response = &SetBackupExpireRuleResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
-// RollbackTables
-// 表格数据回档
+// SetBackupExpireRule
+// 新增、删除、修改备份过期策略， ClusterId必须为具体的集群Id（appid）
 //
 // 可能返回的错误码:
 //  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  FAILEDOPERATION = "FailedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
-//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
-func (c *Client) RollbackTables(request *RollbackTablesRequest) (response *RollbackTablesResponse, err error) {
+func (c *Client) SetBackupExpireRule(request *SetBackupExpireRuleRequest) (response *SetBackupExpireRuleResponse, err error) {
+    return c.SetBackupExpireRuleWithContext(context.Background(), request)
+}
+
+// SetBackupExpireRule
+// 新增、删除、修改备份过期策略， ClusterId必须为具体的集群Id（appid）
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) SetBackupExpireRuleWithContext(ctx context.Context, request *SetBackupExpireRuleRequest) (response *SetBackupExpireRuleResponse, err error) {
     if request == nil {
-        request = NewRollbackTablesRequest()
+        request = NewSetBackupExpireRuleRequest()
     }
-    response = NewRollbackTablesResponse()
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "SetBackupExpireRule")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("SetBackupExpireRule require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewSetBackupExpireRuleResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewSetTableDataFlowRequest() (request *SetTableDataFlowRequest) {
+    request = &SetTableDataFlowRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("tcaplusdb", APIVersion, "SetTableDataFlow")
+    
+    
+    return
+}
+
+func NewSetTableDataFlowResponse() (response *SetTableDataFlowResponse) {
+    response = &SetTableDataFlowResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// SetTableDataFlow
+// 新增、修改表格数据订阅
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) SetTableDataFlow(request *SetTableDataFlowRequest) (response *SetTableDataFlowResponse, err error) {
+    return c.SetTableDataFlowWithContext(context.Background(), request)
+}
+
+// SetTableDataFlow
+// 新增、修改表格数据订阅
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) SetTableDataFlowWithContext(ctx context.Context, request *SetTableDataFlowRequest) (response *SetTableDataFlowResponse, err error) {
+    if request == nil {
+        request = NewSetTableDataFlowRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "SetTableDataFlow")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("SetTableDataFlow require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewSetTableDataFlowResponse()
     err = c.Send(request, response)
     return
 }
@@ -1580,15 +3041,19 @@ func NewSetTableIndexRequest() (request *SetTableIndexRequest) {
     request = &SetTableIndexRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "SetTableIndex")
+    
+    
     return
 }
 
 func NewSetTableIndexResponse() (response *SetTableIndexResponse) {
     response = &SetTableIndexResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // SetTableIndex
@@ -1603,9 +3068,32 @@ func NewSetTableIndexResponse() (response *SetTableIndexResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) SetTableIndex(request *SetTableIndexRequest) (response *SetTableIndexResponse, err error) {
+    return c.SetTableIndexWithContext(context.Background(), request)
+}
+
+// SetTableIndex
+// 设置表格分布式索引
+//
+// 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) SetTableIndexWithContext(ctx context.Context, request *SetTableIndexRequest) (response *SetTableIndexResponse, err error) {
     if request == nil {
         request = NewSetTableIndexRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "SetTableIndex")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("SetTableIndex require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewSetTableIndexResponse()
     err = c.Send(request, response)
     return
@@ -1615,15 +3103,19 @@ func NewUpdateApplyRequest() (request *UpdateApplyRequest) {
     request = &UpdateApplyRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "UpdateApply")
+    
+    
     return
 }
 
 func NewUpdateApplyResponse() (response *UpdateApplyResponse) {
     response = &UpdateApplyResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // UpdateApply
@@ -1639,9 +3131,33 @@ func NewUpdateApplyResponse() (response *UpdateApplyResponse) {
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
 func (c *Client) UpdateApply(request *UpdateApplyRequest) (response *UpdateApplyResponse, err error) {
+    return c.UpdateApplyWithContext(context.Background(), request)
+}
+
+// UpdateApply
+// 更新申请单状态
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  OPERATIONDENIED = "OperationDenied"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+func (c *Client) UpdateApplyWithContext(ctx context.Context, request *UpdateApplyRequest) (response *UpdateApplyResponse, err error) {
     if request == nil {
         request = NewUpdateApplyRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "UpdateApply")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateApply require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewUpdateApplyResponse()
     err = c.Send(request, response)
     return
@@ -1651,15 +3167,19 @@ func NewVerifyIdlFilesRequest() (request *VerifyIdlFilesRequest) {
     request = &VerifyIdlFilesRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
+    
     request.Init().WithApiInfo("tcaplusdb", APIVersion, "VerifyIdlFiles")
+    
+    
     return
 }
 
 func NewVerifyIdlFilesResponse() (response *VerifyIdlFilesResponse) {
     response = &VerifyIdlFilesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // VerifyIdlFiles
@@ -1672,9 +3192,30 @@ func NewVerifyIdlFilesResponse() (response *VerifyIdlFilesResponse) {
 //  MISSINGPARAMETER = "MissingParameter"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 func (c *Client) VerifyIdlFiles(request *VerifyIdlFilesRequest) (response *VerifyIdlFilesResponse, err error) {
+    return c.VerifyIdlFilesWithContext(context.Background(), request)
+}
+
+// VerifyIdlFiles
+// 上传并校验创建表格文件，返回校验合法的表格定义
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) VerifyIdlFilesWithContext(ctx context.Context, request *VerifyIdlFilesRequest) (response *VerifyIdlFilesResponse, err error) {
     if request == nil {
         request = NewVerifyIdlFilesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tcaplusdb", APIVersion, "VerifyIdlFiles")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("VerifyIdlFiles require credential")
+    }
+
+    request.SetContext(ctx)
+    
     response = NewVerifyIdlFilesResponse()
     err = c.Send(request, response)
     return

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,6 +58,9 @@ const (
 
 	// 非法的时间格式。
 	INVALIDPARAMETERVALUE_INVALIDTIMEVALUE = "InvalidParameterValue.InvalidTimeValue"
+
+	// 非法的大区名称。
+	INVALIDPARAMETERVALUE_INVALIDZONENAME = "InvalidParameterValue.InvalidZoneName"
 
 	// 不支持的应用数据描述类型。
 	INVALIDPARAMETERVALUE_UNSUPPORTIDLTYPE = "InvalidParameterValue.UnsupportIdlType"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823/models.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,116 +15,161 @@
 package v20190823
 
 import (
-    "encoding/json"
     tcerr "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
     tchttp "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http"
+    "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/json"
 )
 
 type Application struct {
-
 	// 审批单号
-	ApplicationId *string `json:"ApplicationId,omitempty" name:"ApplicationId"`
+	ApplicationId *string `json:"ApplicationId,omitnil,omitempty" name:"ApplicationId"`
 
 	// 申请类型
-	ApplicationType *int64 `json:"ApplicationType,omitempty" name:"ApplicationType"`
+	ApplicationType *int64 `json:"ApplicationType,omitnil,omitempty" name:"ApplicationType"`
 
 	// 集群Id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 集群名称
-	ClusterName *string `json:"ClusterName,omitempty" name:"ClusterName"`
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 
 	// 表格组名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupName *string `json:"TableGroupName,omitempty" name:"TableGroupName"`
+	TableGroupName *string `json:"TableGroupName,omitnil,omitempty" name:"TableGroupName"`
 
 	// 表格名称
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 申请人
-	Applicant *string `json:"Applicant,omitempty" name:"Applicant"`
+	Applicant *string `json:"Applicant,omitnil,omitempty" name:"Applicant"`
 
 	// 建单时间
-	CreatedTime *string `json:"CreatedTime,omitempty" name:"CreatedTime"`
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
 	// 处理状态 -1 撤回 0-待审核 1-已经审核并提交任务 2-已驳回
-	ApplicationStatus *int64 `json:"ApplicationStatus,omitempty" name:"ApplicationStatus"`
+	ApplicationStatus *int64 `json:"ApplicationStatus,omitnil,omitempty" name:"ApplicationStatus"`
 
 	// 表格组Id
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 已提交的任务Id，未提交申请为0
-	TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 腾讯云上table的唯一键
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableInstanceId *string `json:"TableInstanceId,omitempty" name:"TableInstanceId"`
+	TableInstanceId *string `json:"TableInstanceId,omitnil,omitempty" name:"TableInstanceId"`
 
 	// 更新时间
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	UpdateTime *string `json:"UpdateTime,omitempty" name:"UpdateTime"`
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 
 	// 审批人
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ExecuteUser *string `json:"ExecuteUser,omitempty" name:"ExecuteUser"`
+	ExecuteUser *string `json:"ExecuteUser,omitnil,omitempty" name:"ExecuteUser"`
 
 	// 执行状态
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ExecuteStatus *string `json:"ExecuteStatus,omitempty" name:"ExecuteStatus"`
+	ExecuteStatus *string `json:"ExecuteStatus,omitnil,omitempty" name:"ExecuteStatus"`
 
 	// 该申请单是否可以被当前用户审批
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	CanCensor *bool `json:"CanCensor,omitempty" name:"CanCensor"`
+	CanCensor *bool `json:"CanCensor,omitnil,omitempty" name:"CanCensor"`
 
 	// 该申请单是否可以被当前用户撤回
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	CanWithdrawal *bool `json:"CanWithdrawal,omitempty" name:"CanWithdrawal"`
+	CanWithdrawal *bool `json:"CanWithdrawal,omitnil,omitempty" name:"CanWithdrawal"`
 }
 
 type ApplyResult struct {
-
 	// 申请单id
-	ApplicationId *string `json:"ApplicationId,omitempty" name:"ApplicationId"`
+	ApplicationId *string `json:"ApplicationId,omitnil,omitempty" name:"ApplicationId"`
 
 	// 申请类型
-	ApplicationType *int64 `json:"ApplicationType,omitempty" name:"ApplicationType"`
+	ApplicationType *int64 `json:"ApplicationType,omitnil,omitempty" name:"ApplicationType"`
 
 	// 处理状态 0-待审核 1-已经审核并提交任务 2-已驳回
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ApplicationStatus *int64 `json:"ApplicationStatus,omitempty" name:"ApplicationStatus"`
+	ApplicationStatus *int64 `json:"ApplicationStatus,omitnil,omitempty" name:"ApplicationStatus"`
 
 	// 已提交的任务Id
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 }
 
 type ApplyStatus struct {
-
 	// 集群id-申请单id
-	ApplicationId *string `json:"ApplicationId,omitempty" name:"ApplicationId"`
+	ApplicationId *string `json:"ApplicationId,omitnil,omitempty" name:"ApplicationId"`
 
 	// 处理状态-1-撤回 1-通过 2-驳回，非0状态的申请单不可改变状态。
-	ApplicationStatus *int64 `json:"ApplicationStatus,omitempty" name:"ApplicationStatus"`
+	ApplicationStatus *int64 `json:"ApplicationStatus,omitnil,omitempty" name:"ApplicationStatus"`
 
 	// 申请单类型
-	ApplicationType *int64 `json:"ApplicationType,omitempty" name:"ApplicationType"`
+	ApplicationType *int64 `json:"ApplicationType,omitnil,omitempty" name:"ApplicationType"`
 
 	// 集群Id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+type BackupExpireRuleInfo struct {
+	// 所属表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表名称
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// 文件标签，见上面描述
+	FileTag *uint64 `json:"FileTag,omitnil,omitempty" name:"FileTag"`
+
+	// 淘汰天数，见上面描述
+	ExpireDay *uint64 `json:"ExpireDay,omitnil,omitempty" name:"ExpireDay"`
+
+	// 操作类型，见上面描述
+	OperType *uint64 `json:"OperType,omitnil,omitempty" name:"OperType"`
+}
+
+type BackupRecords struct {
+	// 表格组ID
+	ZoneId *uint64 `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 表名称
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// 备份源
+	BackupType *string `json:"BackupType,omitnil,omitempty" name:"BackupType"`
+
+	// 文件标签：TCAPLUS_FULL或OSDATA
+	FileTag *string `json:"FileTag,omitnil,omitempty" name:"FileTag"`
+
+	// 分片数量
+	ShardCount *uint64 `json:"ShardCount,omitnil,omitempty" name:"ShardCount"`
+
+	// 备份批次日期
+	BackupBatchTime *string `json:"BackupBatchTime,omitnil,omitempty" name:"BackupBatchTime"`
+
+	// 备份文件汇总大小
+	BackupFileSize *uint64 `json:"BackupFileSize,omitnil,omitempty" name:"BackupFileSize"`
+
+	// 备份成功率
+	BackupSuccRate *string `json:"BackupSuccRate,omitnil,omitempty" name:"BackupSuccRate"`
+
+	// 备份文件过期时间
+	BackupExpireTime *string `json:"BackupExpireTime,omitnil,omitempty" name:"BackupExpireTime"`
+
+	// 业务ID
+	AppId *uint64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+}
+
+// Predefined struct for user
+type ClearTablesRequestParams struct {
+	// 表所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待清理表信息列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 type ClearTablesRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 表所属集群实例ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待清理表信息列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *ClearTablesRequest) ToJsonString() string {
@@ -147,19 +192,21 @@ func (r *ClearTablesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ClearTablesResponseParams struct {
+	// 清除表结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 清除表结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ClearTablesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 清除表结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 清除表结果列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ClearTablesResponseParams `json:"Response"`
 }
 
 func (r *ClearTablesResponse) ToJsonString() string {
@@ -174,104 +221,132 @@ func (r *ClearTablesResponse) FromJsonString(s string) error {
 }
 
 type ClusterInfo struct {
-
 	// 集群名称
-	ClusterName *string `json:"ClusterName,omitempty" name:"ClusterName"`
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 
 	// 集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 集群所在地域
-	Region *string `json:"Region,omitempty" name:"Region"`
+	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
 	// 集群数据描述语言类型，如：`PROTO`,`TDR`
-	IdlType *string `json:"IdlType,omitempty" name:"IdlType"`
+	IdlType *string `json:"IdlType,omitnil,omitempty" name:"IdlType"`
 
 	// 网络类型
-	NetworkType *string `json:"NetworkType,omitempty" name:"NetworkType"`
+	NetworkType *string `json:"NetworkType,omitnil,omitempty" name:"NetworkType"`
 
 	// 集群关联的用户私有网络实例ID
-	VpcId *string `json:"VpcId,omitempty" name:"VpcId"`
+	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
 	// 集群关联的用户子网实例ID
-	SubnetId *string `json:"SubnetId,omitempty" name:"SubnetId"`
+	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
 	// 创建时间
-	CreatedTime *string `json:"CreatedTime,omitempty" name:"CreatedTime"`
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
 	// 集群密码
-	Password *string `json:"Password,omitempty" name:"Password"`
+	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
 	// 密码状态
-	PasswordStatus *string `json:"PasswordStatus,omitempty" name:"PasswordStatus"`
+	PasswordStatus *string `json:"PasswordStatus,omitnil,omitempty" name:"PasswordStatus"`
 
 	// TcaplusDB SDK连接参数，接入ID
-	ApiAccessId *string `json:"ApiAccessId,omitempty" name:"ApiAccessId"`
+	ApiAccessId *string `json:"ApiAccessId,omitnil,omitempty" name:"ApiAccessId"`
 
 	// TcaplusDB SDK连接参数，接入地址
-	ApiAccessIp *string `json:"ApiAccessIp,omitempty" name:"ApiAccessIp"`
+	ApiAccessIp *string `json:"ApiAccessIp,omitnil,omitempty" name:"ApiAccessIp"`
 
 	// TcaplusDB SDK连接参数，接入端口
-	ApiAccessPort *int64 `json:"ApiAccessPort,omitempty" name:"ApiAccessPort"`
+	ApiAccessPort *int64 `json:"ApiAccessPort,omitnil,omitempty" name:"ApiAccessPort"`
 
 	// 如果PasswordStatus是unmodifiable说明有旧密码还未过期，此字段将显示旧密码过期的时间，否则为空
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	OldPasswordExpireTime *string `json:"OldPasswordExpireTime,omitempty" name:"OldPasswordExpireTime"`
+	OldPasswordExpireTime *string `json:"OldPasswordExpireTime,omitnil,omitempty" name:"OldPasswordExpireTime"`
 
 	// TcaplusDB SDK连接参数，接入ipv6地址
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ApiAccessIpv6 *string `json:"ApiAccessIpv6,omitempty" name:"ApiAccessIpv6"`
+	ApiAccessIpv6 *string `json:"ApiAccessIpv6,omitnil,omitempty" name:"ApiAccessIpv6"`
 
-	// 集群类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ClusterType *int64 `json:"ClusterType,omitempty" name:"ClusterType"`
+	// 集群类型，0,1:共享集群; 2:独立集群
+	ClusterType *int64 `json:"ClusterType,omitnil,omitempty" name:"ClusterType"`
 
-	// 集群状态
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ClusterStatus *int64 `json:"ClusterStatus,omitempty" name:"ClusterStatus"`
+	// 集群状态, 0：表示正常运行中，1：表示冻结隔离一般欠费进入此状态，2：表示待回收，一般用户主动触发删除进入这个状态，3：待释放，进入这个状态，表示可以释放此表占用的资源了，4：变更中
+	ClusterStatus *int64 `json:"ClusterStatus,omitnil,omitempty" name:"ClusterStatus"`
 
 	// 读CU
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ReadCapacityUnit *int64 `json:"ReadCapacityUnit,omitempty" name:"ReadCapacityUnit"`
+	ReadCapacityUnit *int64 `json:"ReadCapacityUnit,omitnil,omitempty" name:"ReadCapacityUnit"`
 
 	// 写CU
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	WriteCapacityUnit *int64 `json:"WriteCapacityUnit,omitempty" name:"WriteCapacityUnit"`
+	WriteCapacityUnit *int64 `json:"WriteCapacityUnit,omitnil,omitempty" name:"WriteCapacityUnit"`
 
 	// 磁盘容量
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	DiskVolume *int64 `json:"DiskVolume,omitempty" name:"DiskVolume"`
+	DiskVolume *int64 `json:"DiskVolume,omitnil,omitempty" name:"DiskVolume"`
 
 	// 独占server机器信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ServerList []*ServerDetailInfo `json:"ServerList,omitempty" name:"ServerList"`
+	ServerList []*ServerDetailInfo `json:"ServerList,omitnil,omitempty" name:"ServerList"`
 
 	// 独占proxy机器信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ProxyList []*ProxyDetailInfo `json:"ProxyList,omitempty" name:"ProxyList"`
+	ProxyList []*ProxyDetailInfo `json:"ProxyList,omitnil,omitempty" name:"ProxyList"`
 
 	// 是否开启审核 0-不开启 1-开启
-	Censorship *int64 `json:"Censorship,omitempty" name:"Censorship"`
+	Censorship *int64 `json:"Censorship,omitnil,omitempty" name:"Censorship"`
 
 	// 审批人uin列表
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	DbaUins []*string `json:"DbaUins,omitempty" name:"DbaUins"`
+	DbaUins []*string `json:"DbaUins,omitnil,omitempty" name:"DbaUins"`
+
+	// 是否开启了数据订阅
+	DataFlowStatus *int64 `json:"DataFlowStatus,omitnil,omitempty" name:"DataFlowStatus"`
+
+	// 数据订阅的kafka信息
+	KafkaInfo *KafkaInfo `json:"KafkaInfo,omitnil,omitempty" name:"KafkaInfo"`
+
+	// 集群Txh备份文件多少天后过期删除
+	TxhBackupExpireDay *uint64 `json:"TxhBackupExpireDay,omitnil,omitempty" name:"TxhBackupExpireDay"`
+
+	// 集群Ulog备份文件多少天后过期删除
+	UlogBackupExpireDay *uint64 `json:"UlogBackupExpireDay,omitnil,omitempty" name:"UlogBackupExpireDay"`
+
+	// 集群Ulog备份文件过期策略是否为只读， 0： UlogBackupExpire是只读，不可修改， 1： UlogBackupExpire可以修改（当前业务存在Svrid第二段等于clusterid的机器）
+	IsReadOnlyUlogBackupExpireDay *uint64 `json:"IsReadOnlyUlogBackupExpireDay,omitnil,omitempty" name:"IsReadOnlyUlogBackupExpireDay"`
+
+	// restproxy状态
+	RestProxyStatus *int64 `json:"RestProxyStatus,omitnil,omitempty" name:"RestProxyStatus"`
+
+	// 该集群shard总数
+	ShardTotalNum *int64 `json:"ShardTotalNum,omitnil,omitempty" name:"ShardTotalNum"`
+
+	// 已使用的shard总数
+	ShardUsedNum *int64 `json:"ShardUsedNum,omitnil,omitempty" name:"ShardUsedNum"`
+}
+
+// Predefined struct for user
+type CompareIdlFilesRequestParams struct {
+	// 待修改表格所在集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待修改表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+
+	// 选中的已上传IDL文件列表，与NewIdlFiles必选其一
+	ExistingIdlFiles []*IdlFileInfo `json:"ExistingIdlFiles,omitnil,omitempty" name:"ExistingIdlFiles"`
+
+	// 本次上传IDL文件列表，与ExistingIdlFiles必选其一
+	NewIdlFiles []*IdlFileInfo `json:"NewIdlFiles,omitnil,omitempty" name:"NewIdlFiles"`
 }
 
 type CompareIdlFilesRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 待修改表格所在集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待修改表格列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 
 	// 选中的已上传IDL文件列表，与NewIdlFiles必选其一
-	ExistingIdlFiles []*IdlFileInfo `json:"ExistingIdlFiles,omitempty" name:"ExistingIdlFiles"`
+	ExistingIdlFiles []*IdlFileInfo `json:"ExistingIdlFiles,omitnil,omitempty" name:"ExistingIdlFiles"`
 
 	// 本次上传IDL文件列表，与ExistingIdlFiles必选其一
-	NewIdlFiles []*IdlFileInfo `json:"NewIdlFiles,omitempty" name:"NewIdlFiles"`
+	NewIdlFiles []*IdlFileInfo `json:"NewIdlFiles,omitnil,omitempty" name:"NewIdlFiles"`
 }
 
 func (r *CompareIdlFilesRequest) ToJsonString() string {
@@ -296,22 +371,24 @@ func (r *CompareIdlFilesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CompareIdlFilesResponseParams struct {
+	// 本次上传校验所有的IDL文件信息列表
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
+
+	// 本次校验合法的表格数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 读取IDL描述文件后,根据用户指示的所选中表格解析校验结果
+	TableInfos []*ParsedTableInfoNew `json:"TableInfos,omitnil,omitempty" name:"TableInfos"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type CompareIdlFilesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 本次上传校验所有的IDL文件信息列表
-		IdlFiles []*IdlFileInfo `json:"IdlFiles,omitempty" name:"IdlFiles"`
-
-		// 本次校验合法的表格数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 读取IDL描述文件后,根据用户指示的所选中表格解析校验结果
-		TableInfos []*ParsedTableInfoNew `json:"TableInfos,omitempty" name:"TableInfos"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *CompareIdlFilesResponseParams `json:"Response"`
 }
 
 func (r *CompareIdlFilesResponse) ToJsonString() string {
@@ -326,43 +403,54 @@ func (r *CompareIdlFilesResponse) FromJsonString(s string) error {
 }
 
 type CompareTablesInfo struct {
-
 	// 源表格的集群id
-	SrcTableClusterId *string `json:"SrcTableClusterId,omitempty" name:"SrcTableClusterId"`
+	SrcTableClusterId *string `json:"SrcTableClusterId,omitnil,omitempty" name:"SrcTableClusterId"`
 
 	// 源表格的表格组id
-	SrcTableGroupId *string `json:"SrcTableGroupId,omitempty" name:"SrcTableGroupId"`
+	SrcTableGroupId *string `json:"SrcTableGroupId,omitnil,omitempty" name:"SrcTableGroupId"`
 
 	// 源表格的表名
-	SrcTableName *string `json:"SrcTableName,omitempty" name:"SrcTableName"`
+	SrcTableName *string `json:"SrcTableName,omitnil,omitempty" name:"SrcTableName"`
 
 	// 目标表格的集群id
-	DstTableClusterId *string `json:"DstTableClusterId,omitempty" name:"DstTableClusterId"`
+	DstTableClusterId *string `json:"DstTableClusterId,omitnil,omitempty" name:"DstTableClusterId"`
 
 	// 目标表格的表格组id
-	DstTableGroupId *string `json:"DstTableGroupId,omitempty" name:"DstTableGroupId"`
+	DstTableGroupId *string `json:"DstTableGroupId,omitnil,omitempty" name:"DstTableGroupId"`
 
 	// 目标表格的表名
-	DstTableName *string `json:"DstTableName,omitempty" name:"DstTableName"`
+	DstTableName *string `json:"DstTableName,omitnil,omitempty" name:"DstTableName"`
 
 	// 源表格的实例id
-	SrcTableInstanceId *string `json:"SrcTableInstanceId,omitempty" name:"SrcTableInstanceId"`
+	SrcTableInstanceId *string `json:"SrcTableInstanceId,omitnil,omitempty" name:"SrcTableInstanceId"`
 
 	// 目标表格的实例id
-	DstTableInstanceId *string `json:"DstTableInstanceId,omitempty" name:"DstTableInstanceId"`
+	DstTableInstanceId *string `json:"DstTableInstanceId,omitnil,omitempty" name:"DstTableInstanceId"`
+}
+
+// Predefined struct for user
+type CreateBackupRequestParams struct {
+	// 待创建备份表所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待创建备份表信息列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+
+	// 备注信息
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 }
 
 type CreateBackupRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 待创建备份表所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待创建备份表信息列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 
 	// 备注信息
-	Remark *string `json:"Remark,omitempty" name:"Remark"`
+	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 }
 
 func (r *CreateBackupRequest) ToJsonString() string {
@@ -386,21 +474,21 @@ func (r *CreateBackupRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CreateBackupResponseParams struct {
+	// 创建的备份任务ID列表
+	TaskIds []*string `json:"TaskIds,omitnil,omitempty" name:"TaskIds"`
+
+	// 创建的备份申请ID列表
+	ApplicationIds []*string `json:"ApplicationIds,omitnil,omitempty" name:"ApplicationIds"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type CreateBackupResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 创建的备份任务ID列表
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		TaskIds []*string `json:"TaskIds,omitempty" name:"TaskIds"`
-
-		// 创建的备份申请ID列表
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		ApplicationIds []*string `json:"ApplicationIds,omitempty" name:"ApplicationIds"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *CreateBackupResponseParams `json:"Response"`
 }
 
 func (r *CreateBackupResponse) ToJsonString() string {
@@ -414,38 +502,77 @@ func (r *CreateBackupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CreateClusterRequestParams struct {
+	// <p>集群数据描述语言类型，统一填<code>MIX</code></p><p>枚举值：</p><ul><li>MIX： 同时支持<code>PROTO</code>，<code>TDR</code>表</li></ul>
+	IdlType *string `json:"IdlType,omitnil,omitempty" name:"IdlType"`
+
+	// <p>集群名称，可使用中文或英文字符，最大长度32个字符</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+
+	// <p>集群所绑定的私有网络实例ID，形如：vpc-f49l6u0z</p>
+	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
+
+	// <p>集群所绑定的子网实例ID，形如：subnet-pxir56ns</p>
+	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
+
+	// <p>集群访问密码，必须是a-zA-Z0-9的字符,且必须包含数字和大小写字母</p>
+	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
+
+	// <p>集群标签列表</p>
+	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
+	// <p>集群是否开启IPv6功能</p>
+	Ipv6Enable *int64 `json:"Ipv6Enable,omitnil,omitempty" name:"Ipv6Enable"`
+
+	// <p>独占集群占用的svr机器</p>
+	ServerList []*MachineInfo `json:"ServerList,omitnil,omitempty" name:"ServerList"`
+
+	// <p>独占集群占用的proxy机器</p>
+	ProxyList []*MachineInfo `json:"ProxyList,omitnil,omitempty" name:"ProxyList"`
+
+	// <p>集群类型1共享2独占</p>
+	ClusterType *int64 `json:"ClusterType,omitnil,omitempty" name:"ClusterType"`
+
+	// <p>密码认证类型，0 静态认证， 1 签名认证</p>
+	AuthType *int64 `json:"AuthType,omitnil,omitempty" name:"AuthType"`
+}
+
 type CreateClusterRequest struct {
 	*tchttp.BaseRequest
+	
+	// <p>集群数据描述语言类型，统一填<code>MIX</code></p><p>枚举值：</p><ul><li>MIX： 同时支持<code>PROTO</code>，<code>TDR</code>表</li></ul>
+	IdlType *string `json:"IdlType,omitnil,omitempty" name:"IdlType"`
 
-	// 集群数据描述语言类型，如：`PROTO`，`TDR`或`MIX`
-	IdlType *string `json:"IdlType,omitempty" name:"IdlType"`
+	// <p>集群名称，可使用中文或英文字符，最大长度32个字符</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 
-	// 集群名称，可使用中文或英文字符，最大长度32个字符
-	ClusterName *string `json:"ClusterName,omitempty" name:"ClusterName"`
+	// <p>集群所绑定的私有网络实例ID，形如：vpc-f49l6u0z</p>
+	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// 集群所绑定的私有网络实例ID，形如：vpc-f49l6u0z
-	VpcId *string `json:"VpcId,omitempty" name:"VpcId"`
+	// <p>集群所绑定的子网实例ID，形如：subnet-pxir56ns</p>
+	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
-	// 集群所绑定的子网实例ID，形如：subnet-pxir56ns
-	SubnetId *string `json:"SubnetId,omitempty" name:"SubnetId"`
+	// <p>集群访问密码，必须是a-zA-Z0-9的字符,且必须包含数字和大小写字母</p>
+	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
-	// 集群访问密码，必须是a-zA-Z0-9的字符,且必须包含数字和大小写字母
-	Password *string `json:"Password,omitempty" name:"Password"`
+	// <p>集群标签列表</p>
+	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 
-	// 集群标签列表
-	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitempty" name:"ResourceTags"`
+	// <p>集群是否开启IPv6功能</p>
+	Ipv6Enable *int64 `json:"Ipv6Enable,omitnil,omitempty" name:"Ipv6Enable"`
 
-	// 集群是否开启IPv6功能
-	Ipv6Enable *int64 `json:"Ipv6Enable,omitempty" name:"Ipv6Enable"`
+	// <p>独占集群占用的svr机器</p>
+	ServerList []*MachineInfo `json:"ServerList,omitnil,omitempty" name:"ServerList"`
 
-	// 独占集群占用的svr机器
-	ServerList []*MachineInfo `json:"ServerList,omitempty" name:"ServerList"`
+	// <p>独占集群占用的proxy机器</p>
+	ProxyList []*MachineInfo `json:"ProxyList,omitnil,omitempty" name:"ProxyList"`
 
-	// 独占集群占用的proxy机器
-	ProxyList []*MachineInfo `json:"ProxyList,omitempty" name:"ProxyList"`
+	// <p>集群类型1共享2独占</p>
+	ClusterType *int64 `json:"ClusterType,omitnil,omitempty" name:"ClusterType"`
 
-	// 集群类型1共享2独占
-	ClusterType *int64 `json:"ClusterType,omitempty" name:"ClusterType"`
+	// <p>密码认证类型，0 静态认证， 1 签名认证</p>
+	AuthType *int64 `json:"AuthType,omitnil,omitempty" name:"AuthType"`
 }
 
 func (r *CreateClusterRequest) ToJsonString() string {
@@ -470,22 +597,25 @@ func (r *CreateClusterRequest) FromJsonString(s string) error {
 	delete(f, "ServerList")
 	delete(f, "ProxyList")
 	delete(f, "ClusterType")
+	delete(f, "AuthType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateClusterRequest has unknown keys!", "")
 	}
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CreateClusterResponseParams struct {
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type CreateClusterResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 集群ID
-		ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *CreateClusterResponseParams `json:"Response"`
 }
 
 func (r *CreateClusterResponse) ToJsonString() string {
@@ -499,14 +629,23 @@ func (r *CreateClusterResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type CreateSnapshotsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type CreateSnapshotsRequestParams struct {
 	// 表格所属集群id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 快照列表
-	SelectedTables []*SnapshotInfo `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SnapshotInfo `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type CreateSnapshotsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格所属集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 快照列表
+	SelectedTables []*SnapshotInfo `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *CreateSnapshotsRequest) ToJsonString() string {
@@ -529,19 +668,21 @@ func (r *CreateSnapshotsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CreateSnapshotsResponseParams struct {
+	// 批量创建的快照数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 批量创建的快照结果列表
+	TableResults []*SnapshotResult `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type CreateSnapshotsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 批量创建的快照数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 批量创建的快照结果列表
-		TableResults []*SnapshotResult `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *CreateSnapshotsResponseParams `json:"Response"`
 }
 
 func (r *CreateSnapshotsResponse) ToJsonString() string {
@@ -555,20 +696,35 @@ func (r *CreateSnapshotsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type CreateTableGroupRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type CreateTableGroupRequestParams struct {
 	// 表格组所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 表格组名称，可以采用中文、英文或数字字符，最大长度32个字符
-	TableGroupName *string `json:"TableGroupName,omitempty" name:"TableGroupName"`
+	TableGroupName *string `json:"TableGroupName,omitnil,omitempty" name:"TableGroupName"`
 
 	// 表格组ID，可以由用户指定，但在同一个集群内不能重复，如果不指定则采用自增的模式
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 表格组标签列表
-	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitempty" name:"ResourceTags"`
+	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+}
+
+type CreateTableGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格组所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 表格组名称，可以采用中文、英文或数字字符，最大长度32个字符
+	TableGroupName *string `json:"TableGroupName,omitnil,omitempty" name:"TableGroupName"`
+
+	// 表格组ID，可以由用户指定，但在同一个集群内不能重复，如果不指定则采用自增的模式
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表格组标签列表
+	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 }
 
 func (r *CreateTableGroupRequest) ToJsonString() string {
@@ -593,16 +749,18 @@ func (r *CreateTableGroupRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CreateTableGroupResponseParams struct {
+	// 创建成功的表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type CreateTableGroupResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 创建成功的表格组ID
-		TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *CreateTableGroupResponseParams `json:"Response"`
 }
 
 func (r *CreateTableGroupResponse) ToJsonString() string {
@@ -616,20 +774,35 @@ func (r *CreateTableGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type CreateTablesRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type CreateTablesRequestParams struct {
 	// 待创建表格所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 用户选定的建表格IDL文件列表
-	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitempty" name:"IdlFiles"`
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
 
 	// 待创建表格信息列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 
 	// 表格标签列表
-	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitempty" name:"ResourceTags"`
+	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+}
+
+type CreateTablesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待创建表格所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 用户选定的建表格IDL文件列表
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
+
+	// 待创建表格信息列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+
+	// 表格标签列表
+	ResourceTags []*TagInfoUnit `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 }
 
 func (r *CreateTablesRequest) ToJsonString() string {
@@ -654,19 +827,21 @@ func (r *CreateTablesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CreateTablesResponseParams struct {
+	// 批量创建表格结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 批量创建表格结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type CreateTablesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 批量创建表格结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 批量创建表格结果列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *CreateTablesResponseParams `json:"Response"`
 }
 
 func (r *CreateTablesResponse) ToJsonString() string {
@@ -680,11 +855,81 @@ func (r *CreateTablesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DeleteBackupRecordsRequestParams struct {
+	// 待删除备份记录的所在集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待删除备份记录的详情
+	BackupRecords []*BackupRecords `json:"BackupRecords,omitnil,omitempty" name:"BackupRecords"`
+}
+
+type DeleteBackupRecordsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待删除备份记录的所在集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待删除备份记录的详情
+	BackupRecords []*BackupRecords `json:"BackupRecords,omitnil,omitempty" name:"BackupRecords"`
+}
+
+func (r *DeleteBackupRecordsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteBackupRecordsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "BackupRecords")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteBackupRecordsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteBackupRecordsResponseParams struct {
+	// TaskId由 AppInstanceId-taskId 组成，以区分不同集群的任务
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteBackupRecordsResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteBackupRecordsResponseParams `json:"Response"`
+}
+
+func (r *DeleteBackupRecordsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteBackupRecordsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteClusterRequestParams struct {
+	// 待删除的集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
 type DeleteClusterRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 待删除的集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 }
 
 func (r *DeleteClusterRequest) ToJsonString() string {
@@ -706,16 +951,18 @@ func (r *DeleteClusterRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DeleteClusterResponseParams struct {
+	// 删除集群生成的任务ID
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DeleteClusterResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 删除集群生成的任务ID
-		TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DeleteClusterResponseParams `json:"Response"`
 }
 
 func (r *DeleteClusterResponse) ToJsonString() string {
@@ -729,14 +976,23 @@ func (r *DeleteClusterResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DeleteIdlFilesRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DeleteIdlFilesRequestParams struct {
 	// IDL所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待删除的IDL文件信息列表
-	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitempty" name:"IdlFiles"`
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
+}
+
+type DeleteIdlFilesRequest struct {
+	*tchttp.BaseRequest
+	
+	// IDL所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待删除的IDL文件信息列表
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
 }
 
 func (r *DeleteIdlFilesRequest) ToJsonString() string {
@@ -759,19 +1015,21 @@ func (r *DeleteIdlFilesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DeleteIdlFilesResponseParams struct {
+	// 结果记录数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 删除结果
+	IdlFileInfos []*IdlFileInfoWithoutContent `json:"IdlFileInfos,omitnil,omitempty" name:"IdlFileInfos"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DeleteIdlFilesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 结果记录数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 删除结果
-		IdlFileInfos []*IdlFileInfoWithoutContent `json:"IdlFileInfos,omitempty" name:"IdlFileInfos"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DeleteIdlFilesResponseParams `json:"Response"`
 }
 
 func (r *DeleteIdlFilesResponse) ToJsonString() string {
@@ -785,14 +1043,23 @@ func (r *DeleteIdlFilesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DeleteSnapshotsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DeleteSnapshotsRequestParams struct {
 	// 表格所属集群id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 删除的快照列表
-	SelectedTables []*SnapshotInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SnapshotInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type DeleteSnapshotsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格所属集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 删除的快照列表
+	SelectedTables []*SnapshotInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *DeleteSnapshotsRequest) ToJsonString() string {
@@ -815,19 +1082,21 @@ func (r *DeleteSnapshotsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DeleteSnapshotsResponseParams struct {
+	// 批量删除的快照数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 批量删除的快照结果
+	TableResults []*SnapshotResult `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DeleteSnapshotsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 批量删除的快照数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 批量删除的快照结果
-		TableResults []*SnapshotResult `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DeleteSnapshotsResponseParams `json:"Response"`
 }
 
 func (r *DeleteSnapshotsResponse) ToJsonString() string {
@@ -841,14 +1110,90 @@ func (r *DeleteSnapshotsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DeleteTableGroupRequest struct {
-	*tchttp.BaseRequest
+// Predefined struct for user
+type DeleteTableDataFlowRequestParams struct {
+	// 表格所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
+	// 待删除分布式索引的表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type DeleteTableDataFlowRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待删除分布式索引的表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+func (r *DeleteTableDataFlowRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteTableDataFlowRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "SelectedTables")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteTableDataFlowRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteTableDataFlowResponseParams struct {
+	// 删除表格分布式索引结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 删除表格分布式索引结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteTableDataFlowResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteTableDataFlowResponseParams `json:"Response"`
+}
+
+func (r *DeleteTableDataFlowResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteTableDataFlowResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteTableGroupRequestParams struct {
 	// 表格组所属的集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+}
+
+type DeleteTableGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格组所属的集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 }
 
 func (r *DeleteTableGroupRequest) ToJsonString() string {
@@ -871,16 +1216,18 @@ func (r *DeleteTableGroupRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DeleteTableGroupResponseParams struct {
+	// 删除表格组所创建的任务ID
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DeleteTableGroupResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 删除表格组所创建的任务ID
-		TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DeleteTableGroupResponseParams `json:"Response"`
 }
 
 func (r *DeleteTableGroupResponse) ToJsonString() string {
@@ -894,14 +1241,23 @@ func (r *DeleteTableGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DeleteTableIndexRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DeleteTableIndexRequestParams struct {
 	// 表格所属集群实例ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待删除分布式索引的表格列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type DeleteTableIndexRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待删除分布式索引的表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *DeleteTableIndexRequest) ToJsonString() string {
@@ -924,19 +1280,21 @@ func (r *DeleteTableIndexRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DeleteTableIndexResponseParams struct {
+	// 删除表格分布式索引结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 删除表格分布式索引结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DeleteTableIndexResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 删除表格分布式索引结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 删除表格分布式索引结果列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DeleteTableIndexResponseParams `json:"Response"`
 }
 
 func (r *DeleteTableIndexResponse) ToJsonString() string {
@@ -950,14 +1308,23 @@ func (r *DeleteTableIndexResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DeleteTablesRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DeleteTablesRequestParams struct {
 	// 待删除表所在集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待删除表信息列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type DeleteTablesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待删除表所在集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待删除表信息列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *DeleteTablesRequest) ToJsonString() string {
@@ -980,19 +1347,21 @@ func (r *DeleteTablesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DeleteTablesResponseParams struct {
+	// 删除表结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 删除表结果详情列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DeleteTablesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 删除表结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 删除表结果详情列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DeleteTablesResponseParams `json:"Response"`
 }
 
 func (r *DeleteTablesResponse) ToJsonString() string {
@@ -1006,32 +1375,59 @@ func (r *DeleteTablesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeApplicationsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeApplicationsRequestParams struct {
 	// 集群ID，用于获取指定集群的单据
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 分页
-	Limit *uint64 `json:"Limit,omitempty" name:"Limit"`
+	// 分页，限制当前返回多少条记录，大于等于10
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 分页
-	Offset *uint64 `json:"Offset,omitempty" name:"Offset"`
+	// 分页，从多少条数据开始返回
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 申请单状态，用于过滤
-	CensorStatus *int64 `json:"CensorStatus,omitempty" name:"CensorStatus"`
+	// 申请单状态，用于过滤，0-待审核 1-已经审核并提交任务 2-已驳回
+	CensorStatus *int64 `json:"CensorStatus,omitnil,omitempty" name:"CensorStatus"`
 
 	// 表格组id，用于过滤
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 表格名，用于过滤
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 申请人uin，用于过滤
-	Applicant *string `json:"Applicant,omitempty" name:"Applicant"`
+	Applicant *string `json:"Applicant,omitnil,omitempty" name:"Applicant"`
 
-	// 申请类型，用于过滤
-	ApplyType *int64 `json:"ApplyType,omitempty" name:"ApplyType"`
+	// 申请类型，用于过滤，0加表 1删除表 2清理表 3修改表 4表重建 5存储层扩缩容 6接入层扩缩容 7复制表数据 8key回档
+	ApplyType *int64 `json:"ApplyType,omitnil,omitempty" name:"ApplyType"`
+}
+
+type DescribeApplicationsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群ID，用于获取指定集群的单据
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 分页，限制当前返回多少条记录，大于等于10
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 分页，从多少条数据开始返回
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 申请单状态，用于过滤，0-待审核 1-已经审核并提交任务 2-已驳回
+	CensorStatus *int64 `json:"CensorStatus,omitnil,omitempty" name:"CensorStatus"`
+
+	// 表格组id，用于过滤
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表格名，用于过滤
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// 申请人uin，用于过滤
+	Applicant *string `json:"Applicant,omitnil,omitempty" name:"Applicant"`
+
+	// 申请类型，用于过滤，0加表 1删除表 2清理表 3修改表 4表重建 5存储层扩缩容 6接入层扩缩容 7复制表数据 8key回档
+	ApplyType *int64 `json:"ApplyType,omitnil,omitempty" name:"ApplyType"`
 }
 
 func (r *DescribeApplicationsRequest) ToJsonString() string {
@@ -1060,19 +1456,21 @@ func (r *DescribeApplicationsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeApplicationsResponseParams struct {
+	// 申请单列表
+	Applications []*Application `json:"Applications,omitnil,omitempty" name:"Applications"`
+
+	// 申请单个数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeApplicationsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 申请单列表
-		Applications []*Application `json:"Applications,omitempty" name:"Applications"`
-
-		// 申请单个数
-		TotalCount *int64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeApplicationsResponseParams `json:"Response"`
 }
 
 func (r *DescribeApplicationsResponse) ToJsonString() string {
@@ -1086,11 +1484,105 @@ func (r *DescribeApplicationsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeBackupRecordsRequestParams struct {
+	// 集群ID，用于获取指定集群的单据
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 分页
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 分页
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 表格组id，用于过滤
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表格名，用于过滤
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+}
+
+type DescribeBackupRecordsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群ID，用于获取指定集群的单据
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 分页
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 分页
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 表格组id，用于过滤
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表格名，用于过滤
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+}
+
+func (r *DescribeBackupRecordsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeBackupRecordsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "Limit")
+	delete(f, "Offset")
+	delete(f, "TableGroupId")
+	delete(f, "TableName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeBackupRecordsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeBackupRecordsResponseParams struct {
+	// 备份记录详情
+	BackupRecords []*BackupRecords `json:"BackupRecords,omitnil,omitempty" name:"BackupRecords"`
+
+	// 返回记录条数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeBackupRecordsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeBackupRecordsResponseParams `json:"Response"`
+}
+
+func (r *DescribeBackupRecordsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeBackupRecordsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterTagsRequestParams struct {
+	// 集群ID列表
+	ClusterIds []*string `json:"ClusterIds,omitnil,omitempty" name:"ClusterIds"`
+}
+
 type DescribeClusterTagsRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 集群ID列表
-	ClusterIds []*string `json:"ClusterIds,omitempty" name:"ClusterIds"`
+	ClusterIds []*string `json:"ClusterIds,omitnil,omitempty" name:"ClusterIds"`
 }
 
 func (r *DescribeClusterTagsRequest) ToJsonString() string {
@@ -1112,21 +1604,21 @@ func (r *DescribeClusterTagsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeClusterTagsResponseParams struct {
+	// 集群标签信息列表
+	Rows []*TagsInfoOfCluster `json:"Rows,omitnil,omitempty" name:"Rows"`
+
+	// 返回结果个数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeClusterTagsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 集群标签信息列表
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		Rows []*TagsInfoOfCluster `json:"Rows,omitempty" name:"Rows"`
-
-		// 返回结果个数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		TotalCount *int64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeClusterTagsResponseParams `json:"Response"`
 }
 
 func (r *DescribeClusterTagsResponse) ToJsonString() string {
@@ -1140,23 +1632,41 @@ func (r *DescribeClusterTagsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeClustersRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeClustersRequestParams struct {
 	// 指定查询的集群ID列表
-	ClusterIds []*string `json:"ClusterIds,omitempty" name:"ClusterIds"`
+	ClusterIds []*string `json:"ClusterIds,omitnil,omitempty" name:"ClusterIds"`
 
 	// 查询过滤条件
-	Filters []*Filter `json:"Filters,omitempty" name:"Filters"`
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 查询列表偏移量
-	Offset *int64 `json:"Offset,omitempty" name:"Offset"`
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 查询列表返回记录数，默认值20
-	Limit *int64 `json:"Limit,omitempty" name:"Limit"`
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 是否启用Ipv6
-	Ipv6Enable *int64 `json:"Ipv6Enable,omitempty" name:"Ipv6Enable"`
+	Ipv6Enable *int64 `json:"Ipv6Enable,omitnil,omitempty" name:"Ipv6Enable"`
+}
+
+type DescribeClustersRequest struct {
+	*tchttp.BaseRequest
+	
+	// 指定查询的集群ID列表
+	ClusterIds []*string `json:"ClusterIds,omitnil,omitempty" name:"ClusterIds"`
+
+	// 查询过滤条件
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 查询列表偏移量
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 查询列表返回记录数，默认值20
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 是否启用Ipv6
+	Ipv6Enable *int64 `json:"Ipv6Enable,omitnil,omitempty" name:"Ipv6Enable"`
 }
 
 func (r *DescribeClustersRequest) ToJsonString() string {
@@ -1182,19 +1692,21 @@ func (r *DescribeClustersRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeClustersResponseParams struct {
+	// 集群实例数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 集群实例列表
+	Clusters []*ClusterInfo `json:"Clusters,omitnil,omitempty" name:"Clusters"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeClustersResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 集群实例数
-		TotalCount *int64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 集群实例列表
-		Clusters []*ClusterInfo `json:"Clusters,omitempty" name:"Clusters"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeClustersResponseParams `json:"Response"`
 }
 
 func (r *DescribeClustersResponse) ToJsonString() string {
@@ -1208,23 +1720,41 @@ func (r *DescribeClustersResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeIdlFileInfosRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeIdlFileInfosRequestParams struct {
 	// 文件所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 文件所属表格组ID
-	TableGroupIds []*string `json:"TableGroupIds,omitempty" name:"TableGroupIds"`
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
 
 	// 指定文件ID列表
-	IdlFileIds []*string `json:"IdlFileIds,omitempty" name:"IdlFileIds"`
+	IdlFileIds []*string `json:"IdlFileIds,omitnil,omitempty" name:"IdlFileIds"`
 
 	// 查询列表偏移量
-	Offset *int64 `json:"Offset,omitempty" name:"Offset"`
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 查询列表返回记录数
-	Limit *int64 `json:"Limit,omitempty" name:"Limit"`
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeIdlFileInfosRequest struct {
+	*tchttp.BaseRequest
+	
+	// 文件所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 文件所属表格组ID
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
+
+	// 指定文件ID列表
+	IdlFileIds []*string `json:"IdlFileIds,omitnil,omitempty" name:"IdlFileIds"`
+
+	// 查询列表偏移量
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 查询列表返回记录数
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeIdlFileInfosRequest) ToJsonString() string {
@@ -1250,19 +1780,21 @@ func (r *DescribeIdlFileInfosRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeIdlFileInfosResponseParams struct {
+	// 文件数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 文件详情列表
+	IdlFileInfos []*IdlFileInfo `json:"IdlFileInfos,omitnil,omitempty" name:"IdlFileInfos"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeIdlFileInfosResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 文件数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 文件详情列表
-		IdlFileInfos []*IdlFileInfo `json:"IdlFileInfos,omitempty" name:"IdlFileInfos"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeIdlFileInfosResponseParams `json:"Response"`
 }
 
 func (r *DescribeIdlFileInfosResponse) ToJsonString() string {
@@ -1276,11 +1808,17 @@ func (r *DescribeIdlFileInfosResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeMachineRequestParams struct {
+	// 不为0，表示查询支持ipv6的机器
+	Ipv6Enable *int64 `json:"Ipv6Enable,omitnil,omitempty" name:"Ipv6Enable"`
+}
+
 type DescribeMachineRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 不为0，表示查询支持ipv6的机器
-	Ipv6Enable *int64 `json:"Ipv6Enable,omitempty" name:"Ipv6Enable"`
+	Ipv6Enable *int64 `json:"Ipv6Enable,omitnil,omitempty" name:"Ipv6Enable"`
 }
 
 func (r *DescribeMachineRequest) ToJsonString() string {
@@ -1302,16 +1840,18 @@ func (r *DescribeMachineRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeMachineResponseParams struct {
+	// 独占机器资源列表
+	PoolList []*PoolInfo `json:"PoolList,omitnil,omitempty" name:"PoolList"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeMachineResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 独占机器资源列表
-		PoolList []*PoolInfo `json:"PoolList,omitempty" name:"PoolList"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeMachineResponseParams `json:"Response"`
 }
 
 func (r *DescribeMachineResponse) ToJsonString() string {
@@ -1325,8 +1865,14 @@ func (r *DescribeMachineResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeRegionsRequestParams struct {
+
+}
+
 type DescribeRegionsRequest struct {
 	*tchttp.BaseRequest
+	
 }
 
 func (r *DescribeRegionsRequest) ToJsonString() string {
@@ -1341,25 +1887,28 @@ func (r *DescribeRegionsRequest) FromJsonString(s string) error {
 	if err := json.Unmarshal([]byte(s), &f); err != nil {
 		return err
 	}
+	
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeRegionsRequest has unknown keys!", "")
 	}
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeRegionsResponseParams struct {
+	// 可用区详情结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 可用区详情结果列表
+	RegionInfos []*RegionInfo `json:"RegionInfos,omitnil,omitempty" name:"RegionInfos"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeRegionsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 可用区详情结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 可用区详情结果列表
-		RegionInfos []*RegionInfo `json:"RegionInfos,omitempty" name:"RegionInfos"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeRegionsResponseParams `json:"Response"`
 }
 
 func (r *DescribeRegionsResponse) ToJsonString() string {
@@ -1373,20 +1922,41 @@ func (r *DescribeRegionsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeSnapshotsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeSnapshotsRequestParams struct {
 	// 表格所属集群id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 所属表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 表名称
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 快照名称
-	SnapshotName *string `json:"SnapshotName,omitempty" name:"SnapshotName"`
+	SnapshotName *string `json:"SnapshotName,omitnil,omitempty" name:"SnapshotName"`
+
+	// 批量拉取快照的表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type DescribeSnapshotsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格所属集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 所属表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表名称
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// 快照名称
+	SnapshotName *string `json:"SnapshotName,omitnil,omitempty" name:"SnapshotName"`
+
+	// 批量拉取快照的表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *DescribeSnapshotsRequest) ToJsonString() string {
@@ -1405,25 +1975,28 @@ func (r *DescribeSnapshotsRequest) FromJsonString(s string) error {
 	delete(f, "TableGroupId")
 	delete(f, "TableName")
 	delete(f, "SnapshotName")
+	delete(f, "SelectedTables")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeSnapshotsRequest has unknown keys!", "")
 	}
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeSnapshotsResponseParams struct {
+	// 快照数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 快照结果列表
+	TableResults []*SnapshotResult `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeSnapshotsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 快照数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 快照结果列表
-		TableResults []*SnapshotResult `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeSnapshotsResponseParams `json:"Response"`
 }
 
 func (r *DescribeSnapshotsResponse) ToJsonString() string {
@@ -1437,14 +2010,23 @@ func (r *DescribeSnapshotsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeTableGroupTagsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeTableGroupTagsRequestParams struct {
 	// 待查询标签表格组所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待查询标签表格组ID列表
-	TableGroupIds []*string `json:"TableGroupIds,omitempty" name:"TableGroupIds"`
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
+}
+
+type DescribeTableGroupTagsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待查询标签表格组所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待查询标签表格组ID列表
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
 }
 
 func (r *DescribeTableGroupTagsRequest) ToJsonString() string {
@@ -1467,21 +2049,21 @@ func (r *DescribeTableGroupTagsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeTableGroupTagsResponseParams struct {
+	// 表格组标签信息列表
+	Rows []*TagsInfoOfTableGroup `json:"Rows,omitnil,omitempty" name:"Rows"`
+
+	// 返回结果个数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeTableGroupTagsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 表格组标签信息列表
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		Rows []*TagsInfoOfTableGroup `json:"Rows,omitempty" name:"Rows"`
-
-		// 返回结果个数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		TotalCount *int64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeTableGroupTagsResponseParams `json:"Response"`
 }
 
 func (r *DescribeTableGroupTagsResponse) ToJsonString() string {
@@ -1495,23 +2077,41 @@ func (r *DescribeTableGroupTagsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeTableGroupsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeTableGroupsRequestParams struct {
 	// 表格组所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 表格组ID列表
-	TableGroupIds []*string `json:"TableGroupIds,omitempty" name:"TableGroupIds"`
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
 
 	// 过滤条件，本接口支持：TableGroupName，TableGroupId
-	Filters []*Filter `json:"Filters,omitempty" name:"Filters"`
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 查询列表偏移量
-	Offset *int64 `json:"Offset,omitempty" name:"Offset"`
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 查询列表返回记录数
-	Limit *int64 `json:"Limit,omitempty" name:"Limit"`
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeTableGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格组所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 表格组ID列表
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
+
+	// 过滤条件，本接口支持：TableGroupName，TableGroupId
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 查询列表偏移量
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 查询列表返回记录数
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeTableGroupsRequest) ToJsonString() string {
@@ -1537,19 +2137,21 @@ func (r *DescribeTableGroupsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeTableGroupsResponseParams struct {
+	// 表格组数量
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 表格组信息列表
+	TableGroups []*TableGroupInfo `json:"TableGroups,omitnil,omitempty" name:"TableGroups"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeTableGroupsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 表格组数量
-		TotalCount *int64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 表格组信息列表
-		TableGroups []*TableGroupInfo `json:"TableGroups,omitempty" name:"TableGroups"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeTableGroupsResponseParams `json:"Response"`
 }
 
 func (r *DescribeTableGroupsResponse) ToJsonString() string {
@@ -1563,14 +2165,23 @@ func (r *DescribeTableGroupsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeTableTagsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeTableTagsRequestParams struct {
 	// 表格所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 表格列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type DescribeTableTagsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *DescribeTableTagsRequest) ToJsonString() string {
@@ -1593,19 +2204,21 @@ func (r *DescribeTableTagsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeTableTagsResponseParams struct {
+	// 返回结果总数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 表格标签信息列表
+	Rows []*TagsInfoOfTable `json:"Rows,omitnil,omitempty" name:"Rows"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeTableTagsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 返回结果总数
-		TotalCount *int64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 表格标签信息列表
-		Rows []*TagsInfoOfTable `json:"Rows,omitempty" name:"Rows"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeTableTagsResponseParams `json:"Response"`
 }
 
 func (r *DescribeTableTagsResponse) ToJsonString() string {
@@ -1619,23 +2232,41 @@ func (r *DescribeTableTagsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeTablesInRecycleRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeTablesInRecycleRequestParams struct {
 	// 待查询表格所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待查询表格所属表格组ID列表
-	TableGroupIds []*string `json:"TableGroupIds,omitempty" name:"TableGroupIds"`
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
 
 	// 过滤条件，本接口支持：TableName，TableInstanceId
-	Filters []*Filter `json:"Filters,omitempty" name:"Filters"`
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 查询结果偏移量
-	Offset *int64 `json:"Offset,omitempty" name:"Offset"`
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 查询结果返回记录数量
-	Limit *int64 `json:"Limit,omitempty" name:"Limit"`
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeTablesInRecycleRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待查询表格所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待查询表格所属表格组ID列表
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
+
+	// 过滤条件，本接口支持：TableName，TableInstanceId
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 查询结果偏移量
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 查询结果返回记录数量
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeTablesInRecycleRequest) ToJsonString() string {
@@ -1661,19 +2292,21 @@ func (r *DescribeTablesInRecycleRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeTablesInRecycleResponseParams struct {
+	// 表格数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 表格详情结果列表
+	TableInfos []*TableInfoNew `json:"TableInfos,omitnil,omitempty" name:"TableInfos"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeTablesInRecycleResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 表格数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 表格详情结果列表
-		TableInfos []*TableInfoNew `json:"TableInfos,omitempty" name:"TableInfos"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeTablesInRecycleResponseParams `json:"Response"`
 }
 
 func (r *DescribeTablesInRecycleResponse) ToJsonString() string {
@@ -1687,26 +2320,47 @@ func (r *DescribeTablesInRecycleResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeTablesRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeTablesRequestParams struct {
 	// 待查询表格所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待查询表格所属表格组ID列表
-	TableGroupIds []*string `json:"TableGroupIds,omitempty" name:"TableGroupIds"`
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
 
-	// 待查询表格信息列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	// 待查询表格信息列表，用户不用关注，过滤请使用filter
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 
 	// 过滤条件，本接口支持：TableName，TableInstanceId
-	Filters []*Filter `json:"Filters,omitempty" name:"Filters"`
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 查询结果偏移量
-	Offset *int64 `json:"Offset,omitempty" name:"Offset"`
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 查询结果返回记录数量
-	Limit *int64 `json:"Limit,omitempty" name:"Limit"`
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeTablesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待查询表格所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待查询表格所属表格组ID列表
+	TableGroupIds []*string `json:"TableGroupIds,omitnil,omitempty" name:"TableGroupIds"`
+
+	// 待查询表格信息列表，用户不用关注，过滤请使用filter
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+
+	// 过滤条件，本接口支持：TableName，TableInstanceId
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 查询结果偏移量
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 查询结果返回记录数量
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeTablesRequest) ToJsonString() string {
@@ -1733,19 +2387,21 @@ func (r *DescribeTablesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeTablesResponseParams struct {
+	// 表格数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 表格详情结果列表
+	TableInfos []*TableInfoNew `json:"TableInfos,omitnil,omitempty" name:"TableInfos"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeTablesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 表格数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 表格详情结果列表
-		TableInfos []*TableInfoNew `json:"TableInfos,omitempty" name:"TableInfos"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeTablesResponseParams `json:"Response"`
 }
 
 func (r *DescribeTablesResponse) ToJsonString() string {
@@ -1759,23 +2415,41 @@ func (r *DescribeTablesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type DescribeTasksRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type DescribeTasksRequestParams struct {
 	// 需要查询任务所属的集群ID列表
-	ClusterIds []*string `json:"ClusterIds,omitempty" name:"ClusterIds"`
+	ClusterIds []*string `json:"ClusterIds,omitnil,omitempty" name:"ClusterIds"`
 
 	// 需要查询的任务ID列表
-	TaskIds []*string `json:"TaskIds,omitempty" name:"TaskIds"`
+	TaskIds []*string `json:"TaskIds,omitnil,omitempty" name:"TaskIds"`
 
 	// 过滤条件，本接口支持：Content，TaskType, Operator, Time
-	Filters []*Filter `json:"Filters,omitempty" name:"Filters"`
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 查询列表偏移量
-	Offset *int64 `json:"Offset,omitempty" name:"Offset"`
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 查询列表返回记录数
-	Limit *int64 `json:"Limit,omitempty" name:"Limit"`
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeTasksRequest struct {
+	*tchttp.BaseRequest
+	
+	// 需要查询任务所属的集群ID列表
+	ClusterIds []*string `json:"ClusterIds,omitnil,omitempty" name:"ClusterIds"`
+
+	// 需要查询的任务ID列表
+	TaskIds []*string `json:"TaskIds,omitnil,omitempty" name:"TaskIds"`
+
+	// 过滤条件，本接口支持：Content，TaskType, Operator, Time
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 查询列表偏移量
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 查询列表返回记录数
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeTasksRequest) ToJsonString() string {
@@ -1801,19 +2475,21 @@ func (r *DescribeTasksRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeTasksResponseParams struct {
+	// 任务数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 查询到的任务详情列表
+	TaskInfos []*TaskInfoNew `json:"TaskInfos,omitnil,omitempty" name:"TaskInfos"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeTasksResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 任务数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 查询到的任务详情列表
-		TaskInfos []*TaskInfoNew `json:"TaskInfos,omitempty" name:"TaskInfos"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeTasksResponseParams `json:"Response"`
 }
 
 func (r *DescribeTasksResponse) ToJsonString() string {
@@ -1827,8 +2503,14 @@ func (r *DescribeTasksResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeUinInWhitelistRequestParams struct {
+
+}
+
 type DescribeUinInWhitelistRequest struct {
 	*tchttp.BaseRequest
+	
 }
 
 func (r *DescribeUinInWhitelistRequest) ToJsonString() string {
@@ -1843,22 +2525,25 @@ func (r *DescribeUinInWhitelistRequest) FromJsonString(s string) error {
 	if err := json.Unmarshal([]byte(s), &f); err != nil {
 		return err
 	}
+	
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeUinInWhitelistRequest has unknown keys!", "")
 	}
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DescribeUinInWhitelistResponseParams struct {
+	// 查询结果：`FALSE` 否；`TRUE` 是
+	Result *string `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DescribeUinInWhitelistResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 查询结果：`FALSE` 否；`TRUE` 是
-		Result *string `json:"Result,omitempty" name:"Result"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DescribeUinInWhitelistResponseParams `json:"Response"`
 }
 
 func (r *DescribeUinInWhitelistResponse) ToJsonString() string {
@@ -1872,11 +2557,17 @@ func (r *DescribeUinInWhitelistResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DisableRestProxyRequestParams struct {
+	// 对应appid
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
 type DisableRestProxyRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 对应appid
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 }
 
 func (r *DisableRestProxyRequest) ToJsonString() string {
@@ -1898,19 +2589,21 @@ func (r *DisableRestProxyRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DisableRestProxyResponseParams struct {
+	// RestProxy的状态，0为关闭，1为开启中，2为开启，3为关闭中
+	RestProxyStatus *uint64 `json:"RestProxyStatus,omitnil,omitempty" name:"RestProxyStatus"`
+
+	// TaskId由 AppInstanceId-taskId 组成，以区分不同集群的任务
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type DisableRestProxyResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// RestProxy的状态，0为关闭，1为开启中，2为开启，3为关闭中
-		RestProxyStatus *uint64 `json:"RestProxyStatus,omitempty" name:"RestProxyStatus"`
-
-		// TaskId由 AppInstanceId-taskId 组成，以区分不同集群的任务
-		TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *DisableRestProxyResponseParams `json:"Response"`
 }
 
 func (r *DisableRestProxyResponse) ToJsonString() string {
@@ -1924,11 +2617,17 @@ func (r *DisableRestProxyResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type EnableRestProxyRequestParams struct {
+	// 集群 ID。
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
 type EnableRestProxyRequest struct {
 	*tchttp.BaseRequest
-
-	// 对应于appid
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	
+	// 集群 ID。
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 }
 
 func (r *EnableRestProxyRequest) ToJsonString() string {
@@ -1950,19 +2649,21 @@ func (r *EnableRestProxyRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type EnableRestProxyResponseParams struct {
+	// RestProxy的状态，0为关闭，1为开启中，2为开启，3为关闭中
+	RestProxyStatus *uint64 `json:"RestProxyStatus,omitnil,omitempty" name:"RestProxyStatus"`
+
+	// TaskId由 AppInstanceId-taskId 组成，以区分不同集群的任务
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type EnableRestProxyResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// RestProxy的状态，0为关闭，1为开启中，2为开启，3为关闭中
-		RestProxyStatus *uint64 `json:"RestProxyStatus,omitempty" name:"RestProxyStatus"`
-
-		// TaskId由 AppInstanceId-taskId 组成，以区分不同集群的任务
-		TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *EnableRestProxyResponseParams `json:"Response"`
 }
 
 func (r *EnableRestProxyResponse) ToJsonString() string {
@@ -1977,114 +2678,125 @@ func (r *EnableRestProxyResponse) FromJsonString(s string) error {
 }
 
 type ErrorInfo struct {
-
 	// 错误码
-	Code *string `json:"Code,omitempty" name:"Code"`
+	Code *string `json:"Code,omitnil,omitempty" name:"Code"`
 
 	// 错误信息
-	Message *string `json:"Message,omitempty" name:"Message"`
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
 }
 
 type FieldInfo struct {
-
 	// 表格字段名称
-	FieldName *string `json:"FieldName,omitempty" name:"FieldName"`
+	FieldName *string `json:"FieldName,omitnil,omitempty" name:"FieldName"`
 
 	// 字段是否是主键字段
-	IsPrimaryKey *string `json:"IsPrimaryKey,omitempty" name:"IsPrimaryKey"`
+	IsPrimaryKey *string `json:"IsPrimaryKey,omitnil,omitempty" name:"IsPrimaryKey"`
 
 	// 字段类型
-	FieldType *string `json:"FieldType,omitempty" name:"FieldType"`
+	FieldType *string `json:"FieldType,omitnil,omitempty" name:"FieldType"`
 
 	// 字段长度
-	FieldSize *int64 `json:"FieldSize,omitempty" name:"FieldSize"`
+	FieldSize *int64 `json:"FieldSize,omitnil,omitempty" name:"FieldSize"`
 }
 
 type Filter struct {
-
 	// 过滤字段名
-	Name *string `json:"Name,omitempty" name:"Name"`
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
 	// 过滤字段值
-	Value *string `json:"Value,omitempty" name:"Value"`
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
 
 	// 过滤字段值
-	Values []*string `json:"Values,omitempty" name:"Values"`
+	Values []*string `json:"Values,omitnil,omitempty" name:"Values"`
 }
 
 type IdlFileInfo struct {
-
 	// 文件名称，不包含扩展名
-	FileName *string `json:"FileName,omitempty" name:"FileName"`
+	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
 
 	// 数据描述语言（IDL）类型
-	FileType *string `json:"FileType,omitempty" name:"FileType"`
+	FileType *string `json:"FileType,omitnil,omitempty" name:"FileType"`
 
 	// 文件扩展名
-	FileExtType *string `json:"FileExtType,omitempty" name:"FileExtType"`
+	FileExtType *string `json:"FileExtType,omitnil,omitempty" name:"FileExtType"`
 
 	// 文件大小（Bytes）
-	FileSize *int64 `json:"FileSize,omitempty" name:"FileSize"`
+	FileSize *int64 `json:"FileSize,omitnil,omitempty" name:"FileSize"`
 
 	// 文件ID，对于已上传的文件有意义
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	FileId *int64 `json:"FileId,omitempty" name:"FileId"`
+	FileId *int64 `json:"FileId,omitnil,omitempty" name:"FileId"`
 
 	// 文件内容，对于本次新上传的文件有意义
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	FileContent *string `json:"FileContent,omitempty" name:"FileContent"`
+	FileContent *string `json:"FileContent,omitnil,omitempty" name:"FileContent"`
 }
 
 type IdlFileInfoWithoutContent struct {
-
 	// 文件名称，不包含扩展名
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	FileName *string `json:"FileName,omitempty" name:"FileName"`
+	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
 
 	// 数据描述语言（IDL）类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	FileType *string `json:"FileType,omitempty" name:"FileType"`
+	FileType *string `json:"FileType,omitnil,omitempty" name:"FileType"`
 
 	// 文件扩展名
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	FileExtType *string `json:"FileExtType,omitempty" name:"FileExtType"`
+	FileExtType *string `json:"FileExtType,omitnil,omitempty" name:"FileExtType"`
 
 	// 文件大小（Bytes）
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	FileSize *int64 `json:"FileSize,omitempty" name:"FileSize"`
+	FileSize *int64 `json:"FileSize,omitnil,omitempty" name:"FileSize"`
 
 	// 文件ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	FileId *int64 `json:"FileId,omitempty" name:"FileId"`
+	FileId *int64 `json:"FileId,omitnil,omitempty" name:"FileId"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
+}
+
+// Predefined struct for user
+type ImportSnapshotsRequestParams struct {
+	// 表格所属的集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 用于导入的快照信息
+	Snapshots *SnapshotInfo `json:"Snapshots,omitnil,omitempty" name:"Snapshots"`
+
+	// 是否导入部分记录，TRUE表示导入部分记录，FALSE表示全表导入
+	ImportSpecialKey *string `json:"ImportSpecialKey,omitnil,omitempty" name:"ImportSpecialKey"`
+
+	// 是否导入到当前表，TRUE表示导入到当前表，FALSE表示导入到新表
+	ImportOriginTable *string `json:"ImportOriginTable,omitnil,omitempty" name:"ImportOriginTable"`
+
+	// 部分记录的key文件
+	KeyFile *KeyFile `json:"KeyFile,omitnil,omitempty" name:"KeyFile"`
+
+	// 如果导入到新表，此为新表所属的表格组id
+	NewTableGroupId *string `json:"NewTableGroupId,omitnil,omitempty" name:"NewTableGroupId"`
+
+	// 如果导入到新表，此为新表的表名，系统会以该名称自动创建一张结构相同的空表
+	NewTableName *string `json:"NewTableName,omitnil,omitempty" name:"NewTableName"`
 }
 
 type ImportSnapshotsRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 表格所属的集群id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 用于导入的快照信息
-	Snapshots *SnapshotInfo `json:"Snapshots,omitempty" name:"Snapshots"`
+	Snapshots *SnapshotInfo `json:"Snapshots,omitnil,omitempty" name:"Snapshots"`
 
 	// 是否导入部分记录，TRUE表示导入部分记录，FALSE表示全表导入
-	ImportSpecialKey *string `json:"ImportSpecialKey,omitempty" name:"ImportSpecialKey"`
+	ImportSpecialKey *string `json:"ImportSpecialKey,omitnil,omitempty" name:"ImportSpecialKey"`
 
 	// 是否导入到当前表，TRUE表示导入到当前表，FALSE表示导入到新表
-	ImportOriginTable *string `json:"ImportOriginTable,omitempty" name:"ImportOriginTable"`
+	ImportOriginTable *string `json:"ImportOriginTable,omitnil,omitempty" name:"ImportOriginTable"`
 
 	// 部分记录的key文件
-	KeyFile *KeyFile `json:"KeyFile,omitempty" name:"KeyFile"`
+	KeyFile *KeyFile `json:"KeyFile,omitnil,omitempty" name:"KeyFile"`
 
 	// 如果导入到新表，此为新表所属的表格组id
-	NewTableGroupId *string `json:"NewTableGroupId,omitempty" name:"NewTableGroupId"`
+	NewTableGroupId *string `json:"NewTableGroupId,omitnil,omitempty" name:"NewTableGroupId"`
 
 	// 如果导入到新表，此为新表的表名，系统会以该名称自动创建一张结构相同的空表
-	NewTableName *string `json:"NewTableName,omitempty" name:"NewTableName"`
+	NewTableName *string `json:"NewTableName,omitnil,omitempty" name:"NewTableName"`
 }
 
 func (r *ImportSnapshotsRequest) ToJsonString() string {
@@ -2112,17 +2824,21 @@ func (r *ImportSnapshotsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ImportSnapshotsResponseParams struct {
+	// TaskId由 AppInstanceId-taskId 组成，以区分不同集群的任务
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// ApplicationId由 AppInstanceId-applicationId 组成，以区分不同集群的申请
+	ApplicationId *string `json:"ApplicationId,omitnil,omitempty" name:"ApplicationId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ImportSnapshotsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// TaskId由 AppInstanceId-taskId 组成，以区分不同集群的任务
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ImportSnapshotsResponseParams `json:"Response"`
 }
 
 func (r *ImportSnapshotsResponse) ToJsonString() string {
@@ -2136,56 +2852,79 @@ func (r *ImportSnapshotsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type KeyFile struct {
+type KafkaInfo struct {
+	// Kafka address
+	Address *string `json:"Address,omitnil,omitempty" name:"Address"`
 
+	// Kafka topic
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// kafka username
+	User *string `json:"User,omitnil,omitempty" name:"User"`
+
+	// kafka password
+	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
+
+	// ckafka实例
+	Instance *string `json:"Instance,omitnil,omitempty" name:"Instance"`
+
+	// 是否走VPC
+	IsVpc *int64 `json:"IsVpc,omitnil,omitempty" name:"IsVpc"`
+}
+
+type KeyFile struct {
 	// key文件名称
-	FileName *string `json:"FileName,omitempty" name:"FileName"`
+	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
 
 	// key文件扩展名
-	FileExtType *string `json:"FileExtType,omitempty" name:"FileExtType"`
+	FileExtType *string `json:"FileExtType,omitnil,omitempty" name:"FileExtType"`
 
 	// key文件内容
-	FileContent *string `json:"FileContent,omitempty" name:"FileContent"`
+	FileContent *string `json:"FileContent,omitnil,omitempty" name:"FileContent"`
 
 	// key文件大小
-	FileSize *int64 `json:"FileSize,omitempty" name:"FileSize"`
+	FileSize *int64 `json:"FileSize,omitnil,omitempty" name:"FileSize"`
 }
 
 type MachineInfo struct {
-
 	// 机器类型
-	MachineType *string `json:"MachineType,omitempty" name:"MachineType"`
+	MachineType *string `json:"MachineType,omitnil,omitempty" name:"MachineType"`
 
 	// 机器数量
-	MachineNum *int64 `json:"MachineNum,omitempty" name:"MachineNum"`
+	MachineNum *int64 `json:"MachineNum,omitnil,omitempty" name:"MachineNum"`
 }
 
 type MergeTableResult struct {
-
 	// 任务Id
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 成功时此字段返回 null，表示取不到有效值。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 
 	// 对比的表格信息
-	Table *CompareTablesInfo `json:"Table,omitempty" name:"Table"`
+	Table *CompareTablesInfo `json:"Table,omitnil,omitempty" name:"Table"`
 
 	// 申请单Id
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ApplicationId *string `json:"ApplicationId,omitempty" name:"ApplicationId"`
+	ApplicationId *string `json:"ApplicationId,omitnil,omitempty" name:"ApplicationId"`
+}
+
+// Predefined struct for user
+type MergeTablesDataRequestParams struct {
+	// 选取的表格
+	SelectedTables []*MergeTablesInfo `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+
+	// true只做对比，false既对比又执行
+	IsOnlyCompare *bool `json:"IsOnlyCompare,omitnil,omitempty" name:"IsOnlyCompare"`
 }
 
 type MergeTablesDataRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 选取的表格
-	SelectedTables []*MergeTablesInfo `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*MergeTablesInfo `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 
 	// true只做对比，false既对比又执行
-	IsOnlyCompare *bool `json:"IsOnlyCompare,omitempty" name:"IsOnlyCompare"`
+	IsOnlyCompare *bool `json:"IsOnlyCompare,omitnil,omitempty" name:"IsOnlyCompare"`
 }
 
 func (r *MergeTablesDataRequest) ToJsonString() string {
@@ -2208,16 +2947,18 @@ func (r *MergeTablesDataRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type MergeTablesDataResponseParams struct {
+	// 合服结果集
+	Results []*MergeTableResult `json:"Results,omitnil,omitempty" name:"Results"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type MergeTablesDataResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 合服结果集
-		Results []*MergeTableResult `json:"Results,omitempty" name:"Results"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *MergeTablesDataResponseParams `json:"Response"`
 }
 
 func (r *MergeTablesDataResponse) ToJsonString() string {
@@ -2232,25 +2973,36 @@ func (r *MergeTablesDataResponse) FromJsonString(s string) error {
 }
 
 type MergeTablesInfo struct {
-
 	// 合服的表格信息
-	MergeTables *CompareTablesInfo `json:"MergeTables,omitempty" name:"MergeTables"`
+	MergeTables *CompareTablesInfo `json:"MergeTables,omitnil,omitempty" name:"MergeTables"`
 
 	// 是否检查索引
-	CheckIndex *bool `json:"CheckIndex,omitempty" name:"CheckIndex"`
+	CheckIndex *bool `json:"CheckIndex,omitnil,omitempty" name:"CheckIndex"`
+}
+
+// Predefined struct for user
+type ModifyCensorshipRequestParams struct {
+	// 集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 集群是否开启审核 0-关闭 1-开启
+	Censorship *int64 `json:"Censorship,omitnil,omitempty" name:"Censorship"`
+
+	// 审批人uin列表
+	Uins []*string `json:"Uins,omitnil,omitempty" name:"Uins"`
 }
 
 type ModifyCensorshipRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 集群id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 集群是否开启审核 0-关闭 1-开启
-	Censorship *int64 `json:"Censorship,omitempty" name:"Censorship"`
+	Censorship *int64 `json:"Censorship,omitnil,omitempty" name:"Censorship"`
 
 	// 审批人uin列表
-	Uins []*string `json:"Uins,omitempty" name:"Uins"`
+	Uins []*string `json:"Uins,omitnil,omitempty" name:"Uins"`
 }
 
 func (r *ModifyCensorshipRequest) ToJsonString() string {
@@ -2274,23 +3026,24 @@ func (r *ModifyCensorshipRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyCensorshipResponseParams struct {
+	// 集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 已加入审批人的uin
+	Uins []*string `json:"Uins,omitnil,omitempty" name:"Uins"`
+
+	// 集群是否开启审核 0-关闭 1-开启
+	Censorship *int64 `json:"Censorship,omitnil,omitempty" name:"Censorship"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyCensorshipResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 集群id
-		ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
-
-		// 已加入审批人的uin
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		Uins []*string `json:"Uins,omitempty" name:"Uins"`
-
-		// 集群是否开启审核 0-关闭 1-开启
-		Censorship *int64 `json:"Censorship,omitempty" name:"Censorship"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyCensorshipResponseParams `json:"Response"`
 }
 
 func (r *ModifyCensorshipResponse) ToJsonString() string {
@@ -2304,20 +3057,35 @@ func (r *ModifyCensorshipResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyClusterMachineRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyClusterMachineRequestParams struct {
 	// 集群id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// svr占用的机器
-	ServerList []*MachineInfo `json:"ServerList,omitempty" name:"ServerList"`
+	ServerList []*MachineInfo `json:"ServerList,omitnil,omitempty" name:"ServerList"`
 
 	// proxy占用的机器
-	ProxyList []*MachineInfo `json:"ProxyList,omitempty" name:"ProxyList"`
+	ProxyList []*MachineInfo `json:"ProxyList,omitnil,omitempty" name:"ProxyList"`
 
 	// 集群类型1共享集群2独占集群
-	ClusterType *int64 `json:"ClusterType,omitempty" name:"ClusterType"`
+	ClusterType *int64 `json:"ClusterType,omitnil,omitempty" name:"ClusterType"`
+}
+
+type ModifyClusterMachineRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// svr占用的机器
+	ServerList []*MachineInfo `json:"ServerList,omitnil,omitempty" name:"ServerList"`
+
+	// proxy占用的机器
+	ProxyList []*MachineInfo `json:"ProxyList,omitnil,omitempty" name:"ProxyList"`
+
+	// 集群类型1共享集群2独占集群
+	ClusterType *int64 `json:"ClusterType,omitnil,omitempty" name:"ClusterType"`
 }
 
 func (r *ModifyClusterMachineRequest) ToJsonString() string {
@@ -2342,16 +3110,18 @@ func (r *ModifyClusterMachineRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyClusterMachineResponseParams struct {
+	// 集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyClusterMachineResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 集群id
-		ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyClusterMachineResponseParams `json:"Response"`
 }
 
 func (r *ModifyClusterMachineResponse) ToJsonString() string {
@@ -2365,14 +3135,23 @@ func (r *ModifyClusterMachineResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyClusterNameRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyClusterNameRequestParams struct {
 	// 需要修改名称的集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 需要修改的集群名称，可使用中文或英文字符，最大长度32个字符
-	ClusterName *string `json:"ClusterName,omitempty" name:"ClusterName"`
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+}
+
+type ModifyClusterNameRequest struct {
+	*tchttp.BaseRequest
+	
+	// 需要修改名称的集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 需要修改的集群名称，可使用中文或英文字符，最大长度32个字符
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 }
 
 func (r *ModifyClusterNameRequest) ToJsonString() string {
@@ -2395,13 +3174,15 @@ func (r *ModifyClusterNameRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyClusterNameResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyClusterNameResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyClusterNameResponseParams `json:"Response"`
 }
 
 func (r *ModifyClusterNameResponse) ToJsonString() string {
@@ -2415,23 +3196,41 @@ func (r *ModifyClusterNameResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyClusterPasswordRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyClusterPasswordRequestParams struct {
 	// 需要修改密码的集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 集群旧密码
-	OldPassword *string `json:"OldPassword,omitempty" name:"OldPassword"`
+	OldPassword *string `json:"OldPassword,omitnil,omitempty" name:"OldPassword"`
 
 	// 集群旧密码预期失效时间
-	OldPasswordExpireTime *string `json:"OldPasswordExpireTime,omitempty" name:"OldPasswordExpireTime"`
+	OldPasswordExpireTime *string `json:"OldPasswordExpireTime,omitnil,omitempty" name:"OldPasswordExpireTime"`
 
 	// 集群新密码，密码必须是a-zA-Z0-9的字符,且必须包含数字和大小写字母
-	NewPassword *string `json:"NewPassword,omitempty" name:"NewPassword"`
+	NewPassword *string `json:"NewPassword,omitnil,omitempty" name:"NewPassword"`
 
 	// 更新模式： `1` 更新密码；`2` 更新旧密码失效时间，默认为`1` 模式
-	Mode *string `json:"Mode,omitempty" name:"Mode"`
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+}
+
+type ModifyClusterPasswordRequest struct {
+	*tchttp.BaseRequest
+	
+	// 需要修改密码的集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 集群旧密码
+	OldPassword *string `json:"OldPassword,omitnil,omitempty" name:"OldPassword"`
+
+	// 集群旧密码预期失效时间
+	OldPasswordExpireTime *string `json:"OldPasswordExpireTime,omitnil,omitempty" name:"OldPasswordExpireTime"`
+
+	// 集群新密码，密码必须是a-zA-Z0-9的字符,且必须包含数字和大小写字母
+	NewPassword *string `json:"NewPassword,omitnil,omitempty" name:"NewPassword"`
+
+	// 更新模式： `1` 更新密码；`2` 更新旧密码失效时间，默认为`1` 模式
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
 }
 
 func (r *ModifyClusterPasswordRequest) ToJsonString() string {
@@ -2457,13 +3256,15 @@ func (r *ModifyClusterPasswordRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyClusterPasswordResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyClusterPasswordResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyClusterPasswordResponseParams `json:"Response"`
 }
 
 func (r *ModifyClusterPasswordResponse) ToJsonString() string {
@@ -2477,17 +3278,29 @@ func (r *ModifyClusterPasswordResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyClusterTagsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyClusterTagsRequestParams struct {
 	// 待修改标签的集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待增加或修改的标签列表
-	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitempty" name:"ReplaceTags"`
+	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
 	// 待删除的标签
-	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitempty" name:"DeleteTags"`
+	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
+}
+
+type ModifyClusterTagsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待修改标签的集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待增加或修改的标签列表
+	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
+
+	// 待删除的标签
+	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 func (r *ModifyClusterTagsRequest) ToJsonString() string {
@@ -2511,17 +3324,18 @@ func (r *ModifyClusterTagsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyClusterTagsResponseParams struct {
+	// 任务ID
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyClusterTagsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 任务ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyClusterTagsResponseParams `json:"Response"`
 }
 
 func (r *ModifyClusterTagsResponse) ToJsonString() string {
@@ -2535,14 +3349,23 @@ func (r *ModifyClusterTagsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifySnapshotsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifySnapshotsRequestParams struct {
 	// 表格所属集群id
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 快照列表
-	SelectedTables []*SnapshotInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SnapshotInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type ModifySnapshotsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格所属集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 快照列表
+	SelectedTables []*SnapshotInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *ModifySnapshotsRequest) ToJsonString() string {
@@ -2565,19 +3388,21 @@ func (r *ModifySnapshotsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifySnapshotsResponseParams struct {
+	// 批量修改的快照数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 批量修改的快照结果列表
+	TableResults []*SnapshotResult `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifySnapshotsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 批量创建的快照数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 批量创建的快照结果列表
-		TableResults []*SnapshotResult `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifySnapshotsResponseParams `json:"Response"`
 }
 
 func (r *ModifySnapshotsResponse) ToJsonString() string {
@@ -2591,17 +3416,29 @@ func (r *ModifySnapshotsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyTableGroupNameRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyTableGroupNameRequestParams struct {
 	// 表格组所属的集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待修改名称的表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 新的表格组名称，可以使用中英文字符和符号
-	TableGroupName *string `json:"TableGroupName,omitempty" name:"TableGroupName"`
+	TableGroupName *string `json:"TableGroupName,omitnil,omitempty" name:"TableGroupName"`
+}
+
+type ModifyTableGroupNameRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表格组所属的集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待修改名称的表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 新的表格组名称，可以使用中英文字符和符号
+	TableGroupName *string `json:"TableGroupName,omitnil,omitempty" name:"TableGroupName"`
 }
 
 func (r *ModifyTableGroupNameRequest) ToJsonString() string {
@@ -2625,13 +3462,15 @@ func (r *ModifyTableGroupNameRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyTableGroupNameResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyTableGroupNameResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyTableGroupNameResponseParams `json:"Response"`
 }
 
 func (r *ModifyTableGroupNameResponse) ToJsonString() string {
@@ -2645,20 +3484,35 @@ func (r *ModifyTableGroupNameResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyTableGroupTagsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyTableGroupTagsRequestParams struct {
 	// 待修改标签表格组所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待修改标签表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 待增加或修改的标签列表
-	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitempty" name:"ReplaceTags"`
+	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
 	// 待删除的标签
-	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitempty" name:"DeleteTags"`
+	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
+}
+
+type ModifyTableGroupTagsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待修改标签表格组所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待修改标签表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 待增加或修改的标签列表
+	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
+
+	// 待删除的标签
+	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 func (r *ModifyTableGroupTagsRequest) ToJsonString() string {
@@ -2683,17 +3537,18 @@ func (r *ModifyTableGroupTagsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyTableGroupTagsResponseParams struct {
+	// 任务ID
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyTableGroupTagsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 任务ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyTableGroupTagsResponseParams `json:"Response"`
 }
 
 func (r *ModifyTableGroupTagsResponse) ToJsonString() string {
@@ -2707,14 +3562,23 @@ func (r *ModifyTableGroupTagsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyTableMemosRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyTableMemosRequestParams struct {
 	// 表所属集群实例ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 选定表详情列表
-	TableMemos []*SelectedTableInfoNew `json:"TableMemos,omitempty" name:"TableMemos"`
+	TableMemos []*SelectedTableInfoNew `json:"TableMemos,omitnil,omitempty" name:"TableMemos"`
+}
+
+type ModifyTableMemosRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 选定表详情列表
+	TableMemos []*SelectedTableInfoNew `json:"TableMemos,omitnil,omitempty" name:"TableMemos"`
 }
 
 func (r *ModifyTableMemosRequest) ToJsonString() string {
@@ -2737,19 +3601,21 @@ func (r *ModifyTableMemosRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyTableMemosResponseParams struct {
+	// 表备注修改结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 表备注修改结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyTableMemosResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 表备注修改结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 表备注修改结果列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyTableMemosResponseParams `json:"Response"`
 }
 
 func (r *ModifyTableMemosResponse) ToJsonString() string {
@@ -2763,14 +3629,23 @@ func (r *ModifyTableMemosResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyTableQuotasRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyTableQuotasRequestParams struct {
 	// 带扩缩容表所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 已选中待修改的表配额列表
-	TableQuotas []*SelectedTableInfoNew `json:"TableQuotas,omitempty" name:"TableQuotas"`
+	TableQuotas []*SelectedTableInfoNew `json:"TableQuotas,omitnil,omitempty" name:"TableQuotas"`
+}
+
+type ModifyTableQuotasRequest struct {
+	*tchttp.BaseRequest
+	
+	// 带扩缩容表所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 已选中待修改的表配额列表
+	TableQuotas []*SelectedTableInfoNew `json:"TableQuotas,omitnil,omitempty" name:"TableQuotas"`
 }
 
 func (r *ModifyTableQuotasRequest) ToJsonString() string {
@@ -2793,19 +3668,21 @@ func (r *ModifyTableQuotasRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyTableQuotasResponseParams struct {
+	// 扩缩容结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 扩缩容结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyTableQuotasResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 扩缩容结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 扩缩容结果列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyTableQuotasResponseParams `json:"Response"`
 }
 
 func (r *ModifyTableQuotasResponse) ToJsonString() string {
@@ -2819,20 +3696,35 @@ func (r *ModifyTableQuotasResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyTableTagsRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyTableTagsRequestParams struct {
 	// 待修改标签表格所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待修改标签表格列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 
 	// 待增加或修改的标签列表
-	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitempty" name:"ReplaceTags"`
+	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
 	// 待删除的标签列表
-	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitempty" name:"DeleteTags"`
+	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
+}
+
+type ModifyTableTagsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待修改标签表格所属集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待修改标签表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+
+	// 待增加或修改的标签列表
+	ReplaceTags []*TagInfoUnit `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
+
+	// 待删除的标签列表
+	DeleteTags []*TagInfoUnit `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 func (r *ModifyTableTagsRequest) ToJsonString() string {
@@ -2857,19 +3749,21 @@ func (r *ModifyTableTagsRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyTableTagsResponseParams struct {
+	// 返回结果总数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 返回结果
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyTableTagsResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 返回结果总数
-		TotalCount *int64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 返回结果
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyTableTagsResponseParams `json:"Response"`
 }
 
 func (r *ModifyTableTagsResponse) ToJsonString() string {
@@ -2883,17 +3777,29 @@ func (r *ModifyTableTagsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type ModifyTablesRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type ModifyTablesRequestParams struct {
 	// 待修改表格所在集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 选中的改表IDL文件
-	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitempty" name:"IdlFiles"`
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
 
 	// 待改表格列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type ModifyTablesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待修改表格所在集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 选中的改表IDL文件
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
+
+	// 待改表格列表
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *ModifyTablesRequest) ToJsonString() string {
@@ -2917,19 +3823,21 @@ func (r *ModifyTablesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type ModifyTablesResponseParams struct {
+	// 修改表结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 修改表结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type ModifyTablesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 修改表结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 修改表结果列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *ModifyTablesResponseParams `json:"Response"`
 }
 
 func (r *ModifyTablesResponse) ToJsonString() string {
@@ -2944,133 +3852,126 @@ func (r *ModifyTablesResponse) FromJsonString(s string) error {
 }
 
 type ParsedTableInfoNew struct {
-
 	// 表格描述语言类型：`PROTO`或`TDR`
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableIdlType *string `json:"TableIdlType,omitempty" name:"TableIdlType"`
+	TableIdlType *string `json:"TableIdlType,omitnil,omitempty" name:"TableIdlType"`
 
 	// 表格实例ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableInstanceId *string `json:"TableInstanceId,omitempty" name:"TableInstanceId"`
+	TableInstanceId *string `json:"TableInstanceId,omitnil,omitempty" name:"TableInstanceId"`
 
 	// 表格名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 表格数据结构类型：`GENERIC`或`LIST`
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableType *string `json:"TableType,omitempty" name:"TableType"`
+	TableType *string `json:"TableType,omitnil,omitempty" name:"TableType"`
 
 	// 主键字段信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	KeyFields *string `json:"KeyFields,omitempty" name:"KeyFields"`
+	KeyFields *string `json:"KeyFields,omitnil,omitempty" name:"KeyFields"`
 
 	// 原主键字段信息，改表校验时有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	OldKeyFields *string `json:"OldKeyFields,omitempty" name:"OldKeyFields"`
+	OldKeyFields *string `json:"OldKeyFields,omitnil,omitempty" name:"OldKeyFields"`
 
 	// 非主键字段信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ValueFields *string `json:"ValueFields,omitempty" name:"ValueFields"`
+	ValueFields *string `json:"ValueFields,omitnil,omitempty" name:"ValueFields"`
 
 	// 原非主键字段信息，改表校验时有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	OldValueFields *string `json:"OldValueFields,omitempty" name:"OldValueFields"`
+	OldValueFields *string `json:"OldValueFields,omitnil,omitempty" name:"OldValueFields"`
 
 	// 所属表格组ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 主键字段总大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SumKeyFieldSize *int64 `json:"SumKeyFieldSize,omitempty" name:"SumKeyFieldSize"`
+	SumKeyFieldSize *int64 `json:"SumKeyFieldSize,omitnil,omitempty" name:"SumKeyFieldSize"`
 
 	// 非主键字段总大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SumValueFieldSize *int64 `json:"SumValueFieldSize,omitempty" name:"SumValueFieldSize"`
+	SumValueFieldSize *int64 `json:"SumValueFieldSize,omitnil,omitempty" name:"SumValueFieldSize"`
 
 	// 索引键集合
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	IndexKeySet *string `json:"IndexKeySet,omitempty" name:"IndexKeySet"`
+	IndexKeySet *string `json:"IndexKeySet,omitnil,omitempty" name:"IndexKeySet"`
 
 	// 分表因子集合
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ShardingKeySet *string `json:"ShardingKeySet,omitempty" name:"ShardingKeySet"`
+	ShardingKeySet *string `json:"ShardingKeySet,omitnil,omitempty" name:"ShardingKeySet"`
 
 	// TDR版本号
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TdrVersion *int64 `json:"TdrVersion,omitempty" name:"TdrVersion"`
+	TdrVersion *int64 `json:"TdrVersion,omitnil,omitempty" name:"TdrVersion"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 
 	// LIST类型表格元素个数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ListElementNum *int64 `json:"ListElementNum,omitempty" name:"ListElementNum"`
+	ListElementNum *int64 `json:"ListElementNum,omitnil,omitempty" name:"ListElementNum"`
 
 	// SORTLIST类型表格排序字段个数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SortFieldNum *int64 `json:"SortFieldNum,omitempty" name:"SortFieldNum"`
+	SortFieldNum *int64 `json:"SortFieldNum,omitnil,omitempty" name:"SortFieldNum"`
 
 	// SORTLIST类型表格排序顺序
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SortRule *int64 `json:"SortRule,omitempty" name:"SortRule"`
+	SortRule *int64 `json:"SortRule,omitnil,omitempty" name:"SortRule"`
 }
 
 type PoolInfo struct {
-
 	// 唯一id
-	PoolUid *int64 `json:"PoolUid,omitempty" name:"PoolUid"`
+	PoolUid *int64 `json:"PoolUid,omitnil,omitempty" name:"PoolUid"`
 
 	// 是否支持ipv6
-	Ipv6Enable *int64 `json:"Ipv6Enable,omitempty" name:"Ipv6Enable"`
+	Ipv6Enable *int64 `json:"Ipv6Enable,omitnil,omitempty" name:"Ipv6Enable"`
 
 	// 剩余可用app
-	AvailableAppCount *int64 `json:"AvailableAppCount,omitempty" name:"AvailableAppCount"`
+	AvailableAppCount *int64 `json:"AvailableAppCount,omitnil,omitempty" name:"AvailableAppCount"`
 
 	// svr机器列表
-	ServerList []*ServerMachineInfo `json:"ServerList,omitempty" name:"ServerList"`
+	ServerList []*ServerMachineInfo `json:"ServerList,omitnil,omitempty" name:"ServerList"`
 
 	// proxy机器列表
-	ProxyList []*ProxyMachineInfo `json:"ProxyList,omitempty" name:"ProxyList"`
+	ProxyList []*ProxyMachineInfo `json:"ProxyList,omitnil,omitempty" name:"ProxyList"`
 }
 
 type ProxyDetailInfo struct {
-
 	// proxy的唯一id
-	ProxyUid *string `json:"ProxyUid,omitempty" name:"ProxyUid"`
+	ProxyUid *string `json:"ProxyUid,omitnil,omitempty" name:"ProxyUid"`
 
 	// 机器类型
-	MachineType *string `json:"MachineType,omitempty" name:"MachineType"`
+	MachineType *string `json:"MachineType,omitnil,omitempty" name:"MachineType"`
 
 	// 请求包速度
-	ProcessSpeed *int64 `json:"ProcessSpeed,omitempty" name:"ProcessSpeed"`
+	ProcessSpeed *int64 `json:"ProcessSpeed,omitnil,omitempty" name:"ProcessSpeed"`
 
 	// 请求包时延
-	AverageProcessDelay *int64 `json:"AverageProcessDelay,omitempty" name:"AverageProcessDelay"`
+	AverageProcessDelay *int64 `json:"AverageProcessDelay,omitnil,omitempty" name:"AverageProcessDelay"`
 
 	// 慢处理包速度
-	SlowProcessSpeed *int64 `json:"SlowProcessSpeed,omitempty" name:"SlowProcessSpeed"`
+	SlowProcessSpeed *int64 `json:"SlowProcessSpeed,omitnil,omitempty" name:"SlowProcessSpeed"`
+
+	// 版本
+	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
 }
 
 type ProxyMachineInfo struct {
-
 	// 唯一id
-	ProxyUid *string `json:"ProxyUid,omitempty" name:"ProxyUid"`
+	ProxyUid *string `json:"ProxyUid,omitnil,omitempty" name:"ProxyUid"`
 
 	// 机器类型
-	MachineType *string `json:"MachineType,omitempty" name:"MachineType"`
+	MachineType *string `json:"MachineType,omitnil,omitempty" name:"MachineType"`
+
+	// 可分配proxy资源数
+	AvailableCount *int64 `json:"AvailableCount,omitnil,omitempty" name:"AvailableCount"`
+}
+
+// Predefined struct for user
+type RecoverRecycleTablesRequestParams struct {
+	// 表所在集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待恢复表信息
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 type RecoverRecycleTablesRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 表所在集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待恢复表信息
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *RecoverRecycleTablesRequest) ToJsonString() string {
@@ -3093,19 +3994,21 @@ func (r *RecoverRecycleTablesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type RecoverRecycleTablesResponseParams struct {
+	// 恢复表结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 恢复表信息列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type RecoverRecycleTablesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 恢复表结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 恢复表信息列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *RecoverRecycleTablesResponseParams `json:"Response"`
 }
 
 func (r *RecoverRecycleTablesResponse) ToJsonString() string {
@@ -3120,191 +4023,268 @@ func (r *RecoverRecycleTablesResponse) FromJsonString(s string) error {
 }
 
 type RegionInfo struct {
-
 	// 地域Ap-Code
-	RegionName *string `json:"RegionName,omitempty" name:"RegionName"`
+	RegionName *string `json:"RegionName,omitnil,omitempty" name:"RegionName"`
 
 	// 地域缩写
-	RegionAbbr *string `json:"RegionAbbr,omitempty" name:"RegionAbbr"`
+	RegionAbbr *string `json:"RegionAbbr,omitnil,omitempty" name:"RegionAbbr"`
 
 	// 地域ID
-	RegionId *uint64 `json:"RegionId,omitempty" name:"RegionId"`
+	RegionId *uint64 `json:"RegionId,omitnil,omitempty" name:"RegionId"`
 
 	// 是否支持ipv6，0:不支持，1:支持
-	Ipv6Enable *uint64 `json:"Ipv6Enable,omitempty" name:"Ipv6Enable"`
+	Ipv6Enable *uint64 `json:"Ipv6Enable,omitnil,omitempty" name:"Ipv6Enable"`
 }
 
-type RollbackTablesRequest struct {
+type SelectedTableInfoNew struct {
+	// 表所属表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表格名称
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// 表实例ID
+	TableInstanceId *string `json:"TableInstanceId,omitnil,omitempty" name:"TableInstanceId"`
+
+	// 表格描述语言类型：`PROTO`或`TDR`
+	TableIdlType *string `json:"TableIdlType,omitnil,omitempty" name:"TableIdlType"`
+
+	// 表格数据结构类型：`GENERIC`或`LIST`
+	TableType *string `json:"TableType,omitnil,omitempty" name:"TableType"`
+
+	// LIST表元素个数
+	ListElementNum *int64 `json:"ListElementNum,omitnil,omitempty" name:"ListElementNum"`
+
+	// 表格预留容量（GB）
+	ReservedVolume *int64 `json:"ReservedVolume,omitnil,omitempty" name:"ReservedVolume"`
+
+	// 表格预留读CU
+	ReservedReadQps *int64 `json:"ReservedReadQps,omitnil,omitempty" name:"ReservedReadQps"`
+
+	// 表格预留写CU
+	ReservedWriteQps *int64 `json:"ReservedWriteQps,omitnil,omitempty" name:"ReservedWriteQps"`
+
+	// 表格备注信息
+	Memo *string `json:"Memo,omitnil,omitempty" name:"Memo"`
+
+	// Key回档文件名，回档专用
+	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
+
+	// Key回档文件扩展名，回档专用
+	FileExtType *string `json:"FileExtType,omitnil,omitempty" name:"FileExtType"`
+
+	// Key回档文件大小，回档专用
+	FileSize *int64 `json:"FileSize,omitnil,omitempty" name:"FileSize"`
+
+	// Key回档文件内容，回档专用
+	FileContent *string `json:"FileContent,omitnil,omitempty" name:"FileContent"`
+}
+
+type SelectedTableWithField struct {
+	// 表所属表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表格名称
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// 表实例ID
+	TableInstanceId *string `json:"TableInstanceId,omitnil,omitempty" name:"TableInstanceId"`
+
+	// 表格描述语言类型：`PROTO`或`TDR`
+	TableIdlType *string `json:"TableIdlType,omitnil,omitempty" name:"TableIdlType"`
+
+	// 表格数据结构类型：`GENERIC`或`LIST`
+	TableType *string `json:"TableType,omitnil,omitempty" name:"TableType"`
+
+	// 待创建索引、缓写、数据订阅的字段列表
+	SelectedFields []*FieldInfo `json:"SelectedFields,omitnil,omitempty" name:"SelectedFields"`
+
+	// 索引分片数
+	ShardNum *uint64 `json:"ShardNum,omitnil,omitempty" name:"ShardNum"`
+
+	// ckafka实例信息
+	KafkaInfo *KafkaInfo `json:"KafkaInfo,omitnil,omitempty" name:"KafkaInfo"`
+}
+
+type ServerDetailInfo struct {
+	// svr唯一id
+	ServerUid *string `json:"ServerUid,omitnil,omitempty" name:"ServerUid"`
+
+	// 机器类型
+	MachineType *string `json:"MachineType,omitnil,omitempty" name:"MachineType"`
+
+	// 内存占用量
+	MemoryRate *int64 `json:"MemoryRate,omitnil,omitempty" name:"MemoryRate"`
+
+	// 磁盘占用量
+	DiskRate *int64 `json:"DiskRate,omitnil,omitempty" name:"DiskRate"`
+
+	// 读次数
+	ReadNum *int64 `json:"ReadNum,omitnil,omitempty" name:"ReadNum"`
+
+	// 写次数
+	WriteNum *int64 `json:"WriteNum,omitnil,omitempty" name:"WriteNum"`
+
+	// 版本
+	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
+}
+
+type ServerMachineInfo struct {
+	// 机器唯一id
+	ServerUid *string `json:"ServerUid,omitnil,omitempty" name:"ServerUid"`
+
+	// 机器类型
+	MachineType *string `json:"MachineType,omitnil,omitempty" name:"MachineType"`
+}
+
+// Predefined struct for user
+type SetBackupExpireRuleRequestParams struct {
+	// 表所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 淘汰策略数组
+	BackupExpireRules []*BackupExpireRuleInfo `json:"BackupExpireRules,omitnil,omitempty" name:"BackupExpireRules"`
+}
+
+type SetBackupExpireRuleRequest struct {
 	*tchttp.BaseRequest
+	
+	// 表所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 待回档表格所在集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
-
-	// 待回档表格列表
-	SelectedTables []*SelectedTableInfoNew `json:"SelectedTables,omitempty" name:"SelectedTables"`
-
-	// 待回档时间
-	RollbackTime *string `json:"RollbackTime,omitempty" name:"RollbackTime"`
-
-	// 回档模式，支持：`KEYS`
-	Mode *string `json:"Mode,omitempty" name:"Mode"`
+	// 淘汰策略数组
+	BackupExpireRules []*BackupExpireRuleInfo `json:"BackupExpireRules,omitnil,omitempty" name:"BackupExpireRules"`
 }
 
-func (r *RollbackTablesRequest) ToJsonString() string {
+func (r *SetBackupExpireRuleRequest) ToJsonString() string {
     b, _ := json.Marshal(r)
     return string(b)
 }
 
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
-func (r *RollbackTablesRequest) FromJsonString(s string) error {
+func (r *SetBackupExpireRuleRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "BackupExpireRules")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "SetBackupExpireRuleRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type SetBackupExpireRuleResponseParams struct {
+	// TaskId由 AppInstanceId-taskId 组成，以区分不同集群的任务
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type SetBackupExpireRuleResponse struct {
+	*tchttp.BaseResponse
+	Response *SetBackupExpireRuleResponseParams `json:"Response"`
+}
+
+func (r *SetBackupExpireRuleResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *SetBackupExpireRuleResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type SetTableDataFlowRequestParams struct {
+	// 表所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待创建分布式索引表格列表
+	SelectedTables []*SelectedTableWithField `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+type SetTableDataFlowRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待创建分布式索引表格列表
+	SelectedTables []*SelectedTableWithField `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
+}
+
+func (r *SetTableDataFlowRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *SetTableDataFlowRequest) FromJsonString(s string) error {
 	f := make(map[string]interface{})
 	if err := json.Unmarshal([]byte(s), &f); err != nil {
 		return err
 	}
 	delete(f, "ClusterId")
 	delete(f, "SelectedTables")
-	delete(f, "RollbackTime")
-	delete(f, "Mode")
 	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RollbackTablesRequest has unknown keys!", "")
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "SetTableDataFlowRequest has unknown keys!", "")
 	}
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type RollbackTablesResponse struct {
-	*tchttp.BaseResponse
-	Response *struct {
+// Predefined struct for user
+type SetTableDataFlowResponseParams struct {
+	// 表格数据订阅创建结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-		// 表格回档任务结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
+	// 表格数据订阅创建结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
 
-		// 表格回档任务结果列表
-		TableResults []*TableRollbackResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
-func (r *RollbackTablesResponse) ToJsonString() string {
+type SetTableDataFlowResponse struct {
+	*tchttp.BaseResponse
+	Response *SetTableDataFlowResponseParams `json:"Response"`
+}
+
+func (r *SetTableDataFlowResponse) ToJsonString() string {
     b, _ := json.Marshal(r)
     return string(b)
 }
 
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
-func (r *RollbackTablesResponse) FromJsonString(s string) error {
+func (r *SetTableDataFlowResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type SelectedTableInfoNew struct {
+// Predefined struct for user
+type SetTableIndexRequestParams struct {
+	// 表所属集群实例ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 表所属表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
-
-	// 表格名称
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
-
-	// 表实例ID
-	TableInstanceId *string `json:"TableInstanceId,omitempty" name:"TableInstanceId"`
-
-	// 表格描述语言类型：`PROTO`或`TDR`
-	TableIdlType *string `json:"TableIdlType,omitempty" name:"TableIdlType"`
-
-	// 表格数据结构类型：`GENERIC`或`LIST`
-	TableType *string `json:"TableType,omitempty" name:"TableType"`
-
-	// LIST表元素个数
-	ListElementNum *int64 `json:"ListElementNum,omitempty" name:"ListElementNum"`
-
-	// 表格预留容量（GB）
-	ReservedVolume *int64 `json:"ReservedVolume,omitempty" name:"ReservedVolume"`
-
-	// 表格预留读CU
-	ReservedReadQps *int64 `json:"ReservedReadQps,omitempty" name:"ReservedReadQps"`
-
-	// 表格预留写CU
-	ReservedWriteQps *int64 `json:"ReservedWriteQps,omitempty" name:"ReservedWriteQps"`
-
-	// 表格备注信息
-	Memo *string `json:"Memo,omitempty" name:"Memo"`
-
-	// Key回档文件名，回档专用
-	FileName *string `json:"FileName,omitempty" name:"FileName"`
-
-	// Key回档文件扩展名，回档专用
-	FileExtType *string `json:"FileExtType,omitempty" name:"FileExtType"`
-
-	// Key回档文件大小，回档专用
-	FileSize *int64 `json:"FileSize,omitempty" name:"FileSize"`
-
-	// Key回档文件内容，回档专用
-	FileContent *string `json:"FileContent,omitempty" name:"FileContent"`
-}
-
-type SelectedTableWithField struct {
-
-	// 表所属表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
-
-	// 表格名称
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
-
-	// 表实例ID
-	TableInstanceId *string `json:"TableInstanceId,omitempty" name:"TableInstanceId"`
-
-	// 表格描述语言类型：`PROTO`或`TDR`
-	TableIdlType *string `json:"TableIdlType,omitempty" name:"TableIdlType"`
-
-	// 表格数据结构类型：`GENERIC`或`LIST`
-	TableType *string `json:"TableType,omitempty" name:"TableType"`
-
-	// 待创建索引的字段列表
-	SelectedFields []*FieldInfo `json:"SelectedFields,omitempty" name:"SelectedFields"`
-
-	// 索引分片数
-	ShardNum *uint64 `json:"ShardNum,omitempty" name:"ShardNum"`
-}
-
-type ServerDetailInfo struct {
-
-	// svr唯一id
-	ServerUid *string `json:"ServerUid,omitempty" name:"ServerUid"`
-
-	// 机器类型
-	MachineType *string `json:"MachineType,omitempty" name:"MachineType"`
-
-	// 内存占用量
-	MemoryRate *int64 `json:"MemoryRate,omitempty" name:"MemoryRate"`
-
-	// 磁盘占用量
-	DiskRate *int64 `json:"DiskRate,omitempty" name:"DiskRate"`
-
-	// 读次数
-	ReadNum *int64 `json:"ReadNum,omitempty" name:"ReadNum"`
-
-	// 写次数
-	WriteNum *int64 `json:"WriteNum,omitempty" name:"WriteNum"`
-}
-
-type ServerMachineInfo struct {
-
-	// 机器唯一id
-	ServerUid *string `json:"ServerUid,omitempty" name:"ServerUid"`
-
-	// 机器类型
-	MachineType *string `json:"MachineType,omitempty" name:"MachineType"`
+	// 待创建分布式索引表格列表
+	SelectedTables []*SelectedTableWithField `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 type SetTableIndexRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 表所属集群实例ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待创建分布式索引表格列表
-	SelectedTables []*SelectedTableWithField `json:"SelectedTables,omitempty" name:"SelectedTables"`
+	SelectedTables []*SelectedTableWithField `json:"SelectedTables,omitnil,omitempty" name:"SelectedTables"`
 }
 
 func (r *SetTableIndexRequest) ToJsonString() string {
@@ -3327,19 +4307,21 @@ func (r *SetTableIndexRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type SetTableIndexResponseParams struct {
+	// 表格分布式索引创建结果数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 表格分布式索引创建结果列表
+	TableResults []*TableResultNew `json:"TableResults,omitnil,omitempty" name:"TableResults"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type SetTableIndexResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 表格分布式索引创建结果数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 表格分布式索引创建结果列表
-		TableResults []*TableResultNew `json:"TableResults,omitempty" name:"TableResults"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *SetTableIndexResponseParams `json:"Response"`
 }
 
 func (r *SetTableIndexResponse) ToJsonString() string {
@@ -3354,401 +4336,366 @@ func (r *SetTableIndexResponse) FromJsonString(s string) error {
 }
 
 type SnapshotInfo struct {
-
 	// 所属表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 表名称
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 快照名称
-	SnapshotName *string `json:"SnapshotName,omitempty" name:"SnapshotName"`
+	SnapshotName *string `json:"SnapshotName,omitnil,omitempty" name:"SnapshotName"`
 
 	// 快照时间点
-	SnapshotTime *string `json:"SnapshotTime,omitempty" name:"SnapshotTime"`
+	SnapshotTime *string `json:"SnapshotTime,omitnil,omitempty" name:"SnapshotTime"`
 
 	// 快照过期时间点
-	SnapshotDeadTime *string `json:"SnapshotDeadTime,omitempty" name:"SnapshotDeadTime"`
+	SnapshotDeadTime *string `json:"SnapshotDeadTime,omitnil,omitempty" name:"SnapshotDeadTime"`
 }
 
 type SnapshotInfoNew struct {
-
 	// 所属表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 表名称
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 快照名称
-	SnapshotName *string `json:"SnapshotName,omitempty" name:"SnapshotName"`
+	SnapshotName *string `json:"SnapshotName,omitnil,omitempty" name:"SnapshotName"`
 
 	// 快照过期时间点
-	SnapshotDeadTime *string `json:"SnapshotDeadTime,omitempty" name:"SnapshotDeadTime"`
+	SnapshotDeadTime *string `json:"SnapshotDeadTime,omitnil,omitempty" name:"SnapshotDeadTime"`
 }
 
 type SnapshotResult struct {
-
 	// 表格所属表格组ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 表格名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 任务ID，对于创建单任务的接口有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 
 	// 快照名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SnapshotName *string `json:"SnapshotName,omitempty" name:"SnapshotName"`
+	SnapshotName *string `json:"SnapshotName,omitnil,omitempty" name:"SnapshotName"`
 
 	// 快照的时间点
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SnapshotTime *string `json:"SnapshotTime,omitempty" name:"SnapshotTime"`
+	SnapshotTime *string `json:"SnapshotTime,omitnil,omitempty" name:"SnapshotTime"`
 
 	// 快照的过期时间点
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SnapshotDeadTime *string `json:"SnapshotDeadTime,omitempty" name:"SnapshotDeadTime"`
+	SnapshotDeadTime *string `json:"SnapshotDeadTime,omitnil,omitempty" name:"SnapshotDeadTime"`
 
 	// 快照创建时间点
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SnapshotCreateTime *string `json:"SnapshotCreateTime,omitempty" name:"SnapshotCreateTime"`
+	SnapshotCreateTime *string `json:"SnapshotCreateTime,omitnil,omitempty" name:"SnapshotCreateTime"`
 
 	// 快照大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SnapshotSize *uint64 `json:"SnapshotSize,omitempty" name:"SnapshotSize"`
+	SnapshotSize *uint64 `json:"SnapshotSize,omitnil,omitempty" name:"SnapshotSize"`
 
 	// 快照状态，0 生成中 1 正常 2 删除中 3 已失效 4 回档使用中
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SnapshotStatus *uint64 `json:"SnapshotStatus,omitempty" name:"SnapshotStatus"`
+	SnapshotStatus *uint64 `json:"SnapshotStatus,omitnil,omitempty" name:"SnapshotStatus"`
+
+	// 申请单ID
+	ApplicationId *string `json:"ApplicationId,omitnil,omitempty" name:"ApplicationId"`
+}
+
+type SyncTableField struct {
+	// TcaplusDB表字段名称
+	SourceName *string `json:"SourceName,omitnil,omitempty" name:"SourceName"`
+
+	// 目标缓写表的字段名称
+	TargetName *string `json:"TargetName,omitnil,omitempty" name:"TargetName"`
+}
+
+type SyncTableInfo struct {
+	// 目标缓写表的分表数目
+	TargetTableSplitNum *uint64 `json:"TargetTableSplitNum,omitnil,omitempty" name:"TargetTableSplitNum"`
+
+	// 目标缓写表名前缀
+	TargetTableNamePrefix []*string `json:"TargetTableNamePrefix,omitnil,omitempty" name:"TargetTableNamePrefix"`
+
+	// 缓写数据库实例ID
+	TargetSyncDBInstanceId *string `json:"TargetSyncDBInstanceId,omitnil,omitempty" name:"TargetSyncDBInstanceId"`
+
+	// 缓写表所在数据库名称
+	TargetDatabaseName *string `json:"TargetDatabaseName,omitnil,omitempty" name:"TargetDatabaseName"`
+
+	// 缓写状态，0：创建中，1：进行中，2：关闭，-1：被删除
+	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// 表格所在集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 表格所在表格组ID
+	TableGroupId *uint64 `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表格名称
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// 表格ID
+	TableId *string `json:"TableId,omitnil,omitempty" name:"TableId"`
+
+	// TcaplusDB表主键字段到目标缓写表字段的映射
+	KeyFieldMapping []*SyncTableField `json:"KeyFieldMapping,omitnil,omitempty" name:"KeyFieldMapping"`
+
+	// TcaplusDB表字段到目标缓写表字段的映射
+	ValueFieldMapping []*SyncTableField `json:"ValueFieldMapping,omitnil,omitempty" name:"ValueFieldMapping"`
 }
 
 type TableGroupInfo struct {
-
 	// 表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 表格组名称
-	TableGroupName *string `json:"TableGroupName,omitempty" name:"TableGroupName"`
+	TableGroupName *string `json:"TableGroupName,omitnil,omitempty" name:"TableGroupName"`
 
 	// 表格组创建时间
-	CreatedTime *string `json:"CreatedTime,omitempty" name:"CreatedTime"`
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
 	// 表格组包含的表格数量
-	TableCount *uint64 `json:"TableCount,omitempty" name:"TableCount"`
+	TableCount *uint64 `json:"TableCount,omitnil,omitempty" name:"TableCount"`
 
 	// 表格组包含的表格存储总量（MB）
-	TotalSize *uint64 `json:"TotalSize,omitempty" name:"TotalSize"`
+	TotalSize *uint64 `json:"TotalSize,omitnil,omitempty" name:"TotalSize"`
+
+	// 表格Txh备份文件多少天后过期删除
+	TxhBackupExpireDay *uint64 `json:"TxhBackupExpireDay,omitnil,omitempty" name:"TxhBackupExpireDay"`
+
+	// 是否开启mysql负载均衡,0未开启 1开启中 2已开启
+	EnableMysql *uint64 `json:"EnableMysql,omitnil,omitempty" name:"EnableMysql"`
+
+	// mysql负载均衡vip
+	MysqlConnIp *string `json:"MysqlConnIp,omitnil,omitempty" name:"MysqlConnIp"`
+
+	// mysql负载均衡vport
+	MysqlConnPort *uint64 `json:"MysqlConnPort,omitnil,omitempty" name:"MysqlConnPort"`
 }
 
 type TableInfoNew struct {
-
 	// 表格名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 表格实例ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableInstanceId *string `json:"TableInstanceId,omitempty" name:"TableInstanceId"`
+	TableInstanceId *string `json:"TableInstanceId,omitnil,omitempty" name:"TableInstanceId"`
 
 	// 表格数据结构类型，如：`GENERIC`或`LIST`
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableType *string `json:"TableType,omitempty" name:"TableType"`
+	TableType *string `json:"TableType,omitnil,omitempty" name:"TableType"`
 
 	// 表格数据描述语言（IDL）类型，如：`PROTO`或`TDR`
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableIdlType *string `json:"TableIdlType,omitempty" name:"TableIdlType"`
+	TableIdlType *string `json:"TableIdlType,omitnil,omitempty" name:"TableIdlType"`
 
 	// 表格所属集群ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 表格所属集群名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ClusterName *string `json:"ClusterName,omitempty" name:"ClusterName"`
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 
 	// 表格所属表格组ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 表格所属表格组名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupName *string `json:"TableGroupName,omitempty" name:"TableGroupName"`
+	TableGroupName *string `json:"TableGroupName,omitnil,omitempty" name:"TableGroupName"`
 
 	// 表格主键字段结构json字符串
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	KeyStruct *string `json:"KeyStruct,omitempty" name:"KeyStruct"`
+	KeyStruct *string `json:"KeyStruct,omitnil,omitempty" name:"KeyStruct"`
 
 	// 表格非主键字段结构json字符串
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ValueStruct *string `json:"ValueStruct,omitempty" name:"ValueStruct"`
+	ValueStruct *string `json:"ValueStruct,omitnil,omitempty" name:"ValueStruct"`
 
 	// 表格分表因子集合，对PROTO类型表格有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ShardingKeySet *string `json:"ShardingKeySet,omitempty" name:"ShardingKeySet"`
+	ShardingKeySet *string `json:"ShardingKeySet,omitnil,omitempty" name:"ShardingKeySet"`
 
 	// 表格索引键字段集合，对PROTO类型表格有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	IndexStruct *string `json:"IndexStruct,omitempty" name:"IndexStruct"`
+	IndexStruct *string `json:"IndexStruct,omitnil,omitempty" name:"IndexStruct"`
 
 	// LIST类型表格元素个数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ListElementNum *uint64 `json:"ListElementNum,omitempty" name:"ListElementNum"`
+	ListElementNum *uint64 `json:"ListElementNum,omitnil,omitempty" name:"ListElementNum"`
 
 	// 表格所关联IDL文件信息列表
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitempty" name:"IdlFiles"`
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
 
 	// 表格预留容量（GB）
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ReservedVolume *int64 `json:"ReservedVolume,omitempty" name:"ReservedVolume"`
+	ReservedVolume *int64 `json:"ReservedVolume,omitnil,omitempty" name:"ReservedVolume"`
 
 	// 表格预留读CU
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ReservedReadQps *int64 `json:"ReservedReadQps,omitempty" name:"ReservedReadQps"`
+	ReservedReadQps *int64 `json:"ReservedReadQps,omitnil,omitempty" name:"ReservedReadQps"`
 
 	// 表格预留写CU
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ReservedWriteQps *int64 `json:"ReservedWriteQps,omitempty" name:"ReservedWriteQps"`
+	ReservedWriteQps *int64 `json:"ReservedWriteQps,omitnil,omitempty" name:"ReservedWriteQps"`
 
 	// 表格实际数据量大小（MB）
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableSize *int64 `json:"TableSize,omitempty" name:"TableSize"`
+	TableSize *int64 `json:"TableSize,omitnil,omitempty" name:"TableSize"`
 
 	// 表格状态
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Status *string `json:"Status,omitempty" name:"Status"`
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
 
 	// 表格创建时间
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	CreatedTime *string `json:"CreatedTime,omitempty" name:"CreatedTime"`
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
 	// 表格最后一次修改时间
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	UpdatedTime *string `json:"UpdatedTime,omitempty" name:"UpdatedTime"`
+	UpdatedTime *string `json:"UpdatedTime,omitnil,omitempty" name:"UpdatedTime"`
 
 	// 表格备注信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Memo *string `json:"Memo,omitempty" name:"Memo"`
+	Memo *string `json:"Memo,omitnil,omitempty" name:"Memo"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 
 	// TcaplusDB SDK数据访问接入ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ApiAccessId *string `json:"ApiAccessId,omitempty" name:"ApiAccessId"`
+	ApiAccessId *string `json:"ApiAccessId,omitnil,omitempty" name:"ApiAccessId"`
 
 	// SORTLIST类型表格排序字段个数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SortFieldNum *int64 `json:"SortFieldNum,omitempty" name:"SortFieldNum"`
+	SortFieldNum *int64 `json:"SortFieldNum,omitnil,omitempty" name:"SortFieldNum"`
 
 	// SORTLIST类型表格排序顺序
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SortRule *int64 `json:"SortRule,omitempty" name:"SortRule"`
+	SortRule *int64 `json:"SortRule,omitnil,omitempty" name:"SortRule"`
 
-	// 表格分布式索引信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	DbClusterInfoStruct *string `json:"DbClusterInfoStruct,omitempty" name:"DbClusterInfoStruct"`
+	// 表格分布式索引/缓写、kafka数据订阅信息
+	DbClusterInfoStruct *string `json:"DbClusterInfoStruct,omitnil,omitempty" name:"DbClusterInfoStruct"`
+
+	// 表格Txh备份文件多少天后过期删除
+	TxhBackupExpireDay *uint64 `json:"TxhBackupExpireDay,omitnil,omitempty" name:"TxhBackupExpireDay"`
+
+	// 表格的缓写信息
+	SyncTableInfo *SyncTableInfo `json:"SyncTableInfo,omitnil,omitempty" name:"SyncTableInfo"`
+
+	// 表格分片数量
+	ShardNum *uint64 `json:"ShardNum,omitnil,omitempty" name:"ShardNum"`
 }
 
 type TableResultNew struct {
-
 	// 表格实例ID，形如：tcaplus-3be64cbb
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableInstanceId *string `json:"TableInstanceId,omitempty" name:"TableInstanceId"`
+	TableInstanceId *string `json:"TableInstanceId,omitnil,omitempty" name:"TableInstanceId"`
 
 	// 任务ID，对于创建单任务的接口有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 表格名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 表格数据结构类型，如：`GENERIC`或`LIST`
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableType *string `json:"TableType,omitempty" name:"TableType"`
+	TableType *string `json:"TableType,omitnil,omitempty" name:"TableType"`
 
 	// 表数据描述语言（IDL）类型，如：`PROTO`或`TDR`
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableIdlType *string `json:"TableIdlType,omitempty" name:"TableIdlType"`
+	TableIdlType *string `json:"TableIdlType,omitnil,omitempty" name:"TableIdlType"`
 
 	// 表格所属表格组ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 
 	// 任务ID列表，对于创建多任务的接口有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TaskIds []*string `json:"TaskIds,omitempty" name:"TaskIds"`
+	TaskIds []*string `json:"TaskIds,omitnil,omitempty" name:"TaskIds"`
 
 	// 腾讯云申请审核单Id
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ApplicationId *string `json:"ApplicationId,omitempty" name:"ApplicationId"`
-}
-
-type TableRollbackResultNew struct {
-
-	// 表格实例ID，形如：tcaplus-3be64cbb
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableInstanceId *string `json:"TableInstanceId,omitempty" name:"TableInstanceId"`
-
-	// 任务ID，对于创建单任务的接口有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
-
-	// 表格名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
-
-	// 表格数据结构类型，如：`GENERIC`或`LIST`
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableType *string `json:"TableType,omitempty" name:"TableType"`
-
-	// 表格数据描述语言（IDL）类型，如：`PROTO`或`TDR`
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableIdlType *string `json:"TableIdlType,omitempty" name:"TableIdlType"`
-
-	// 表格所属表格组ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
-
-	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
-
-	// 任务ID列表，对于创建多任务的接口有效
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TaskIds []*string `json:"TaskIds,omitempty" name:"TaskIds"`
-
-	// 上传的key文件ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	FileId *string `json:"FileId,omitempty" name:"FileId"`
-
-	// 校验成功Key数量
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SuccKeyNum *uint64 `json:"SuccKeyNum,omitempty" name:"SuccKeyNum"`
-
-	// Key文件中包含总的Key数量
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TotalKeyNum *uint64 `json:"TotalKeyNum,omitempty" name:"TotalKeyNum"`
+	ApplicationId *string `json:"ApplicationId,omitnil,omitempty" name:"ApplicationId"`
 }
 
 type TagInfoUnit struct {
-
 	// 标签键
-	TagKey *string `json:"TagKey,omitempty" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TagValue *string `json:"TagValue,omitempty" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type TagsInfoOfCluster struct {
-
 	// 集群ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 标签信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Tags []*TagInfoUnit `json:"Tags,omitempty" name:"Tags"`
+	Tags []*TagInfoUnit `json:"Tags,omitnil,omitempty" name:"Tags"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 }
 
 type TagsInfoOfTable struct {
-
 	// 表格实例ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableInstanceId *string `json:"TableInstanceId,omitempty" name:"TableInstanceId"`
+	TableInstanceId *string `json:"TableInstanceId,omitnil,omitempty" name:"TableInstanceId"`
 
 	// 表格名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableName *string `json:"TableName,omitempty" name:"TableName"`
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
 
 	// 表格组ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 标签信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Tags []*TagInfoUnit `json:"Tags,omitempty" name:"Tags"`
+	Tags []*TagInfoUnit `json:"Tags,omitnil,omitempty" name:"Tags"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 }
 
 type TagsInfoOfTableGroup struct {
-
 	// 集群ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 表格组ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 标签信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Tags []*TagInfoUnit `json:"Tags,omitempty" name:"Tags"`
+	Tags []*TagInfoUnit `json:"Tags,omitnil,omitempty" name:"Tags"`
 
 	// 错误信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Error *ErrorInfo `json:"Error,omitempty" name:"Error"`
+	Error *ErrorInfo `json:"Error,omitnil,omitempty" name:"Error"`
 }
 
 type TaskInfoNew struct {
-
 	// 任务ID
-	TaskId *string `json:"TaskId,omitempty" name:"TaskId"`
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 任务类型
-	TaskType *string `json:"TaskType,omitempty" name:"TaskType"`
+	TaskType *string `json:"TaskType,omitnil,omitempty" name:"TaskType"`
 
 	// 任务所关联的TcaplusDB内部事务ID
-	TransId *string `json:"TransId,omitempty" name:"TransId"`
+	TransId *string `json:"TransId,omitnil,omitempty" name:"TransId"`
 
 	// 任务所属集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 任务所属集群名称
-	ClusterName *string `json:"ClusterName,omitempty" name:"ClusterName"`
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 
 	// 任务进度
-	Progress *int64 `json:"Progress,omitempty" name:"Progress"`
+	Progress *int64 `json:"Progress,omitnil,omitempty" name:"Progress"`
 
 	// 任务创建时间
-	StartTime *string `json:"StartTime,omitempty" name:"StartTime"`
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
 	// 任务最后更新时间
-	UpdateTime *string `json:"UpdateTime,omitempty" name:"UpdateTime"`
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 
 	// 操作者
-	Operator *string `json:"Operator,omitempty" name:"Operator"`
+	Operator *string `json:"Operator,omitnil,omitempty" name:"Operator"`
 
 	// 任务详情
-	Content *string `json:"Content,omitempty" name:"Content"`
+	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
+
+	// 表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 表格组名称
+	TableGroupName *string `json:"TableGroupName,omitnil,omitempty" name:"TableGroupName"`
+
+	// 表名称
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+}
+
+// Predefined struct for user
+type UpdateApplyRequestParams struct {
+	// 申请单状态
+	ApplyStatus []*ApplyStatus `json:"ApplyStatus,omitnil,omitempty" name:"ApplyStatus"`
 }
 
 type UpdateApplyRequest struct {
 	*tchttp.BaseRequest
-
+	
 	// 申请单状态
-	ApplyStatus []*ApplyStatus `json:"ApplyStatus,omitempty" name:"ApplyStatus"`
+	ApplyStatus []*ApplyStatus `json:"ApplyStatus,omitnil,omitempty" name:"ApplyStatus"`
 }
 
 func (r *UpdateApplyRequest) ToJsonString() string {
@@ -3770,20 +4717,21 @@ func (r *UpdateApplyRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type UpdateApplyResponseParams struct {
+	// 已更新的申请单列表
+	ApplyResults []*ApplyResult `json:"ApplyResults,omitnil,omitempty" name:"ApplyResults"`
+
+	// 更新数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type UpdateApplyResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 已更新的申请单列表
-	// 注意：此字段可能返回 null，表示取不到有效值。
-		ApplyResults []*ApplyResult `json:"ApplyResults,omitempty" name:"ApplyResults"`
-
-		// 更新数量
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *UpdateApplyResponseParams `json:"Response"`
 }
 
 func (r *UpdateApplyResponse) ToJsonString() string {
@@ -3797,20 +4745,35 @@ func (r *UpdateApplyResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type VerifyIdlFilesRequest struct {
-	*tchttp.BaseRequest
-
+// Predefined struct for user
+type VerifyIdlFilesRequestParams struct {
 	// 待创建表格的集群ID
-	ClusterId *string `json:"ClusterId,omitempty" name:"ClusterId"`
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 待创建表格的表格组ID
-	TableGroupId *string `json:"TableGroupId,omitempty" name:"TableGroupId"`
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
 
 	// 曾经上传过的IDL文件信息列表，与NewIdlFiles至少有一者
-	ExistingIdlFiles []*IdlFileInfo `json:"ExistingIdlFiles,omitempty" name:"ExistingIdlFiles"`
+	ExistingIdlFiles []*IdlFileInfo `json:"ExistingIdlFiles,omitnil,omitempty" name:"ExistingIdlFiles"`
 
 	// 待上传的IDL文件信息列表，与ExistingIdlFiles至少有一者
-	NewIdlFiles []*IdlFileInfo `json:"NewIdlFiles,omitempty" name:"NewIdlFiles"`
+	NewIdlFiles []*IdlFileInfo `json:"NewIdlFiles,omitnil,omitempty" name:"NewIdlFiles"`
+}
+
+type VerifyIdlFilesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 待创建表格的集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 待创建表格的表格组ID
+	TableGroupId *string `json:"TableGroupId,omitnil,omitempty" name:"TableGroupId"`
+
+	// 曾经上传过的IDL文件信息列表，与NewIdlFiles至少有一者
+	ExistingIdlFiles []*IdlFileInfo `json:"ExistingIdlFiles,omitnil,omitempty" name:"ExistingIdlFiles"`
+
+	// 待上传的IDL文件信息列表，与ExistingIdlFiles至少有一者
+	NewIdlFiles []*IdlFileInfo `json:"NewIdlFiles,omitnil,omitempty" name:"NewIdlFiles"`
 }
 
 func (r *VerifyIdlFilesRequest) ToJsonString() string {
@@ -3835,22 +4798,24 @@ func (r *VerifyIdlFilesRequest) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type VerifyIdlFilesResponseParams struct {
+	// 本次上传校验所有的IDL文件信息列表
+	IdlFiles []*IdlFileInfo `json:"IdlFiles,omitnil,omitempty" name:"IdlFiles"`
+
+	// 读取IDL描述文件后解析出的合法表数量，不包含已经创建的表
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 读取IDL描述文件后解析出的合法表列表，不包含已经创建的表
+	TableInfos []*ParsedTableInfoNew `json:"TableInfos,omitnil,omitempty" name:"TableInfos"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
 type VerifyIdlFilesResponse struct {
 	*tchttp.BaseResponse
-	Response *struct {
-
-		// 本次上传校验所有的IDL文件信息列表
-		IdlFiles []*IdlFileInfo `json:"IdlFiles,omitempty" name:"IdlFiles"`
-
-		// 读取IDL描述文件后解析出的合法表数量，不包含已经创建的表
-		TotalCount *uint64 `json:"TotalCount,omitempty" name:"TotalCount"`
-
-		// 读取IDL描述文件后解析出的合法表列表，不包含已经创建的表
-		TableInfos []*ParsedTableInfoNew `json:"TableInfos,omitempty" name:"TableInfos"`
-
-		// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-		RequestId *string `json:"RequestId,omitempty" name:"RequestId"`
-	} `json:"Response"`
+	Response *VerifyIdlFilesResponseParams `json:"Response"`
 }
 
 func (r *VerifyIdlFilesResponse) ToJsonString() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1281,7 +1281,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter/v20230110
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/csip/v20221121
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 ## explicit; go 1.14
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
 ## explicit; go 1.14
@@ -1422,7 +1421,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat/v20201028
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.0.199
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcm v1.0.547

--- a/website/docs/r/tcaplus_tablegroup.html.markdown
+++ b/website/docs/r/tcaplus_tablegroup.html.markdown
@@ -16,32 +16,45 @@ Use this resource to create TcaplusDB table group.
 ### Create a tcaplusdb table group
 
 ```hcl
-locals {
-  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
-  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
-}
-
-variable "availability_zone" {
-  default = "ap-guangzhou-3"
-}
-
-data "tencentcloud_vpc_subnets" "vpc" {
-  is_default        = true
-  availability_zone = var.availability_zone
-}
-
 resource "tencentcloud_tcaplus_cluster" "example" {
   idl_type                 = "PROTO"
   cluster_name             = "tf_example_tcaplus_cluster"
-  vpc_id                   = local.vpc_id
-  subnet_id                = local.subnet_id
-  password                 = "your_pw_123111"
+  vpc_id                   = "vpc-i5yyodl9"
+  subnet_id                = "subnet-hhi88a58"
+  password                 = "Password@2026"
   old_password_expire_last = 3600
 }
 
 resource "tencentcloud_tcaplus_tablegroup" "example" {
   cluster_id      = tencentcloud_tcaplus_cluster.example.id
   tablegroup_name = "tf_example_group_name"
+  resource_tags {
+    tag_key   = "CreatedBy"
+    tag_value = "Terraform"
+  }
+}
+```
+
+### Create a tcaplusdb table group with user-specified table group id
+
+```hcl
+resource "tencentcloud_tcaplus_cluster" "example" {
+  idl_type                 = "PROTO"
+  cluster_name             = "tf_example_tcaplus_cluster"
+  vpc_id                   = "vpc-i5yyodl9"
+  subnet_id                = "subnet-hhi88a58"
+  password                 = "Password@2026"
+  old_password_expire_last = 3600
+}
+
+resource "tencentcloud_tcaplus_tablegroup" "example" {
+  cluster_id      = tencentcloud_tcaplus_cluster.example.id
+  tablegroup_name = "tf_example_group_name"
+  table_group_id  = "109"
+  resource_tags {
+    tag_key   = "CreatedBy"
+    tag_value = "Terraform"
+  }
 }
 ```
 
@@ -50,7 +63,14 @@ resource "tencentcloud_tcaplus_tablegroup" "example" {
 The following arguments are supported:
 
 * `cluster_id` - (Required, String, ForceNew) ID of the TcaplusDB cluster to which the table group belongs.
-* `tablegroup_name` - (Required, String) Name of the TcaplusDB table group. Name length should be between 1 and 30.
+* `tablegroup_name` - (Required, String) Table group name; may consist of Chinese characters, English letters, or numeric characters, with a maximum length of 32 characters.
+* `resource_tags` - (Optional, Set) Set of table group tags.
+* `table_group_id` - (Optional, String, ForceNew) ID of the TcaplusDB table group, can be user-specified (must be unique within the cluster) or auto-incremented by the API when not set. Immutable after creation.
+
+The `resource_tags` object supports the following:
+
+* `tag_key` - (Required, String) Tag key.
+* `tag_value` - (Required, String) Tag value.
 
 ## Attributes Reference
 
@@ -61,4 +81,12 @@ In addition to all arguments above, the following attributes are exported:
 * `table_count` - Number of tables.
 * `total_size` - Total storage size (MB).
 
+
+## Import
+
+TcaplusDB table group can be imported using the clusterId:tableGroupId, e.g.
+
+```
+terraform import tencentcloud_tcaplus_tablegroup.example 5516511420:52
+```
 


### PR DESCRIPTION
Add an optional table_group_id parameter to the tencentcloud_tcaplus_tablegroup resource, allowing users to specify a custom table group ID at creation time. When not set, the API auto-increments the ID. The parameter is immutable after creation and rejected via the immutableArgs check in the Update function.