### PR TITLE
fix(tke): [132816033] `tencentcloud_kubernetes_cluster_attachment` add new filed `user_script`

### DIFF
--- a/.changelog/4349.txt
+++ b/.changelog/4349.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_kubernetes_cluster_attachment: add new filed `user_script`
+```

--- a/tencentcloud/services/tke/resource_tc_kubernetes_cluster_attachment.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_cluster_attachment.go
@@ -158,10 +158,19 @@ func ResourceTencentCloudKubernetesClusterAttachment() *schema.Resource {
 							},
 						},
 						"user_data": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							ForceNew:    true,
-							Description: "Base64-encoded User Data text, the length limit is 16KB.",
+							Type:          schema.TypeString,
+							Optional:      true,
+							ForceNew:      true,
+							Deprecated:    "It has been deprecated from version 1.83.16. Use `user_script` instead.",
+							ConflictsWith: []string{"worker_config.0.user_script"},
+							Description:   "Base64-encoded User Data text, the length limit is 16KB.",
+						},
+						"user_script": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ForceNew:      true,
+							ConflictsWith: []string{"worker_config.0.user_data"},
+							Description:   "A Base64-encoded user script that executes after Kubernetes components start. Users must ensure the script supports re-entrancy and retry logic. The script and its generated log files can be found in the `/data/ccs_userscript/` directory on the node. If the node should only join the scheduling pool after initialization is complete, the `unschedulable` parameter can be used; in this case, add the command `kubectl uncordon nodename --kubeconfig=/root/.kube/config` at the end of the user script to enable scheduling on the node. Note: This field may return null, indicating that no valid value is available. Example value: `#!/bin/sh echo \"hello world\"`.",
 						},
 						"pre_start_user_script": {
 							Type:        schema.TypeString,
@@ -518,7 +527,13 @@ func resourceTencentCloudKubernetesClusterAttachmentCreate(d *schema.ResourceDat
 				instanceAdvancedSettings.DataDisks = append(instanceAdvancedSettings.DataDisks, &dataDisk)
 			}
 		}
-		if v, ok := instanceAdvancedSettingsMap["user_data"]; ok {
+		// user_script (new) and user_data (deprecated) are mutually exclusive
+		// (ConflictsWith). InterfacesHeadMap returns a map containing every
+		// block attribute (unset ones are ""), so check non-empty to pick the
+		// actually configured one, preferring the new user_script field.
+		if v, ok := instanceAdvancedSettingsMap["user_script"]; ok && v.(string) != "" {
+			instanceAdvancedSettings.UserScript = helper.String(v.(string))
+		} else if v, ok := instanceAdvancedSettingsMap["user_data"]; ok && v.(string) != "" {
 			instanceAdvancedSettings.UserScript = helper.String(v.(string))
 		}
 		if v, ok := instanceAdvancedSettingsMap["pre_start_user_script"]; ok {
@@ -680,8 +695,8 @@ func resourceTencentCloudKubernetesClusterAttachmentRead(d *schema.ResourceData,
 	}
 
 	if respData == nil {
+		log.Printf("[WARN]%s resource `tencentcloud_kubernetes_cluster_attachment` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
-		log.Printf("[WARN]%s resource `kubernetes_cluster_attachment` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		return nil
 	}
 
@@ -691,8 +706,8 @@ func resourceTencentCloudKubernetesClusterAttachmentRead(d *schema.ResourceData,
 	}
 
 	if respData1 == nil {
+		log.Printf("[WARN]%s resource `tencentcloud_kubernetes_cluster_attachment` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
-		log.Printf("[WARN]%s resource `kubernetes_cluster_attachment` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		return nil
 	}
 	if respData1.LoginSettings != nil {
@@ -728,8 +743,8 @@ func resourceTencentCloudKubernetesClusterAttachmentRead(d *schema.ResourceData,
 	}
 
 	if respData2 == nil {
+		log.Printf("[WARN]%s resource `tencentcloud_kubernetes_cluster_attachment` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
-		log.Printf("[WARN]%s resource `kubernetes_cluster_attachment` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		return nil
 	}
 	if respData2.InstanceAdvancedSettings != nil {

--- a/website/docs/r/kubernetes_cluster_attachment.html.markdown
+++ b/website/docs/r/kubernetes_cluster_attachment.html.markdown
@@ -187,7 +187,8 @@ The `worker_config` object supports the following:
 * `mount_target` - (Optional, String, ForceNew) Mount target. Default is not mounting.
 * `pre_start_user_script` - (Optional, String, ForceNew) Base64-encoded user script, executed before initializing the node, currently only effective for adding existing nodes.
 * `taints` - (Optional, List, ForceNew) Node taint.
-* `user_data` - (Optional, String, ForceNew) Base64-encoded User Data text, the length limit is 16KB.
+* `user_data` - (Optional, String, ForceNew, **Deprecated**) It has been deprecated from version 1.83.16. Use `user_script` instead. Base64-encoded User Data text, the length limit is 16KB.
+* `user_script` - (Optional, String, ForceNew) A Base64-encoded user script that executes after Kubernetes components start. Users must ensure the script supports re-entrancy and retry logic. The script and its generated log files can be found in the `/data/ccs_userscript/` directory on the node. If the node should only join the scheduling pool after initialization is complete, the `unschedulable` parameter can be used; in this case, add the command `kubectl uncordon nodename --kubeconfig=/root/.kube/config` at the end of the user script to enable scheduling on the node. Note: This field may return null, indicating that no valid value is available. Example value: `#!/bin/sh echo "hello world"`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
