### PR TITLE
fix(vpc): allow ALL for security group rule port range

### DIFF
--- a/tencentcloud/services/vpc/resource_tc_security_group_rule.go
+++ b/tencentcloud/services/vpc/resource_tc_security_group_rule.go
@@ -76,12 +76,12 @@ func ResourceTencentCloudSecurityGroupRule() *schema.Resource {
 				},
 				ForceNew:    true,
 				Computed:    true,
-				Description: "Range of the port. The available value can be one, multiple or one segment. E.g. `80`, `80,90` and `80-90`. Default to all ports, and confilicts with `protocol_template`.",
+				Description: "Range of the port. The available value can be `ALL`, one port, multiple ports or one port range. E.g. `ALL`, `80`, `80,90` and `80-90`. Default to all ports, and conflicts with `protocol_template`.",
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					match, _ := regexp.MatchString("^(\\d{1,5},)*\\d{1,5}$|^\\d{1,5}-\\d{1,5}$", value)
+					match, _ := regexp.MatchString(`^(ALL|(\d{1,5},)*\d{1,5}|\d{1,5}-\d{1,5})$`, value)
 					if !match {
-						errors = append(errors, fmt.Errorf("%s example: `53`, `80,443` and `80-90`, Not configured to represent all ports", k))
+						errors = append(errors, fmt.Errorf("%s must be `ALL`, a single port, multiple ports, or a port range; examples: `ALL`, `53`, `80,443`, and `80-90`", k))
 					}
 					return
 				},

--- a/tencentcloud/services/vpc/resource_tc_security_group_rule_test.go
+++ b/tencentcloud/services/vpc/resource_tc_security_group_rule_test.go
@@ -14,6 +14,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func TestUnitTencentCloudSecurityGroupRulePortRangeValidation(t *testing.T) {
+	validate := svcvpc.ResourceTencentCloudSecurityGroupRule().Schema["port_range"].ValidateFunc
+	testCases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "all ports", value: "ALL"},
+		{name: "single port", value: "53"},
+		{name: "multiple ports", value: "80,443"},
+		{name: "port range", value: "80-90"},
+		{name: "invalid value", value: "invalid", wantErr: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, errs := validate(testCase.value, "port_range")
+			if gotErr := len(errs) > 0; gotErr != testCase.wantErr {
+				t.Fatalf("validate(%q) returned errors %v, wantErr %t", testCase.value, errs, testCase.wantErr)
+			}
+		})
+	}
+}
+
 func TestAccTencentCloudSecurityGroupRuleResource_basic(t *testing.T) {
 	t.Parallel()
 	var sgrId string
@@ -404,6 +428,8 @@ resource "tencentcloud_security_group_rule" "egress-drop" {
   security_group_id = tencentcloud_security_group.foo.id
   cidr_ip           = "0.0.0.0/0"
   type              = "ingress"
+  ip_protocol       = "ALL"
+  port_range        = "ALL"
   policy            = "DROP"
 }
 `


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What
fix #4328 
<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
