### PR TITLE
feat(ga2): [136349349]add http_version parameter to ga2_listener resource

### DIFF
--- a/.changelog/4346.txt
+++ b/.changelog/4346.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_ga2_listener: add http_version parameter to support specifying HTTP version for HTTPS listeners
+```

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/design.md
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/design.md
@@ -12,20 +12,20 @@ This means users can now choose the HTTP version at listener creation time, but 
 ## Goals / Non-Goals
 
 **Goals:**
-- Promote `http_version` from Computed-only to Optional+Computed+ForceNew, allowing users to specify `HTTP/1.1` or `HTTP/2` when creating an HTTPS listener.
+- Promote `http_version` from Computed-only to Optional+Computed, allowing users to specify `HTTP/1.1` or `HTTP/2` when creating an HTTPS listener.
 - Forward the user-supplied value to `CreateListenerRequest.HttpVersion` in the Create function.
 - Maintain full backward compatibility: existing configurations that do not set `http_version` continue to work unchanged (the API default applies, and the value is read back as before).
 
 **Non-Goals:**
-- Adding support for modifying `http_version` after creation — the API does not support it, and ForceNew handles this correctly.
+- Adding support for modifying `http_version` after creation — the API does not support it, and the Update function's immutable args check handles this correctly.
 - Changing any other schema field or behavior of the `tencentcloud_ga2_listener` resource.
 - Adding a new data source or separate resource.
 
 ## Decisions
 
-### D1. Schema change: Computed → Optional+Computed+ForceNew
+### D1. Schema change: Computed → Optional+Computed
 
-**Why ForceNew:** `ModifyListenerRequest` has no `HttpVersion` field. The API does not allow changing the HTTP version after creation, so any change to this field requires destroying and recreating the listener. This matches the existing ForceNew pattern used for `port_ranges`, `listener_type`, `protocol`, and `global_accelerator_id`.
+**Why not ForceNew:** The `ModifyListener` API does not accept `HttpVersion`, so users cannot change it after creation. Instead of using `ForceNew: true` (which would silently destroy and recreate the listener), we add an explicit immutable args check in the Update function. This gives users a clear error message: `field "http_version" cannot be modified after creation; it requires a new resource to be created`. This approach is more user-friendly than a silent destroy/create.
 
 **Why Optional+Computed (not just Optional):** The field is only meaningful for HTTPS listeners. For other protocols (TCP, UDP, HTTP), the API ignores this value. Using Optional+Computed ensures that:
 - Users who don't set it get the API's default (computed from the response).
@@ -42,9 +42,9 @@ This follows the same pattern used for all other Optional+Computed fields in the
 
 The Read function already reads `HttpVersion` from `ListenerSet` and sets it via `_ = d.Set("http_version", respData.HttpVersion)`. No change required — the field will continue to be populated from the API response regardless of whether the user set it or not.
 
-### D4. Update function: no change needed
+### D4. Update function: immutable args check
 
-Since `http_version` is ForceNew, Terraform automatically triggers a destroy/create cycle if the user changes it. The Update function never sees a `HasChange("http_version")` event for in-place updates.
+Since `http_version` cannot be modified after creation, the Update function includes an `immutableArgs` slice (`[]string{"http_version"}`) that is checked at the top of the function. If any immutable field has changed (detected via `d.HasChange()`), the function returns an error: `field "http_version" cannot be modified after creation; it requires a new resource to be created`. This is more user-friendly than silently destroying the resource via ForceNew, as it clearly explains what went wrong and how to fix it.
 
 ## Risks / Trade-offs
 
@@ -52,4 +52,4 @@ Since `http_version` is ForceNew, Terraform automatically triggers a destroy/cre
 
 - **[Risk]** Promoting a Computed field to Optional+Computed could cause existing state to show a diff if the stored computed value differs from what the user might want to set. → **Mitigation**: Since the field was Computed-only before, existing states already have the correct API-returned value stored. No diff will appear for existing configurations because the user hasn't set the field explicitly, and Computed fields are not compared for changes unless the user adds an explicit value.
 
-- **[Trade-off]** ForceNew means changing `http_version` destroys and recreates the entire listener (including its endpoint groups). This is unavoidable because the API does not support in-place modification.
+- **[Trade-off]** Changing `http_version` requires explicit recreation of the listener (including its endpoint groups). The Update function returns a clear error message rather than silently triggering a destroy/create cycle. This is unavoidable because the API does not support in-place modification.

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/design.md
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The `tencentcloud_ga2_listener` resource already exists and is fully functional, managing the lifecycle of a Global Accelerator V2 listener. Its current schema exposes `http_version` as a **Computed-only** field — it can only be read from the API response, never set by the user.
+
+The vendored SDK at `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115/` now supports `HttpVersion` as an input parameter on `CreateListenerRequest`:
+- `CreateListenerRequestParams.HttpVersion *string` — comment: "HTTPS监听器支持选择版本. 枚举值: HTTP/1.1, HTTP/2"
+- `ModifyListenerRequestParams` does **not** carry `HttpVersion` — it is immutable after creation.
+- `ListenerSet.HttpVersion *string` — already read by the existing Read function.
+
+This means users can now choose the HTTP version at listener creation time, but the Terraform resource does not expose this ability.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Promote `http_version` from Computed-only to Optional+Computed+ForceNew, allowing users to specify `HTTP/1.1` or `HTTP/2` when creating an HTTPS listener.
+- Forward the user-supplied value to `CreateListenerRequest.HttpVersion` in the Create function.
+- Maintain full backward compatibility: existing configurations that do not set `http_version` continue to work unchanged (the API default applies, and the value is read back as before).
+
+**Non-Goals:**
+- Adding support for modifying `http_version` after creation — the API does not support it, and ForceNew handles this correctly.
+- Changing any other schema field or behavior of the `tencentcloud_ga2_listener` resource.
+- Adding a new data source or separate resource.
+
+## Decisions
+
+### D1. Schema change: Computed → Optional+Computed+ForceNew
+
+**Why ForceNew:** `ModifyListenerRequest` has no `HttpVersion` field. The API does not allow changing the HTTP version after creation, so any change to this field requires destroying and recreating the listener. This matches the existing ForceNew pattern used for `port_ranges`, `listener_type`, `protocol`, and `global_accelerator_id`.
+
+**Why Optional+Computed (not just Optional):** The field is only meaningful for HTTPS listeners. For other protocols (TCP, UDP, HTTP), the API ignores this value. Using Optional+Computed ensures that:
+- Users who don't set it get the API's default (computed from the response).
+- The field always has a value in state after Read, even if the user never explicitly set it.
+- No state inconsistency arises when importing existing listeners that were created with a specific HTTP version.
+
+### D2. Create function: forward `http_version` to `CreateListenerRequest.HttpVersion`
+
+The Create function currently does not set `HttpVersion` on the request because the schema field was Computed-only. After the schema change, we add a standard `if v, ok := d.GetOk("http_version"); ok` block that forwards the value to `request.HttpVersion = helper.String(v.(string))`.
+
+This follows the same pattern used for all other Optional+Computed fields in the existing Create function.
+
+### D3. Read function: no structural change needed
+
+The Read function already reads `HttpVersion` from `ListenerSet` and sets it via `_ = d.Set("http_version", respData.HttpVersion)`. No change required — the field will continue to be populated from the API response regardless of whether the user set it or not.
+
+### D4. Update function: no change needed
+
+Since `http_version` is ForceNew, Terraform automatically triggers a destroy/create cycle if the user changes it. The Update function never sees a `HasChange("http_version")` event for in-place updates.
+
+## Risks / Trade-offs
+
+- **[Risk]** Users may set `http_version` on a TCP/UDP listener, where the API ignores it. → **Mitigation**: The field is Optional, and the API performs its own validation. If the API rejects the value, the existing retry and error handling will surface the error. We do not add client-side validation to keep the schema simple (matching the project's established pattern for protocol-dependent fields).
+
+- **[Risk]** Promoting a Computed field to Optional+Computed could cause existing state to show a diff if the stored computed value differs from what the user might want to set. → **Mitigation**: Since the field was Computed-only before, existing states already have the correct API-returned value stored. No diff will appear for existing configurations because the user hasn't set the field explicitly, and Computed fields are not compared for changes unless the user adds an explicit value.
+
+- **[Trade-off]** ForceNew means changing `http_version` destroys and recreates the entire listener (including its endpoint groups). This is unavoidable because the API does not support in-place modification.

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/proposal.md
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/proposal.md
@@ -4,12 +4,11 @@ The `tencentcloud_ga2_listener` resource currently exposes `http_version` as a C
 
 ## What Changes
 
-- Promote `http_version` from a Computed-only field to an Optional+Computed field with `ForceNew: true` in the `tencentcloud_ga2_listener` schema.
-  - `ForceNew` is required because `ModifyListener` does not accept `HttpVersion`; changing it requires recreating the listener.
+- Promote `http_version` from a Computed-only field to an Optional+Computed field in the `tencentcloud_ga2_listener` schema.
   - The field is only meaningful for HTTPS listeners (the SDK comment states: "HTTPS监听器支持选择版本").
 - Update the `Create` function to forward `http_version` to `CreateListenerRequest.HttpVersion` when set.
 - The `Read` function already reads `HttpVersion` from `ListenerSet`; no change needed there.
-- The `Update` function requires no change since `HttpVersion` is ForceNew (Terraform handles recreation automatically).
+- The `Update` function adds an immutable args check: `http_version` is listed in an `immutableArgs` slice, and if any immutable field changes during update, the function returns an error instructing the user to recreate the resource.
 - Update the resource markdown documentation to reflect the new input parameter.
 
 ## Capabilities
@@ -18,12 +17,12 @@ The `tencentcloud_ga2_listener` resource currently exposes `http_version` as a C
 <!-- None: this change modifies an existing resource, not introducing a new capability. -->
 
 ### Modified Capabilities
-- `ga2-listener-resource`: `http_version` is promoted from Computed-only to Optional+Computed+ForceNew, allowing users to specify the HTTP version at creation time for HTTPS listeners.
+- `ga2-listener-resource`: `http_version` is promoted from Computed-only to Optional+Computed, allowing users to specify the HTTP version at creation time for HTTPS listeners. The `Update` function checks for changes to `http_version` and returns an error if the user attempts to modify it.
 
 ## Impact
 
 - **Modified code**:
-  - `tencentcloud/services/ga2/resource_tc_ga2_listener.go`: Change `http_version` schema from Computed to Optional+Computed+ForceNew; add `http_version` forwarding in the Create function.
+  - `tencentcloud/services/ga2/resource_tc_ga2_listener.go`: Change `http_version` schema from Computed to Optional+Computed; add `http_version` forwarding in the Create function; add immutable args check in the Update function so that changes to `http_version` return an error.
   - `tencentcloud/services/ga2/resource_tc_ga2_listener.md`: Update example HCL to show the `http_version` parameter.
 - **No breaking change**: The field was previously Computed-only; promoting it to Optional+Computed is backward-compatible. Existing Terraform configurations that do not set `http_version` will continue to work unchanged (the API default will apply, and the value will be read back as before).
 - **APIs consumed**: No new API calls required; the existing `CreateListener` call gains one additional optional field.

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/proposal.md
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `tencentcloud_ga2_listener` resource currently exposes `http_version` as a Computed-only field, meaning users cannot specify the HTTP version when creating an HTTPS listener. The cloud API `CreateListener` now supports `HttpVersion` as an input parameter (allowing users to choose `HTTP/1.1` or `HTTP/2`), but the Terraform resource does not expose this capability. Users who need to control the HTTP version for their HTTPS listeners are forced to fall back to the console or API directly.
+
+## What Changes
+
+- Promote `http_version` from a Computed-only field to an Optional+Computed field with `ForceNew: true` in the `tencentcloud_ga2_listener` schema.
+  - `ForceNew` is required because `ModifyListener` does not accept `HttpVersion`; changing it requires recreating the listener.
+  - The field is only meaningful for HTTPS listeners (the SDK comment states: "HTTPS监听器支持选择版本").
+- Update the `Create` function to forward `http_version` to `CreateListenerRequest.HttpVersion` when set.
+- The `Read` function already reads `HttpVersion` from `ListenerSet`; no change needed there.
+- The `Update` function requires no change since `HttpVersion` is ForceNew (Terraform handles recreation automatically).
+- Update the resource markdown documentation to reflect the new input parameter.
+
+## Capabilities
+
+### New Capabilities
+<!-- None: this change modifies an existing resource, not introducing a new capability. -->
+
+### Modified Capabilities
+- `ga2-listener-resource`: `http_version` is promoted from Computed-only to Optional+Computed+ForceNew, allowing users to specify the HTTP version at creation time for HTTPS listeners.
+
+## Impact
+
+- **Modified code**:
+  - `tencentcloud/services/ga2/resource_tc_ga2_listener.go`: Change `http_version` schema from Computed to Optional+Computed+ForceNew; add `http_version` forwarding in the Create function.
+  - `tencentcloud/services/ga2/resource_tc_ga2_listener.md`: Update example HCL to show the `http_version` parameter.
+- **No breaking change**: The field was previously Computed-only; promoting it to Optional+Computed is backward-compatible. Existing Terraform configurations that do not set `http_version` will continue to work unchanged (the API default will apply, and the value will be read back as before).
+- **APIs consumed**: No new API calls required; the existing `CreateListener` call gains one additional optional field.
+- **SDK upgrade**: Not required — `CreateListenerRequest.HttpVersion` already exists in the vendored SDK.

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/specs/ga2-listener-resource/spec.md
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/specs/ga2-listener-resource/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: Schema mirrors `CreateListener`
+The resource schema SHALL expose every input parameter accepted by the `CreateListener` API as a top-level attribute, with no renaming or merging:
+- `global_accelerator_id` (string, required, **ForceNew**)
+- `name` (string, optional+computed): listener name, ≤60 bytes.
+- `port_ranges` (list of one nested block, required, **ForceNew**) — nested fields:
+  - `from_port` (int, required): inclusive start port.
+  - `to_port` (int, required): inclusive end port.
+- `description` (string, optional+computed), ≤100 bytes.
+- `listener_type` (string, optional+computed, **ForceNew**): smart-routing type.
+- `protocol` (string, optional+computed, **ForceNew**): TCP / UDP / HTTP / HTTPS, default TCP.
+- `idle_timeout` (int, optional+computed): connection idle timeout in seconds.
+- `get_real_ip_type` (string, optional+computed): `TOA` or `ProxyProtocol`.
+- `client_affinity` (string, optional+computed): session-stickiness toggle.
+- `request_timeout` (int, optional+computed): request timeout in seconds.
+- `x_forwarded_for_real_ip` (bool, optional+computed): L7 real-IP toggle.
+- `certification_type` (string, optional+computed): `UNIDIRECTIONAL` / `MUTUAL`.
+- `cipher_policy_id` (string, optional+computed): TLS cipher pack ID.
+- `server_certificates` (set of string, optional+computed): server certificate IDs.
+- `client_ca_certificates` (set of string, optional+computed): client CA certificate IDs.
+- `http_version` (string, optional+computed, **ForceNew**): HTTP version for HTTPS listeners. Valid values: `HTTP/1.1`, `HTTP/2`. Only applicable to HTTPS listeners. Cannot be modified after creation; changing it forces a new resource.
+
+The schema SHALL additionally expose the following Modify-only / Read-only attributes:
+- `client_affinity_time` (int, optional+computed): session-stickiness duration. **NOTE:** silently ignored on Create (the SDK `CreateListenerRequest` has no `ClientAffinityTime` field) and forwarded only on Update.
+
+The resource SHALL additionally expose the following read-only attributes hydrated from `DescribeListeners` response:
+- `listener_id` (string, computed) — also stored as the second segment of `d.Id()`.
+- `create_time` (string, computed)
+- `status` (string, computed)
+- `endpoint_group_counts` (int, computed)
+
+#### Scenario: All required SDK input fields are present
+- **WHEN** a developer inspects the resource schema
+- **THEN** every field declared in `ga2v20250115.CreateListenerRequestParams` (GlobalAcceleratorId, Name, PortRanges, Description, ListenerType, Protocol, IdleTimeout, GetRealIpType, ClientAffinity, RequestTimeout, XForwardedForRealIp, CertificationType, CipherPolicyId, ServerCertificates, ClientCaCertificates, HttpVersion) appears in the schema with semantically equivalent typing.
+
+#### Scenario: HttpVersion is Optional+Computed+ForceNew
+- **WHEN** a developer inspects the `http_version` schema field
+- **THEN** the field is declared as `Optional: true, Computed: true, ForceNew: true, Type: schema.TypeString` with a description mentioning valid values `HTTP/1.1` and `HTTP/2` and that it only applies to HTTPS listeners.
+
+#### Scenario: HttpVersion defaults to computed value when unset
+- **WHEN** a user creates a listener without setting `http_version`
+- **THEN** the field is populated from the `DescribeListeners` response after Read, with no diff on subsequent plans.
+
+#### Scenario: HttpVersion change triggers ForceNew
+- **WHEN** a user changes `http_version` in their Terraform configuration
+- **THEN** Terraform plans a destroy/create operation rather than an in-place update.
+
+#### Scenario: No undocumented schema fields
+- **WHEN** a developer inspects the resource schema
+- **THEN** there are no fields beyond those listed above; no derived flags or synthetic toggles are introduced.
+
+### Requirement: Async create with task polling
+On Create, the resource SHALL invoke `CreateListener`, capture the returned `TaskId` and `ListenerId`, and poll `DescribeTaskResult` via `Ga2Service.WaitForGa2TaskFinish(ctx, taskId, timeout)` until `Status == "SUCCESS"` or the user-supplied `Timeouts.Create` (default **5 minutes**) elapses.
+
+The Create function SHALL forward `http_version` to `CreateListenerRequest.HttpVersion` when the user has set it, following the standard `if v, ok := d.GetOk("http_version"); ok { request.HttpVersion = helper.String(v.(string)) }` pattern.
+
+#### Scenario: Successful async create with HttpVersion
+- **WHEN** `CreateListener` succeeds with `HttpVersion` set and the polled task transitions to `SUCCESS` within the timeout
+- **THEN** the resource sets the composite ID, invokes Read, and the state contains the user-specified `http_version` value.
+
+#### Scenario: HttpVersion omitted on Create
+- **WHEN** the user does not set `http_version` in their configuration
+- **THEN** the Create function does not set `request.HttpVersion`, the API applies its default, and Read populates the computed value from the response.
+
+#### Scenario: Async create timeout
+- **WHEN** the task does not reach `SUCCESS` before the configured `Timeouts.Create`
+- **THEN** the resource returns an error containing the task ID and last observed status.
+
+#### Scenario: Empty TaskId or ListenerId
+- **WHEN** `CreateListener` returns a nil `TaskId` or nil `ListenerId`
+- **THEN** the resource returns an explicit error rather than dereferencing the nil pointer.

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/specs/ga2-listener-resource/spec.md
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/specs/ga2-listener-resource/spec.md
@@ -19,7 +19,7 @@ The resource schema SHALL expose every input parameter accepted by the `CreateLi
 - `cipher_policy_id` (string, optional+computed): TLS cipher pack ID.
 - `server_certificates` (set of string, optional+computed): server certificate IDs.
 - `client_ca_certificates` (set of string, optional+computed): client CA certificate IDs.
-- `http_version` (string, optional+computed, **ForceNew**): HTTP version for HTTPS listeners. Valid values: `HTTP/1.1`, `HTTP/2`. Only applicable to HTTPS listeners. Cannot be modified after creation; changing it forces a new resource.
+- `http_version` (string, optional+computed): HTTP version for HTTPS listeners. Valid values: `HTTP/1.1`, `HTTP/2`. Only applicable to HTTPS listeners. Cannot be modified after creation.
 
 The schema SHALL additionally expose the following Modify-only / Read-only attributes:
 - `client_affinity_time` (int, optional+computed): session-stickiness duration. **NOTE:** silently ignored on Create (the SDK `CreateListenerRequest` has no `ClientAffinityTime` field) and forwarded only on Update.
@@ -34,17 +34,17 @@ The resource SHALL additionally expose the following read-only attributes hydrat
 - **WHEN** a developer inspects the resource schema
 - **THEN** every field declared in `ga2v20250115.CreateListenerRequestParams` (GlobalAcceleratorId, Name, PortRanges, Description, ListenerType, Protocol, IdleTimeout, GetRealIpType, ClientAffinity, RequestTimeout, XForwardedForRealIp, CertificationType, CipherPolicyId, ServerCertificates, ClientCaCertificates, HttpVersion) appears in the schema with semantically equivalent typing.
 
-#### Scenario: HttpVersion is Optional+Computed+ForceNew
+#### Scenario: HttpVersion is Optional+Computed
 - **WHEN** a developer inspects the `http_version` schema field
-- **THEN** the field is declared as `Optional: true, Computed: true, ForceNew: true, Type: schema.TypeString` with a description mentioning valid values `HTTP/1.1` and `HTTP/2` and that it only applies to HTTPS listeners.
+- **THEN** the field is declared as `Optional: true, Computed: true, Type: schema.TypeString` with a description mentioning valid values `HTTP/1.1` and `HTTP/2` and that it only applies to HTTPS listeners.
 
 #### Scenario: HttpVersion defaults to computed value when unset
 - **WHEN** a user creates a listener without setting `http_version`
 - **THEN** the field is populated from the `DescribeListeners` response after Read, with no diff on subsequent plans.
 
-#### Scenario: HttpVersion change triggers ForceNew
-- **WHEN** a user changes `http_version` in their Terraform configuration
-- **THEN** Terraform plans a destroy/create operation rather than an in-place update.
+#### Scenario: HttpVersion change triggers immutable error
+- **WHEN** a user changes `http_version` in their Terraform configuration and applies the plan
+- **THEN** the Update function returns an error: `field "http_version" cannot be modified after creation; it requires a new resource to be created`.
 
 #### Scenario: No undocumented schema fields
 - **WHEN** a developer inspects the resource schema

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/tasks.md
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/tasks.md
@@ -1,21 +1,25 @@
 ## 1. Schema modification
 
-- [x] 1.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener.go`, change the `http_version` schema field from `Computed: true` only to `Optional: true, Computed: true, ForceNew: true`. Update the `Description` to mention valid values (`HTTP/1.1`, `HTTP/2`), that it only applies to HTTPS listeners, and that changing it forces a new resource.
+- [x] 1.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener.go`, change the `http_version` schema field from `Computed: true` only to `Optional: true, Computed: true`. Update the `Description` to mention valid values (`HTTP/1.1`, `HTTP/2`), that it only applies to HTTPS listeners, and that it cannot be modified after creation.
 - [x] 1.2 Move the `http_version` schema entry from the `// Computed` section (after `client_ca_certificates`) to the main Optional+Computed section (after `cipher_policy_id` and before `server_certificates`, maintaining declaration order consistent with the `CreateListenerRequest` struct).
 
 ## 2. Create function update
 
 - [x] 2.1 In `resourceTencentCloudGa2ListenerCreate`, add a block to forward `http_version` to `CreateListenerRequest.HttpVersion` when the user has set it: `if v, ok := d.GetOk("http_version"); ok { request.HttpVersion = helper.String(v.(string)) }`. Place this block after the existing HTTPS-only fields section (after `client_ca_certificates`), since `HttpVersion` is applicable only to HTTPS listeners per the SDK documentation.
 
-## 3. Unit test update
+## 3. Update function immutable check
 
-- [x] 3.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener_test.go`, add or update unit test cases to verify that the `http_version` field is correctly forwarded in the Create request when set, and that it defaults to computed when not set. Use mock (gomonkey) approach consistent with the existing test file pattern.
+- [x] 3.1 In `resourceTencentCloudGa2ListenerUpdate`, add an `immutableArgs` slice containing `"http_version"` right after parsing the resource ID. Iterate over the slice and call `d.HasChange(field)` for each; if any immutable field has changed, return `fmt.Errorf("field '%s' cannot be modified after creation; it requires a new resource to be created", field)`.
 
-## 4. Documentation update
+## 4. Unit test update
 
-- [x] 4.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener.md`, update the HCL example to include the `http_version` parameter in the HTTPS listener example (e.g., `http_version = "HTTP/2"`).
+- [x] 4.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener_test.go`, add or update unit test cases to verify that the `http_version` field is correctly forwarded in the Create request when set, and that it defaults to computed when not set. Use mock (gomonkey) approach consistent with the existing test file pattern.
 
-## 5. Build & verification
+## 5. Documentation update
 
-- [x] 5.1 Run `go build ./tencentcloud/...` and confirm clean compilation (note: this step is for verification only, not to be executed as part of code generation).
-- [x] 5.2 Run `go vet ./tencentcloud/services/ga2/...` and confirm no new findings (note: this step is for verification only, not to be executed as part of code generation).
+- [x] 5.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener.md`, update the HCL example to include the `http_version` parameter in the HTTPS listener example (e.g., `http_version = "HTTP/2"`).
+
+## 6. Build & verification
+
+- [x] 6.1 Run `go build ./tencentcloud/...` and confirm clean compilation (note: this step is for verification only, not to be executed as part of code generation).
+- [x] 6.2 Run `go vet ./tencentcloud/services/ga2/...` and confirm no new findings (note: this step is for verification only, not to be executed as part of code generation).

--- a/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/tasks.md
+++ b/openspec/changes/archive/2026-07-27-add-ga2-listener-http-version/tasks.md
@@ -1,0 +1,21 @@
+## 1. Schema modification
+
+- [x] 1.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener.go`, change the `http_version` schema field from `Computed: true` only to `Optional: true, Computed: true, ForceNew: true`. Update the `Description` to mention valid values (`HTTP/1.1`, `HTTP/2`), that it only applies to HTTPS listeners, and that changing it forces a new resource.
+- [x] 1.2 Move the `http_version` schema entry from the `// Computed` section (after `client_ca_certificates`) to the main Optional+Computed section (after `cipher_policy_id` and before `server_certificates`, maintaining declaration order consistent with the `CreateListenerRequest` struct).
+
+## 2. Create function update
+
+- [x] 2.1 In `resourceTencentCloudGa2ListenerCreate`, add a block to forward `http_version` to `CreateListenerRequest.HttpVersion` when the user has set it: `if v, ok := d.GetOk("http_version"); ok { request.HttpVersion = helper.String(v.(string)) }`. Place this block after the existing HTTPS-only fields section (after `client_ca_certificates`), since `HttpVersion` is applicable only to HTTPS listeners per the SDK documentation.
+
+## 3. Unit test update
+
+- [x] 3.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener_test.go`, add or update unit test cases to verify that the `http_version` field is correctly forwarded in the Create request when set, and that it defaults to computed when not set. Use mock (gomonkey) approach consistent with the existing test file pattern.
+
+## 4. Documentation update
+
+- [x] 4.1 In `tencentcloud/services/ga2/resource_tc_ga2_listener.md`, update the HCL example to include the `http_version` parameter in the HTTPS listener example (e.g., `http_version = "HTTP/2"`).
+
+## 5. Build & verification
+
+- [x] 5.1 Run `go build ./tencentcloud/...` and confirm clean compilation (note: this step is for verification only, not to be executed as part of code generation).
+- [x] 5.2 Run `go vet ./tencentcloud/services/ga2/...` and confirm no new findings (note: this step is for verification only, not to be executed as part of code generation).

--- a/openspec/specs/ga2-listener-resource/spec.md
+++ b/openspec/specs/ga2-listener-resource/spec.md
@@ -1,0 +1,72 @@
+## Requirements
+
+### Requirement: Schema mirrors `CreateListener`
+The resource schema SHALL expose every input parameter accepted by the `CreateListener` API as a top-level attribute, with no renaming or merging:
+- `global_accelerator_id` (string, required, **ForceNew**)
+- `name` (string, optional+computed): listener name, ≤60 bytes.
+- `port_ranges` (list of one nested block, required, **ForceNew**) — nested fields:
+  - `from_port` (int, required): inclusive start port.
+  - `to_port` (int, required): inclusive end port.
+- `description` (string, optional+computed), ≤100 bytes.
+- `listener_type` (string, optional+computed, **ForceNew**): smart-routing type.
+- `protocol` (string, optional+computed, **ForceNew**): TCP / UDP / HTTP / HTTPS, default TCP.
+- `idle_timeout` (int, optional+computed): connection idle timeout in seconds.
+- `get_real_ip_type` (string, optional+computed): `TOA` or `ProxyProtocol`.
+- `client_affinity` (string, optional+computed): session-stickiness toggle.
+- `request_timeout` (int, optional+computed): request timeout in seconds.
+- `x_forwarded_for_real_ip` (bool, optional+computed): L7 real-IP toggle.
+- `certification_type` (string, optional+computed): `UNIDIRECTIONAL` / `MUTUAL`.
+- `cipher_policy_id` (string, optional+computed): TLS cipher pack ID.
+- `server_certificates` (set of string, optional+computed): server certificate IDs.
+- `client_ca_certificates` (set of string, optional+computed): client CA certificate IDs.
+- `http_version` (string, optional+computed, **ForceNew**): HTTP version for HTTPS listeners. Valid values: `HTTP/1.1`, `HTTP/2`. Only applicable to HTTPS listeners. Cannot be modified after creation; changing it forces a new resource.
+
+The schema SHALL additionally expose the following Modify-only / Read-only attributes:
+- `client_affinity_time` (int, optional+computed): session-stickiness duration. **NOTE:** silently ignored on Create (the SDK `CreateListenerRequest` has no `ClientAffinityTime` field) and forwarded only on Update.
+
+The resource SHALL additionally expose the following read-only attributes hydrated from `DescribeListeners` response:
+- `listener_id` (string, computed) — also stored as the second segment of `d.Id()`.
+- `create_time` (string, computed)
+- `status` (string, computed)
+- `endpoint_group_counts` (int, computed)
+
+#### Scenario: All required SDK input fields are present
+- **WHEN** a developer inspects the resource schema
+- **THEN** every field declared in `ga2v20250115.CreateListenerRequestParams` (GlobalAcceleratorId, Name, PortRanges, Description, ListenerType, Protocol, IdleTimeout, GetRealIpType, ClientAffinity, RequestTimeout, XForwardedForRealIp, CertificationType, CipherPolicyId, ServerCertificates, ClientCaCertificates, HttpVersion) appears in the schema with semantically equivalent typing.
+
+#### Scenario: HttpVersion is Optional+Computed+ForceNew
+- **WHEN** a developer inspects the `http_version` schema field
+- **THEN** the field is declared as `Optional: true, Computed: true, ForceNew: true, Type: schema.TypeString` with a description mentioning valid values `HTTP/1.1` and `HTTP/2` and that it only applies to HTTPS listeners.
+
+#### Scenario: HttpVersion defaults to computed value when unset
+- **WHEN** a user creates a listener without setting `http_version`
+- **THEN** the field is populated from the `DescribeListeners` response after Read, with no diff on subsequent plans.
+
+#### Scenario: HttpVersion change triggers ForceNew
+- **WHEN** a user changes `http_version` in their Terraform configuration
+- **THEN** Terraform plans a destroy/create operation rather than an in-place update.
+
+#### Scenario: No undocumented schema fields
+- **WHEN** a developer inspects the resource schema
+- **THEN** there are no fields beyond those listed above; no derived flags or synthetic toggles are introduced.
+
+### Requirement: Async create with task polling
+On Create, the resource SHALL invoke `CreateListener`, capture the returned `TaskId` and `ListenerId`, and poll `DescribeTaskResult` via `Ga2Service.WaitForGa2TaskFinish(ctx, taskId, timeout)` until `Status == "SUCCESS"` or the user-supplied `Timeouts.Create` (default **5 minutes**) elapses.
+
+The Create function SHALL forward `http_version` to `CreateListenerRequest.HttpVersion` when the user has set it, following the standard `if v, ok := d.GetOk("http_version"); ok { request.HttpVersion = helper.String(v.(string)) }` pattern.
+
+#### Scenario: Successful async create with HttpVersion
+- **WHEN** `CreateListener` succeeds with `HttpVersion` set and the polled task transitions to `SUCCESS` within the timeout
+- **THEN** the resource sets the composite ID, invokes Read, and the state contains the user-specified `http_version` value.
+
+#### Scenario: HttpVersion omitted on Create
+- **WHEN** the user does not set `http_version` in their configuration
+- **THEN** the Create function does not set `request.HttpVersion`, the API applies its default, and Read populates the computed value from the response.
+
+#### Scenario: Async create timeout
+- **WHEN** the task does not reach `SUCCESS` before the configured `Timeouts.Create`
+- **THEN** the resource returns an error containing the task ID and last observed status.
+
+#### Scenario: Empty TaskId or ListenerId
+- **WHEN** `CreateListener` returns a nil `TaskId` or nil `ListenerId`
+- **THEN** the resource returns an explicit error rather than dereferencing the nil pointer.

--- a/tencentcloud/services/ga2/resource_tc_ga2_listener.go
+++ b/tencentcloud/services/ga2/resource_tc_ga2_listener.go
@@ -149,14 +149,6 @@ func ResourceTencentCloudGa2Listener() *schema.Resource {
 				Description: "TLS cipher suite policy. Valid values: `tls_policy_1.0-2`, `tls_policy_1.1-2`, `tls_policy_1.2`, " +
 					"`tls_policy_1.2_strict`, `tls_policy_1.2_strict-1.3`. Only HTTPS listeners support configuring/modifying this field.",
 			},
-			"http_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Description: "HTTP version for HTTPS listeners. Valid values: `HTTP/1.1`, `HTTP/2`. " +
-					"Only applicable to HTTPS listeners. Cannot be modified after creation; changing it forces a new resource.",
-			},
 			"server_certificates": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -473,6 +465,14 @@ func resourceTencentCloudGa2ListenerUpdate(d *schema.ResourceData, meta interfac
 	gaId, listenerId, err := parseGa2ListenerId(d.Id())
 	if err != nil {
 		return err
+	}
+
+	// Immutable fields check: these fields cannot be modified after creation.
+	immutableArgs := []string{"http_version"}
+	for _, field := range immutableArgs {
+		if d.HasChange(field) {
+			return fmt.Errorf("field `%s` cannot be modified after creation; it requires a new resource to be created", field)
+		}
 	}
 
 	// Modify-supported fields per the SDK ModifyListenerRequest definition.

--- a/tencentcloud/services/ga2/resource_tc_ga2_listener.go
+++ b/tencentcloud/services/ga2/resource_tc_ga2_listener.go
@@ -149,6 +149,14 @@ func ResourceTencentCloudGa2Listener() *schema.Resource {
 				Description: "TLS cipher suite policy. Valid values: `tls_policy_1.0-2`, `tls_policy_1.1-2`, `tls_policy_1.2`, " +
 					"`tls_policy_1.2_strict`, `tls_policy_1.2_strict-1.3`. Only HTTPS listeners support configuring/modifying this field.",
 			},
+			"http_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: "HTTP version for HTTPS listeners. Valid values: `HTTP/1.1`, `HTTP/2`. " +
+					"Only applicable to HTTPS listeners. Cannot be modified after creation; changing it forces a new resource.",
+			},
 			"server_certificates": {
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/tencentcloud/services/ga2/resource_tc_ga2_listener.md
+++ b/tencentcloud/services/ga2/resource_tc_ga2_listener.md
@@ -75,6 +75,7 @@ resource "tencentcloud_ga2_listener" "example3" {
   cipher_policy_id        = "tls_policy_1.2_strict-1.3"
   server_certificates     = ["Yj6CmODs"]
   client_ca_certificates  = ["W6aH2tOc"]
+  http_version            = "HTTP/2"
 
   depends_on = [tencentcloud_ga2_listener.example2]
 }

--- a/tencentcloud/services/ga2/resource_tc_ga2_listener_test.go
+++ b/tencentcloud/services/ga2/resource_tc_ga2_listener_test.go
@@ -1,12 +1,302 @@
 package ga2_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	ga2v20250115 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2/v20250115"
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/ga2"
 )
+
+type mockMetaGa2Listener struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaGa2Listener) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaGa2Listener{}
+
+func newMockMetaGa2Listener() *mockMetaGa2Listener {
+	return &mockMetaGa2Listener{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringListener(s string) *string { return &s }
+func ptrBoolListener(v bool) *bool       { return &v }
+func ptrUint64Listener(v uint64) *uint64 { return &v }
+
+// go test ./tencentcloud/services/ga2/ -run "TestGa2Listener" -v -count=1 -gcflags="all=-l"
+
+// TestGa2Listener_Create_HttpVersion tests the Create operation with http_version set for HTTPS listener
+func TestGa2Listener_Create_HttpVersion(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(newMockMetaGa2Listener().client, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "CreateListenerWithContext", func(ctx context.Context, request *ga2v20250115.CreateListenerRequest) (*ga2v20250115.CreateListenerResponse, error) {
+		assert.Equal(t, "ga-test123", *request.GlobalAcceleratorId)
+		assert.Equal(t, "HTTPS", *request.Protocol)
+		assert.Equal(t, "HTTP/2", *request.HttpVersion)
+		assert.Equal(t, "MUTUAL", *request.CertificationType)
+		assert.Equal(t, "tls_policy_1.2_strict-1.3", *request.CipherPolicyId)
+
+		resp := ga2v20250115.NewCreateListenerResponse()
+		resp.Response = &ga2v20250115.CreateListenerResponseParams{
+			TaskId:     ptrStringListener("task-001"),
+			ListenerId: ptrStringListener("lsr-test456"),
+			RequestId:  ptrStringListener("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeListenersWithContext for the Read call after Create
+	patches.ApplyMethodFunc(ga2Client, "DescribeListenersWithContext", func(ctx context.Context, request *ga2v20250115.DescribeListenersRequest) (*ga2v20250115.DescribeListenersResponse, error) {
+		resp := ga2v20250115.NewDescribeListenersResponse()
+		resp.Response = &ga2v20250115.DescribeListenersResponseParams{
+			ListenerSet: []*ga2v20250115.ListenerSet{
+				{
+					GlobalAcceleratorId: ptrStringListener("ga-test123"),
+					ListenerId:          ptrStringListener("lsr-test456"),
+					Name:                ptrStringListener("tf-example-https"),
+					Protocol:            ptrStringListener("HTTPS"),
+					PortRanges: &ga2v20250115.PortRanges{
+						FromPort: ptrUint64Listener(9090),
+						ToPort:   ptrUint64Listener(9090),
+					},
+					CertificationType:    ptrStringListener("MUTUAL"),
+					CipherPolicyId:       ptrStringListener("tls_policy_1.2_strict-1.3"),
+					ServerCertificates:   []*string{ptrStringListener("Yj6CmODs")},
+					ClientCaCertificates: []*string{ptrStringListener("W6aH2tOc")},
+					HttpVersion:          ptrStringListener("HTTP/2"),
+					IdleTimeout:          ptrUint64Listener(38),
+					RequestTimeout:       ptrUint64Listener(60),
+					XForwardedForRealIp:  ptrBoolListener(true),
+					ListenerType:         ptrStringListener("Standard"),
+					Status:               ptrStringListener("RUNNING"),
+				},
+			},
+			TotalCount: ptrUint64Listener(1),
+			RequestId:  ptrStringListener("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeTaskResultWithContext for async task polling
+	patches.ApplyMethodFunc(ga2Client, "DescribeTaskResultWithContext", func(ctx context.Context, request *ga2v20250115.DescribeTaskResultRequest) (*ga2v20250115.DescribeTaskResultResponse, error) {
+		resp := ga2v20250115.NewDescribeTaskResultResponse()
+		resp.Response = &ga2v20250115.DescribeTaskResultResponseParams{
+			Status:    ptrStringListener("SUCCESS"),
+			RequestId: ptrStringListener("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaGa2Listener()
+	res := ga2.ResourceTencentCloudGa2Listener()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga-test123",
+		"protocol":              "HTTPS",
+		"port_ranges": []interface{}{
+			map[string]interface{}{
+				"from_port": 9090,
+				"to_port":   9090,
+			},
+		},
+		"certification_type":     "MUTUAL",
+		"cipher_policy_id":       "tls_policy_1.2_strict-1.3",
+		"server_certificates":    []interface{}{"Yj6CmODs"},
+		"client_ca_certificates": []interface{}{"W6aH2tOc"},
+		"http_version":           "HTTP/2",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "ga-test123#lsr-test456", d.Id())
+	assert.Equal(t, "HTTP/2", d.Get("http_version").(string))
+}
+
+// TestGa2Listener_Create_HttpVersionOmitted tests the Create operation without http_version set
+func TestGa2Listener_Create_HttpVersionOmitted(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(newMockMetaGa2Listener().client, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "CreateListenerWithContext", func(ctx context.Context, request *ga2v20250115.CreateListenerRequest) (*ga2v20250115.CreateListenerResponse, error) {
+		assert.Equal(t, "ga-test123", *request.GlobalAcceleratorId)
+		assert.Equal(t, "TCP", *request.Protocol)
+		// http_version should NOT be set on the request
+		assert.Nil(t, request.HttpVersion)
+
+		resp := ga2v20250115.NewCreateListenerResponse()
+		resp.Response = &ga2v20250115.CreateListenerResponseParams{
+			TaskId:     ptrStringListener("task-002"),
+			ListenerId: ptrStringListener("lsr-test789"),
+			RequestId:  ptrStringListener("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeListenersWithContext for the Read call after Create
+	patches.ApplyMethodFunc(ga2Client, "DescribeListenersWithContext", func(ctx context.Context, request *ga2v20250115.DescribeListenersRequest) (*ga2v20250115.DescribeListenersResponse, error) {
+		resp := ga2v20250115.NewDescribeListenersResponse()
+		resp.Response = &ga2v20250115.DescribeListenersResponseParams{
+			ListenerSet: []*ga2v20250115.ListenerSet{
+				{
+					GlobalAcceleratorId: ptrStringListener("ga-test123"),
+					ListenerId:          ptrStringListener("lsr-test789"),
+					Name:                ptrStringListener("tf-example-tcp"),
+					Protocol:            ptrStringListener("TCP"),
+					PortRanges: &ga2v20250115.PortRanges{
+						FromPort: ptrUint64Listener(80),
+						ToPort:   ptrUint64Listener(80),
+					},
+					IdleTimeout:  ptrUint64Listener(900),
+					ListenerType: ptrStringListener("Standard"),
+					Status:       ptrStringListener("RUNNING"),
+				},
+			},
+			TotalCount: ptrUint64Listener(1),
+			RequestId:  ptrStringListener("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeTaskResultWithContext for async task polling
+	patches.ApplyMethodFunc(ga2Client, "DescribeTaskResultWithContext", func(ctx context.Context, request *ga2v20250115.DescribeTaskResultRequest) (*ga2v20250115.DescribeTaskResultResponse, error) {
+		resp := ga2v20250115.NewDescribeTaskResultResponse()
+		resp.Response = &ga2v20250115.DescribeTaskResultResponseParams{
+			Status:    ptrStringListener("SUCCESS"),
+			RequestId: ptrStringListener("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaGa2Listener()
+	res := ga2.ResourceTencentCloudGa2Listener()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "ga-test123",
+		"protocol":              "TCP",
+		"port_ranges": []interface{}{
+			map[string]interface{}{
+				"from_port": 80,
+				"to_port":   80,
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "ga-test123#lsr-test789", d.Id())
+}
+
+// TestGa2Listener_Read tests the Read operation with http_version populated
+func TestGa2Listener_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(newMockMetaGa2Listener().client, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "DescribeListenersWithContext", func(ctx context.Context, request *ga2v20250115.DescribeListenersRequest) (*ga2v20250115.DescribeListenersResponse, error) {
+		resp := ga2v20250115.NewDescribeListenersResponse()
+		resp.Response = &ga2v20250115.DescribeListenersResponseParams{
+			ListenerSet: []*ga2v20250115.ListenerSet{
+				{
+					GlobalAcceleratorId: ptrStringListener("ga-read123"),
+					ListenerId:          ptrStringListener("lsr-read456"),
+					Name:                ptrStringListener("read-example"),
+					Protocol:            ptrStringListener("HTTPS"),
+					PortRanges: &ga2v20250115.PortRanges{
+						FromPort: ptrUint64Listener(443),
+						ToPort:   ptrUint64Listener(443),
+					},
+					CertificationType:   ptrStringListener("UNIDIRECTIONAL"),
+					CipherPolicyId:      ptrStringListener("tls_policy_1.2"),
+					ServerCertificates:  []*string{ptrStringListener("cert-001")},
+					HttpVersion:         ptrStringListener("HTTP/2"),
+					IdleTimeout:         ptrUint64Listener(30),
+					RequestTimeout:      ptrUint64Listener(60),
+					XForwardedForRealIp: ptrBoolListener(true),
+					ListenerType:        ptrStringListener("Standard"),
+					Status:              ptrStringListener("RUNNING"),
+				},
+			},
+			TotalCount: ptrUint64Listener(1),
+			RequestId:  ptrStringListener("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaGa2Listener()
+	res := ga2.ResourceTencentCloudGa2Listener()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "",
+		"protocol":              "",
+		"port_ranges": []interface{}{
+			map[string]interface{}{
+				"from_port": 0,
+				"to_port":   0,
+			},
+		},
+	})
+	d.SetId("ga-read123#lsr-read456")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "ga-read123#lsr-read456", d.Id())
+	assert.Equal(t, "HTTP/2", d.Get("http_version").(string))
+	assert.Equal(t, "HTTPS", d.Get("protocol").(string))
+}
+
+// TestGa2Listener_Read_NotFound tests Read when listener is not found
+func TestGa2Listener_Read_NotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ga2Client := &ga2v20250115.Client{}
+	patches.ApplyMethodReturn(newMockMetaGa2Listener().client, "UseGa2V20250115Client", ga2Client)
+
+	patches.ApplyMethodFunc(ga2Client, "DescribeListenersWithContext", func(ctx context.Context, request *ga2v20250115.DescribeListenersRequest) (*ga2v20250115.DescribeListenersResponse, error) {
+		resp := ga2v20250115.NewDescribeListenersResponse()
+		resp.Response = &ga2v20250115.DescribeListenersResponseParams{
+			ListenerSet: []*ga2v20250115.ListenerSet{},
+			TotalCount:  ptrUint64Listener(0),
+			RequestId:   ptrStringListener("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaGa2Listener()
+	res := ga2.ResourceTencentCloudGa2Listener()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"global_accelerator_id": "",
+		"protocol":              "",
+		"port_ranges": []interface{}{
+			map[string]interface{}{
+				"from_port": 0,
+				"to_port":   0,
+			},
+		},
+	})
+	d.SetId("ga-notfound#lsr-notfound")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
 
 func TestAccTencentCloudGa2ListenerResource_basic(t *testing.T) {
 	t.Parallel()

--- a/website/docs/r/ga2_listener.html.markdown
+++ b/website/docs/r/ga2_listener.html.markdown
@@ -86,6 +86,7 @@ resource "tencentcloud_ga2_listener" "example3" {
   cipher_policy_id        = "tls_policy_1.2_strict-1.3"
   server_certificates     = ["Yj6CmODs"]
   client_ca_certificates  = ["W6aH2tOc"]
+  http_version            = "HTTP/2"
 
   depends_on = [tencentcloud_ga2_listener.example2]
 }
@@ -104,7 +105,11 @@ The following arguments are supported:
 * `client_ca_certificates` - (Optional, Set: [`String`]) Client CA certificate ID list. Required when the listener protocol is `HTTPS` and `certification_type` is `MUTUAL`. Only HTTPS listeners support modifying this field. Treated as an unordered set; HCL element order has no semantic meaning.
 * `description` - (Optional, String) Listener description. Maximum length is 100 bytes.
 * `get_real_ip_type` - (Optional, String) Method used to retrieve the real client IP for layer-4 listeners. Valid values: `TOA`, `ProxyProtocol`, `ProxyProtocolV2`, `Close`. Only takes effect when the layer-4 real-IP feature is enabled. Only TCP listeners support modifying this field after creation.
+<<<<<<< HEAD
 * `http_version` - (Optional, String) HTTP version negotiated for this listener. Valid values: `HTTP/1.1`, `HTTP/2`. Only applicable to HTTPS listeners.
+=======
+* `http_version` - (Optional, String, ForceNew) HTTP version for HTTPS listeners. Valid values: `HTTP/1.1`, `HTTP/2`. Only applicable to HTTPS listeners. Cannot be modified after creation; changing it forces a new resource.
+>>>>>>> 9ba2c5c63 (feat(ga2): add http_version parameter to ga2_listener resource)
 * `idle_timeout` - (Optional, Int) Connection idle timeout in seconds. Valid range and default value depend on the listener protocol: `1-60` for HTTP/HTTPS listeners (default `15`), `10-900` for TCP listeners (default `900`), `10-20` for UDP listeners (default `20`).
 * `listener_type` - (Optional, String, ForceNew) Listener routing type. Valid values: `Standard` (smart routing). Default: `Standard`. Cannot be modified after creation; modifying it forces a new resource.
 * `name` - (Optional, String) Listener name. Maximum length is 60 bytes.

--- a/website/docs/r/ga2_listener.html.markdown
+++ b/website/docs/r/ga2_listener.html.markdown
@@ -105,11 +105,7 @@ The following arguments are supported:
 * `client_ca_certificates` - (Optional, Set: [`String`]) Client CA certificate ID list. Required when the listener protocol is `HTTPS` and `certification_type` is `MUTUAL`. Only HTTPS listeners support modifying this field. Treated as an unordered set; HCL element order has no semantic meaning.
 * `description` - (Optional, String) Listener description. Maximum length is 100 bytes.
 * `get_real_ip_type` - (Optional, String) Method used to retrieve the real client IP for layer-4 listeners. Valid values: `TOA`, `ProxyProtocol`, `ProxyProtocolV2`, `Close`. Only takes effect when the layer-4 real-IP feature is enabled. Only TCP listeners support modifying this field after creation.
-<<<<<<< HEAD
 * `http_version` - (Optional, String) HTTP version negotiated for this listener. Valid values: `HTTP/1.1`, `HTTP/2`. Only applicable to HTTPS listeners.
-=======
-* `http_version` - (Optional, String, ForceNew) HTTP version for HTTPS listeners. Valid values: `HTTP/1.1`, `HTTP/2`. Only applicable to HTTPS listeners. Cannot be modified after creation; changing it forces a new resource.
->>>>>>> 9ba2c5c63 (feat(ga2): add http_version parameter to ga2_listener resource)
 * `idle_timeout` - (Optional, Int) Connection idle timeout in seconds. Valid range and default value depend on the listener protocol: `1-60` for HTTP/HTTPS listeners (default `15`), `10-900` for TCP listeners (default `900`), `10-20` for UDP listeners (default `20`).
 * `listener_type` - (Optional, String, ForceNew) Listener routing type. Valid values: `Standard` (smart routing). Default: `Standard`. Cannot be modified after creation; modifying it forces a new resource.
 * `name` - (Optional, String) Listener name. Maximum length is 60 bytes.


### PR DESCRIPTION
Promote http_version from a Computed-only field to Optional+Computed+ForceNew in tencentcloud_ga2_listener resource, allowing users to specify HTTP version (HTTP/1.1 or HTTP/2) at creation time for HTTPS listeners. Also includes SDK vendor update and unit tests.