### PR TITLE
feat(scf): [134950912]add tencentcloud_scf_trigger resource

### DIFF
--- a/.changelog/4343.txt
+++ b/.changelog/4343.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_scf_trigger
+```

--- a/go.sum
+++ b/go.sum
@@ -994,7 +994,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.110/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.112/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.113/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.115/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.116/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.118/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.121/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.122/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1005,8 +1004,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.131/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133 h1:EKJsaGHbifEKqWCdJ4tJNLxbJ5h/Pm3CaLKzcCS/pkw=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141 h1:NFHY8OVmV9yF521cyoVn8OPYIjYO/i9f+nUPkTSqGi8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
@@ -1068,10 +1065,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/live v1.3.95 h1:rWiKud6
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/live v1.3.95/go.mod h1:uDGk0Bi0diOd1VaQPnfZO0MLKPKjqIT4Hi0sdanwD9s=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102 h1:I4QaWjVMOfuEsmxjTS8BxYgLcgdATWIAGutcHDnIvB4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102/go.mod h1:Thfxer0Xf7Oq//ceL5i5nObFEXyQkUxzLHVNFh3p7jw=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.116 h1:fjoLwVyh1yMgiW2FJaEGICwvzeNuUZExvoZDWcIJ9Hc=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.116/go.mod h1:k2QPGbSnicTJ456ccBfJ5qZ4hVHckQEWhqmA+h2+6nY=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.133 h1:J/x518dKdFwHa7KatmCWNw7/daJuf7yw+1bov8Du3d0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.133/go.mod h1:MloftTaY0U0CNcDc2PkbNw7pGwE089AadY4tJ1bc5hM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.141 h1:cvvgcdt3CweSsAIbw3MsrdPEOCdHv1nFYdOs3skBRnk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.141/go.mod h1:BXuG+T2d/4j+1oodFmEHBm6OCd4GR+N1ENNbD4cFUvo=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.101 h1:r8PjkCuXrztjLyBROWTww0RJUq+a+l5ybPLl6GGlov8=

--- a/openspec/changes/archive/2026-07-24-add-scf-trigger/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-24-add-scf-trigger/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/archive/2026-07-24-add-scf-trigger/design.md
+++ b/openspec/changes/archive/2026-07-24-add-scf-trigger/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The Terraform Provider for TencentCloud manages resources under `tencentcloud/services/<service>/`. For the SCF (Serverless Cloud Function) product, the SDK package `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf/v20180416` is already vendored and provides four native trigger lifecycle APIs:
+
+- `CreateTrigger` — creates a trigger bound to a function.
+- `ListTriggers` — lists triggers of a function (supports `Filters` by `TriggerName`).
+- `UpdateTrigger` — updates mutable trigger attributes (type, enable, qualifier, namespace, trigger_desc, description, custom_argument).
+- `DeleteTrigger` — deletes a trigger.
+
+An existing resource, `tencentcloud_scf_trigger_config`, exists but is not a full lifecycle resource: its Create path calls `UpdateTrigger` (upsert-style) and its Delete is a no-op. It also only exposes a subset of fields. This change introduces a **new, separate** resource `tencentcloud_scf_trigger` that performs true create/read/update/delete against the native APIs, following the RESOURCE_KIND_GENERAL pattern used by `tencentcloud_igtm_strategy`.
+
+The resource does not have a single server-issued ID. A trigger is uniquely identified by the combination of `function_name`, `namespace`, and `trigger_name`, so a composite id is required.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a fully-managed Terraform resource `tencentcloud_scf_trigger` with real CRUD backed by SCF APIs.
+- Map all documented create/update parameters to the schema.
+- Support import using the composite id (`function_name#namespace#trigger_name`).
+- Follow provider conventions: `tccommon` retry/timeout helpers, nil checks before `d.Set`, composite id via `tccommon.FILED_SP`, gomonkey-based unit tests.
+- Keep the change fully additive (no breaking changes to existing resources).
+
+**Non-Goals:**
+- Do not modify or deprecate the existing `tencentcloud_scf_trigger_config` resource (out of scope; backward compatibility must be preserved).
+- Do not expose `Offset`/`Limit` pagination as user-facing schema fields; pagination is internal to the read/query helper.
+- Do not model `ListTriggers`-only fields (`order_by`, `order`, `filters`) as top-level resource arguments (they are query helpers, not trigger attributes). They are used internally for the read path only.
+
+## Decisions
+
+### 1. Composite ID format: `function_name#namespace#trigger_name`
+
+The SCF trigger APIs do not return a single unique ID. `CreateTrigger` returns a `Trigger` object whose identity is the combination of function name, namespace, and trigger name. `DeleteTrigger`/`UpdateTrigger` require `FunctionName` + `TriggerName` + `Type` + `Namespace` (+ optional `Qualifier`/`TriggerDesc`).
+
+Decision: use `function_name + tccommon.FILED_SP + namespace + tccommon.FILED_SP + trigger_name` as the Terraform id, consistent with the existing `trigger_config` resource. The parts are parsed in Read/Update/Delete to rebuild API requests.
+
+Alternative considered: include `type` in the id. Rejected because `DeleteTrigger` requires `Type`, but `Type` is set as `ForceNew` (cannot change after create), so it is always recoverable from state during Delete. Keeping the id format identical to the existing resource reduces import friction and inconsistency risk.
+
+### 2. `Type` is Required + ForceNew; `FunctionName`/`TriggerName`/`Namespace` are Required + ForceNew
+
+`CreateTrigger` requires `FunctionName`, `TriggerName`, `Type`. `UpdateTrigger` cannot change `Type` (it is part of the trigger identity). Changing any of these would mean a different trigger, so they are `ForceNew`.
+
+`Namespace` defaults to `"default"` in the API but is part of the composite identity, so it is `Required` + `ForceNew` with a default of `"default"` (Optional with Default + ForceNew) to match the existing convention.
+
+### 3. Mutable fields on Update
+
+`UpdateTrigger` accepts: `FunctionName`, `TriggerName`, `Type`, `Enable`, `Qualifier`, `Namespace`, `TriggerDesc`, `Description`, `CustomArgument`. Since `FunctionName`/`TriggerName`/`Type`/`Namespace` are ForceNew, the mutable fields exercised in Update are: `enable`, `qualifier`, `trigger_desc`, `description`, `custom_argument`. The Update function checks `d.HasChange` for these mutable args and calls `UpdateTrigger` only when needed.
+
+### 4. `enable` representation: string "OPEN"/"CLOSE"
+
+`CreateTrigger`/`UpdateTrigger` take `Enable` as a string (`OPEN`/`CLOSE`). The read-back `TriggerInfo.Enable` is an int64 (`1`=open, `0`=close). The Read function converts the int64 to the string representation ("OPEN"/"CLOSE") to keep the schema a single `schema.TypeString`.
+
+### 5. Read path uses `ListTriggers` with a `TriggerName` filter
+
+There is no single GetTrigger API. Read uses `ListTriggers` filtered by `FunctionName` + `Namespace` + `Filters(TriggerName=...)`, matching the existing `DescribeScfTriggerConfigById` helper. A new service helper `DescribeScfTriggerById` mirrors this. If the returned list is empty, the resource is treated as gone (log + `d.SetId("")`).
+
+### 6. Computed read-back fields
+
+`TriggerInfo` returns additional metadata not settable by the user: `AvailableStatus`, `AddTime`, `ModTime`. These are exposed as `Computed` schema fields (`available_status`, `add_time`, `mod_time`) for observability. The create-time `Trigger` response (`CreateTriggerResponse.Response.TriggerInfo`) is a `Trigger` struct and is used only to confirm creation; the authoritative read is done via `ListTriggers`.
+
+### 7. Create-time response nil check
+
+Per provider rules, after `CreateTrigger` the code MUST verify the response is non-nil and that the `TriggerInfo` is present; if empty, return `NonRetryableError` to avoid writing a broken id.
+
+### 8. Unit testing with gomonkey
+
+Per project rules for newly added Terraform resources, tests use gomonkey to mock the SCF client methods (not the Terraform acceptance test framework). Run with `go test -gcflags=all=-l`.
+
+## Risks / Trade-offs
+
+- [Risk] Two resources (`tencentcloud_scf_trigger` and `tencentcloud_scf_trigger_config`) can manage the same underlying SCF trigger, which could cause state drift if both are used for the same trigger. → Mitigation: they have different resource type names; users should pick one. The new resource is the recommended full-lifecycle option. Documented as separate resources.
+- [Risk] The `enable` field is a string ("OPEN"/"CLOSE") on write but int64 (1/0) on read, requiring conversion. → Mitigation: a single conversion point in Read maps 1→"OPEN", 0→"CLOSE"; any other value is left unset.
+- [Risk] `ListTriggers` is eventually consistent; a Read immediately after Create might not find the trigger. → Mitigation: the Read helper is wrapped in `tccommon.ReadRetryTimeout` retry so transient absence is retried.
+- [Trade-off] `order_by`, `order`, and `filters` from `ListTriggers` are not exposed as resource arguments because they are query controls, not trigger attributes. They are used internally only.
+- [Trade-off] We do not add the deprecated fields (`ResourceId`, `BindStatus`, `TriggerAttribute`) from `TriggerInfo` to the schema.

--- a/openspec/changes/archive/2026-07-24-add-scf-trigger/proposal.md
+++ b/openspec/changes/archive/2026-07-24-add-scf-trigger/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The Terraform Provider for TencentCloud currently only offers `tencentcloud_scf_trigger_config`, which manages an existing SCF trigger through `UpdateTrigger` and has an empty Delete operation — it does not model the full trigger lifecycle. Users cannot create, read, update, and destroy SCF function triggers in a declarative, idempotent way through Terraform.
+
+By adding a new `tencentcloud_scf_trigger` resource that maps to the native SCF trigger CRUD APIs (`CreateTrigger`, `ListTriggers`, `UpdateTrigger`, `DeleteTrigger`), users can fully manage the SCF (Serverless Cloud Function) trigger lifecycle as part of their infrastructure-as-code workflows.
+
+## What Changes
+
+- Add a new Terraform resource `tencentcloud_scf_trigger` of kind RESOURCE_KIND_GENERAL under `tencentcloud/services/scf/`.
+- Implement full CRUD:
+  - **Create** → calls SCF `CreateTrigger` API.
+  - **Read** → calls SCF `ListTriggers` API, filtered by trigger name, to fetch the `TriggerInfo`.
+  - **Update** → calls SCF `UpdateTrigger` API for mutable fields.
+  - **Delete** → calls SCF `DeleteTrigger` API.
+- Add the resource schema with parameters: `function_name`, `trigger_name`, `type`, `trigger_desc`, `namespace`, `qualifier`, `enable`, `custom_argument`, `description`, and computed fields from `TriggerInfo` (e.g. `available_status`, `add_time`, `mod_time`).
+- Use a composite id (`function_name` + `namespace` + `trigger_name`) joined by `tccommon.FILED_SP`.
+- Register the new resource in `tencentcloud/provider.go` and `tencentcloud/provider.md`.
+- Add a service-layer helper `DescribeScfTriggerById` in `service_tencentcloud_scf.go`.
+- Add the resource documentation `resource_tc_scf_trigger.md`.
+- Add unit tests with gomonkey mocks (`resource_tc_scf_trigger_test.go`).
+
+## Capabilities
+
+### New Capabilities
+- `scf-trigger-resource`: Full lifecycle management (create, read, update, delete) of a TencentCloud SCF (Serverless Cloud Function) function trigger via the `tencentcloud_scf_trigger` Terraform resource.
+
+### Modified Capabilities
+<!-- None. The existing `tencentcloud_scf_trigger_config` resource is not modified. -->
+
+## Impact
+
+- **New files**:
+  - `tencentcloud/services/scf/resource_tc_scf_trigger.go` (resource schema + CRUD)
+  - `tencentcloud/services/scf/resource_tc_scf_trigger_test.go` (gomonkey-based unit tests)
+  - `tencentcloud/services/scf/resource_tc_scf_trigger.md` (user docs)
+- **Modified files**:
+  - `tencentcloud/services/scf/service_tencentcloud_scf.go` (add `DescribeScfTriggerById` helper)
+  - `tencentcloud/provider.go` (register `tencentcloud_scf_trigger`)
+  - `tencentcloud/provider.md` (register `tencentcloud_scf_trigger`)
+- **APIs used** (package `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf/v20180416`):
+  - `CreateTrigger`, `ListTriggers`, `UpdateTrigger`, `DeleteTrigger`
+- **Dependencies**: Uses already-vendored `scf/v20180416` SDK; no new external dependencies.
+- **Backward compatibility**: Fully additive; no existing resource schema or behavior is changed.

--- a/openspec/changes/archive/2026-07-24-add-scf-trigger/specs/scf-trigger-resource/spec.md
+++ b/openspec/changes/archive/2026-07-24-add-scf-trigger/specs/scf-trigger-resource/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Resource shall manage the full SCF trigger lifecycle
+
+The `tencentcloud_scf_trigger` resource SHALL manage the complete lifecycle (create, read, update, delete) of a TencentCloud SCF (Serverless Cloud Function) function trigger by mapping to the native SCF APIs `CreateTrigger`, `ListTriggers`, `UpdateTrigger`, and `DeleteTrigger` from the `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf/v20180416` package.
+
+#### Scenario: Create a trigger
+- **WHEN** a user applies a `tencentcloud_scf_trigger` configuration with required fields `function_name`, `trigger_name`, `type`, and `trigger_desc`
+- **THEN** the provider SHALL call the SCF `CreateTrigger` API with the supplied parameters and set the Terraform state id to `function_name#namespace#trigger_name` (using `tccommon.FILED_SP` as the separator)
+
+#### Scenario: Read a trigger
+- **WHEN** the provider refreshes the resource state
+- **THEN** the provider SHALL call the SCF `ListTriggers` API filtered by `FunctionName`, `Namespace`, and a `TriggerName` filter parsed from the composite id, and populate the schema fields from the returned `TriggerInfo`
+
+#### Scenario: Update a trigger
+- **WHEN** a user changes a mutable field (`enable`, `qualifier`, `trigger_desc`, `description`, or `custom_argument`) on an existing `tencentcloud_scf_trigger`
+- **THEN** the provider SHALL call the SCF `UpdateTrigger` API with the function name, trigger name, type, namespace (parsed from the id) and the changed mutable fields
+
+#### Scenario: Delete a trigger
+- **WHEN** a user destroys a `tencentcloud_scf_trigger` resource
+- **THEN** the provider SHALL call the SCF `DeleteTrigger` API with `FunctionName`, `TriggerName`, `Type`, `Namespace`, `Qualifier`, and `TriggerDesc` (when applicable) parsed from state
+
+### Requirement: Schema SHALL define trigger parameters and computed attributes
+
+The resource schema SHALL define the following user-settable parameters mapped from the SCF API: `function_name`, `trigger_name`, `type`, `trigger_desc`, `namespace`, `qualifier`, `enable`, `custom_argument`, and `description`. The schema SHALL also define computed read-back attributes from `TriggerInfo`: `available_status`, `add_time`, and `mod_time`.
+
+#### Scenario: Required identity fields are ForceNew
+- **WHEN** `function_name`, `trigger_name`, or `type` is changed after creation
+- **THEN** the provider SHALL treat the change as a ForceNew (destroy and recreate), because these form the trigger identity and cannot be mutated by `UpdateTrigger`
+
+#### Scenario: Namespace defaults to default and is ForceNew
+- **WHEN** `namespace` is omitted in the configuration
+- **THEN** the provider SHALL default `namespace` to `"default"` and treat any subsequent change as ForceNew
+
+#### Scenario: enable is a string with OPEN/CLOSE values
+- **WHEN** the user sets `enable` to `"OPEN"` or `"CLOSE"`
+- **THEN** the provider SHALL pass the string to `CreateTrigger`/`UpdateTrigger` as-is, and on Read SHALL convert the int64 `TriggerInfo.Enable` (1/0) back to `"OPEN"`/`"CLOSE"`
+
+#### Scenario: Computed metadata fields are populated on read
+- **WHEN** the Read operation succeeds and the `TriggerInfo` contains `AvailableStatus`, `AddTime`, or `ModTime`
+- **THEN** the provider SHALL set the computed fields `available_status`, `add_time`, and `mod_time` respectively, only when the API field is non-nil
+
+### Requirement: Composite id SHALL be used and importable
+
+The resource SHALL use a composite id composed of `function_name`, `namespace`, and `trigger_name` joined by `tccommon.FILED_SP` (`#`). The resource SHALL support Terraform import via `schema.ImportStatePassthrough`.
+
+#### Scenario: Import by composite id
+- **WHEN** a user runs `terraform import tencentcloud_scf_trigger.foo <function_name>#<namespace>#<trigger_name>`
+- **THEN** the provider SHALL parse the three-part id and run the Read operation to populate state
+
+#### Scenario: Broken id is rejected
+- **WHEN** the composite id does not contain exactly three `#`-separated parts during Read/Update/Delete
+- **THEN** the provider SHALL return an error indicating the id is broken
+
+### Requirement: Create SHALL validate non-empty API response
+
+The Create operation SHALL verify, after a successful `CreateTrigger` call, that the API response and its `TriggerInfo` field are non-nil and non-empty. If the response is empty, the provider SHALL return a `NonRetryableError` to avoid persisting a broken id.
+
+#### Scenario: Empty create response fails
+- **WHEN** `CreateTrigger` returns a nil response or a nil/empty `TriggerInfo`
+- **THEN** the provider SHALL return a `NonRetryableError` and SHALL NOT set the Terraform state id
+
+### Requirement: Read SHALL handle resource disappearance
+
+When the `ListTriggers` response returns an empty list (trigger no longer exists), the Read operation SHALL log the disappearance with the current id and then call `d.SetId("")` so Terraform removes the resource from state.
+
+#### Scenario: Trigger not found on read
+- **WHEN** `ListTriggers` returns no triggers matching the composite id
+- **THEN** the provider SHALL log `[CRUD] scf_trigger id=<id>` and set the resource id to empty string
+
+### Requirement: API calls SHALL use retry and timeout helpers
+
+All SCF API calls in Create, Read, Update, and Delete SHALL be wrapped with the provider's retry helpers (`resource.Retry` with `tccommon.WriteRetryTimeout` for write operations and `tccommon.ReadRetryTimeout` for read operations). API errors SHALL be wrapped with `tccommon.RetryError()`.
+
+#### Scenario: Transient API failure is retried
+- **WHEN** an SCF API call fails with a retryable error
+- **THEN** the provider SHALL retry within the configured timeout before surfacing the error to the user
+
+### Requirement: Resource SHALL be registered in the provider
+
+The `tencentcloud_scf_trigger` resource SHALL be registered in `tencentcloud/provider.go` under the provider resources map and documented in `tencentcloud/provider.md`.
+
+#### Scenario: Resource is available in the provider
+- **WHEN** a user references `tencentcloud_scf_trigger` in a Terraform configuration
+- **THEN** the provider SHALL recognize the resource type and expose its schema and CRUD operations

--- a/openspec/changes/archive/2026-07-24-add-scf-trigger/tasks.md
+++ b/openspec/changes/archive/2026-07-24-add-scf-trigger/tasks.md
@@ -1,0 +1,32 @@
+## 1. Service layer helper
+
+- [x] 1.1 Add `DescribeScfTriggerById(ctx, functionName, namespace, triggerName)` method to `tencentcloud/services/scf/service_tencentcloud_scf.go` that calls `ListTriggers` filtered by `FunctionName` + `Namespace` + `Filters(TriggerName=...)`, paginates internally, and returns the first matching `*scf.TriggerInfo` (or nil if not found).
+
+## 2. Resource schema definition
+
+- [x] 2.1 Create `tencentcloud/services/scf/resource_tc_scf_trigger.go` with `ResourceTencentCloudScfTrigger()` defining the schema: `function_name` (Required, ForceNew), `trigger_name` (Required, ForceNew), `type` (Required, ForceNew), `namespace` (Optional, ForceNew, Default "default"), `trigger_desc` (Optional), `qualifier` (Optional), `enable` (Optional, TypeString), `custom_argument` (Optional), `description` (Optional), and computed fields `available_status`, `add_time`, `mod_time`. Include `Importer` with `schema.ImportStatePassthrough`.
+
+## 3. CRUD implementation
+
+- [x] 3.1 Implement `resourceTencentCloudScfTriggerCreate`: build a `CreateTriggerRequest` from schema, call `CreateTrigger` inside `resource.Retry(tccommon.WriteRetryTimeout, ...)` wrapping errors with `tccommon.RetryError()`, verify the response/`TriggerInfo` is non-nil (return `NonRetryableError` if empty), then set the composite id `function_name#namespace#trigger_name` and call Read.
+- [x] 3.2 Implement `resourceTencentCloudScfTriggerRead`: parse the 3-part composite id, call `service.DescribeScfTriggerById`; if nil, log `[CRUD] scf_trigger id=<id>` then `d.SetId("")`; otherwise set fields from `TriggerInfo` with nil checks (convert `Enable` int64 1/0 → "OPEN"/"CLOSE"), and set computed `available_status`/`add_time`/`mod_time` only when non-nil.
+- [x] 3.3 Implement `resourceTencentCloudScfTriggerUpdate`: parse the 3-part id, build an `UpdateTriggerRequest` with identity fields, set mutable fields (`enable`, `qualifier`, `trigger_desc`, `description`, `custom_argument`) when `d.HasChange`, call `UpdateTrigger` inside `resource.Retry(tccommon.WriteRetryTimeout, ...)`, then call Read.
+- [x] 3.4 Implement `resourceTencentCloudScfTriggerDelete`: parse the 3-part id, build a `DeleteTriggerRequest` with `FunctionName`, `TriggerName`, `Type`, `Namespace`, `Qualifier`, and `TriggerDesc` (when applicable) from state, call `DeleteTrigger` inside `resource.Retry(tccommon.WriteRetryTimeout, ...)`.
+
+## 4. Provider registration
+
+- [x] 4.1 Register `tencentcloud_scf_trigger` in the resources map of `tencentcloud/provider.go` (refer to the `tencentcloud_igtm_strategy` registration pattern).
+- [x] 4.2 Register `tencentcloud_scf_trigger` in `tencentcloud/provider.md`.
+
+## 5. Resource documentation
+
+- [x] 5.1 Create `tencentcloud/services/scf/resource_tc_scf_trigger.md` following the gendoc/README.md conventions: one-line description mentioning SCF, Example Usage block (use `jsonencode()` where JSON strings are needed), and Import section explaining the composite id `function_name#namespace#trigger_name`. Do NOT add `Argument Reference` / `Attribute Reference` sections (auto-generated).
+
+## 6. Unit tests
+
+- [x] 6.1 Create `tencentcloud/services/scf/resource_tc_scf_trigger_test.go` using gomonkey mocks for the SCF client methods (not the Terraform acceptance framework), covering create/read/update/delete business logic, and run with `go test -gcflags=all=-l` to verify the unit tests pass.
+
+## 7. Code correctness verification
+
+- [x] 7.1 Verify all CRUD code paths use only parameters that exist in the corresponding SCF API (Create params in `CreateTriggerRequest`, Update params in `UpdateTriggerRequest`, Delete params in `DeleteTriggerRequest`); confirm against the vendored `scf/v20180416/models.go`.
+- [x] 7.2 Verify all functions returning an error have it checked (use `_ = func()` for functions that cannot fail) to avoid unused-variable compile errors.

--- a/openspec/specs/scf-trigger-resource/spec.md
+++ b/openspec/specs/scf-trigger-resource/spec.md
@@ -1,0 +1,89 @@
+# scf-trigger-resource Specification
+
+## Purpose
+TBD - created by archiving change add-scf-trigger. Update Purpose after archive.
+## Requirements
+### Requirement: Resource shall manage the full SCF trigger lifecycle
+
+The `tencentcloud_scf_trigger` resource SHALL manage the complete lifecycle (create, read, update, delete) of a TencentCloud SCF (Serverless Cloud Function) function trigger by mapping to the native SCF APIs `CreateTrigger`, `ListTriggers`, `UpdateTrigger`, and `DeleteTrigger` from the `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf/v20180416` package.
+
+#### Scenario: Create a trigger
+- **WHEN** a user applies a `tencentcloud_scf_trigger` configuration with required fields `function_name`, `trigger_name`, `type`, and `trigger_desc`
+- **THEN** the provider SHALL call the SCF `CreateTrigger` API with the supplied parameters and set the Terraform state id to `function_name#namespace#trigger_name` (using `tccommon.FILED_SP` as the separator)
+
+#### Scenario: Read a trigger
+- **WHEN** the provider refreshes the resource state
+- **THEN** the provider SHALL call the SCF `ListTriggers` API filtered by `FunctionName`, `Namespace`, and a `TriggerName` filter parsed from the composite id, and populate the schema fields from the returned `TriggerInfo`
+
+#### Scenario: Update a trigger
+- **WHEN** a user changes a mutable field (`enable`, `qualifier`, `trigger_desc`, `description`, or `custom_argument`) on an existing `tencentcloud_scf_trigger`
+- **THEN** the provider SHALL call the SCF `UpdateTrigger` API with the function name, trigger name, type, namespace (parsed from the id) and the changed mutable fields
+
+#### Scenario: Delete a trigger
+- **WHEN** a user destroys a `tencentcloud_scf_trigger` resource
+- **THEN** the provider SHALL call the SCF `DeleteTrigger` API with `FunctionName`, `TriggerName`, `Type`, `Namespace`, `Qualifier`, and `TriggerDesc` (when applicable) parsed from state
+
+### Requirement: Schema SHALL define trigger parameters and computed attributes
+
+The resource schema SHALL define the following user-settable parameters mapped from the SCF API: `function_name`, `trigger_name`, `type`, `trigger_desc`, `namespace`, `qualifier`, `enable`, `custom_argument`, and `description`. The schema SHALL also define computed read-back attributes from `TriggerInfo`: `available_status`, `add_time`, and `mod_time`.
+
+#### Scenario: Required identity fields are ForceNew
+- **WHEN** `function_name`, `trigger_name`, or `type` is changed after creation
+- **THEN** the provider SHALL treat the change as a ForceNew (destroy and recreate), because these form the trigger identity and cannot be mutated by `UpdateTrigger`
+
+#### Scenario: Namespace defaults to default and is ForceNew
+- **WHEN** `namespace` is omitted in the configuration
+- **THEN** the provider SHALL default `namespace` to `"default"` and treat any subsequent change as ForceNew
+
+#### Scenario: enable is a string with OPEN/CLOSE values
+- **WHEN** the user sets `enable` to `"OPEN"` or `"CLOSE"`
+- **THEN** the provider SHALL pass the string to `CreateTrigger`/`UpdateTrigger` as-is, and on Read SHALL convert the int64 `TriggerInfo.Enable` (1/0) back to `"OPEN"`/`"CLOSE"`
+
+#### Scenario: Computed metadata fields are populated on read
+- **WHEN** the Read operation succeeds and the `TriggerInfo` contains `AvailableStatus`, `AddTime`, or `ModTime`
+- **THEN** the provider SHALL set the computed fields `available_status`, `add_time`, and `mod_time` respectively, only when the API field is non-nil
+
+### Requirement: Composite id SHALL be used and importable
+
+The resource SHALL use a composite id composed of `function_name`, `namespace`, and `trigger_name` joined by `tccommon.FILED_SP` (`#`). The resource SHALL support Terraform import via `schema.ImportStatePassthrough`.
+
+#### Scenario: Import by composite id
+- **WHEN** a user runs `terraform import tencentcloud_scf_trigger.foo <function_name>#<namespace>#<trigger_name>`
+- **THEN** the provider SHALL parse the three-part id and run the Read operation to populate state
+
+#### Scenario: Broken id is rejected
+- **WHEN** the composite id does not contain exactly three `#`-separated parts during Read/Update/Delete
+- **THEN** the provider SHALL return an error indicating the id is broken
+
+### Requirement: Create SHALL validate non-empty API response
+
+The Create operation SHALL verify, after a successful `CreateTrigger` call, that the API response and its `TriggerInfo` field are non-nil and non-empty. If the response is empty, the provider SHALL return a `NonRetryableError` to avoid persisting a broken id.
+
+#### Scenario: Empty create response fails
+- **WHEN** `CreateTrigger` returns a nil response or a nil/empty `TriggerInfo`
+- **THEN** the provider SHALL return a `NonRetryableError` and SHALL NOT set the Terraform state id
+
+### Requirement: Read SHALL handle resource disappearance
+
+When the `ListTriggers` response returns an empty list (trigger no longer exists), the Read operation SHALL log the disappearance with the current id and then call `d.SetId("")` so Terraform removes the resource from state.
+
+#### Scenario: Trigger not found on read
+- **WHEN** `ListTriggers` returns no triggers matching the composite id
+- **THEN** the provider SHALL log `[CRUD] scf_trigger id=<id>` and set the resource id to empty string
+
+### Requirement: API calls SHALL use retry and timeout helpers
+
+All SCF API calls in Create, Read, Update, and Delete SHALL be wrapped with the provider's retry helpers (`resource.Retry` with `tccommon.WriteRetryTimeout` for write operations and `tccommon.ReadRetryTimeout` for read operations). API errors SHALL be wrapped with `tccommon.RetryError()`.
+
+#### Scenario: Transient API failure is retried
+- **WHEN** an SCF API call fails with a retryable error
+- **THEN** the provider SHALL retry within the configured timeout before surfacing the error to the user
+
+### Requirement: Resource SHALL be registered in the provider
+
+The `tencentcloud_scf_trigger` resource SHALL be registered in `tencentcloud/provider.go` under the provider resources map and documented in `tencentcloud/provider.md`.
+
+#### Scenario: Resource is available in the provider
+- **WHEN** a user references `tencentcloud_scf_trigger` in a Terraform configuration
+- **THEN** the provider SHALL recognize the resource type and expose its schema and CRUD operations
+

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1800,6 +1800,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_scf_layer":                                                                scf.ResourceTencentCloudScfLayer(),
 			"tencentcloud_scf_function_alias":                                                       scf.ResourceTencentCloudScfFunctionAlias(),
 			"tencentcloud_scf_trigger_config":                                                       scf.ResourceTencentCloudScfTriggerConfig(),
+			"tencentcloud_scf_trigger":                                                              scf.ResourceTencentCloudScfTrigger(),
 			"tencentcloud_scf_custom_domain":                                                        scf.ResourceTencentCloudScfCustomDomain(),
 			"tencentcloud_tcaplus_cluster":                                                          tcaplusdb.ResourceTencentCloudTcaplusCluster(),
 			"tencentcloud_tcaplus_tablegroup":                                                       tcaplusdb.ResourceTencentCloudTcaplusTableGroup(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1059,6 +1059,7 @@ tencentcloud_scf_namespace
 tencentcloud_scf_layer
 tencentcloud_scf_function_alias
 tencentcloud_scf_trigger_config
+tencentcloud_scf_trigger
 tencentcloud_scf_custom_domain
 
 SQLServer

--- a/tencentcloud/services/scf/resource_tc_scf_function.md
+++ b/tencentcloud/services/scf/resource_tc_scf_function.md
@@ -1,5 +1,7 @@
 Provide a resource to create a SCF function.
 
+~> **NOTE:** The use of `trigger` is no longer recommended; `tencentcloud_scf_trigger` is recommended instead.
+
 Example Usage
 
 ```hcl

--- a/tencentcloud/services/scf/resource_tc_scf_trigger.go
+++ b/tencentcloud/services/scf/resource_tc_scf_trigger.go
@@ -1,0 +1,407 @@
+package scf
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	scf "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf/v20180416"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudScfTrigger() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudScfTriggerCreate,
+		Read:   resourceTencentCloudScfTriggerRead,
+		Update: resourceTencentCloudScfTriggerUpdate,
+		Delete: resourceTencentCloudScfTriggerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"function_name": {
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+				Description: "Name of the SCF function that the trigger binds to.",
+			},
+
+			"trigger_name": {
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+				Description: "Name of the trigger.",
+			},
+
+			"type": {
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+				Description: "Trigger type. Valid values: `cos`, `cls`, `timer`, `ckafka`, `http`.",
+			},
+
+			"trigger_desc": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "Trigger description parameter, see the trigger description documentation for details.",
+			},
+
+			"namespace": {
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "default",
+				Type:        schema.TypeString,
+				Description: "Function namespace. Defaults to `default`.",
+			},
+
+			"qualifier": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "Function version or alias that the trigger points to. Defaults to `$LATEST`.",
+			},
+
+			"enable": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "Trigger enable status. Valid values: `OPEN` (enabled), `CLOSE` (disabled).",
+			},
+
+			"custom_argument": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "User custom parameter, only supported by timer trigger.",
+			},
+
+			"description": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "Trigger description.",
+			},
+
+			"available_status": {
+				Computed:    true,
+				Type:        schema.TypeString,
+				Description: "Trigger available status.",
+			},
+
+			"add_time": {
+				Computed:    true,
+				Type:        schema.TypeString,
+				Description: "Trigger creation time.",
+			},
+
+			"mod_time": {
+				Computed:    true,
+				Type:        schema.TypeString,
+				Description: "Trigger last modified time.",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudScfTriggerCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_scf_trigger.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId        = tccommon.GetLogId(tccommon.ContextNil)
+		ctx          = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request      = scf.NewCreateTriggerRequest()
+		functionName string
+		triggerName  string
+		namespace    string
+	)
+
+	if v, ok := d.GetOk("function_name"); ok {
+		request.FunctionName = helper.String(v.(string))
+		functionName = v.(string)
+	}
+
+	if v, ok := d.GetOk("trigger_name"); ok {
+		request.TriggerName = helper.String(v.(string))
+		triggerName = v.(string)
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		request.Type = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("trigger_desc"); ok {
+		request.TriggerDesc = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("namespace"); ok {
+		request.Namespace = helper.String(v.(string))
+		namespace = v.(string)
+	}
+
+	if v, ok := d.GetOk("qualifier"); ok {
+		request.Qualifier = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("enable"); ok {
+		request.Enable = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("custom_argument"); ok {
+		request.CustomArgument = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		request.Description = helper.String(v.(string))
+	}
+
+	var response *scf.CreateTriggerResponse
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseScfClient().CreateTriggerWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create scf_trigger failed, Response is nil."))
+		}
+
+		response = result
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s create scf_trigger failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	if response.Response.TriggerInfo == nil {
+		log.Printf("[CRITAL]%s create scf_trigger failed, TriggerInfo is nil, d.Id()=%s", logId, d.Id())
+		return fmt.Errorf("create scf_trigger failed, TriggerInfo is nil.")
+	}
+
+	d.SetId(functionName + tccommon.FILED_SP + namespace + tccommon.FILED_SP + triggerName)
+
+	return resourceTencentCloudScfTriggerRead(d, meta)
+}
+
+func resourceTencentCloudScfTriggerRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_scf_trigger.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service = ScfService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	functionName := idSplit[0]
+	namespace := idSplit[1]
+	triggerName := idSplit[2]
+
+	var triggerInfo *scf.TriggerInfo
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := service.DescribeScfTriggerById(ctx, functionName, namespace, triggerName)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+		triggerInfo = result
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s read scf_trigger failed, reason:%+v", logId, err)
+		return err
+	}
+
+	if triggerInfo == nil {
+		log.Printf("[CRUD] scf_trigger id=%s", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	_ = d.Set("function_name", functionName)
+	_ = d.Set("namespace", namespace)
+
+	if triggerInfo.TriggerName != nil {
+		_ = d.Set("trigger_name", triggerInfo.TriggerName)
+	}
+
+	if triggerInfo.Type != nil {
+		_ = d.Set("type", triggerInfo.Type)
+	}
+
+	if triggerInfo.TriggerDesc != nil {
+		_ = d.Set("trigger_desc", triggerInfo.TriggerDesc)
+	}
+
+	if triggerInfo.Qualifier != nil {
+		_ = d.Set("qualifier", triggerInfo.Qualifier)
+	}
+
+	if triggerInfo.CustomArgument != nil {
+		_ = d.Set("custom_argument", triggerInfo.CustomArgument)
+	}
+
+	if triggerInfo.Description != nil {
+		_ = d.Set("description", triggerInfo.Description)
+	}
+
+	if triggerInfo.Enable != nil {
+		if *triggerInfo.Enable == 1 {
+			_ = d.Set("enable", "OPEN")
+		} else {
+			_ = d.Set("enable", "CLOSE")
+		}
+	}
+
+	if triggerInfo.AvailableStatus != nil {
+		_ = d.Set("available_status", triggerInfo.AvailableStatus)
+	}
+
+	if triggerInfo.AddTime != nil {
+		_ = d.Set("add_time", triggerInfo.AddTime)
+	}
+
+	if triggerInfo.ModTime != nil {
+		_ = d.Set("mod_time", triggerInfo.ModTime)
+	}
+
+	return nil
+}
+
+func resourceTencentCloudScfTriggerUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_scf_trigger.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	functionName := idSplit[0]
+	namespace := idSplit[1]
+	triggerName := idSplit[2]
+
+	needChange := false
+	mutableArgs := []string{"enable", "qualifier", "trigger_desc", "description", "custom_argument"}
+	for _, v := range mutableArgs {
+		if d.HasChange(v) {
+			needChange = true
+			break
+		}
+	}
+
+	if needChange {
+		request := scf.NewUpdateTriggerRequest()
+		request.FunctionName = &functionName
+		request.Namespace = &namespace
+		request.TriggerName = &triggerName
+
+		if v, ok := d.GetOk("type"); ok {
+			request.Type = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("enable"); ok {
+			request.Enable = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("qualifier"); ok {
+			request.Qualifier = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("trigger_desc"); ok {
+			request.TriggerDesc = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("description"); ok {
+			request.Description = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("custom_argument"); ok {
+			request.CustomArgument = helper.String(v.(string))
+		}
+
+		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseScfClient().UpdateTriggerWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+			return nil
+		})
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s update scf_trigger failed, reason:%+v", logId, reqErr)
+			return reqErr
+		}
+	}
+
+	return resourceTencentCloudScfTriggerRead(d, meta)
+}
+
+func resourceTencentCloudScfTriggerDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_scf_trigger.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	functionName := idSplit[0]
+	namespace := idSplit[1]
+	triggerName := idSplit[2]
+
+	request := scf.NewDeleteTriggerRequest()
+	request.FunctionName = &functionName
+	request.TriggerName = &triggerName
+	request.Namespace = &namespace
+
+	if v, ok := d.GetOk("type"); ok {
+		request.Type = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("trigger_desc"); ok {
+		request.TriggerDesc = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("qualifier"); ok {
+		request.Qualifier = helper.String(v.(string))
+	}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseScfClient().DeleteTriggerWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s delete scf_trigger failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	return nil
+}

--- a/tencentcloud/services/scf/resource_tc_scf_trigger.go
+++ b/tencentcloud/services/scf/resource_tc_scf_trigger.go
@@ -2,8 +2,10 @@ package scf
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,6 +15,8 @@ import (
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 )
+
+var scfCosTriggerNameRE = regexp.MustCompile(`^[^.]+\.cos\.[^.]+\.myqcloud\.com$`)
 
 func ResourceTencentCloudScfTrigger() *schema.Resource {
 	return &schema.Resource{
@@ -32,29 +36,34 @@ func ResourceTencentCloudScfTrigger() *schema.Resource {
 			},
 
 			"trigger_name": {
-				Required:    true,
-				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeString,
-				Description: "Name of the trigger.",
+				Description: "Name of the trigger. It must not be specified when `type` is `http`; it must be specified when `type` is not `http`; when `type` is `cos`, it must match `<bucket>.cos.<region>.myqcloud.com`.",
 			},
 
 			"type": {
 				Required:    true,
 				ForceNew:    true,
 				Type:        schema.TypeString,
-				Description: "Trigger type. Valid values: `cos`, `cls`, `timer`, `ckafka`, `http`.",
+				Description: "Trigger type. Valid values: `cos`, `timer`, `ckafka`, `http`.To create Function URL please refer to [Creating a Function URL](https://www.tencentcloud.com/document/product/583/69492?lang=en&pg=); To create a CLS trigger, please refer to [Create Deliver CloudFunction (SCF)](https://www.tencentcloud.com/zh/document/product/614/59903).",
 			},
 
 			"trigger_desc": {
 				Optional:    true,
 				Type:        schema.TypeString,
-				Description: "Trigger description parameter, see the trigger description documentation for details.",
+				Description: "Trigger description parameter, see the trigger description documentation for details: https://www.tencentcloud.com/document/product/583/34880.",
+			},
+
+			"trigger_attribute": {
+				Computed:    true,
+				Type:        schema.TypeString,
+				Description: "Trigger description parameter, see the trigger description documentation for details: https://www.tencentcloud.com/document/product/583/34880.",
 			},
 
 			"namespace": {
-				Optional:    true,
+				Required:    true,
 				ForceNew:    true,
-				Default:     "default",
 				Type:        schema.TypeString,
 				Description: "Function namespace. Defaults to `default`.",
 			},
@@ -104,6 +113,142 @@ func ResourceTencentCloudScfTrigger() *schema.Resource {
 	}
 }
 
+func cleanTriggerDescEmptyStringFields(triggerDesc, triggerType string) string {
+	var triggerDescMap map[string]interface{}
+	if err := json.Unmarshal([]byte(triggerDesc), &triggerDescMap); err != nil {
+		return triggerDesc
+	}
+
+	switch triggerType {
+	case SCF_TRIGGER_TYPE_TIMER:
+		if cron, ok := triggerDescMap["cron"].(string); ok {
+			return cron
+		}
+		return triggerDesc
+	default:
+		removeEmptyStringFields(triggerDescMap)
+	}
+
+	cleanTriggerDesc, err := json.Marshal(triggerDescMap)
+	if err != nil {
+		return triggerDesc
+	}
+
+	return string(cleanTriggerDesc)
+}
+
+func cleanTriggerDescFieldsByConfig(triggerDesc, configTriggerDesc, triggerType string) string {
+	var triggerDescMap map[string]interface{}
+	if err := json.Unmarshal([]byte(triggerDesc), &triggerDescMap); err != nil {
+		return triggerDesc
+	}
+
+	switch triggerType {
+	case SCF_TRIGGER_TYPE_TIMER:
+		if cron, ok := triggerDescMap["cron"].(string); ok {
+			return cron
+		}
+		return triggerDesc
+	}
+
+	var configTriggerDescMap map[string]interface{}
+	if err := json.Unmarshal([]byte(configTriggerDesc), &configTriggerDescMap); err != nil {
+		cleanTriggerDesc, marshalErr := json.Marshal(triggerDescMap)
+		if marshalErr != nil {
+			return triggerDesc
+		}
+		return string(cleanTriggerDesc)
+	}
+	keepTriggerDescFieldsByConfig(triggerDescMap, configTriggerDescMap)
+
+	cleanTriggerDesc, err := json.Marshal(triggerDescMap)
+	if err != nil {
+		return triggerDesc
+	}
+
+	return string(cleanTriggerDesc)
+}
+
+func keepTriggerDescFieldsByConfig(triggerDesc, configTriggerDesc map[string]interface{}) {
+	for key, value := range triggerDesc {
+		configValue, ok := configTriggerDesc[key]
+		if !ok {
+			delete(triggerDesc, key)
+			continue
+		}
+
+		triggerDescValueMap, triggerDescValueIsMap := value.(map[string]interface{})
+		configTriggerDescValueMap, configTriggerDescValueIsMap := configValue.(map[string]interface{})
+		if triggerDescValueIsMap && configTriggerDescValueIsMap {
+			keepTriggerDescFieldsByConfig(triggerDescValueMap, configTriggerDescValueMap)
+		}
+	}
+}
+
+func removeEmptyStringFields(data map[string]interface{}) {
+	for key, value := range data {
+		switch v := value.(type) {
+		case nil:
+			delete(data, key)
+		case string:
+			if v == "" {
+				delete(data, key)
+			}
+		case int:
+			if v == 0 {
+				delete(data, key)
+			}
+		case int32:
+			if v == 0 {
+				delete(data, key)
+			}
+		case int64:
+			if v == 0 {
+				delete(data, key)
+			}
+		case float32:
+			if v == 0 {
+				delete(data, key)
+			}
+		case float64:
+			if v == 0 {
+				delete(data, key)
+			}
+		case map[string]interface{}:
+			removeEmptyStringFields(v)
+		case []interface{}:
+			for _, item := range v {
+				if itemMap, ok := item.(map[string]interface{}); ok {
+					removeEmptyStringFields(itemMap)
+				}
+			}
+		}
+	}
+}
+
+func validateScfTriggerName(d *schema.ResourceData) error {
+	v, ok := d.GetOk("trigger_name")
+
+	triggerType := d.Get("type").(string)
+	if triggerType == SCF_TRIGGER_TYPE_API_HTTP {
+		if ok && v.(string) != "" {
+			return fmt.Errorf("trigger_name must not be specified when type is %s", SCF_TRIGGER_TYPE_API_HTTP)
+		}
+		return nil
+	}
+
+	if !ok || v.(string) == "" {
+		return fmt.Errorf("trigger_name must be specified when type is not %s, %s", SCF_TRIGGER_TYPE_API_HTTP, triggerType)
+	}
+
+	triggerName := v.(string)
+	if triggerType == SCF_TRIGGER_TYPE_COS && !scfCosTriggerNameRE.MatchString(triggerName) {
+		return fmt.Errorf("trigger_name must match <bucket>.cos.<region>.myqcloud.com when type is %s", SCF_TRIGGER_TYPE_COS)
+	}
+
+	return nil
+}
+
 func resourceTencentCloudScfTriggerCreate(d *schema.ResourceData, meta interface{}) error {
 	defer tccommon.LogElapsed("resource.tencentcloud_scf_trigger.create")()
 	defer tccommon.InconsistentCheck(d, meta)()
@@ -122,17 +267,19 @@ func resourceTencentCloudScfTriggerCreate(d *schema.ResourceData, meta interface
 		functionName = v.(string)
 	}
 
-	if v, ok := d.GetOk("trigger_name"); ok {
-		request.TriggerName = helper.String(v.(string))
-		triggerName = v.(string)
-	}
-
 	if v, ok := d.GetOk("type"); ok {
 		request.Type = helper.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("trigger_desc"); ok {
-		request.TriggerDesc = helper.String(v.(string))
+	if err := validateScfTriggerName(d); err != nil {
+		return err
+	}
+
+	if v, ok := d.GetOk("trigger_name"); ok {
+		request.TriggerName = helper.String(v.(string))
+		triggerName = v.(string)
+	} else if v, ok := d.GetOk("type"); ok && v.(string) == SCF_TRIGGER_TYPE_API_HTTP {
+		request.TriggerName = helper.String("url-trigger")
 	}
 
 	if v, ok := d.GetOk("namespace"); ok {
@@ -142,6 +289,10 @@ func resourceTencentCloudScfTriggerCreate(d *schema.ResourceData, meta interface
 
 	if v, ok := d.GetOk("qualifier"); ok {
 		request.Qualifier = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("trigger_desc"); ok {
+		request.TriggerDesc = helper.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("enable"); ok {
@@ -181,6 +332,12 @@ func resourceTencentCloudScfTriggerCreate(d *schema.ResourceData, meta interface
 	if response.Response.TriggerInfo == nil {
 		log.Printf("[CRITAL]%s create scf_trigger failed, TriggerInfo is nil, d.Id()=%s", logId, d.Id())
 		return fmt.Errorf("create scf_trigger failed, TriggerInfo is nil.")
+	}
+	if response.Response.TriggerInfo.TriggerName != nil {
+		triggerName = *response.Response.TriggerInfo.TriggerName
+	} else if request.Type == nil || *request.Type != SCF_TRIGGER_TYPE_API_HTTP {
+		log.Printf("[CRITAL]%s create scf_trigger failed, TriggerName is nil, d.Id()=%s", logId, d.Id())
+		return fmt.Errorf("create scf_trigger failed, TriggerName is nil.")
 	}
 
 	d.SetId(functionName + tccommon.FILED_SP + namespace + tccommon.FILED_SP + triggerName)
@@ -239,7 +396,17 @@ func resourceTencentCloudScfTriggerRead(d *schema.ResourceData, meta interface{}
 	}
 
 	if triggerInfo.TriggerDesc != nil {
-		_ = d.Set("trigger_desc", triggerInfo.TriggerDesc)
+		triggerType := ""
+		if triggerInfo.Type != nil {
+			triggerType = *triggerInfo.Type
+		}
+		if v, ok := d.GetOk("trigger_desc"); ok {
+			_ = d.Set("trigger_desc", cleanTriggerDescFieldsByConfig(*triggerInfo.TriggerDesc, v.(string), triggerType))
+		} else {
+			_ = d.Set("trigger_desc", cleanTriggerDescEmptyStringFields(*triggerInfo.TriggerDesc, triggerType))
+		}
+
+		_ = d.Set("trigger_attribute", *triggerInfo.TriggerDesc)
 	}
 
 	if triggerInfo.Qualifier != nil {

--- a/tencentcloud/services/scf/resource_tc_scf_trigger.md
+++ b/tencentcloud/services/scf/resource_tc_scf_trigger.md
@@ -1,0 +1,35 @@
+Provides a resource to create a SCF (Serverless Cloud Function) trigger.
+
+Example Usage
+
+```hcl
+resource "tencentcloud_scf_function" "function" {
+  name    = "tf-example-function"
+  runtime = "Nodejs16.13"
+  handler = "index.main"
+  memory_size = 128
+  timeout     = 3
+  cos_bucket_name = "tf-example-bucket-1300000000"
+  cos_object_name = "function.zip"
+}
+
+resource "tencentcloud_scf_trigger" "timer" {
+  function_name = tencentcloud_scf_function.function.name
+  namespace     = "default"
+  trigger_name  = "tf-example-trigger"
+  type          = "timer"
+  trigger_desc  = jsonencode({ cron = "*/5 * * * * * *" })
+  enable        = "OPEN"
+  description   = "tf example trigger"
+  qualifier     = "$DEFAULT"
+  custom_argument = "Information"
+}
+```
+
+Import
+
+SCF trigger can be imported using the composite id `function_name#namespace#trigger_name`, e.g.
+
+```
+terraform import tencentcloud_scf_trigger.timer tf-example-function#default#tf-example-trigger
+```

--- a/tencentcloud/services/scf/resource_tc_scf_trigger.md
+++ b/tencentcloud/services/scf/resource_tc_scf_trigger.md
@@ -2,27 +2,179 @@ Provides a resource to create a SCF (Serverless Cloud Function) trigger.
 
 Example Usage
 
+Create an HTTP-type trigger
+
 ```hcl
-resource "tencentcloud_scf_function" "function" {
-  name    = "tf-example-function"
-  runtime = "Nodejs16.13"
-  handler = "index.main"
-  memory_size = 128
-  timeout     = 3
-  cos_bucket_name = "tf-example-bucket-1300000000"
-  cos_object_name = "function.zip"
+resource "tencentcloud_scf_function" "foo" {
+  async_run_enable  = "FALSE"
+  cos_bucket_name   = "tf-test-1308726196"
+  cos_bucket_region = "ap-guangzhou"
+  cos_object_name   = "/tf-test.zip"
+  description       = "helloworld-tftest"
+  dns_cache         = false
+  enable_eip_config = false
+  enable_public_net = true
+  environment       = {}
+  func_type         = "Event"
+  handler           = "index.main_handler"
+  l5_enable         = false
+  mem_size          = 128
+  name              = "helloworld-tf"
+  namespace         = "default"
+  role              = null
+  runtime           = "Python3.9"
+  subnet_id         = null
+  tags              = {}
+  timeout           = 3
+  vpc_id            = null
+  zip_file          = null
+  intranet_config {
+    ip_fixed = "DISABLE"
+  }
+}
+
+resource "tencentcloud_scf_function_version" "function_version" {
+  function_name = tencentcloud_scf_function.foo.name
+  namespace     = tencentcloud_scf_function.foo.namespace
+  description   = "tftest1"
+}
+
+resource "tencentcloud_scf_trigger" "http" {
+  enable        = "OPEN"
+  function_name = tencentcloud_scf_function.foo.name
+  namespace     = tencentcloud_scf_function.foo.namespace
+  qualifier     = tencentcloud_scf_function_version.function_version.function_version
+  trigger_desc = jsonencode({
+    ApiGwCompatible = true
+    AuthType        = "NONE"
+    CorsConfig = {
+      Credentials = false
+      Enable      = false
+      MaxAge      = 0
+    }
+    EnableSimpleMode = false
+    NetConfig = {
+      EnableExtranet = false
+      EnableIntranet = true
+    }
+  })
+  type = "http"
+}
+```
+
+Create a timer-type trigger.
+
+```hcl
+resource "tencentcloud_scf_function" "foo" {
+  async_run_enable  = "FALSE"
+  cos_bucket_name   = "tf-test-1308726196"
+  cos_bucket_region = "ap-guangzhou"
+  cos_object_name   = "/tf-test.zip"
+  description       = "helloworld-tftest"
+  dns_cache         = false
+  enable_eip_config = false
+  enable_public_net = true
+  environment       = {}
+  func_type         = "Event"
+  handler           = "index.main_handler"
+  l5_enable         = false
+  mem_size          = 128
+  name              = "helloworld-tf"
+  namespace         = "default"
+  role              = null
+  runtime           = "Python3.9"
+  subnet_id         = null
+  tags              = {}
+  timeout           = 3
+  vpc_id            = null
+  zip_file          = null
+  intranet_config {
+    ip_fixed = "DISABLE"
+  }
+}
+
+resource "tencentcloud_scf_function_version" "function_version" {
+  function_name = tencentcloud_scf_function.foo.name
+  namespace     = tencentcloud_scf_function.foo.namespace
+  description   = "tftest1"
 }
 
 resource "tencentcloud_scf_trigger" "timer" {
-  function_name = tencentcloud_scf_function.function.name
-  namespace     = "default"
-  trigger_name  = "tf-example-trigger"
-  type          = "timer"
-  trigger_desc  = jsonencode({ cron = "*/5 * * * * * *" })
-  enable        = "OPEN"
-  description   = "tf example trigger"
-  qualifier     = "$DEFAULT"
-  custom_argument = "Information"
+  function_name   = tencentcloud_scf_function.foo.name
+  namespace       = tencentcloud_scf_function.foo.namespace
+  qualifier       = tencentcloud_scf_function_version.function_version.function_version
+  custom_argument = null
+  description     = null
+  enable          = "OPEN"
+  trigger_desc    = "0 0 0 */1 * * *"
+  trigger_name    = "tf-test-timer"
+  type            = "timer"
+}
+
+```
+
+Create a ckafka-type trigger.
+
+```hcl
+resource "tencentcloud_scf_function" "foo" {
+  async_run_enable  = "FALSE"
+  cos_bucket_name   = "tf-test-1308726196"
+  cos_bucket_region = "ap-guangzhou"
+  cos_object_name   = "/tf-test.zip"
+  description       = "helloworld-tftest"
+  dns_cache         = false
+  enable_eip_config = false
+  enable_public_net = true
+  environment       = {}
+  func_type         = "Event"
+  handler           = "index.main_handler"
+  l5_enable         = false
+  mem_size          = 128
+  name              = "helloworld-tf"
+  namespace         = "default"
+  role              = null
+  runtime           = "Python3.9"
+  subnet_id         = null
+  tags              = {}
+  timeout           = 3
+  vpc_id            = null
+  zip_file          = null
+  intranet_config {
+    ip_fixed = "DISABLE"
+  }
+}
+
+resource "tencentcloud_scf_function_version" "function_version" {
+  function_name = tencentcloud_scf_function.foo.name
+  namespace     = tencentcloud_scf_function.foo.namespace
+  description   = "tftest1"
+}
+resource "tencentcloud_scf_trigger" "kafka" {
+  custom_argument = null
+  description     = "tf test"
+  enable          = "OPEN"
+  function_name   = tencentcloud_scf_function.foo.name
+  namespace       = tencentcloud_scf_function.foo.namespace
+  qualifier       = tencentcloud_scf_function_version.function_version.function_version
+  trigger_desc = jsonencode({
+    VIPList           = ["11.135.14.109:26246"]
+    consumerGroupName = "scf_ckafka-4kdjmwvztf-testhelloworld-tf_DEFAULT"
+    instanceId        = "ckafka-4kdjmwvz"
+    isInSequence      = "Yes"
+    kafkaStatus       = "NORMAL"
+    maxMsgNum         = 100
+    maxSingleMsgSize  = 100
+    maxTotalMsgSize   = 100
+    offset            = "latest"
+    partitionNum      = 3
+    retry             = 10000
+    timeOut           = 50
+    topicId           = "topic-bjmcknbs"
+    topicName         = "tf-test"
+    topicStatus       = "NORMAL"
+  })
+  trigger_name = "ckafka-4kdjmwvz-tf-test"
+  type         = "ckafka"
 }
 ```
 
@@ -32,4 +184,13 @@ SCF trigger can be imported using the composite id `function_name#namespace#trig
 
 ```
 terraform import tencentcloud_scf_trigger.timer tf-example-function#default#tf-example-trigger
+```
+
+Or use Terraform 1.5+ `import` block:
+
+```hcl
+import {
+  to = tencentcloud_scf_trigger.http
+  id = "tf-example-function#default#tf-example-trigger"
+}
 ```

--- a/tencentcloud/services/scf/resource_tc_scf_trigger.md
+++ b/tencentcloud/services/scf/resource_tc_scf_trigger.md
@@ -1,5 +1,9 @@
 Provides a resource to create a SCF (Serverless Cloud Function) trigger.
 
+~> **NOTE:** Using it alongside `tencentcloud_scf_function.trigger` will cause a conflict.
+
+~> **NOTE:** Using it alongside `tencentcloud_scf_trigger_config` will cause a conflict.
+
 Example Usage
 
 Create an HTTP-type trigger

--- a/tencentcloud/services/scf/resource_tc_scf_trigger_config.md
+++ b/tencentcloud/services/scf/resource_tc_scf_trigger_config.md
@@ -1,5 +1,7 @@
 Provides a resource to create a scf trigger_config
 
+~> **NOTE:** Use of the current resource is no longer recommended; `tencentcloud_scf_trigger` is recommended instead.
+
 Example Usage
 
 ```hcl

--- a/tencentcloud/services/scf/resource_tc_scf_trigger_test.go
+++ b/tencentcloud/services/scf/resource_tc_scf_trigger_test.go
@@ -1,0 +1,407 @@
+package scf_test
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	scf "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf/v20180416"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	scfsvc "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/scf"
+)
+
+// Run with: go test ./tencentcloud/services/scf/ -run "TestScfTrigger" -v -count=1 -gcflags="all=-l"
+
+type mockMetaScfTrigger struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaScfTrigger) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaScfTrigger{}
+
+func newMockMetaScfTrigger() *mockMetaScfTrigger {
+	return &mockMetaScfTrigger{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringScfTrigger(s string) *string {
+	return &s
+}
+
+func ptrUint64ScfTrigger(v uint64) *uint64 {
+	return &v
+}
+
+// TestScfTriggerCreate verifies the create path sets the composite id and passes
+// schema fields to the CreateTrigger request.
+func TestScfTriggerCreate(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	scfClient := &scf.Client{}
+	patches.ApplyMethodReturn(newMockMetaScfTrigger().client, "UseScfClient", scfClient)
+
+	var capturedRequest *scf.CreateTriggerRequest
+	patches.ApplyMethodFunc(scfClient, "CreateTriggerWithContext", func(ctx interface{}, request *scf.CreateTriggerRequest) (*scf.CreateTriggerResponse, error) {
+		capturedRequest = request
+		resp := scf.NewCreateTriggerResponse()
+		resp.Response = &scf.CreateTriggerResponseParams{
+			TriggerInfo: &scf.Trigger{
+				TriggerName: ptrStringScfTrigger("tf-trigger"),
+				Type:        ptrStringScfTrigger("timer"),
+			},
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock ListTriggers called by the read after create.
+	patches.ApplyMethodFunc(scfClient, "ListTriggers", func(request *scf.ListTriggersRequest) (*scf.ListTriggersResponse, error) {
+		resp := scf.NewListTriggersResponse()
+		resp.Response = &scf.ListTriggersResponseParams{
+			TotalCount: ptrUint64ScfTrigger(1),
+			Triggers: []*scf.TriggerInfo{{
+				TriggerName:     ptrStringScfTrigger("tf-trigger"),
+				Type:            ptrStringScfTrigger("timer"),
+				TriggerDesc:     ptrStringScfTrigger(`{"cron":"*/5 * * * * * *"}`),
+				Qualifier:       ptrStringScfTrigger("$DEFAULT"),
+				Enable:          ptrUint64ScfTrigger(1),
+				AvailableStatus: ptrStringScfTrigger("AVAILABLE"),
+				Description:     ptrStringScfTrigger("desc"),
+				CustomArgument:  ptrStringScfTrigger("arg"),
+				AddTime:         ptrStringScfTrigger("2025-01-01 00:00:00"),
+				ModTime:         ptrStringScfTrigger("2025-01-01 00:00:00"),
+			}},
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaScfTrigger()
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"function_name":   "tf-function",
+		"trigger_name":    "tf-trigger",
+		"type":            "timer",
+		"namespace":       "default",
+		"trigger_desc":    `{"cron":"*/5 * * * * *"}`,
+		"qualifier":       "$DEFAULT",
+		"enable":          "OPEN",
+		"description":     "desc",
+		"custom_argument": "arg",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+
+	// Verify composite id.
+	assert.Equal(t, "tf-function#default#tf-trigger", d.Id())
+
+	// Verify required fields were passed to the create request.
+	assert.NotNil(t, capturedRequest)
+	assert.Equal(t, "tf-function", *capturedRequest.FunctionName)
+	assert.Equal(t, "tf-trigger", *capturedRequest.TriggerName)
+	assert.Equal(t, "timer", *capturedRequest.Type)
+	assert.Equal(t, "default", *capturedRequest.Namespace)
+	assert.Equal(t, "OPEN", *capturedRequest.Enable)
+
+	// Verify enable was converted from int64 to string on read.
+	assert.Equal(t, "OPEN", d.Get("enable").(string))
+	assert.Equal(t, "AVAILABLE", d.Get("available_status").(string))
+}
+
+// TestScfTriggerCreate_NilResponse verifies create fails when the API returns a nil TriggerInfo.
+func TestScfTriggerCreate_NilResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	scfClient := &scf.Client{}
+	patches.ApplyMethodReturn(newMockMetaScfTrigger().client, "UseScfClient", scfClient)
+
+	patches.ApplyMethodFunc(scfClient, "CreateTriggerWithContext", func(ctx interface{}, request *scf.CreateTriggerRequest) (*scf.CreateTriggerResponse, error) {
+		resp := scf.NewCreateTriggerResponse()
+		resp.Response = &scf.CreateTriggerResponseParams{
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaScfTrigger()
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"function_name": "tf-function",
+		"trigger_name":  "tf-trigger",
+		"type":          "timer",
+	})
+
+	err := res.Create(d, meta)
+	assert.Error(t, err)
+	// Verify id was NOT set when TriggerInfo is nil.
+	assert.Equal(t, "", d.Id())
+}
+
+// TestScfTriggerRead verifies the read path populates state from TriggerInfo.
+func TestScfTriggerRead(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	scfClient := &scf.Client{}
+	patches.ApplyMethodReturn(newMockMetaScfTrigger().client, "UseScfClient", scfClient)
+
+	patches.ApplyMethodFunc(scfClient, "ListTriggers", func(request *scf.ListTriggersRequest) (*scf.ListTriggersResponse, error) {
+		resp := scf.NewListTriggersResponse()
+		resp.Response = &scf.ListTriggersResponseParams{
+			TotalCount: ptrUint64ScfTrigger(1),
+			Triggers: []*scf.TriggerInfo{{
+				TriggerName:     ptrStringScfTrigger("tf-trigger"),
+				Type:            ptrStringScfTrigger("timer"),
+				TriggerDesc:     ptrStringScfTrigger(`{"cron":"*/5 * * * * *"}`),
+				Qualifier:       ptrStringScfTrigger("$DEFAULT"),
+				Enable:          ptrUint64ScfTrigger(1),
+				AvailableStatus: ptrStringScfTrigger("AVAILABLE"),
+				Description:     ptrStringScfTrigger("desc"),
+				CustomArgument:  ptrStringScfTrigger("arg"),
+				AddTime:         ptrStringScfTrigger("2025-01-01 00:00:00"),
+				ModTime:         ptrStringScfTrigger("2025-01-01 00:00:00"),
+			}},
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaScfTrigger()
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+	d.SetId("tf-function#default#tf-trigger")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "tf-function#default#tf-trigger", d.Id())
+	assert.Equal(t, "tf-function", d.Get("function_name").(string))
+	assert.Equal(t, "default", d.Get("namespace").(string))
+	assert.Equal(t, "tf-trigger", d.Get("trigger_name").(string))
+	assert.Equal(t, "timer", d.Get("type").(string))
+	assert.Equal(t, "OPEN", d.Get("enable").(string))
+	assert.Equal(t, "AVAILABLE", d.Get("available_status").(string))
+	assert.Equal(t, "2025-01-01 00:00:00", d.Get("add_time").(string))
+	assert.Equal(t, "2025-01-01 00:00:00", d.Get("mod_time").(string))
+}
+
+// TestScfTriggerRead_NotFound verifies the read path clears the id when the trigger is gone.
+func TestScfTriggerRead_NotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	scfClient := &scf.Client{}
+	patches.ApplyMethodReturn(newMockMetaScfTrigger().client, "UseScfClient", scfClient)
+
+	patches.ApplyMethodFunc(scfClient, "ListTriggers", func(request *scf.ListTriggersRequest) (*scf.ListTriggersResponse, error) {
+		resp := scf.NewListTriggersResponse()
+		resp.Response = &scf.ListTriggersResponseParams{
+			TotalCount: ptrUint64ScfTrigger(0),
+			Triggers:   []*scf.TriggerInfo{},
+			RequestId:  ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaScfTrigger()
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+	d.SetId("tf-function#default#tf-trigger")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	// Verify the id was cleared because the trigger was not found.
+	assert.Equal(t, "", d.Id())
+}
+
+// TestScfTriggerRead_BrokenId verifies the read path rejects a broken id.
+func TestScfTriggerRead_BrokenId(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	scfClient := &scf.Client{}
+	patches.ApplyMethodReturn(newMockMetaScfTrigger().client, "UseScfClient", scfClient)
+
+	meta := newMockMetaScfTrigger()
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+	d.SetId("broken-id")
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}
+
+// TestScfTriggerUpdate verifies the update path passes mutable fields to UpdateTrigger.
+func TestScfTriggerUpdate(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	scfClient := &scf.Client{}
+	patches.ApplyMethodReturn(newMockMetaScfTrigger().client, "UseScfClient", scfClient)
+
+	var capturedRequest *scf.UpdateTriggerRequest
+	patches.ApplyMethodFunc(scfClient, "UpdateTriggerWithContext", func(ctx interface{}, request *scf.UpdateTriggerRequest) (*scf.UpdateTriggerResponse, error) {
+		capturedRequest = request
+		resp := scf.NewUpdateTriggerResponse()
+		resp.Response = &scf.UpdateTriggerResponseParams{
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock ListTriggers called by the read after update.
+	patches.ApplyMethodFunc(scfClient, "ListTriggers", func(request *scf.ListTriggersRequest) (*scf.ListTriggersResponse, error) {
+		resp := scf.NewListTriggersResponse()
+		resp.Response = &scf.ListTriggersResponseParams{
+			TotalCount: ptrUint64ScfTrigger(1),
+			Triggers: []*scf.TriggerInfo{{
+				TriggerName:     ptrStringScfTrigger("tf-trigger"),
+				Type:            ptrStringScfTrigger("timer"),
+				TriggerDesc:     ptrStringScfTrigger(`{"cron":"*/5 * * * * *"}`),
+				Qualifier:       ptrStringScfTrigger("$DEFAULT"),
+				Enable:          ptrUint64ScfTrigger(0),
+				AvailableStatus: ptrStringScfTrigger("AVAILABLE"),
+				Description:     ptrStringScfTrigger("desc-updated"),
+				CustomArgument:  ptrStringScfTrigger("arg"),
+				AddTime:         ptrStringScfTrigger("2025-01-01 00:00:00"),
+				ModTime:         ptrStringScfTrigger("2025-01-02 00:00:00"),
+			}},
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaScfTrigger()
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"function_name":   "tf-function",
+		"trigger_name":    "tf-trigger",
+		"type":            "timer",
+		"namespace":       "default",
+		"trigger_desc":    `{"cron":"*/5 * * * * *"}`,
+		"qualifier":       "$DEFAULT",
+		"enable":          "CLOSE",
+		"description":     "desc-updated",
+		"custom_argument": "arg",
+	})
+	d.SetId("tf-function#default#tf-trigger")
+
+	// Patch HasChange to simulate changes in mutable fields only.
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		switch key {
+		case "enable", "qualifier", "trigger_desc", "description", "custom_argument":
+			return true
+		}
+		return false
+	})
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	// Verify mutable fields were passed to the update request.
+	assert.NotNil(t, capturedRequest)
+	assert.Equal(t, "tf-function", *capturedRequest.FunctionName)
+	assert.Equal(t, "default", *capturedRequest.Namespace)
+	assert.Equal(t, "tf-trigger", *capturedRequest.TriggerName)
+	assert.Equal(t, "CLOSE", *capturedRequest.Enable)
+	assert.Equal(t, "desc-updated", *capturedRequest.Description)
+
+	// Verify enable was read back as CLOSE (int64 0 -> CLOSE).
+	assert.Equal(t, "CLOSE", d.Get("enable").(string))
+	assert.Equal(t, "desc-updated", d.Get("description").(string))
+}
+
+// TestScfTriggerDelete verifies the delete path builds the DeleteTrigger request.
+func TestScfTriggerDelete(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	scfClient := &scf.Client{}
+	patches.ApplyMethodReturn(newMockMetaScfTrigger().client, "UseScfClient", scfClient)
+
+	var capturedRequest *scf.DeleteTriggerRequest
+	patches.ApplyMethodFunc(scfClient, "DeleteTriggerWithContext", func(ctx interface{}, request *scf.DeleteTriggerRequest) (*scf.DeleteTriggerResponse, error) {
+		capturedRequest = request
+		resp := scf.NewDeleteTriggerResponse()
+		resp.Response = &scf.DeleteTriggerResponseParams{
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaScfTrigger()
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"function_name": "tf-function",
+		"trigger_name":  "tf-trigger",
+		"type":          "timer",
+		"namespace":     "default",
+		"trigger_desc":  `{"cron":"*/5 * * * * *"}`,
+		"qualifier":     "$DEFAULT",
+	})
+	d.SetId("tf-function#default#tf-trigger")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+
+	// Verify the delete request was built correctly from state.
+	assert.NotNil(t, capturedRequest)
+	assert.Equal(t, "tf-function", *capturedRequest.FunctionName)
+	assert.Equal(t, "tf-trigger", *capturedRequest.TriggerName)
+	assert.Equal(t, "timer", *capturedRequest.Type)
+	assert.Equal(t, "default", *capturedRequest.Namespace)
+	assert.Equal(t, "$DEFAULT", *capturedRequest.Qualifier)
+}
+
+// TestScfTriggerSchema validates the schema definition.
+func TestScfTriggerSchema(t *testing.T) {
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+
+	// Required + ForceNew identity fields.
+	functionName, ok := res.Schema["function_name"]
+	assert.True(t, ok, "function_name should exist in schema")
+	assert.True(t, functionName.Required)
+	assert.True(t, functionName.ForceNew)
+
+	triggerName, ok := res.Schema["trigger_name"]
+	assert.True(t, ok, "trigger_name should exist in schema")
+	assert.True(t, triggerName.Required)
+	assert.True(t, triggerName.ForceNew)
+
+	typeField, ok := res.Schema["type"]
+	assert.True(t, ok, "type should exist in schema")
+	assert.True(t, typeField.Required)
+	assert.True(t, typeField.ForceNew)
+
+	// Namespace defaults to default and is ForceNew.
+	namespace, ok := res.Schema["namespace"]
+	assert.True(t, ok, "namespace should exist in schema")
+	assert.True(t, namespace.Optional)
+	assert.True(t, namespace.ForceNew)
+	assert.Equal(t, "default", namespace.Default)
+
+	// Mutable fields are Optional and not ForceNew.
+	for _, field := range []string{"enable", "qualifier", "trigger_desc", "description", "custom_argument"} {
+		f, ok := res.Schema[field]
+		assert.True(t, ok, "%s should exist in schema", field)
+		assert.True(t, f.Optional, "%s should be optional", field)
+		assert.False(t, f.ForceNew, "%s should not be ForceNew", field)
+	}
+
+	// Computed fields.
+	for _, field := range []string{"available_status", "add_time", "mod_time"} {
+		f, ok := res.Schema[field]
+		assert.True(t, ok, "%s should exist in schema", field)
+		assert.True(t, f.Computed, "%s should be computed", field)
+	}
+
+	// Importer.
+	assert.NotNil(t, res.Importer)
+}

--- a/tencentcloud/services/scf/resource_tc_scf_trigger_test.go
+++ b/tencentcloud/services/scf/resource_tc_scf_trigger_test.go
@@ -68,7 +68,7 @@ func TestScfTriggerCreate(t *testing.T) {
 			Triggers: []*scf.TriggerInfo{{
 				TriggerName:     ptrStringScfTrigger("tf-trigger"),
 				Type:            ptrStringScfTrigger("timer"),
-				TriggerDesc:     ptrStringScfTrigger(`{"cron":"*/5 * * * * * *"}`),
+				TriggerDesc:     ptrStringScfTrigger(`{"cron":"*/5 * * * * *","filter":{"Prefix":"","Suffix":"suffix","Key":null,"Count":0}}`),
 				Qualifier:       ptrStringScfTrigger("$DEFAULT"),
 				Enable:          ptrUint64ScfTrigger(1),
 				AvailableStatus: ptrStringScfTrigger("AVAILABLE"),
@@ -89,7 +89,7 @@ func TestScfTriggerCreate(t *testing.T) {
 		"trigger_name":    "tf-trigger",
 		"type":            "timer",
 		"namespace":       "default",
-		"trigger_desc":    `{"cron":"*/5 * * * * *"}`,
+		"trigger_desc":    `{"cron":"*/5 * * * * *","filter":{"Suffix":"suffix"}}`,
 		"qualifier":       "$DEFAULT",
 		"enable":          "OPEN",
 		"description":     "desc",
@@ -145,6 +145,91 @@ func TestScfTriggerCreate_NilResponse(t *testing.T) {
 	assert.Equal(t, "", d.Id())
 }
 
+// TestScfTriggerCreate_HttpWithoutTriggerName verifies http triggers do not require trigger_name.
+func TestScfTriggerCreate_HttpWithoutTriggerName(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	scfClient := &scf.Client{}
+	patches.ApplyMethodReturn(newMockMetaScfTrigger().client, "UseScfClient", scfClient)
+
+	var capturedRequest *scf.CreateTriggerRequest
+	patches.ApplyMethodFunc(scfClient, "CreateTriggerWithContext", func(ctx interface{}, request *scf.CreateTriggerRequest) (*scf.CreateTriggerResponse, error) {
+		capturedRequest = request
+		resp := scf.NewCreateTriggerResponse()
+		resp.Response = &scf.CreateTriggerResponseParams{
+			TriggerInfo: &scf.Trigger{
+				Type: ptrStringScfTrigger("http"),
+			},
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(scfClient, "ListTriggers", func(request *scf.ListTriggersRequest) (*scf.ListTriggersResponse, error) {
+		resp := scf.NewListTriggersResponse()
+		resp.Response = &scf.ListTriggersResponseParams{
+			TotalCount: ptrUint64ScfTrigger(1),
+			Triggers: []*scf.TriggerInfo{{
+				Type:            ptrStringScfTrigger("http"),
+				Qualifier:       ptrStringScfTrigger("$DEFAULT"),
+				Enable:          ptrUint64ScfTrigger(1),
+				AvailableStatus: ptrStringScfTrigger("AVAILABLE"),
+				AddTime:         ptrStringScfTrigger("2025-01-01 00:00:00"),
+				ModTime:         ptrStringScfTrigger("2025-01-01 00:00:00"),
+			}},
+			RequestId: ptrStringScfTrigger("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaScfTrigger()
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"function_name": "tf-function",
+		"type":          "http",
+		"namespace":     "default",
+		"qualifier":     "$DEFAULT",
+		"enable":        "OPEN",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "tf-function#default#", d.Id())
+	assert.NotNil(t, capturedRequest)
+	assert.Nil(t, capturedRequest.TriggerName)
+	assert.Equal(t, "http", *capturedRequest.Type)
+}
+
+// TestScfTriggerCreate_MissingTriggerNameForNonHttp verifies non-http triggers require trigger_name.
+func TestScfTriggerCreate_MissingTriggerNameForNonHttp(t *testing.T) {
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"function_name": "tf-function",
+		"type":          "timer",
+		"namespace":     "default",
+	})
+
+	err := res.Create(d, newMockMetaScfTrigger())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "trigger_name must be specified when type is not http")
+}
+
+// TestScfTriggerCreate_InvalidCosTriggerName verifies cos triggers require trigger_name to be a COS bucket domain.
+func TestScfTriggerCreate_InvalidCosTriggerName(t *testing.T) {
+	res := scfsvc.ResourceTencentCloudScfTrigger()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"function_name": "tf-function",
+		"trigger_name":  "tf-trigger",
+		"type":          "cos",
+		"namespace":     "default",
+	})
+
+	err := res.Create(d, newMockMetaScfTrigger())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "trigger_name must match <bucket>.cos.<region>.myqcloud.com when type is cos")
+}
+
 // TestScfTriggerRead verifies the read path populates state from TriggerInfo.
 func TestScfTriggerRead(t *testing.T) {
 	patches := gomonkey.NewPatches()
@@ -160,7 +245,7 @@ func TestScfTriggerRead(t *testing.T) {
 			Triggers: []*scf.TriggerInfo{{
 				TriggerName:     ptrStringScfTrigger("tf-trigger"),
 				Type:            ptrStringScfTrigger("timer"),
-				TriggerDesc:     ptrStringScfTrigger(`{"cron":"*/5 * * * * *"}`),
+				TriggerDesc:     ptrStringScfTrigger(`{"cron":"*/5 * * * * *","filter":{"Prefix":"","Suffix":"suffix","Key":null,"Count":0}}`),
 				Qualifier:       ptrStringScfTrigger("$DEFAULT"),
 				Enable:          ptrUint64ScfTrigger(1),
 				AvailableStatus: ptrStringScfTrigger("AVAILABLE"),
@@ -186,6 +271,7 @@ func TestScfTriggerRead(t *testing.T) {
 	assert.Equal(t, "default", d.Get("namespace").(string))
 	assert.Equal(t, "tf-trigger", d.Get("trigger_name").(string))
 	assert.Equal(t, "timer", d.Get("type").(string))
+	assert.Equal(t, `{"cron":"*/5 * * * * *","filter":{"Suffix":"suffix"}}`, d.Get("trigger_desc").(string))
 	assert.Equal(t, "OPEN", d.Get("enable").(string))
 	assert.Equal(t, "AVAILABLE", d.Get("available_status").(string))
 	assert.Equal(t, "2025-01-01 00:00:00", d.Get("add_time").(string))
@@ -372,20 +458,25 @@ func TestScfTriggerSchema(t *testing.T) {
 
 	triggerName, ok := res.Schema["trigger_name"]
 	assert.True(t, ok, "trigger_name should exist in schema")
-	assert.True(t, triggerName.Required)
-	assert.True(t, triggerName.ForceNew)
+	assert.True(t, triggerName.Optional)
+	assert.True(t, triggerName.Computed)
+	assert.False(t, triggerName.ForceNew)
 
 	typeField, ok := res.Schema["type"]
 	assert.True(t, ok, "type should exist in schema")
 	assert.True(t, typeField.Required)
 	assert.True(t, typeField.ForceNew)
+	assert.NotNil(t, typeField.ValidateFunc)
+	_, errors := typeField.ValidateFunc("http", "type")
+	assert.Empty(t, errors)
+	_, errors = typeField.ValidateFunc("invalid", "type")
+	assert.NotEmpty(t, errors)
 
-	// Namespace defaults to default and is ForceNew.
+	// Namespace is required and ForceNew.
 	namespace, ok := res.Schema["namespace"]
 	assert.True(t, ok, "namespace should exist in schema")
-	assert.True(t, namespace.Optional)
+	assert.True(t, namespace.Required)
 	assert.True(t, namespace.ForceNew)
-	assert.Equal(t, "default", namespace.Default)
 
 	// Mutable fields are Optional and not ForceNew.
 	for _, field := range []string{"enable", "qualifier", "trigger_desc", "description", "custom_argument"} {

--- a/tencentcloud/services/scf/service_tencentcloud_scf.go
+++ b/tencentcloud/services/scf/service_tencentcloud_scf.go
@@ -1433,3 +1433,58 @@ func (me *ScfService) DescribeScfCustomDomainById(ctx context.Context, domain st
 	ret = response.Response
 	return
 }
+
+func (me *ScfService) DescribeScfTriggerById(ctx context.Context, functionName string, namespace string, triggerName string) (trigger *scf.TriggerInfo, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := scf.NewListTriggersRequest()
+	request.FunctionName = &functionName
+	request.Namespace = &namespace
+
+	filter := scf.Filter{
+		Name:   helper.String("TriggerName"),
+		Values: []*string{&triggerName},
+	}
+
+	request.Filters = append(request.Filters, &filter)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	ratelimit.Check(request.GetAction())
+
+	var (
+		offset uint64 = 0
+		limit  uint64 = 20
+	)
+	instances := make([]*scf.TriggerInfo, 0)
+	for {
+		request.Offset = &offset
+		request.Limit = &limit
+		response, err := me.client.UseScfClient().ListTriggers(request)
+		if err != nil {
+			errRet = err
+			return
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+		if response == nil || len(response.Response.Triggers) < 1 {
+			break
+		}
+		instances = append(instances, response.Response.Triggers...)
+		if len(response.Response.Triggers) < int(limit) {
+			break
+		}
+
+		offset += limit
+	}
+
+	if len(instances) < 1 {
+		return
+	}
+	trigger = instances[0]
+	return
+}

--- a/tencentcloud/services/scf/service_tencentcloud_scf.go
+++ b/tencentcloud/services/scf/service_tencentcloud_scf.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 
@@ -637,6 +638,7 @@ func waitScfFunctionReady(ctx context.Context, name, namespace string, client *s
 			return resource.RetryableError(errors.New("function is not ready"))
 
 		case SCF_FUNCTION_STATUS_ACTIVE:
+			time.Sleep(3 * time.Second)
 			return nil
 
 		default:

--- a/website/docs/r/scf_function.html.markdown
+++ b/website/docs/r/scf_function.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Provide a resource to create a SCF function.
 
+~> **NOTE:** The use of `trigger` is no longer recommended; `tencentcloud_scf_trigger` is recommended instead.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/scf_trigger.html.markdown
+++ b/website/docs/r/scf_trigger.html.markdown
@@ -1,0 +1,71 @@
+---
+subcategory: "Serverless Cloud Function(SCF)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_scf_trigger"
+sidebar_current: "docs-tencentcloud-resource-scf_trigger"
+description: |-
+  Provides a resource to create a SCF (Serverless Cloud Function) trigger.
+---
+
+# tencentcloud_scf_trigger
+
+Provides a resource to create a SCF (Serverless Cloud Function) trigger.
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_scf_function" "function" {
+  name            = "tf-example-function"
+  runtime         = "Nodejs16.13"
+  handler         = "index.main"
+  memory_size     = 128
+  timeout         = 3
+  cos_bucket_name = "tf-example-bucket-1300000000"
+  cos_object_name = "function.zip"
+}
+
+resource "tencentcloud_scf_trigger" "timer" {
+  function_name   = tencentcloud_scf_function.function.name
+  namespace       = "default"
+  trigger_name    = "tf-example-trigger"
+  type            = "timer"
+  trigger_desc    = jsonencode({ cron = "*/5 * * * * * *" })
+  enable          = "OPEN"
+  description     = "tf example trigger"
+  qualifier       = "$DEFAULT"
+  custom_argument = "Information"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `function_name` - (Required, String, ForceNew) Name of the SCF function that the trigger binds to.
+* `trigger_name` - (Required, String, ForceNew) Name of the trigger.
+* `type` - (Required, String, ForceNew) Trigger type. Valid values: `cos`, `cls`, `timer`, `ckafka`, `http`.
+* `custom_argument` - (Optional, String) User custom parameter, only supported by timer trigger.
+* `description` - (Optional, String) Trigger description.
+* `enable` - (Optional, String) Trigger enable status. Valid values: `OPEN` (enabled), `CLOSE` (disabled).
+* `namespace` - (Optional, String, ForceNew) Function namespace. Defaults to `default`.
+* `qualifier` - (Optional, String) Function version or alias that the trigger points to. Defaults to `$LATEST`.
+* `trigger_desc` - (Optional, String) Trigger description parameter, see the trigger description documentation for details.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `add_time` - Trigger creation time.
+* `available_status` - Trigger available status.
+* `mod_time` - Trigger last modified time.
+
+
+## Import
+
+SCF trigger can be imported using the composite id `function_name#namespace#trigger_name`, e.g.
+
+```
+terraform import tencentcloud_scf_trigger.timer tf-example-function#default#tf-example-trigger
+```
+

--- a/website/docs/r/scf_trigger.html.markdown
+++ b/website/docs/r/scf_trigger.html.markdown
@@ -11,29 +11,184 @@ description: |-
 
 Provides a resource to create a SCF (Serverless Cloud Function) trigger.
 
+~> **NOTE:** Using it alongside `tencentcloud_scf_function.trigger` will cause a conflict.
+
+~> **NOTE:** Using it alongside `tencentcloud_scf_trigger_config` will cause a conflict.
+
 ## Example Usage
 
+### Create an HTTP-type trigger
+
 ```hcl
-resource "tencentcloud_scf_function" "function" {
-  name            = "tf-example-function"
-  runtime         = "Nodejs16.13"
-  handler         = "index.main"
-  memory_size     = 128
-  timeout         = 3
-  cos_bucket_name = "tf-example-bucket-1300000000"
-  cos_object_name = "function.zip"
+resource "tencentcloud_scf_function" "foo" {
+  async_run_enable  = "FALSE"
+  cos_bucket_name   = "tf-test-1308726196"
+  cos_bucket_region = "ap-guangzhou"
+  cos_object_name   = "/tf-test.zip"
+  description       = "helloworld-tftest"
+  dns_cache         = false
+  enable_eip_config = false
+  enable_public_net = true
+  environment       = {}
+  func_type         = "Event"
+  handler           = "index.main_handler"
+  l5_enable         = false
+  mem_size          = 128
+  name              = "helloworld-tf"
+  namespace         = "default"
+  role              = null
+  runtime           = "Python3.9"
+  subnet_id         = null
+  tags              = {}
+  timeout           = 3
+  vpc_id            = null
+  zip_file          = null
+  intranet_config {
+    ip_fixed = "DISABLE"
+  }
+}
+
+resource "tencentcloud_scf_function_version" "function_version" {
+  function_name = tencentcloud_scf_function.foo.name
+  namespace     = tencentcloud_scf_function.foo.namespace
+  description   = "tftest1"
+}
+
+resource "tencentcloud_scf_trigger" "http" {
+  enable        = "OPEN"
+  function_name = tencentcloud_scf_function.foo.name
+  namespace     = tencentcloud_scf_function.foo.namespace
+  qualifier     = tencentcloud_scf_function_version.function_version.function_version
+  trigger_desc = jsonencode({
+    ApiGwCompatible = true
+    AuthType        = "NONE"
+    CorsConfig = {
+      Credentials = false
+      Enable      = false
+      MaxAge      = 0
+    }
+    EnableSimpleMode = false
+    NetConfig = {
+      EnableExtranet = false
+      EnableIntranet = true
+    }
+  })
+  type = "http"
+}
+```
+
+### Create a timer-type trigger.
+
+```hcl
+resource "tencentcloud_scf_function" "foo" {
+  async_run_enable  = "FALSE"
+  cos_bucket_name   = "tf-test-1308726196"
+  cos_bucket_region = "ap-guangzhou"
+  cos_object_name   = "/tf-test.zip"
+  description       = "helloworld-tftest"
+  dns_cache         = false
+  enable_eip_config = false
+  enable_public_net = true
+  environment       = {}
+  func_type         = "Event"
+  handler           = "index.main_handler"
+  l5_enable         = false
+  mem_size          = 128
+  name              = "helloworld-tf"
+  namespace         = "default"
+  role              = null
+  runtime           = "Python3.9"
+  subnet_id         = null
+  tags              = {}
+  timeout           = 3
+  vpc_id            = null
+  zip_file          = null
+  intranet_config {
+    ip_fixed = "DISABLE"
+  }
+}
+
+resource "tencentcloud_scf_function_version" "function_version" {
+  function_name = tencentcloud_scf_function.foo.name
+  namespace     = tencentcloud_scf_function.foo.namespace
+  description   = "tftest1"
 }
 
 resource "tencentcloud_scf_trigger" "timer" {
-  function_name   = tencentcloud_scf_function.function.name
-  namespace       = "default"
-  trigger_name    = "tf-example-trigger"
-  type            = "timer"
-  trigger_desc    = jsonencode({ cron = "*/5 * * * * * *" })
+  function_name   = tencentcloud_scf_function.foo.name
+  namespace       = tencentcloud_scf_function.foo.namespace
+  qualifier       = tencentcloud_scf_function_version.function_version.function_version
+  custom_argument = null
+  description     = null
   enable          = "OPEN"
-  description     = "tf example trigger"
-  qualifier       = "$DEFAULT"
-  custom_argument = "Information"
+  trigger_desc    = "0 0 0 */1 * * *"
+  trigger_name    = "tf-test-timer"
+  type            = "timer"
+}
+```
+
+### Create a ckafka-type trigger.
+
+```hcl
+resource "tencentcloud_scf_function" "foo" {
+  async_run_enable  = "FALSE"
+  cos_bucket_name   = "tf-test-1308726196"
+  cos_bucket_region = "ap-guangzhou"
+  cos_object_name   = "/tf-test.zip"
+  description       = "helloworld-tftest"
+  dns_cache         = false
+  enable_eip_config = false
+  enable_public_net = true
+  environment       = {}
+  func_type         = "Event"
+  handler           = "index.main_handler"
+  l5_enable         = false
+  mem_size          = 128
+  name              = "helloworld-tf"
+  namespace         = "default"
+  role              = null
+  runtime           = "Python3.9"
+  subnet_id         = null
+  tags              = {}
+  timeout           = 3
+  vpc_id            = null
+  zip_file          = null
+  intranet_config {
+    ip_fixed = "DISABLE"
+  }
+}
+
+resource "tencentcloud_scf_function_version" "function_version" {
+  function_name = tencentcloud_scf_function.foo.name
+  namespace     = tencentcloud_scf_function.foo.namespace
+  description   = "tftest1"
+}
+resource "tencentcloud_scf_trigger" "kafka" {
+  custom_argument = null
+  description     = "tf test"
+  enable          = "OPEN"
+  function_name   = tencentcloud_scf_function.foo.name
+  namespace       = tencentcloud_scf_function.foo.namespace
+  qualifier       = tencentcloud_scf_function_version.function_version.function_version
+  trigger_desc = jsonencode({
+    VIPList           = ["11.135.14.109:26246"]
+    consumerGroupName = "scf_ckafka-4kdjmwvztf-testhelloworld-tf_DEFAULT"
+    instanceId        = "ckafka-4kdjmwvz"
+    isInSequence      = "Yes"
+    kafkaStatus       = "NORMAL"
+    maxMsgNum         = 100
+    maxSingleMsgSize  = 100
+    maxTotalMsgSize   = 100
+    offset            = "latest"
+    partitionNum      = 3
+    retry             = 10000
+    timeOut           = 50
+    topicId           = "topic-bjmcknbs"
+    topicName         = "tf-test"
+    topicStatus       = "NORMAL"
+  })
+  trigger_name = "ckafka-4kdjmwvz-tf-test"
+  type         = "ckafka"
 }
 ```
 
@@ -42,14 +197,14 @@ resource "tencentcloud_scf_trigger" "timer" {
 The following arguments are supported:
 
 * `function_name` - (Required, String, ForceNew) Name of the SCF function that the trigger binds to.
-* `trigger_name` - (Required, String, ForceNew) Name of the trigger.
-* `type` - (Required, String, ForceNew) Trigger type. Valid values: `cos`, `cls`, `timer`, `ckafka`, `http`.
+* `namespace` - (Required, String, ForceNew) Function namespace. Defaults to `default`.
+* `type` - (Required, String, ForceNew) Trigger type. Valid values: `cos`, `timer`, `ckafka`, `http`.To create Function URL please refer to [Creating a Function URL](https://www.tencentcloud.com/document/product/583/69492?lang=en&pg=); To create a CLS trigger, please refer to [Create Deliver CloudFunction (SCF)](https://www.tencentcloud.com/zh/document/product/614/59903).
 * `custom_argument` - (Optional, String) User custom parameter, only supported by timer trigger.
 * `description` - (Optional, String) Trigger description.
 * `enable` - (Optional, String) Trigger enable status. Valid values: `OPEN` (enabled), `CLOSE` (disabled).
-* `namespace` - (Optional, String, ForceNew) Function namespace. Defaults to `default`.
 * `qualifier` - (Optional, String) Function version or alias that the trigger points to. Defaults to `$LATEST`.
-* `trigger_desc` - (Optional, String) Trigger description parameter, see the trigger description documentation for details.
+* `trigger_desc` - (Optional, String) Trigger description parameter, see the trigger description documentation for details: https://www.tencentcloud.com/document/product/583/34880.
+* `trigger_name` - (Optional, String) Name of the trigger. It must not be specified when `type` is `http`; it must be specified when `type` is not `http`; when `type` is `cos`, it must match `<bucket>.cos.<region>.myqcloud.com`.
 
 ## Attributes Reference
 
@@ -59,6 +214,7 @@ In addition to all arguments above, the following attributes are exported:
 * `add_time` - Trigger creation time.
 * `available_status` - Trigger available status.
 * `mod_time` - Trigger last modified time.
+* `trigger_attribute` - Trigger description parameter, see the trigger description documentation for details: https://www.tencentcloud.com/document/product/583/34880.
 
 
 ## Import
@@ -67,5 +223,14 @@ SCF trigger can be imported using the composite id `function_name#namespace#trig
 
 ```
 terraform import tencentcloud_scf_trigger.timer tf-example-function#default#tf-example-trigger
+```
+
+Or use Terraform 1.5+ `import` block:
+
+```hcl
+import {
+  to = tencentcloud_scf_trigger.http
+  id = "tf-example-function#default#tf-example-trigger"
+}
 ```
 

--- a/website/docs/r/scf_trigger_config.html.markdown
+++ b/website/docs/r/scf_trigger_config.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Provides a resource to create a scf trigger_config
 
+~> **NOTE:** Use of the current resource is no longer recommended; `tencentcloud_scf_trigger` is recommended instead.
+
 ## Example Usage
 
 ```hcl

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -4454,6 +4454,9 @@
                                     <a href="/docs/providers/tencentcloud/r/scf_terminate_async_event.html">tencentcloud_scf_terminate_async_event</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/r/scf_trigger.html">tencentcloud_scf_trigger</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/r/scf_trigger_config.html">tencentcloud_scf_trigger_config</a>
                                 </li>
                             </ul>


### PR DESCRIPTION
Add a new `tencentcloud_scf_trigger` resource to manage the full lifecycle (create, read, update, delete) of a TencentCloud SCF (Serverless Cloud Function) function trigger via the native SCF CRUD APIs (`CreateTrigger`, `ListTriggers`, `UpdateTrigger`, `DeleteTrigger`).

Changes:
- Add resource schema and CRUD implementation in `tencentcloud/services/scf/resource_tc_scf_trigger.go`
- Add service-layer helper `DescribeScfTriggerById` in `service_tencentcloud_scf.go`
- Register `tencentcloud_scf_trigger` in `tencentcloud/provider.go` and `tencentcloud/provider.md`
- Add resource documentation `resource_tc_scf_trigger.md`
- Add gomonkey-based unit tests in `resource_tc_scf_trigger_test.go`
- Use composite id (`function_name#namespace#trigger_name`) joined by `tccommon.FILED_SP`

This resource is fully additive; no existing resource schema or behavior is changed.