### PR TITLE
feat(cloudaudit): [135686956]add compress parameter to audit track storage

### DIFF
--- a/.changelog/4337.txt
+++ b/.changelog/4337.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_audit_track: support compress parameter in storage block
+```

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.122
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.105
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.0.1033
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.131
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80

--- a/go.sum
+++ b/go.sum
@@ -919,8 +919,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.122 h1:731S
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.122/go.mod h1:08TZKLvdHy6fRt0TNhLdxOy5J7yP/7yTX2t5GjAl0a8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.105 h1:AW+NpDv5AJsHckp26XL8/1QNlNBfoiCVAuQd8OFdbf8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.105/go.mod h1:lf7XnEH0gIRVxi7l8qRtf7QYLwtlsBYqpRixe709zcs=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.0.1033 h1:dIr+MVsZeUBiKZELfJh5HRJdI+BI6lCp5pv/2oXekuk=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.0.1033/go.mod h1:7oFlNimGSTHFy6JV7W/IZKuJWr+NUjCnGLTvb9MWNrY=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40 h1:bhPBpfz0w3mdVyEolvXrtELUf+gE00O0WnAYIHZq70s=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40/go.mod h1:taTki0q8SHBIUFhjtnDA5UkiVic/WaPQzTqoXeGH3Ns=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.131 h1:W5bga49N/a29x7Av9JdwUdZaIXM9zJkdI610Ri9dkJA=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.131/go.mod h1:uPgSWRbsxJ94GFsVCzSUvYWJ0jxBE4fHRWkYhfd/y+4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.414/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
@@ -948,7 +948,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.860/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.970/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.993/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.998/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1033/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1126/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1127/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1145/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=

--- a/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/design.md
+++ b/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`tencentcloud_audit_track` 资源（`tencentcloud/services/cloudaudit/resource_tc_audit_track.go`）管理 CloudAudit 跟踪集，支持将审计日志投递到 cos/cls/ckafka。当前 `storage` block 包含 `storage_type`、`storage_region`、`storage_name`、`storage_prefix`、`storage_account_id`、`storage_app_id` 等字段，但缺少云 API 已支持的 `Compress`（压缩）配置。
+
+云 SDK（`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319`）的 `Storage` 结构体已新增 `Compress *uint64` 字段（`1:压缩 2:不压缩`），且该字段通过 `CreateAuditTrackRequest.Storage`、`ModifyAuditTrackRequest.Storage`、`DescribeAuditTrackResponseParams.Storage` 三个接口均可用。`DeleteAuditTrackRequest` 仅含 `TrackId`，不涉及 `Storage`。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 `tencentcloud_audit_track` 资源的 `storage` block 中新增 `compress` 可选字段
+- 在 Create / Read / Update 三个 CRUD 方法中正确映射 `compress` 字段与云 API 的 `Storage.Compress`
+- 保持向后兼容：`compress` 为 `Optional`，不影响现有配置和 state
+
+**Non-Goals:**
+- 不修改 `DeleteAuditTrack` 相关逻辑（该接口不涉及 `Storage`）
+- 不修改 `storage` block 中其他已有字段
+- 不改变资源的 ID 规则、import 行为
+- 不引入 `_extension.go` 文件
+
+## Decisions
+
+### 决策 1：`compress` 字段类型与位置
+- **选择**：在 `storage` block（`TypeList`, `MaxItems:1`）的子 schema 中新增 `compress`，类型为 `schema.TypeInt`，`Optional: true`。
+- **理由**：云 API 的 `Compress` 为 `*uint64`，使用 `schema.TypeInt` 与资源中已有的 `status`（同为 `uint64`）保持一致，便于用户书写 HCL。
+- **取值约束**：`1` 表示压缩，`2` 表示不压缩（与云 API 文档一致）。在 schema `Description` 中注明取值含义，不做 `ValidateFunc` 硬校验（与现有同类字段风格一致）。
+
+### 决策 2：Create / Update 中 compress 的映射
+- **选择**：在现有 `if dMap, ok := helper.InterfacesHeadMap(d, "storage"); ok` 分支内，新增 `if v, ok := dMap["compress"]; ok { storage.Compress = helper.IntUint64(v.(int)) }`。
+- **理由**：复用现有的 storage 读取逻辑，最小化改动；`helper.IntUint64` 已用于同文件的 `status` / `track_for_all_members` 字段。
+- **Update 中的处理**：`ModifyAuditTrack` 在 `d.HasChange("storage")` 分支内执行，`compress` 作为 `storage` 子字段，其变更会触发 `d.HasChange("storage")` 为 true，无需单独判断。
+
+### 决策 3：Read 中 compress 的回填
+- **选择**：在 `if track.Storage != nil` 分支的 `storageMap` 中新增 `if track.Storage.Compress != nil { storageMap["compress"] = track.Storage.Compress }`。
+- **理由**：遵循"先判断 nil 再 set"的硬约束，与同分支其他字段处理方式一致。
+
+### 决策 4：compress 默认不设置
+- **选择**：当用户未配置 `compress` 时，不向云 API 传值（`Compress` 保持 nil），由云服务端使用默认行为。
+- **理由**：保持向后兼容，避免对现有资源产生意外变更。
+
+## Risks / Trade-offs
+
+- **[Risk] 云 API 返回的 `Compress` 可能为 nil（历史数据）** → 在 Read 中先判断 `track.Storage.Compress != nil` 再 set，nil 时跳过，不影响其他字段回填。
+- **[Risk] 用户配置非法取值（非 1/2）** → 云 API 会返回错误，由现有 retry / 错误处理机制透传给用户；不在 Terraform 侧做硬校验，与现有字段风格一致。
+- **[Trade-off] `compress` 为 Optional 但不设置时不传值** → 行为依赖云服务端默认值，可接受，因为这是新增字段。

--- a/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/proposal.md
+++ b/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+云产品 CloudAudit 的 `tencentcloud_audit_track` 资源目前不支持配置数据投递存储的压缩选项。云 API 已在 `Storage` 结构体中新增 `Compress` 字段（`1:压缩 2:不压缩`），允许用户控制投递到 cos/cls/ckafka 的审计日志是否压缩。为保持 Terraform 资源与云 API 能力同步，需要在资源中暴露该参数。
+
+## What Changes
+
+- 在 `tencentcloud_audit_track` 资源的 `storage` block 中新增 `compress` 子字段（`TypeInt`, `Optional`），取值为 `1`（压缩）或 `2`（不压缩）。
+- 在资源 Create 方法（`CreateAuditTrack`）中，将 `compress` 映射到 `request.Storage.Compress`。
+- 在资源 Read 方法（`DescribeAuditTrack`）中，将 `response.Storage.Compress` 回填到 `compress` 字段。
+- 在资源 Update 方法（`ModifyAuditTrack`）中，将 `compress` 映射到 `request.Storage.Compress`。
+- 资源 Delete 方法（`DeleteAuditTrack`）仅接收 `TrackId`，不涉及 `Storage` 参数，无需变更。
+- 更新资源文档 `resource_tc_audit_track.md` 补充 `compress` 字段说明。
+
+## Capabilities
+
+### New Capabilities
+<!-- 无新增能力，复用现有资源 -->
+
+### Modified Capabilities
+- `cloudaudit-track-resource`: 在 `storage` block 中新增 `compress` 可选参数，支持配置数据投递存储的压缩选项
+
+## Impact
+
+- **代码**:
+  - `tencentcloud/services/cloudaudit/resource_tc_audit_track.go`：Schema、Create、Read、Update 方法
+  - `tencentcloud/services/cloudaudit/resource_tc_audit_track_test.go`：补充单元测试用例
+- **文档**: `tencentcloud/services/cloudaudit/resource_tc_audit_track.md`
+- **依赖**: 已通过 vendor 引入 `Compress *uint64` 字段（`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319`）
+- **兼容性**: 新增 `Optional` 字段，向后兼容，不影响现有 TF 配置和 state

--- a/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/specs/cloudaudit-track-resource/spec.md
+++ b/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/specs/cloudaudit-track-resource/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Storage compress field
+
+`tencentcloud_audit_track` 资源的 `storage` block SHALL 提供可选字段 `compress`（`TypeInt`, `Optional`），用于控制数据投递存储的压缩行为，取值为 `1`（压缩）或 `2`（不压缩）。当用户未配置该字段时，资源 SHALL NOT 向云 API 传值，由云服务端使用默认行为。
+
+#### Scenario: Create with compress specified
+
+- **WHEN** 用户在 `storage` block 中配置 `compress = 1`
+- **THEN** 资源 Create 方法调用 `CreateAuditTrack` 时，`request.Storage.Compress` SHALL 被设置为 `1`
+- **AND** 创建完成后 Read 方法 SHALL 将 `compress` 回填到 state
+
+#### Scenario: Create without compress
+
+- **WHEN** 用户在 `storage` block 中未配置 `compress`
+- **THEN** 资源 Create 方法调用 `CreateAuditTrack` 时，`request.Storage.Compress` SHALL NOT 被设置（保持 nil）
+- **AND** 创建完成后若云 API 返回 `Compress` 非 nil，Read 方法 SHALL 将其回填；若为 nil，Read 方法 SHALL 跳过回填
+
+#### Scenario: Update compress
+
+- **WHEN** 用户修改 `storage.compress` 的值
+- **THEN** `d.HasChange("storage")` SHALL 返回 true
+- **AND** 资源 Update 方法调用 `ModifyAuditTrack` 时，`request.Storage.Compress` SHALL 被设置为新值
+- **AND** 更新完成后 Read 方法 SHALL 将新值回填到 state
+
+#### Scenario: Read compress from cloud API
+
+- **WHEN** 资源执行 Read 并调用 `DescribeAuditTrack`
+- **AND** 云 API 返回 `response.Storage.Compress` 非 nil
+- **THEN** Read 方法 SHALL 将该值回填到 `storage.compress` 字段
+
+#### Scenario: Read with nil compress
+
+- **WHEN** 资源执行 Read 并调用 `DescribeAuditTrack`
+- **AND** 云 API 返回 `response.Storage` 为 nil 或 `Compress` 为 nil
+- **THEN** Read 方法 SHALL 跳过 `compress` 字段的 set，不影响 `storage` block 中其他字段的回填
+
+#### Scenario: Delete unaffected
+
+- **WHEN** 资源执行 Delete 并调用 `DeleteAuditTrack`
+- **THEN** 该方法仅使用 `TrackId`，SHALL NOT 涉及 `Storage.Compress` 参数

--- a/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/tasks.md
+++ b/openspec/changes/archive/2026-07-24-add-cloudaudit-track-compress/tasks.md
@@ -1,0 +1,18 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/cloudaudit/resource_tc_audit_track.go` 的 `storage` block schema 中新增 `compress` 字段（`schema.TypeInt`, `Optional: true`，Description 注明取值 `1:压缩 2:不压缩`）
+
+## 2. CRUD 函数实现
+
+- [x] 2.1 在 `resourceTencentCloudAuditTrackCreate` 的 `storage` 处理分支（`helper.InterfacesHeadMap(d, "storage")`）中新增 `compress` 到 `request.Storage.Compress` 的映射（`helper.IntUint64`），保持 nil 时不传值
+- [x] 2.2 在 `resourceTencentCloudAuditTrackRead` 的 `track.Storage != nil` 分支的 `storageMap` 中新增 `compress` 回填逻辑（先判断 `track.Storage.Compress != nil`）
+- [x] 2.3 在 `resourceTencentCloudAuditTrackUpdate` 的 `d.HasChange("storage")` 分支中新增 `compress` 到 `request.Storage.Compress` 的映射（`helper.IntUint64`）
+
+## 3. 单元测试
+
+- [x] 3.1 在 `tencentcloud/services/cloudaudit/resource_tc_audit_track_test.go` 中使用 gomonkey 对云 API 进行 mock，补充 `compress` 字段的 Create/Read/Update 单元测试用例
+- [x] 3.2 使用 `go test -gcflags=all=-l` 运行涉及的单元测试文件，确保通过
+
+## 4. 文档
+
+- [x] 4.1 更新 `tencentcloud/services/cloudaudit/resource_tc_audit_track.md`，在 Example Usage 的 `storage` block 中补充 `compress` 字段示例（由 make doc 最终生成 website/docs）

--- a/openspec/specs/cloudaudit-track-resource/spec.md
+++ b/openspec/specs/cloudaudit-track-resource/spec.md
@@ -1,0 +1,44 @@
+# cloudaudit-track-resource Specification
+
+## Purpose
+TBD - created by archiving change add-cloudaudit-track-compress. Update Purpose after archive.
+## Requirements
+### Requirement: Storage compress field
+
+`tencentcloud_audit_track` 资源的 `storage` block SHALL 提供可选字段 `compress`（`TypeInt`, `Optional`），用于控制数据投递存储的压缩行为，取值为 `1`（压缩）或 `2`（不压缩）。当用户未配置该字段时，资源 SHALL NOT 向云 API 传值，由云服务端使用默认行为。
+
+#### Scenario: Create with compress specified
+
+- **WHEN** 用户在 `storage` block 中配置 `compress = 1`
+- **THEN** 资源 Create 方法调用 `CreateAuditTrack` 时，`request.Storage.Compress` SHALL 被设置为 `1`
+- **AND** 创建完成后 Read 方法 SHALL 将 `compress` 回填到 state
+
+#### Scenario: Create without compress
+
+- **WHEN** 用户在 `storage` block 中未配置 `compress`
+- **THEN** 资源 Create 方法调用 `CreateAuditTrack` 时，`request.Storage.Compress` SHALL NOT 被设置（保持 nil）
+- **AND** 创建完成后若云 API 返回 `Compress` 非 nil，Read 方法 SHALL 将其回填；若为 nil，Read 方法 SHALL 跳过回填
+
+#### Scenario: Update compress
+
+- **WHEN** 用户修改 `storage.compress` 的值
+- **THEN** `d.HasChange("storage")` SHALL 返回 true
+- **AND** 资源 Update 方法调用 `ModifyAuditTrack` 时，`request.Storage.Compress` SHALL 被设置为新值
+- **AND** 更新完成后 Read 方法 SHALL 将新值回填到 state
+
+#### Scenario: Read compress from cloud API
+
+- **WHEN** 资源执行 Read 并调用 `DescribeAuditTrack`
+- **AND** 云 API 返回 `response.Storage.Compress` 非 nil
+- **THEN** Read 方法 SHALL 将该值回填到 `storage.compress` 字段
+
+#### Scenario: Read with nil compress
+
+- **WHEN** 资源执行 Read 并调用 `DescribeAuditTrack`
+- **AND** 云 API 返回 `response.Storage` 为 nil 或 `Compress` 为 nil
+- **THEN** Read 方法 SHALL 跳过 `compress` 字段的 set，不影响 `storage` block 中其他字段的回填
+
+#### Scenario: Delete unaffected
+
+- **WHEN** 资源执行 Delete 并调用 `DeleteAuditTrack`
+- **THEN** 该方法仅使用 `TrackId`，SHALL NOT 涉及 `Storage.Compress` 参数

--- a/tencentcloud/services/cloudaudit/resource_tc_audit_track.go
+++ b/tencentcloud/services/cloudaudit/resource_tc_audit_track.go
@@ -94,6 +94,11 @@ func ResourceTencentCloudAuditTrack() *schema.Resource {
 							Optional:    true,
 							Description: "Designated to store user appid.",
 						},
+						"compress": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Whether to compress. `1`: compress, `2`: do not compress.",
+						},
 					},
 				},
 			},
@@ -168,6 +173,9 @@ func resourceTencentCloudAuditTrackCreate(d *schema.ResourceData, meta interface
 		}
 		if v, ok := dMap["storage_app_id"]; ok && v != "" {
 			storage.StorageAppId = helper.String(v.(string))
+		}
+		if v, ok := dMap["compress"]; ok && v != 0 {
+			storage.Compress = helper.IntUint64(v.(int))
 		}
 		request.Storage = &storage
 	}
@@ -261,6 +269,9 @@ func resourceTencentCloudAuditTrackRead(d *schema.ResourceData, meta interface{}
 		if track.Storage.StorageAppId != nil {
 			storageMap["storage_app_id"] = track.Storage.StorageAppId
 		}
+		if track.Storage.Compress != nil {
+			storageMap["compress"] = track.Storage.Compress
+		}
 		_ = d.Set("storage", []interface{}{storageMap})
 	}
 
@@ -341,6 +352,9 @@ func resourceTencentCloudAuditTrackUpdate(d *schema.ResourceData, meta interface
 			}
 			if v, ok := dMap["storage_app_id"]; ok && v != "" {
 				storage.StorageAppId = helper.String(v.(string))
+			}
+			if v, ok := dMap["compress"]; ok && v != 0 {
+				storage.Compress = helper.IntUint64(v.(int))
 			}
 			request.Storage = &storage
 		}

--- a/tencentcloud/services/cloudaudit/resource_tc_audit_track.go
+++ b/tencentcloud/services/cloudaudit/resource_tc_audit_track.go
@@ -97,6 +97,7 @@ func ResourceTencentCloudAuditTrack() *schema.Resource {
 						"compress": {
 							Type:        schema.TypeInt,
 							Optional:    true,
+							Computed:    true,
 							Description: "Whether to compress. `1`: compress, `2`: do not compress.",
 						},
 					},

--- a/tencentcloud/services/cloudaudit/resource_tc_audit_track.md
+++ b/tencentcloud/services/cloudaudit/resource_tc_audit_track.md
@@ -42,6 +42,7 @@ resource "tencentcloud_audit_track" "example" {
     storage_type       = "cos"
     storage_account_id = "100037717137"
     storage_app_id     = "1309116520"
+    compress           = 1
   }
 }
 ```

--- a/tencentcloud/services/cloudaudit/resource_tc_audit_track_test.go
+++ b/tencentcloud/services/cloudaudit/resource_tc_audit_track_test.go
@@ -3,9 +3,17 @@ package cloudaudit_test
 import (
 	"testing"
 
-	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
-
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	audit "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	auditsvc "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cloudaudit"
+
+	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 )
 
 func TestAccTencentCloudAuditTrackResource_basic(t *testing.T) {
@@ -54,3 +62,371 @@ resource "tencentcloud_audit_track" "track" {
   }
 }
 `
+
+// ---- gomonkey-based unit tests for storage.compress ----
+// Run with: go test ./tencentcloud/services/cloudaudit/ -run "TestAuditTrackCompress" -v -count=1 -gcflags="all=-l"
+
+type mockMetaAuditTrack struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaAuditTrack) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaAuditTrack{}
+
+func newMockMetaAuditTrack() *mockMetaAuditTrack {
+	return &mockMetaAuditTrack{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrUint64AuditTrack(v uint64) *uint64 {
+	return &v
+}
+
+func ptrStringAuditTrack(s string) *string {
+	return &s
+}
+
+func ptrStrListAuditTrack(values ...string) []*string {
+	ret := make([]*string, 0, len(values))
+	for i := range values {
+		ret = append(ret, &values[i])
+	}
+	return ret
+}
+
+func auditTrackStorageRaw(compress int) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"storage_type":   "cos",
+			"storage_region": "ap-guangzhou",
+			"storage_name":   "keep-bucket",
+			"storage_prefix": "cloudaudit",
+			"compress":       compress,
+		},
+	}
+}
+
+// TestAuditTrackCompress_Create verifies compress is passed to CreateAuditTrack.
+func TestAuditTrackCompress_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	auditClient := &audit.Client{}
+	patches.ApplyMethodReturn(newMockMetaAuditTrack().client, "UseAuditClient", auditClient)
+
+	var capturedRequest *audit.CreateAuditTrackRequest
+	patches.ApplyMethodFunc(auditClient, "CreateAuditTrack", func(request *audit.CreateAuditTrackRequest) (*audit.CreateAuditTrackResponse, error) {
+		capturedRequest = request
+		resp := audit.NewCreateAuditTrackResponse()
+		resp.Response = &audit.CreateAuditTrackResponseParams{
+			TrackId:   ptrUint64AuditTrack(1001),
+			RequestId: ptrStringAuditTrack("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(auditClient, "DescribeAuditTrack", func(request *audit.DescribeAuditTrackRequest) (*audit.DescribeAuditTrackResponse, error) {
+		resp := audit.NewDescribeAuditTrackResponse()
+		resp.Response = &audit.DescribeAuditTrackResponseParams{
+			Name:         ptrStringAuditTrack("tf_audit_track"),
+			ActionType:   ptrStringAuditTrack("Read"),
+			ResourceType: ptrStringAuditTrack("*"),
+			Status:       ptrUint64AuditTrack(1),
+			EventNames:   ptrStrListAuditTrack("*"),
+			Storage: &audit.Storage{
+				StorageType:   ptrStringAuditTrack("cos"),
+				StorageRegion: ptrStringAuditTrack("ap-guangzhou"),
+				StorageName:   ptrStringAuditTrack("keep-bucket"),
+				StoragePrefix: ptrStringAuditTrack("cloudaudit"),
+				Compress:      ptrUint64AuditTrack(1),
+			},
+			TrackForAllMembers: ptrUint64AuditTrack(0),
+			RequestId:          ptrStringAuditTrack("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaAuditTrack()
+	res := auditsvc.ResourceTencentCloudAuditTrack()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":                  "tf_audit_track",
+		"action_type":           "Read",
+		"resource_type":         "*",
+		"status":                1,
+		"event_names":           []interface{}{"*"},
+		"storage":               auditTrackStorageRaw(1),
+		"track_for_all_members": 0,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "1001", d.Id())
+
+	assert.NotNil(t, capturedRequest.Storage)
+	assert.NotNil(t, capturedRequest.Storage.Compress)
+	assert.Equal(t, uint64(1), *capturedRequest.Storage.Compress)
+
+	storageList := d.Get("storage").([]interface{})
+	assert.Len(t, storageList, 1)
+	storageMap := storageList[0].(map[string]interface{})
+	assert.Equal(t, 1, storageMap["compress"].(int))
+}
+
+// TestAuditTrackCompress_CreateDefault verifies compress is not sent when not specified.
+func TestAuditTrackCompress_CreateDefault(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	auditClient := &audit.Client{}
+	patches.ApplyMethodReturn(newMockMetaAuditTrack().client, "UseAuditClient", auditClient)
+
+	var capturedRequest *audit.CreateAuditTrackRequest
+	patches.ApplyMethodFunc(auditClient, "CreateAuditTrack", func(request *audit.CreateAuditTrackRequest) (*audit.CreateAuditTrackResponse, error) {
+		capturedRequest = request
+		resp := audit.NewCreateAuditTrackResponse()
+		resp.Response = &audit.CreateAuditTrackResponseParams{
+			TrackId:   ptrUint64AuditTrack(1002),
+			RequestId: ptrStringAuditTrack("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(auditClient, "DescribeAuditTrack", func(request *audit.DescribeAuditTrackRequest) (*audit.DescribeAuditTrackResponse, error) {
+		resp := audit.NewDescribeAuditTrackResponse()
+		resp.Response = &audit.DescribeAuditTrackResponseParams{
+			Name:         ptrStringAuditTrack("tf_audit_track"),
+			ActionType:   ptrStringAuditTrack("Read"),
+			ResourceType: ptrStringAuditTrack("*"),
+			Status:       ptrUint64AuditTrack(1),
+			EventNames:   ptrStrListAuditTrack("*"),
+			Storage: &audit.Storage{
+				StorageType:   ptrStringAuditTrack("cos"),
+				StorageRegion: ptrStringAuditTrack("ap-guangzhou"),
+				StorageName:   ptrStringAuditTrack("keep-bucket"),
+				StoragePrefix: ptrStringAuditTrack("cloudaudit"),
+			},
+			TrackForAllMembers: ptrUint64AuditTrack(0),
+			RequestId:          ptrStringAuditTrack("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaAuditTrack()
+	res := auditsvc.ResourceTencentCloudAuditTrack()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":          "tf_audit_track",
+		"action_type":   "Read",
+		"resource_type": "*",
+		"status":        1,
+		"event_names":   []interface{}{"*"},
+		"storage": []interface{}{
+			map[string]interface{}{
+				"storage_type":   "cos",
+				"storage_region": "ap-guangzhou",
+				"storage_name":   "keep-bucket",
+				"storage_prefix": "cloudaudit",
+			},
+		},
+		"track_for_all_members": 0,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, capturedRequest.Storage)
+	assert.Nil(t, capturedRequest.Storage.Compress)
+}
+
+// TestAuditTrackCompress_Update verifies compress change triggers ModifyAuditTrack.
+func TestAuditTrackCompress_Update(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	auditClient := &audit.Client{}
+	patches.ApplyMethodReturn(newMockMetaAuditTrack().client, "UseAuditClient", auditClient)
+
+	var capturedRequest *audit.ModifyAuditTrackRequest
+	patches.ApplyMethodFunc(auditClient, "ModifyAuditTrack", func(request *audit.ModifyAuditTrackRequest) (*audit.ModifyAuditTrackResponse, error) {
+		capturedRequest = request
+		resp := audit.NewModifyAuditTrackResponse()
+		resp.Response = &audit.ModifyAuditTrackResponseParams{
+			RequestId: ptrStringAuditTrack("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(auditClient, "DescribeAuditTrack", func(request *audit.DescribeAuditTrackRequest) (*audit.DescribeAuditTrackResponse, error) {
+		resp := audit.NewDescribeAuditTrackResponse()
+		resp.Response = &audit.DescribeAuditTrackResponseParams{
+			Name:         ptrStringAuditTrack("tf_audit_track"),
+			ActionType:   ptrStringAuditTrack("Read"),
+			ResourceType: ptrStringAuditTrack("*"),
+			Status:       ptrUint64AuditTrack(1),
+			EventNames:   ptrStrListAuditTrack("*"),
+			Storage: &audit.Storage{
+				StorageType:   ptrStringAuditTrack("cos"),
+				StorageRegion: ptrStringAuditTrack("ap-guangzhou"),
+				StorageName:   ptrStringAuditTrack("keep-bucket"),
+				StoragePrefix: ptrStringAuditTrack("cloudaudit"),
+				Compress:      ptrUint64AuditTrack(2),
+			},
+			TrackForAllMembers: ptrUint64AuditTrack(0),
+			RequestId:          ptrStringAuditTrack("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaAuditTrack()
+	res := auditsvc.ResourceTencentCloudAuditTrack()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":                  "tf_audit_track",
+		"action_type":           "Read",
+		"resource_type":         "*",
+		"status":                1,
+		"event_names":           []interface{}{"*"},
+		"storage":               auditTrackStorageRaw(2),
+		"track_for_all_members": 0,
+	})
+	d.SetId("1003")
+
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		return key == "storage"
+	})
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, capturedRequest)
+	assert.NotNil(t, capturedRequest.Storage)
+	assert.NotNil(t, capturedRequest.Storage.Compress)
+	assert.Equal(t, uint64(2), *capturedRequest.Storage.Compress)
+
+	storageList := d.Get("storage").([]interface{})
+	assert.Len(t, storageList, 1)
+	storageMap := storageList[0].(map[string]interface{})
+	assert.Equal(t, 2, storageMap["compress"].(int))
+}
+
+// TestAuditTrackCompress_ReadNil verifies Read does not panic and skips
+// compress when the API returns nil for Compress. Since the whole storage
+// block is overwritten by d.Set, compress falls back to its zero value (0).
+func TestAuditTrackCompress_ReadNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	auditClient := &audit.Client{}
+	patches.ApplyMethodReturn(newMockMetaAuditTrack().client, "UseAuditClient", auditClient)
+
+	patches.ApplyMethodFunc(auditClient, "DescribeAuditTrack", func(request *audit.DescribeAuditTrackRequest) (*audit.DescribeAuditTrackResponse, error) {
+		resp := audit.NewDescribeAuditTrackResponse()
+		resp.Response = &audit.DescribeAuditTrackResponseParams{
+			Name:         ptrStringAuditTrack("tf_audit_track"),
+			ActionType:   ptrStringAuditTrack("Read"),
+			ResourceType: ptrStringAuditTrack("*"),
+			Status:       ptrUint64AuditTrack(1),
+			EventNames:   ptrStrListAuditTrack("*"),
+			Storage: &audit.Storage{
+				StorageType:   ptrStringAuditTrack("cos"),
+				StorageRegion: ptrStringAuditTrack("ap-guangzhou"),
+				StorageName:   ptrStringAuditTrack("keep-bucket"),
+				StoragePrefix: ptrStringAuditTrack("cloudaudit"),
+			},
+			TrackForAllMembers: ptrUint64AuditTrack(0),
+			RequestId:          ptrStringAuditTrack("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaAuditTrack()
+	res := auditsvc.ResourceTencentCloudAuditTrack()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":                  "tf_audit_track",
+		"action_type":           "Read",
+		"resource_type":         "*",
+		"status":                1,
+		"event_names":           []interface{}{"*"},
+		"storage":               auditTrackStorageRaw(1),
+		"track_for_all_members": 0,
+	})
+	d.SetId("1004")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	storageList := d.Get("storage").([]interface{})
+	assert.Len(t, storageList, 1)
+	storageMap := storageList[0].(map[string]interface{})
+	// Compress is nil in the API response, so it is skipped and falls back to 0.
+	assert.Equal(t, 0, storageMap["compress"].(int))
+	// Other storage fields are still populated correctly.
+	assert.Equal(t, "cos", storageMap["storage_type"].(string))
+	assert.Equal(t, "keep-bucket", storageMap["storage_name"].(string))
+}
+
+// TestAuditTrackCompress_ReadValue verifies Read sets compress when API returns a value.
+func TestAuditTrackCompress_ReadValue(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	auditClient := &audit.Client{}
+	patches.ApplyMethodReturn(newMockMetaAuditTrack().client, "UseAuditClient", auditClient)
+
+	patches.ApplyMethodFunc(auditClient, "DescribeAuditTrack", func(request *audit.DescribeAuditTrackRequest) (*audit.DescribeAuditTrackResponse, error) {
+		resp := audit.NewDescribeAuditTrackResponse()
+		resp.Response = &audit.DescribeAuditTrackResponseParams{
+			Name:         ptrStringAuditTrack("tf_audit_track"),
+			ActionType:   ptrStringAuditTrack("Read"),
+			ResourceType: ptrStringAuditTrack("*"),
+			Status:       ptrUint64AuditTrack(1),
+			EventNames:   ptrStrListAuditTrack("*"),
+			Storage: &audit.Storage{
+				StorageType:   ptrStringAuditTrack("cos"),
+				StorageRegion: ptrStringAuditTrack("ap-guangzhou"),
+				StorageName:   ptrStringAuditTrack("keep-bucket"),
+				StoragePrefix: ptrStringAuditTrack("cloudaudit"),
+				Compress:      ptrUint64AuditTrack(2),
+			},
+			TrackForAllMembers: ptrUint64AuditTrack(0),
+			RequestId:          ptrStringAuditTrack("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaAuditTrack()
+	res := auditsvc.ResourceTencentCloudAuditTrack()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"name":                  "tf_audit_track",
+		"action_type":           "Read",
+		"resource_type":         "*",
+		"status":                1,
+		"event_names":           []interface{}{"*"},
+		"storage":               auditTrackStorageRaw(0),
+		"track_for_all_members": 0,
+	})
+	d.SetId("1005")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	storageList := d.Get("storage").([]interface{})
+	assert.Len(t, storageList, 1)
+	storageMap := storageList[0].(map[string]interface{})
+	assert.Equal(t, 2, storageMap["compress"].(int))
+}
+
+// TestAuditTrackCompress_Schema validates the compress schema definition.
+func TestAuditTrackCompress_Schema(t *testing.T) {
+	res := auditsvc.ResourceTencentCloudAuditTrack()
+
+	storageField, ok := res.Schema["storage"]
+	assert.True(t, ok, "storage should exist in schema")
+
+	storageSchema := storageField.Elem.(*schema.Resource).Schema
+	field, ok := storageSchema["compress"]
+	assert.True(t, ok, "compress should exist in storage schema")
+	assert.Equal(t, schema.TypeInt, field.Type)
+	assert.True(t, field.Optional)
+	assert.False(t, field.ForceNew, "compress should not be ForceNew")
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -106,6 +106,7 @@ func (c *Client) CreateAuditTrackWithContext(ctx context.Context, request *Creat
     if request == nil {
         request = NewCreateAuditTrackRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "CreateAuditTrack")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateAuditTrack require credential")
@@ -179,6 +180,7 @@ func (c *Client) CreateEventsAuditTrackWithContext(ctx context.Context, request 
     if request == nil {
         request = NewCreateEventsAuditTrackRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "CreateEventsAuditTrack")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateEventsAuditTrack require credential")
@@ -236,6 +238,7 @@ func (c *Client) DeleteAuditTrackWithContext(ctx context.Context, request *Delet
     if request == nil {
         request = NewDeleteAuditTrackRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "DeleteAuditTrack")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteAuditTrack require credential")
@@ -287,6 +290,7 @@ func (c *Client) DescribeAuditWithContext(ctx context.Context, request *Describe
     if request == nil {
         request = NewDescribeAuditRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "DescribeAudit")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeAudit require credential")
@@ -344,6 +348,7 @@ func (c *Client) DescribeAuditTrackWithContext(ctx context.Context, request *Des
     if request == nil {
         request = NewDescribeAuditTrackRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "DescribeAuditTrack")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeAuditTrack require credential")
@@ -399,6 +404,7 @@ func (c *Client) DescribeAuditTracksWithContext(ctx context.Context, request *De
     if request == nil {
         request = NewDescribeAuditTracksRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "DescribeAuditTracks")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeAuditTracks require credential")
@@ -435,9 +441,12 @@ func NewDescribeEventsResponse() (response *DescribeEventsResponse) {
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_MEMBERNOTAUDITROLE = "FailedOperation.MemberNotAuditRole"
+//  FAILEDOPERATION_MEMBERNOTINORGANIZATION = "FailedOperation.MemberNotInOrganization"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  LIMITEXCEEDED_OVERAMOUNT = "LimitExceeded.OverAmount"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
 func (c *Client) DescribeEvents(request *DescribeEventsRequest) (response *DescribeEventsResponse, err error) {
     return c.DescribeEventsWithContext(context.Background(), request)
 }
@@ -447,13 +456,17 @@ func (c *Client) DescribeEvents(request *DescribeEventsRequest) (response *Descr
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_MEMBERNOTAUDITROLE = "FailedOperation.MemberNotAuditRole"
+//  FAILEDOPERATION_MEMBERNOTINORGANIZATION = "FailedOperation.MemberNotInOrganization"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  LIMITEXCEEDED_OVERAMOUNT = "LimitExceeded.OverAmount"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
 func (c *Client) DescribeEventsWithContext(ctx context.Context, request *DescribeEventsRequest) (response *DescribeEventsResponse, err error) {
     if request == nil {
         request = NewDescribeEventsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "DescribeEvents")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeEvents require credential")
@@ -503,6 +516,7 @@ func (c *Client) GetAttributeKeyWithContext(ctx context.Context, request *GetAtt
     if request == nil {
         request = NewGetAttributeKeyRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "GetAttributeKey")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetAttributeKey require credential")
@@ -552,6 +566,7 @@ func (c *Client) InquireAuditCreditWithContext(ctx context.Context, request *Inq
     if request == nil {
         request = NewInquireAuditCreditRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "InquireAuditCredit")
     
     if c.GetCredential() == nil {
         return nil, errors.New("InquireAuditCredit require credential")
@@ -601,6 +616,7 @@ func (c *Client) ListAuditsWithContext(ctx context.Context, request *ListAuditsR
     if request == nil {
         request = NewListAuditsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "ListAudits")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListAudits require credential")
@@ -633,7 +649,7 @@ func NewListCmqEnableRegionResponse() (response *ListCmqEnableRegionResponse) {
 }
 
 // ListCmqEnableRegion
-// 查询云审计支持的cmq的可用区
+// 查询操作审计支持的cmq的可用区
 //
 // 可能返回的错误码:
 //  INTERNALERROR_LISTCMQENABLEREGIONERROR = "InternalError.ListCmqEnableRegionError"
@@ -642,7 +658,7 @@ func (c *Client) ListCmqEnableRegion(request *ListCmqEnableRegionRequest) (respo
 }
 
 // ListCmqEnableRegion
-// 查询云审计支持的cmq的可用区
+// 查询操作审计支持的cmq的可用区
 //
 // 可能返回的错误码:
 //  INTERNALERROR_LISTCMQENABLEREGIONERROR = "InternalError.ListCmqEnableRegionError"
@@ -650,6 +666,7 @@ func (c *Client) ListCmqEnableRegionWithContext(ctx context.Context, request *Li
     if request == nil {
         request = NewListCmqEnableRegionRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "ListCmqEnableRegion")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListCmqEnableRegion require credential")
@@ -682,7 +699,7 @@ func NewListCosEnableRegionResponse() (response *ListCosEnableRegionResponse) {
 }
 
 // ListCosEnableRegion
-// 查询云审计支持的cos可用区
+// 查询操作审计支持的cos可用区
 //
 // 可能返回的错误码:
 //  INTERNALERROR_LISTCOSENABLEREGIONERROR = "InternalError.ListCosEnableRegionError"
@@ -691,7 +708,7 @@ func (c *Client) ListCosEnableRegion(request *ListCosEnableRegionRequest) (respo
 }
 
 // ListCosEnableRegion
-// 查询云审计支持的cos可用区
+// 查询操作审计支持的cos可用区
 //
 // 可能返回的错误码:
 //  INTERNALERROR_LISTCOSENABLEREGIONERROR = "InternalError.ListCosEnableRegionError"
@@ -699,6 +716,7 @@ func (c *Client) ListCosEnableRegionWithContext(ctx context.Context, request *Li
     if request == nil {
         request = NewListCosEnableRegionRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "ListCosEnableRegion")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListCosEnableRegion require credential")
@@ -752,6 +770,7 @@ func (c *Client) ListKeyAliasByRegionWithContext(ctx context.Context, request *L
     if request == nil {
         request = NewListKeyAliasByRegionRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "ListKeyAliasByRegion")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListKeyAliasByRegion require credential")
@@ -792,7 +811,6 @@ func NewLookUpEventsResponse() (response *LookUpEventsResponse) {
 //  INVALIDPARAMETERVALUE_MAXRESULT = "InvalidParameterValue.MaxResult"
 //  INVALIDPARAMETERVALUE_TIME = "InvalidParameterValue.Time"
 //  INVALIDPARAMETERVALUE_ATTRIBUTEKEY = "InvalidParameterValue.attributeKey"
-//  LIMITEXCEEDED_OVERAMOUNT = "LimitExceeded.OverAmount"
 //  LIMITEXCEEDED_OVERTIME = "LimitExceeded.OverTime"
 func (c *Client) LookUpEvents(request *LookUpEventsRequest) (response *LookUpEventsResponse, err error) {
     return c.LookUpEventsWithContext(context.Background(), request)
@@ -807,12 +825,12 @@ func (c *Client) LookUpEvents(request *LookUpEventsRequest) (response *LookUpEve
 //  INVALIDPARAMETERVALUE_MAXRESULT = "InvalidParameterValue.MaxResult"
 //  INVALIDPARAMETERVALUE_TIME = "InvalidParameterValue.Time"
 //  INVALIDPARAMETERVALUE_ATTRIBUTEKEY = "InvalidParameterValue.attributeKey"
-//  LIMITEXCEEDED_OVERAMOUNT = "LimitExceeded.OverAmount"
 //  LIMITEXCEEDED_OVERTIME = "LimitExceeded.OverTime"
 func (c *Client) LookUpEventsWithContext(ctx context.Context, request *LookUpEventsRequest) (response *LookUpEventsResponse, err error) {
     if request == nil {
         request = NewLookUpEventsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "LookUpEvents")
     
     if c.GetCredential() == nil {
         return nil, errors.New("LookUpEvents require credential")
@@ -888,6 +906,7 @@ func (c *Client) ModifyAuditTrackWithContext(ctx context.Context, request *Modif
     if request == nil {
         request = NewModifyAuditTrackRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "ModifyAuditTrack")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ModifyAuditTrack require credential")
@@ -963,6 +982,7 @@ func (c *Client) ModifyEventsAuditTrackWithContext(ctx context.Context, request 
     if request == nil {
         request = NewModifyEventsAuditTrackRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "ModifyEventsAuditTrack")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ModifyEventsAuditTrack require credential")
@@ -1014,6 +1034,7 @@ func (c *Client) StartLoggingWithContext(ctx context.Context, request *StartLogg
     if request == nil {
         request = NewStartLoggingRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "StartLogging")
     
     if c.GetCredential() == nil {
         return nil, errors.New("StartLogging require credential")
@@ -1065,6 +1086,7 @@ func (c *Client) StopLoggingWithContext(ctx context.Context, request *StopLoggin
     if request == nil {
         request = NewStopLoggingRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "StopLogging")
     
     if c.GetCredential() == nil {
         return nil, errors.New("StopLogging require credential")
@@ -1150,6 +1172,7 @@ func (c *Client) UpdateAuditWithContext(ctx context.Context, request *UpdateAudi
     if request == nil {
         request = NewUpdateAuditRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "cloudaudit", APIVersion, "UpdateAudit")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateAudit require credential")

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,12 @@ const (
 
 	// 拉取cos存储桶列表失败。
 	FAILEDOPERATION_GETCOSBUCKETLISTFAILED = "FailedOperation.GetCosBucketListFailed"
+
+	// 当前查询的用户还未开通操作审计权限，如需查询该用户审计记录，请联系其开通！
+	FAILEDOPERATION_MEMBERNOTAUDITROLE = "FailedOperation.MemberNotAuditRole"
+
+	// 成员不在集团组织中。
+	FAILEDOPERATION_MEMBERNOTINORGANIZATION = "FailedOperation.MemberNotInOrganization"
 
 	// 内部错误。
 	INTERNALERROR = "InternalError"
@@ -133,4 +139,7 @@ const (
 
 	// 角色不存在。
 	RESOURCENOTFOUND_ROLENOTEXIST = "ResourceNotFound.RoleNotExist"
+
+	// 未授权操作。
+	UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
 )

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319/models.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,51 +69,57 @@ type CosRegionInfo struct {
 
 // Predefined struct for user
 type CreateAuditTrackRequestParams struct {
-	// 跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符
+	// <p>跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 跟踪事件类型（读：Read；写：Write；全部：*）
-	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
-
-	// 跟踪事件所属产品（支持全部产品或单个产品，如：cos，全部：*）
-	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
-
-	// 跟踪集状态（未开启：0；开启：1）
+	// <p>跟踪集状态（未开启：0；开启：1）</p>
 	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：["*"]；指定ResourceType时，支持全部接口：["*"]；支持部分接口：["cos", "cls"]，接口列表上限10个）
-	EventNames []*string `json:"EventNames,omitnil,omitempty" name:"EventNames"`
-
-	// 数据投递存储（目前支持 cos、cls）
+	// <p>数据投递存储（目前支持 cos、cls 、ckafka）</p>
 	Storage *Storage `json:"Storage,omitnil,omitempty" name:"Storage"`
 
-	// 是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能) 
+	// <p>跟踪事件类型（读：Read；写：Write；全部：*）</p>
+	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
+
+	// <p>跟踪事件所属产品（支持全部产品或单个产品，如：cos，全部：*）</p>
+	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
+
+	// <p>跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：[&quot;*&quot;]；指定ResourceType时，支持全部接口：[&quot;*&quot;]；支持部分接口：[&quot;cos&quot;, &quot;cls&quot;]，接口列表上限10个）</p>
+	EventNames []*string `json:"EventNames,omitnil,omitempty" name:"EventNames"`
+
+	// <p>是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能)</p>
 	TrackForAllMembers *uint64 `json:"TrackForAllMembers,omitnil,omitempty" name:"TrackForAllMembers"`
+
+	// <p>任务ID</p>
+	ExportId *string `json:"ExportId,omitnil,omitempty" name:"ExportId"`
 }
 
 type CreateAuditTrackRequest struct {
 	*tchttp.BaseRequest
 	
-	// 跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符
+	// <p>跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 跟踪事件类型（读：Read；写：Write；全部：*）
-	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
-
-	// 跟踪事件所属产品（支持全部产品或单个产品，如：cos，全部：*）
-	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
-
-	// 跟踪集状态（未开启：0；开启：1）
+	// <p>跟踪集状态（未开启：0；开启：1）</p>
 	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：["*"]；指定ResourceType时，支持全部接口：["*"]；支持部分接口：["cos", "cls"]，接口列表上限10个）
-	EventNames []*string `json:"EventNames,omitnil,omitempty" name:"EventNames"`
-
-	// 数据投递存储（目前支持 cos、cls）
+	// <p>数据投递存储（目前支持 cos、cls 、ckafka）</p>
 	Storage *Storage `json:"Storage,omitnil,omitempty" name:"Storage"`
 
-	// 是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能) 
+	// <p>跟踪事件类型（读：Read；写：Write；全部：*）</p>
+	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
+
+	// <p>跟踪事件所属产品（支持全部产品或单个产品，如：cos，全部：*）</p>
+	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
+
+	// <p>跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：[&quot;*&quot;]；指定ResourceType时，支持全部接口：[&quot;*&quot;]；支持部分接口：[&quot;cos&quot;, &quot;cls&quot;]，接口列表上限10个）</p>
+	EventNames []*string `json:"EventNames,omitnil,omitempty" name:"EventNames"`
+
+	// <p>是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能)</p>
 	TrackForAllMembers *uint64 `json:"TrackForAllMembers,omitnil,omitempty" name:"TrackForAllMembers"`
+
+	// <p>任务ID</p>
+	ExportId *string `json:"ExportId,omitnil,omitempty" name:"ExportId"`
 }
 
 func (r *CreateAuditTrackRequest) ToJsonString() string {
@@ -129,12 +135,13 @@ func (r *CreateAuditTrackRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "Name")
+	delete(f, "Status")
+	delete(f, "Storage")
 	delete(f, "ActionType")
 	delete(f, "ResourceType")
-	delete(f, "Status")
 	delete(f, "EventNames")
-	delete(f, "Storage")
 	delete(f, "TrackForAllMembers")
+	delete(f, "ExportId")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateAuditTrackRequest has unknown keys!", "")
 	}
@@ -143,7 +150,7 @@ func (r *CreateAuditTrackRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateAuditTrackResponseParams struct {
-	// 跟踪集 ID
+	// <p>跟踪集 ID</p>
 	TrackId *uint64 `json:"TrackId,omitnil,omitempty" name:"TrackId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -168,38 +175,38 @@ func (r *CreateAuditTrackResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateEventsAuditTrackRequestParams struct {
-	// 跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符
+	// <p>跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 跟踪集状态（未开启：0；开启：1）
+	// <p>跟踪集状态（未开启：0；开启：1）</p>
 	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 数据投递存储（目前支持 cos、cls）
+	// <p>数据投递存储（目前支持 cos、cls、ckafka）</p>
 	Storage *Storage `json:"Storage,omitnil,omitempty" name:"Storage"`
 
-	// 数据过滤条件
+	// <p>数据过滤条件</p>
 	Filters *Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能) 
+	// <p>是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能)</p>
 	TrackForAllMembers *uint64 `json:"TrackForAllMembers,omitnil,omitempty" name:"TrackForAllMembers"`
 }
 
 type CreateEventsAuditTrackRequest struct {
 	*tchttp.BaseRequest
 	
-	// 跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符
+	// <p>跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 跟踪集状态（未开启：0；开启：1）
+	// <p>跟踪集状态（未开启：0；开启：1）</p>
 	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 数据投递存储（目前支持 cos、cls）
+	// <p>数据投递存储（目前支持 cos、cls、ckafka）</p>
 	Storage *Storage `json:"Storage,omitnil,omitempty" name:"Storage"`
 
-	// 数据过滤条件
+	// <p>数据过滤条件</p>
 	Filters *Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能) 
+	// <p>是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能)</p>
 	TrackForAllMembers *uint64 `json:"TrackForAllMembers,omitnil,omitempty" name:"TrackForAllMembers"`
 }
 
@@ -228,7 +235,7 @@ func (r *CreateEventsAuditTrackRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateEventsAuditTrackResponseParams struct {
-	// 跟踪集 ID
+	// <p>跟踪集 ID</p>
 	TrackId *uint64 `json:"TrackId,omitnil,omitempty" name:"TrackId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -454,11 +461,9 @@ type DescribeAuditTrackResponseParams struct {
 	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
 	// 是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	TrackForAllMembers *uint64 `json:"TrackForAllMembers,omitnil,omitempty" name:"TrackForAllMembers"`
 
 	// 数据投递过滤条件
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	Filters *Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -562,7 +567,21 @@ type DescribeEventsRequestParams struct {
 	// 返回日志的最大条数（最大 50 条）
 	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 检索条件（目前支持 RequestId：请求 ID、EventName：事件名称、ActionType：操作类型（Write：写；Read：读）、PrincipalId：子账号、ResourceType：资源类型、ResourceId：资源Id、ResourceName：资源名称、AccessKeyId：密钥 ID、SensitiveAction：是否敏感操作、ApiErrorCode：API 错误码、CamErrorCode：CAM 错误码、Tags：标签（AttributeValue格式：[{"key":"*","value":"*"}]）备注:检索的各个条件间是与的关系,EventName传多个值内部是或的关系）
+	// 检索条件（目前支持：
+	// RequestId：请求 ID
+	// EventName：事件名称
+	// ActionType：操作类型（Write：写；Read：读）
+	// PrincipalId：子账号
+	// ResourceType：资源类型
+	// ResourceId：资源Id
+	// ResourceName：资源名称
+	// AccessKeyId：密钥 ID
+	// SensitiveAction：是否敏感操作
+	// ApiErrorCode：API 错误码
+	// CamErrorCode：CAM 错误码
+	// SourceIPAddress：请求IP
+	// Tags：标签（AttributeValue格式：[{"key":"*","value":"*"}]）
+	// 备注:检索的各个条件间是与的关系,EventName传多个值内部是或的关系）
 	LookupAttributes []*LookupAttribute `json:"LookupAttributes,omitnil,omitempty" name:"LookupAttributes"`
 
 	// 是否返回 IP 归属地（1 返回，0 不返回）
@@ -584,7 +603,21 @@ type DescribeEventsRequest struct {
 	// 返回日志的最大条数（最大 50 条）
 	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 检索条件（目前支持 RequestId：请求 ID、EventName：事件名称、ActionType：操作类型（Write：写；Read：读）、PrincipalId：子账号、ResourceType：资源类型、ResourceId：资源Id、ResourceName：资源名称、AccessKeyId：密钥 ID、SensitiveAction：是否敏感操作、ApiErrorCode：API 错误码、CamErrorCode：CAM 错误码、Tags：标签（AttributeValue格式：[{"key":"*","value":"*"}]）备注:检索的各个条件间是与的关系,EventName传多个值内部是或的关系）
+	// 检索条件（目前支持：
+	// RequestId：请求 ID
+	// EventName：事件名称
+	// ActionType：操作类型（Write：写；Read：读）
+	// PrincipalId：子账号
+	// ResourceType：资源类型
+	// ResourceId：资源Id
+	// ResourceName：资源名称
+	// AccessKeyId：密钥 ID
+	// SensitiveAction：是否敏感操作
+	// ApiErrorCode：API 错误码
+	// CamErrorCode：CAM 错误码
+	// SourceIPAddress：请求IP
+	// Tags：标签（AttributeValue格式：[{"key":"*","value":"*"}]）
+	// 备注:检索的各个条件间是与的关系,EventName传多个值内部是或的关系）
 	LookupAttributes []*LookupAttribute `json:"LookupAttributes,omitnil,omitempty" name:"LookupAttributes"`
 
 	// 是否返回 IP 归属地（1 返回，0 不返回）
@@ -624,11 +657,9 @@ type DescribeEventsResponseParams struct {
 	NextToken *uint64 `json:"NextToken,omitnil,omitempty" name:"NextToken"`
 
 	// 日志集合
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	Events []*Event `json:"Events,omitnil,omitempty" name:"Events"`
 
 	// 此字段已经废弃。翻页请使用ListOver配合NextToken，在ListOver为false进行下一页数据读取。
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -674,7 +705,6 @@ type Event struct {
 	EventName *string `json:"EventName,omitnil,omitempty" name:"EventName"`
 
 	// 证书ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	SecretId *string `json:"SecretId,omitnil,omitempty" name:"SecretId"`
 
 	// 请求来源
@@ -690,7 +720,6 @@ type Event struct {
 	AccountID *int64 `json:"AccountID,omitnil,omitempty" name:"AccountID"`
 
 	// 源IP
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	SourceIPAddress *string `json:"SourceIPAddress,omitnil,omitempty" name:"SourceIPAddress"`
 
 	// 事件名称中文描述（此字段请按需使用，如果您是其他语言使用者，可以忽略该字段描述）
@@ -708,7 +737,6 @@ type Event struct {
 
 type Filter struct {
 	// 资源筛选条件
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	ResourceFields []*ResourceField `json:"ResourceFields,omitnil,omitempty" name:"ResourceFields"`
 }
 
@@ -863,7 +891,6 @@ func (r *ListAuditsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type ListAuditsResponseParams struct {
 	// 查询跟踪集概要集合
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	AuditSummarys []*AuditSummary `json:"AuditSummarys,omitnil,omitempty" name:"AuditSummarys"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -920,7 +947,7 @@ func (r *ListCmqEnableRegionRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ListCmqEnableRegionResponseParams struct {
-	// 云审计支持的cmq的可用区
+	// 操作审计支持的cmq的可用区
 	EnableRegions []*CmqRegionInfo `json:"EnableRegions,omitnil,omitempty" name:"EnableRegions"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -977,7 +1004,7 @@ func (r *ListCosEnableRegionRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ListCosEnableRegionResponseParams struct {
-	// 云审计支持的cos可用区
+	// 操作审计支持的cos可用区
 	EnableRegions []*CosRegionInfo `json:"EnableRegions,omitnil,omitempty" name:"EnableRegions"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -1091,7 +1118,7 @@ type LookUpEventsRequestParams struct {
 	// 返回日志的最大条数
 	MaxResults *int64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 云审计模式，有效值：standard | quick，其中standard是标准模式，quick是极速模式。默认为标准模式
+	// 操作审计模式，有效值：standard | quick，其中standard是标准模式，quick是极速模式。默认为标准模式
 	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
 }
 
@@ -1113,7 +1140,7 @@ type LookUpEventsRequest struct {
 	// 返回日志的最大条数
 	MaxResults *int64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 云审计模式，有效值：standard | quick，其中standard是标准模式，quick是极速模式。默认为标准模式
+	// 操作审计模式，有效值：standard | quick，其中standard是标准模式，quick是极速模式。默认为标准模式
 	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
 }
 
@@ -1144,16 +1171,16 @@ func (r *LookUpEventsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type LookUpEventsResponseParams struct {
 	// 查看更多日志的凭证
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	NextToken *string `json:"NextToken,omitnil,omitempty" name:"NextToken"`
 
 	// 日志集合
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	Events []*Event `json:"Events,omitnil,omitempty" name:"Events"`
 
 	// 日志集合是否结束
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	ListOver *bool `json:"ListOver,omitnil,omitempty" name:"ListOver"`
+
+	// 数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -1176,7 +1203,7 @@ func (r *LookUpEventsResponse) FromJsonString(s string) error {
 }
 
 type LookupAttribute struct {
-	// AttributeKey的有效取值范围是:RequestId、EventName、ReadOnly、Username、ResourceType、ResourceName和AccessKeyId，EventId
+	// AttributeKey的有效取值范围是:RequestId、EventName、ActionType、PrincipalId、ResourceId、ResourceName、AccessKeyId、SensitiveAction、ApiErrorCode、CamErrorCode、SourceIPAddress、Tags
 	AttributeKey *string `json:"AttributeKey,omitnil,omitempty" name:"AttributeKey"`
 
 	// AttributeValue的值
@@ -1185,56 +1212,56 @@ type LookupAttribute struct {
 
 // Predefined struct for user
 type ModifyAuditTrackRequestParams struct {
-	// 跟踪集 ID
+	// <p>跟踪集 ID</p>
 	TrackId *uint64 `json:"TrackId,omitnil,omitempty" name:"TrackId"`
 
-	// 跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符
+	// <p>跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 跟踪事件类型（读：Read；写：Write；全部：*）
+	// <p>跟踪事件类型（读：Read；写：Write；全部：*）</p>
 	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
 
-	// 跟踪事件所属产品（支持全部产品或单个产品，如：cos，全部：*）
+	// <p>跟踪事件所属产品（支持全部产品或单个产品，如：cos，全部：*）</p>
 	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
 
-	// 跟踪集状态（未开启：0；开启：1）
+	// <p>跟踪集状态（未开启：0；开启：1）</p>
 	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：["*"]；指定ResourceType时，支持全部接口：["*"]；支持部分接口：["cos", "cls"]，接口列表上限10个）
+	// <p>跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：[&quot;*&quot;]；指定ResourceType时，支持全部接口：[&quot;*&quot;]；支持部分接口：[&quot;cos&quot;, &quot;cls&quot;]，接口列表上限10个）</p>
 	EventNames []*string `json:"EventNames,omitnil,omitempty" name:"EventNames"`
 
-	// 数据投递存储（目前支持 cos、cls）
+	// <p>数据投递存储（目前支持 cos、cls、ckafka）</p>
 	Storage *Storage `json:"Storage,omitnil,omitempty" name:"Storage"`
 
-	// 是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能)
+	// <p>是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能)</p>
 	TrackForAllMembers *uint64 `json:"TrackForAllMembers,omitnil,omitempty" name:"TrackForAllMembers"`
 }
 
 type ModifyAuditTrackRequest struct {
 	*tchttp.BaseRequest
 	
-	// 跟踪集 ID
+	// <p>跟踪集 ID</p>
 	TrackId *uint64 `json:"TrackId,omitnil,omitempty" name:"TrackId"`
 
-	// 跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符
+	// <p>跟踪集名称，仅支持大小写字母、数字、-以及_的组合，3-48个字符</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 跟踪事件类型（读：Read；写：Write；全部：*）
+	// <p>跟踪事件类型（读：Read；写：Write；全部：*）</p>
 	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
 
-	// 跟踪事件所属产品（支持全部产品或单个产品，如：cos，全部：*）
+	// <p>跟踪事件所属产品（支持全部产品或单个产品，如：cos，全部：*）</p>
 	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
 
-	// 跟踪集状态（未开启：0；开启：1）
+	// <p>跟踪集状态（未开启：0；开启：1）</p>
 	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：["*"]；指定ResourceType时，支持全部接口：["*"]；支持部分接口：["cos", "cls"]，接口列表上限10个）
+	// <p>跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：[&quot;*&quot;]；指定ResourceType时，支持全部接口：[&quot;*&quot;]；支持部分接口：[&quot;cos&quot;, &quot;cls&quot;]，接口列表上限10个）</p>
 	EventNames []*string `json:"EventNames,omitnil,omitempty" name:"EventNames"`
 
-	// 数据投递存储（目前支持 cos、cls）
+	// <p>数据投递存储（目前支持 cos、cls、ckafka）</p>
 	Storage *Storage `json:"Storage,omitnil,omitempty" name:"Storage"`
 
-	// 是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能)
+	// <p>是否开启将集团成员操作日志投递到集团管理账号或者可信服务管理账号(0：未开启，1：开启，只能集团管理账号或者可信服务管理账号开启此项功能)</p>
 	TrackForAllMembers *uint64 `json:"TrackForAllMembers,omitnil,omitempty" name:"TrackForAllMembers"`
 }
 
@@ -1377,25 +1404,20 @@ func (r *ModifyEventsAuditTrackResponse) FromJsonString(s string) error {
 
 type Resource struct {
 	// 资源类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
 
 	// 资源名称
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	ResourceName *string `json:"ResourceName,omitnil,omitempty" name:"ResourceName"`
 }
 
 type ResourceField struct {
 	// 跟踪事件所属产品（支持全部产品或单个产品，如：cam，全部：*）
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
 
 	// 跟踪事件类型（读：Read；写：Write；全部：*）
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
 
 	// 跟踪事件接口名列表（ResourceType为 * 时，EventNames必须为全部：[""]；指定ResourceType时，支持全部接口：[""]；支持部分接口：["cos", "cls"]，接口列表上限10个）
-	// 注意：此字段可能返回 null，表示取不到有效值。
 	EventNames []*string `json:"EventNames,omitnil,omitempty" name:"EventNames"`
 }
 
@@ -1514,25 +1536,26 @@ func (r *StopLoggingResponse) FromJsonString(s string) error {
 }
 
 type Storage struct {
-	// 存储类型（目前支持 cos、cls）
+	// <p>存储类型（目前支持 cos、cls、ckafka）</p>
 	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
 
-	// 存储所在地域
+	// <p>存储所在地域</p>
 	StorageRegion *string `json:"StorageRegion,omitnil,omitempty" name:"StorageRegion"`
 
-	// 存储名称(cos：存储名称为用户自定义的存储桶名称，不包含"-APPID"，仅支持小写字母、数字以及中划线"-"的组合，不能超过50字符，且不支持中划线"-"开头或结尾； cls：存储名称为日志主题id，字符长度为1-50个字符)
+	// <p>存储名称(cos：存储名称为用户自定义的存储桶名称，不包含&quot;-APPID&quot;，仅支持小写字母、数字以及中划线&quot;-&quot;的组合，不能超过50字符，且不支持中划线&quot;-&quot;开头或结尾； cls：存储名称为日志主题id，字符长度为1-50个字符； ckafka： ckafka实例ID/topic. 举例：ckafka-xxxxxx/tencent_test_audit_log)</p>
 	StorageName *string `json:"StorageName,omitnil,omitempty" name:"StorageName"`
 
-	// 存储目录前缀，cos日志文件前缀仅支持字母和数字的组合，3-40个字符
+	// <p>存储目录前缀，cos日志文件前缀仅支持字母和数字的组合，3-40个字符</p>
 	StoragePrefix *string `json:"StoragePrefix,omitnil,omitempty" name:"StoragePrefix"`
 
-	// 被指定存储用户ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
+	// <p>被指定存储用户ID</p>
 	StorageAccountId *string `json:"StorageAccountId,omitnil,omitempty" name:"StorageAccountId"`
 
-	// 被指定存储用户appid
-	// 注意：此字段可能返回 null，表示取不到有效值。
+	// <p>被指定存储用户appid</p>
 	StorageAppId *string `json:"StorageAppId,omitnil,omitempty" name:"StorageAppId"`
+
+	// <p>是否压缩。<br>1:压缩  2:不压缩</p>
+	Compress *uint64 `json:"Compress,omitnil,omitempty" name:"Compress"`
 }
 
 type Tracks struct {
@@ -1566,19 +1589,19 @@ type UpdateAuditRequestParams struct {
 	// 跟踪集名称
 	AuditName *string `json:"AuditName,omitnil,omitempty" name:"AuditName"`
 
-	// 是否开启cmq消息通知。1：是，0：否。目前仅支持cmq的队列服务。如果开启cmq消息通知服务，云审计会将您的日志内容实时投递到您指定地域的指定队列中。
+	// 是否开启cmq消息通知。1：是，0：否。目前仅支持cmq的队列服务。如果开启cmq消息通知服务，操作审计会将您的日志内容实时投递到您指定地域的指定队列中。
 	IsEnableCmqNotify *int64 `json:"IsEnableCmqNotify,omitnil,omitempty" name:"IsEnableCmqNotify"`
 
 	// 管理事件的读写属性。1：只读，2：只写，3：全部。
 	ReadWriteAttribute *int64 `json:"ReadWriteAttribute,omitnil,omitempty" name:"ReadWriteAttribute"`
 
-	// CMK的全局唯一标识符，如果不是新创建的kms，该值是必填值。可以通过ListKeyAliasByRegion来获取。云审计不会校验KeyId的合法性，请您谨慎填写，避免给您的数据造成损失。
+	// CMK的全局唯一标识符，如果不是新创建的kms，该值是必填值。可以通过ListKeyAliasByRegion来获取。操作审计不会校验KeyId的合法性，请您谨慎填写，避免给您的数据造成损失。
 	KeyId *string `json:"KeyId,omitnil,omitempty" name:"KeyId"`
 
 	// cos地域。目前支持的地域可以使用ListCosEnableRegion来获取。
 	CosRegion *string `json:"CosRegion,omitnil,omitempty" name:"CosRegion"`
 
-	// 队列名称。队列名称是一个不超过64个字符的字符串，必须以字母为首字符，剩余部分可以包含字母、数字和横划线(-)。如果IsEnableCmqNotify值是1的话，此值属于必填字段。如果不是新创建的队列，云审计不会去校验该队列是否真的存在，请谨慎填写，避免日志通知不成功，导致您的数据丢失。
+	// 队列名称。队列名称是一个不超过64个字符的字符串，必须以字母为首字符，剩余部分可以包含字母、数字和横划线(-)。如果IsEnableCmqNotify值是1的话，此值属于必填字段。如果不是新创建的队列，操作审计不会去校验该队列是否真的存在，请谨慎填写，避免日志通知不成功，导致您的数据丢失。
 	CmqQueueName *string `json:"CmqQueueName,omitnil,omitempty" name:"CmqQueueName"`
 
 	// 是否创建新的cos存储桶。1：是，0：否。
@@ -1590,7 +1613,7 @@ type UpdateAuditRequestParams struct {
 	// 是否开启kms加密。1：是，0：否。如果开启KMS加密，数据在投递到cos时，会将数据加密。
 	IsEnableKmsEncry *int64 `json:"IsEnableKmsEncry,omitnil,omitempty" name:"IsEnableKmsEncry"`
 
-	// cos的存储桶名称。仅支持小写英文字母和数字即[a-z，0-9]、中划线“-”及其组合。用户自定义的字符串支持1 - 40个字符。存储桶命名不能以“-”开头或结尾。如果不是新创建的存储桶，云审计不会去校验该存储桶是否真的存在，请谨慎填写，避免日志投递不成功，导致您的数据丢失。
+	// cos的存储桶名称。仅支持小写英文字母和数字即[a-z，0-9]、中划线“-”及其组合。用户自定义的字符串支持1 - 40个字符。存储桶命名不能以“-”开头或结尾。如果不是新创建的存储桶，操作审计不会去校验该存储桶是否真的存在，请谨慎填写，避免日志投递不成功，导致您的数据丢失。
 	CosBucketName *string `json:"CosBucketName,omitnil,omitempty" name:"CosBucketName"`
 
 	// 队列所在的地域。可以通过ListCmqEnableRegion获取支持的cmq地域。如果IsEnableCmqNotify值是1的话，此值属于必填字段。
@@ -1609,19 +1632,19 @@ type UpdateAuditRequest struct {
 	// 跟踪集名称
 	AuditName *string `json:"AuditName,omitnil,omitempty" name:"AuditName"`
 
-	// 是否开启cmq消息通知。1：是，0：否。目前仅支持cmq的队列服务。如果开启cmq消息通知服务，云审计会将您的日志内容实时投递到您指定地域的指定队列中。
+	// 是否开启cmq消息通知。1：是，0：否。目前仅支持cmq的队列服务。如果开启cmq消息通知服务，操作审计会将您的日志内容实时投递到您指定地域的指定队列中。
 	IsEnableCmqNotify *int64 `json:"IsEnableCmqNotify,omitnil,omitempty" name:"IsEnableCmqNotify"`
 
 	// 管理事件的读写属性。1：只读，2：只写，3：全部。
 	ReadWriteAttribute *int64 `json:"ReadWriteAttribute,omitnil,omitempty" name:"ReadWriteAttribute"`
 
-	// CMK的全局唯一标识符，如果不是新创建的kms，该值是必填值。可以通过ListKeyAliasByRegion来获取。云审计不会校验KeyId的合法性，请您谨慎填写，避免给您的数据造成损失。
+	// CMK的全局唯一标识符，如果不是新创建的kms，该值是必填值。可以通过ListKeyAliasByRegion来获取。操作审计不会校验KeyId的合法性，请您谨慎填写，避免给您的数据造成损失。
 	KeyId *string `json:"KeyId,omitnil,omitempty" name:"KeyId"`
 
 	// cos地域。目前支持的地域可以使用ListCosEnableRegion来获取。
 	CosRegion *string `json:"CosRegion,omitnil,omitempty" name:"CosRegion"`
 
-	// 队列名称。队列名称是一个不超过64个字符的字符串，必须以字母为首字符，剩余部分可以包含字母、数字和横划线(-)。如果IsEnableCmqNotify值是1的话，此值属于必填字段。如果不是新创建的队列，云审计不会去校验该队列是否真的存在，请谨慎填写，避免日志通知不成功，导致您的数据丢失。
+	// 队列名称。队列名称是一个不超过64个字符的字符串，必须以字母为首字符，剩余部分可以包含字母、数字和横划线(-)。如果IsEnableCmqNotify值是1的话，此值属于必填字段。如果不是新创建的队列，操作审计不会去校验该队列是否真的存在，请谨慎填写，避免日志通知不成功，导致您的数据丢失。
 	CmqQueueName *string `json:"CmqQueueName,omitnil,omitempty" name:"CmqQueueName"`
 
 	// 是否创建新的cos存储桶。1：是，0：否。
@@ -1633,7 +1656,7 @@ type UpdateAuditRequest struct {
 	// 是否开启kms加密。1：是，0：否。如果开启KMS加密，数据在投递到cos时，会将数据加密。
 	IsEnableKmsEncry *int64 `json:"IsEnableKmsEncry,omitnil,omitempty" name:"IsEnableKmsEncry"`
 
-	// cos的存储桶名称。仅支持小写英文字母和数字即[a-z，0-9]、中划线“-”及其组合。用户自定义的字符串支持1 - 40个字符。存储桶命名不能以“-”开头或结尾。如果不是新创建的存储桶，云审计不会去校验该存储桶是否真的存在，请谨慎填写，避免日志投递不成功，导致您的数据丢失。
+	// cos的存储桶名称。仅支持小写英文字母和数字即[a-z，0-9]、中划线“-”及其组合。用户自定义的字符串支持1 - 40个字符。存储桶命名不能以“-”开头或结尾。如果不是新创建的存储桶，操作审计不会去校验该存储桶是否真的存在，请谨慎填写，避免日志投递不成功，导致您的数据丢失。
 	CosBucketName *string `json:"CosBucketName,omitnil,omitempty" name:"CosBucketName"`
 
 	// 队列所在的地域。可以通过ListCmqEnableRegion获取支持的cmq地域。如果IsEnableCmqNotify值是1的话，此值属于必填字段。

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1256,7 +1256,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.105
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.0.1033
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.131

--- a/website/docs/r/audit_track.html.markdown
+++ b/website/docs/r/audit_track.html.markdown
@@ -53,6 +53,7 @@ resource "tencentcloud_audit_track" "example" {
     storage_type       = "cos"
     storage_account_id = "100037717137"
     storage_app_id     = "1309116520"
+    compress           = 1
   }
 }
 ```
@@ -75,6 +76,7 @@ The `storage` object supports the following:
 * `storage_prefix` - (Required, String) Storage path prefix.
 * `storage_region` - (Required, String) Storage region.
 * `storage_type` - (Required, String) Track Storage type, optional:- `cos`- `cls`- `ckafka`.
+* `compress` - (Optional, Int) Whether to compress. `1`: compress, `2`: do not compress.
 * `storage_account_id` - (Optional, String) Designated to store user ID.
 * `storage_app_id` - (Optional, String) Designated to store user appid.
 


### PR DESCRIPTION
Add the optional `compress` parameter to the `storage` block of the `tencentcloud_audit_track` resource, allowing users to configure whether delivered audit logs are compressed (1: compress, 2: no compress). The parameter is mapped to the cloud API `Storage.Compress` field in the Create, Read, and Update methods. Unit tests using gomonkey mocks are added for the new field.