### PR TITLE
fix(redis): [136391073] `tencentcloud_redis_log_delivery` support `is_delete_topic` and `is_delete_logset`

### DIFF
--- a/.changelog/4333.txt
+++ b/.changelog/4333.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_redis_log_delivery: support `is_delete_topic` and `is_delete_logset`
+```

--- a/tencentcloud/services/crs/resource_tc_redis_log_delivery.go
+++ b/tencentcloud/services/crs/resource_tc_redis_log_delivery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	clsv20201016 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
 	svcCls "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cls"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -81,6 +82,18 @@ func ResourceTencentCloudRedisLogDelivery() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "Whether to create an index when creating a log topic.",
+			},
+
+			"is_delete_topic": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to delete the associated Topic when deleting the log delivery. Default is false.",
+			},
+
+			"is_delete_logset": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to delete the associated Logset when deleting the log delivery. Default is false.",
 			},
 		},
 	}
@@ -355,5 +368,65 @@ func resourceTencentCloudRedisLogDeliveryDelete(d *schema.ResourceData, meta int
 
 	_ = response
 	_ = instanceId
+
+	var (
+		isDeleteTopic  bool
+		isDeleteLogset bool
+	)
+
+	if v, ok := d.GetOkExists("is_delete_topic"); ok {
+		isDeleteTopic = v.(bool)
+	}
+
+	if v, ok := d.GetOkExists("is_delete_logset"); ok {
+		isDeleteLogset = v.(bool)
+	}
+
+	if isDeleteTopic {
+		request := clsv20201016.NewDeleteTopicRequest()
+		if v, ok := d.GetOk("topic_id"); ok {
+			request.TopicId = helper.String(v.(string))
+		}
+
+		err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsV20201016Client().DeleteTopicWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s delete regis log delivery topic failed, reason:%+v", logId, err)
+			return err
+		}
+	}
+
+	if isDeleteLogset {
+		request := clsv20201016.NewDeleteLogsetRequest()
+		if v, ok := d.GetOk("logset_id"); ok {
+			request.LogsetId = helper.String(v.(string))
+		}
+
+		err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsV20201016Client().DeleteLogsetWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s delete regis log delivery logset failed, reason:%+v", logId, err)
+			return err
+		}
+	}
+
 	return nil
 }

--- a/tencentcloud/services/crs/resource_tc_redis_log_delivery.md
+++ b/tencentcloud/services/crs/resource_tc_redis_log_delivery.md
@@ -19,8 +19,8 @@ Use exist cls logset and create new topic
 
 ```hcl
 resource "tencentcloud_redis_log_delivery" "example" {
-  instance_id = "crs-dmjj8en7"
-  logset_id   = "cc31d9d6-74c0-4888-8b2f-b8148c3bcc5c"
+  instance_id  = "crs-dmjj8en7"
+  logset_id    = "cc31d9d6-74c0-4888-8b2f-b8148c3bcc5c"
   topic_name   = "tf-example"
   period       = 20
   create_index = true
@@ -31,19 +31,21 @@ Create new cls logset and topic
 
 ```hcl
 resource "tencentcloud_redis_log_delivery" "example" {
-  instance_id  = "crs-dmjj8en7"
-  log_region   = "ap-guangzhou"
-  logset_name  = "tf-example"
-  topic_name   = "tf-example"
-  period       = 20
-  create_index = true
+  instance_id      = "crs-dmjj8en7"
+  log_region       = "ap-guangzhou"
+  logset_name      = "tf-example132"
+  topic_name       = "tf-example132"
+  period           = 20
+  create_index     = true
+  is_delete_topic  = true
+  is_delete_logset = true
 }
 ```
 
 Import
 
-Redis log delivery can be imported, e.g.
+Redis log delivery can be imported using the instanceId, e.g.
 
 ```
-$ terraform import tencentcloud_redis_log_delivery.example crs-dmjj8en7
+terraform import tencentcloud_redis_log_delivery.example crs-dmjj8en7
 ```

--- a/website/docs/r/redis_log_delivery.html.markdown
+++ b/website/docs/r/redis_log_delivery.html.markdown
@@ -42,12 +42,14 @@ resource "tencentcloud_redis_log_delivery" "example" {
 
 ```hcl
 resource "tencentcloud_redis_log_delivery" "example" {
-  instance_id  = "crs-dmjj8en7"
-  log_region   = "ap-guangzhou"
-  logset_name  = "tf-example"
-  topic_name   = "tf-example"
-  period       = 20
-  create_index = true
+  instance_id      = "crs-dmjj8en7"
+  log_region       = "ap-guangzhou"
+  logset_name      = "tf-example132"
+  topic_name       = "tf-example132"
+  period           = 20
+  create_index     = true
+  is_delete_topic  = true
+  is_delete_logset = true
 }
 ```
 
@@ -57,6 +59,8 @@ The following arguments are supported:
 
 * `instance_id` - (Required, String, ForceNew) Instance ID.
 * `create_index` - (Optional, Bool) Whether to create an index when creating a log topic.
+* `is_delete_logset` - (Optional, Bool) Whether to delete the associated Logset when deleting the log delivery. Default is false.
+* `is_delete_topic` - (Optional, Bool) Whether to delete the associated Topic when deleting the log delivery. Default is false.
 * `log_region` - (Optional, String) The region where the log set is located; if not specified, the region where the instance is located will be used by default.
 * `logset_id` - (Optional, String) The ID of the log set being delivered.
 * `logset_name` - (Optional, String) Log set name. If LogsetId does not specify a specific log set ID, please configure this parameter to set the log set name, and the system will automatically create a new log set with the specified name.
@@ -74,9 +78,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Redis log delivery can be imported, e.g.
+Redis log delivery can be imported using the instanceId, e.g.
 
 ```
-$ terraform import tencentcloud_redis_log_delivery.example crs-dmjj8en7
+terraform import tencentcloud_redis_log_delivery.example crs-dmjj8en7
 ```
 


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
