### PR TITLE
fix(tke): [136390945] `tencentcloud_kubernetes_native_node_pool` optimize code logic

### DIFF
--- a/.changelog/4332.txt
+++ b/.changelog/4332.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_kubernetes_native_node_pool: optimize code logic
+```

--- a/tencentcloud/services/tke/resource_tc_kubernetes_native_node_pool.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_native_node_pool.go
@@ -586,12 +586,6 @@ func ResourceTencentCloudKubernetesNativeNodePool() *schema.Resource {
 				},
 			},
 
-			"node_pool_instance_delete_mode": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Node pool instance deletion mode. Valid values: `terminate`, `retain`. Default is `terminate`.",
-			},
-
 			"life_state": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/tencentcloud/services/tke/resource_tc_kubernetes_native_node_pool.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_native_node_pool.go
@@ -586,6 +586,12 @@ func ResourceTencentCloudKubernetesNativeNodePool() *schema.Resource {
 				},
 			},
 
+			"node_pool_instance_delete_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Node pool instance deletion mode. Valid values: `terminate`, `retain`. Default is `terminate`.",
+			},
+
 			"life_state": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -1798,13 +1804,47 @@ func resourceTencentCloudKubernetesNativeNodePoolDelete(d *schema.ResourceData, 
 
 	logId := tccommon.GetLogId(tccommon.ContextNil)
 	ctx := tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+	service := TkeService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
 	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
 	if len(idSplit) != 2 {
 		return fmt.Errorf("id is broken,%s", d.Id())
 	}
+
 	clusterId := idSplit[0]
 	nodePoolId := idSplit[1]
+
+	var machineNames []*string
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		respData, errRet := service.DescribeClusterMachinesById(ctx, clusterId, "")
+		if errRet != nil {
+			return tccommon.RetryError(errRet)
+		}
+
+		if respData == nil || len(respData) == 0 {
+			return nil
+		}
+
+		// temp code logic, wait tke fix
+		for _, item := range respData {
+			if item != nil && item.MachineName != nil {
+				if strings.HasPrefix(*item.MachineName, nodePoolId) {
+					machineNames = append(machineNames, item.MachineName)
+				}
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s describe kubernetes cluster machines failed, reason:%+v", logId, err)
+		return err
+	}
+
+	if len(machineNames) == 0 {
+		return nil
+	}
 
 	var (
 		request  = tke2.NewDeleteNodePoolRequest()
@@ -1812,10 +1852,8 @@ func resourceTencentCloudKubernetesNativeNodePoolDelete(d *schema.ResourceData, 
 	)
 
 	request.ClusterId = &clusterId
-
 	request.NodePoolId = &nodePoolId
-
-	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTke2Client().DeleteNodePoolWithContext(ctx, request)
 		if e != nil {
 			return tccommon.RetryError(e)
@@ -1833,7 +1871,6 @@ func resourceTencentCloudKubernetesNativeNodePoolDelete(d *schema.ResourceData, 
 	_ = response
 
 	// wait node pool for delete ok
-	service := TkeService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 	err = resource.Retry(5*tccommon.ReadRetryTimeout, func() *resource.RetryError {
 		respData, errRet := service.DescribeKubernetesNativeNodePoolById(ctx, clusterId, nodePoolId)
 		if errRet != nil {
@@ -1855,26 +1892,36 @@ func resourceTencentCloudKubernetesNativeNodePoolDelete(d *schema.ResourceData, 
 		return err
 	}
 
-	// wait node pool instances for delete ok
+	// wait machines for delete ok
 	err = resource.Retry(5*tccommon.ReadRetryTimeout, func() *resource.RetryError {
-		respData, errRet := service.DescribeKubernetesClusteInstancesById(ctx, clusterId, nodePoolId)
+		respData, errRet := service.DescribeClusterMachinesById(ctx, clusterId, "")
 		if errRet != nil {
-			errCode := errRet.(*sdkErrors.TencentCloudSDKError).Code
-			if strings.Contains(errCode, "InternalError") {
-				return nil
-			}
-			return tccommon.RetryError(errRet, tccommon.InternalError)
+			return tccommon.RetryError(errRet)
 		}
 
-		if len(respData.InstanceSet) == 0 {
+		if respData == nil || len(respData) == 0 {
 			return nil
 		}
 
-		return resource.NonRetryableError(fmt.Errorf("native node pool instances still deleteing"))
+		machineNames = []*string{}
+		// temp code logic, wait tke fix
+		for _, item := range respData {
+			if item != nil && item.MachineName != nil {
+				if strings.HasPrefix(*item.MachineName, nodePoolId) {
+					machineNames = append(machineNames, item.MachineName)
+				}
+			}
+		}
+
+		if len(machineNames) == 0 {
+			return nil
+		}
+
+		return resource.RetryableError(fmt.Errorf("cluster machines still deleteting"))
 	})
 
 	if err != nil {
-		log.Printf("[CRITAL]%s delete kubernetes native node pool failed, reason:%+v", logId, err)
+		log.Printf("[CRITAL]%s describe kubernetes cluster machines failed, reason:%+v", logId, err)
 		return err
 	}
 

--- a/tencentcloud/services/tke/service_tencentcloud_tke.go
+++ b/tencentcloud/services/tke/service_tencentcloud_tke.go
@@ -3984,6 +3984,73 @@ func (me *TkeService) DescribeKubernetesClusteInstancesById(ctx context.Context,
 	return
 }
 
+func (me *TkeService) DescribeClusterMachinesById(ctx context.Context, clusterId, nodePoolId string) (ret []*tke2.Machine, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := tke2.NewDescribeClusterMachinesRequest()
+	response := tke2.NewDescribeClusterMachinesResponse()
+	request.ClusterId = helper.String(clusterId)
+	// error key NodePoolsId, wait tke fix
+	if nodePoolId != "" {
+		request.Filters = []*tke2.Filter{
+			{
+				Name:   common.StringPtr("NodePoolsId"),
+				Values: common.StringPtrs([]string{nodePoolId}),
+			},
+		}
+	}
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	var (
+		offset int64 = 0
+		limit  int64 = 100
+	)
+
+	for {
+		request.Offset = &offset
+		request.Limit = &limit
+		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			ratelimit.Check(request.GetAction())
+			result, err := me.client.UseTkeV20220501Client().DescribeClusterMachines(request)
+			if err != nil {
+				return tccommon.RetryError(err)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Describe kubernetes cluster machines failed, Response is nil."))
+			}
+
+			response = result
+			return nil
+		})
+
+		if err != nil {
+			errRet = err
+			return
+		}
+
+		if len(response.Response.Machines) < 1 {
+			break
+		}
+
+		ret = append(ret, response.Response.Machines...)
+		if len(response.Response.Machines) < int(limit) {
+			break
+		}
+
+		offset += limit
+	}
+
+	return
+}
+
 func (me *TkeService) DescribeKubernetesClusterPendingReleaseById(ctx context.Context, clusterId, clusterReleaseId string) (ret *tke.PendingRelease, errRet error) {
 	logId := tccommon.GetLogId(ctx)
 

--- a/website/docs/r/kubernetes_native_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_native_node_pool.html.markdown
@@ -117,7 +117,6 @@ The following arguments are supported:
 * `annotations` - (Optional, Set) Node Annotation List.
 * `deletion_protection` - (Optional, Bool) Whether to enable deletion protection.
 * `labels` - (Optional, Set) Node Labels.
-* `node_pool_instance_delete_mode` - (Optional, String) Node pool instance deletion mode. Valid values: `terminate`, `retain`. Default is `terminate`.
 * `tags` - (Optional, Set) Node tags.
 * `taints` - (Optional, List) Node taint.
 * `unschedulable` - (Optional, Bool) Whether the node is not schedulable by default. The native node is not aware of it and passes false by default.

--- a/website/docs/r/kubernetes_native_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_native_node_pool.html.markdown
@@ -117,6 +117,7 @@ The following arguments are supported:
 * `annotations` - (Optional, Set) Node Annotation List.
 * `deletion_protection` - (Optional, Bool) Whether to enable deletion protection.
 * `labels` - (Optional, Set) Node Labels.
+* `node_pool_instance_delete_mode` - (Optional, String) Node pool instance deletion mode. Valid values: `terminate`, `retain`. Default is `terminate`.
 * `tags` - (Optional, Set) Node tags.
 * `taints` - (Optional, List) Node taint.
 * `unschedulable` - (Optional, Bool) Whether the node is not schedulable by default. The native node is not aware of it and passes false by default.


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
