### PR TITLE
feat(trocket): [135094203] add pay_mode, renew_flag, time_span, max_topic_num and zone_ids params to rocketmq_instance resource

### DIFF
--- a/.changelog/4356.txt
+++ b/.changelog/4356.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_trocket_rocketmq_instance: support pay_mode, renew_flag, time_span, max_topic_num and zone_ids parameters
+```

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.121
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.107
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.1.0
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.3.129
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tse v1.0.857
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tsf v1.0.674
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod v1.3.127

--- a/go.sum
+++ b/go.sum
@@ -952,7 +952,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1126/go.mod
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1127/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1145/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.0/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.7/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.11/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.13/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1000,6 +999,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.123/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.124/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.125/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.129/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1126,8 +1126,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998 h1:f4/n0d
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998/go.mod h1:fyi/HUwCwVe2NCCCjz8k/C5GwPu3QazCZO+OBJ3MhLk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.107 h1:Yky7eL8FnkO89MvxERN3tniBQjstZzjIX8I91A4la/k=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.107/go.mod h1:Vh7Ox8y4eKUY8LOUp8LA+KS2ZdoVh41U3v+ukVYy8Zo=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.1.0 h1:fqEgijEVva4B2DP//usKyz89PB/5kfDFHbaOwipW33U=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.1.0/go.mod h1:u+2ti+5s1Rz15HcxLQ/HLUl6TfQffMOH/11R8kkl8hw=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.3.129 h1:qY2+yxWhTeHw3d4C2zpaWuRDb+C2jGVqTEhQ6Gqujy0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.3.129/go.mod h1:o5fYk3eP1FIPVuJzblKpppsDZnL4XYiv/qkWdA5cW2Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tse v1.0.857 h1:TkJnvSeRSXsRCwOwcwXSvruSK9s/kw8LC3FLeccw+A0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tse v1.0.857/go.mod h1:CSGh7HSEzUoY09G67XTABi/aqNy3dSLCSuenb1i5x6k=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tsf v1.0.674 h1:VsMV1/vsgVzespG7jUzraZS/AbAUllVQjmtVAlA9W/M=

--- a/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/design.md
+++ b/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`tencentcloud_trocket_rocketmq_instance` 是一个 RESOURCE_KIND_GENERAL 资源，管理腾讯云 TROcket（RocketMQ 5.x）实例的完整生命周期。当前 Schema 仅覆盖创建后付费实例所需的最小参数集。
+
+云 API `CreateInstance`（trocket v20230308）已支持预付费相关入参与可用区/主题数配置，但 Terraform Schema 尚未暴露。本次变更需要将以下五个入参引入 Schema，覆盖 Create / Read / Update 链路：
+
+| Schema 字段 | 云 API Create 字段 | 云 API Describe 字段 | 云 API Modify 字段 | 类型 |
+|---|---|---|---|---|
+| `pay_mode` | `request.PayMode` (*int64) | `response.PayMode` (*string) | 无 | int |
+| `renew_flag` | `request.RenewFlag` (*int64) | `response.RenewFlag` (*int64) | 无 | int |
+| `time_span` | `request.TimeSpan` (*int64) | 无对应字段 | 无 | int |
+| `max_topic_num` | `request.MaxTopicNum` (*int64) | 无直接字段（有 TopicNumLimit/TopicNumUpperLimit） | `request.MaxTopicNum` (*int64) | int |
+| `zone_ids` | `request.ZoneIds` ([]*int64) | `response.ZoneIds` ([]*int64) | `request.ZoneIds` ([]*string) | list[int] |
+
+约束：必须保持向后兼容（纯新增 Optional 字段，不影响已有 state）；所有 SDK 调用使用 `tccommon.ReadRetryTimeout`/`WriteRetryTimeout` 并通过 `tccommon.RetryError` 包装错误。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 Schema 中新增 `pay_mode`、`renew_flag`、`time_span`、`max_topic_num`、`zone_ids` 五个 Optional 字段。
+- Create 操作将五个字段填充到 `CreateInstanceRequest`。
+- Read 操作从 `DescribeInstance` 响应回填 `pay_mode`、`renew_flag`、`zone_ids`。
+- Update 操作支持 `max_topic_num`、`zone_ids` 原地更新；`pay_mode`/`renew_flag`/`time_span` 作为不可变参数。
+- 补充单元测试与资源文档。
+
+**Non-Goals:**
+- 不修改既有任何 Schema 字段（instance_type、name、sku_code、remark、vpc_id、subnet_id、enable_public、bandwidth、ip_rules、message_retention 等）。
+- 不新增 `_extension.go` 文件。
+- 不处理 `time_span` 到期续费的定时任务类逻辑。
+
+## Decisions
+
+### Decision 1: `pay_mode`、`renew_flag`、`time_span` 标记为不可变（immutable）
+
+Create 入参 `PayMode`、`RenewFlag`、`TimeSpan` 在 `ModifyInstanceRequest` 中不存在，云 API 不支持创建后修改付费模式/续费标志/购买时长。因此将这三个字段加入现有 Update 方法的 `immutableArgs` 数组，一旦变更返回 `fmt.Errorf("argument %s cannot be changed", v)`。
+
+**备选方案**：将这些字段设为 `ForceNew`，但重建 RocketMQ 实例代价过高（数据丢失、实例 ID 变更），且付费模式变更本身不是合法运维操作，故选择 immutable 报错而非 ForceNew。
+
+### Decision 2: `max_topic_num`、`zone_ids` 支持原地更新
+
+`ModifyInstanceRequest` 同时包含 `MaxTopicNum`（*int64）和 `ZoneIds`（[]*string）。因此 `max_topic_num`、`zone_ids` 可在 Update 方法中原地修改，纳入 `request1`（`ModifyInstanceRequest`）的处理逻辑。
+
+### Decision 3: `zone_ids` 类型差异处理
+
+注意类型在 Create 与 Modify 接口间不一致：
+- `CreateInstanceRequest.ZoneIds` 为 `[]*int64`
+- `ModifyInstanceRequest.ZoneIds` 为 `[]*string`
+- `DescribeInstanceResponseParams.ZoneIds` 为 `[]*int64`
+
+Schema 统一使用 `TypeList` + `Elem: schema.TypeInt`。在 Create 中将 int 转为 `*int64`；在 Update 中将 int 转为 `*string`（`helper.IntToStr`）；在 Read 中将 `[]*int64` 转回 `[]interface{}` int。
+
+### Decision 4: Read 回填 `pay_mode` 的枚举映射
+
+云 API `DescribeInstance` 返回的 `PayMode` 为字符串枚举：`POSTPAID`（后付费）/ `PREPAID`（预付费），而 Create 入参 `PayMode` 为 int64（0=后付费，1=预付费）。为保持 Terraform Schema 类型一致（int），Read 时做映射：`POSTPAID` → 0，`PREPAID` → 1，其他值默认 0。
+
+### Decision 5: Read 对 `time_span`、`max_topic_num` 的处理
+
+`DescribeInstance` 响应无 `TimeSpan` 字段（购买时长不回显），故 `time_span` 在 Read 中不回填，仅在 state 中保持用户配置值（Optional 非 Computed，Terraform 不会因 read 未 set 而报 diff）。`max_topic_num` 无直接对应响应字段，同样不在 Read 中回填。
+
+### Decision 6: Create 使用 `GetOk` 判断 Optional 字段
+
+五个新字段均为 Optional。`pay_mode`、`renew_flag`、`time_span` 有默认值语义（0/0/1），但为避免与云 API 默认行为冲突并保证 0 值可显式传入，Create 中使用 `d.GetOk`（对 int 0 会判为 absent）。若用户未设置则不填入 request，由云 API 使用默认值。这与现有 `enable_public` 用 `GetOkExists` 区分 false/absent 的场景不同——此处无需区分 0 与 absent，因为 0 即等于云 API 默认值。
+
+## Risks / Trade-offs
+
+- **[Risk] `pay_mode` Read 枚举映射不覆盖未来新增计费模式** → 仅处理当前已知的 `POSTPAID`/`PREPAID`，未知值兜底为 0，并在注释中说明；云 API 若新增枚举后续再补。
+- **[Risk] `time_span` 无法 Read 回填导致 state 与远端不同步** → 该字段为创建时一次性参数，生命周期内不变，不可变约束保证不会被误更新，state 中保留用户配置值即可。
+- **[Trade-off] `zone_ids` Create/Modify 类型不一致增加代码复杂度** → 在 Create/Update 分别做 int→*int64 与 int→*string 转换，属于云 API 不规范的既定约束，无法规避。

--- a/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/proposal.md
+++ b/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`tencentcloud_trocket_rocketmq_instance` 资源当前仅支持创建后付费（按量计费）实例，且无法指定部署可用区与最大主题数等关键创建参数。云 API `CreateInstance` 已提供 `PayMode`、`RenewFlag`、`TimeSpan`、`MaxTopicNum`、`ZoneIds` 入参，但 Terraform Schema 尚未暴露这些字段，导致用户无法通过 Terraform 创建预付费（包年包月）实例、配置自动续费、购买时长、自定义最大主题数及部署可用区。本次变更新增这五个参数以补齐云 API 能力。
+
+## What Changes
+
+- 在 `tencentcloud_trocket_rocketmq_instance` 资源 Schema 中新增五个 Optional 字段：
+  - `pay_mode` (TypeInt, Optional, Default 0): 付费模式（0: 后付费；1: 预付费），默认值为 0。
+  - `renew_flag` (TypeInt, Optional, Default 0): 预付费集群是否自动续费（0: 不自动续费；1: 自动续费），默认值为 0。
+  - `time_span` (TypeInt, Optional, Default 1): 预付费集群的购买时长（单位：月），取值范围 1～60，默认值为 1。
+  - `max_topic_num` (TypeInt, Optional): 最大可创建主题数。
+  - `zone_ids` (TypeList of TypeInt, Optional): 部署可用区列表。
+- Create 操作：将五个新增字段填充到 `CreateInstanceRequest` 中。
+- Read 操作：从 `DescribeInstance` 响应中回填 `pay_mode`、`renew_flag`、`zone_ids`（注意云 API 返回的 `PayMode` 为字符串枚举 `POSTPAID`/`PREPAID`，需映射为 int 0/1；`renew_flag` 与 `zone_ids` 直接回填）。
+- Update 操作：`max_topic_num` 和 `zone_ids` 支持通过 `ModifyInstance` 接口原地更新；`pay_mode`、`renew_flag`、`time_span` 为创建时参数，加入 `immutableArgs` 数组，变更时报错。
+- 补充单元测试与资源文档。
+
+## Capabilities
+
+### New Capabilities
+- `trocket-rocketmq-instance-params`: 为 `tencentcloud_trocket_rocketmq_instance` 资源新增付费模式、自动续费标志、购买时长、最大主题数、部署可用区列表等创建/更新参数，覆盖 Create、Read、Update 全链路。
+
+### Modified Capabilities
+<!-- 无：本次变更新增参数，不改变既有 spec 级别的需求行为。 -->
+
+## Impact
+
+- **Modified code**:
+  - `tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.go`: Schema 新增五个字段；Create/Read/Update 函数补充参数处理逻辑。
+  - `tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance_test.go`: 补充新增参数的单元测试用例。
+  - `tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.md`: 更新示例用法文档。
+- **APIs consumed**: `CreateInstance`、`DescribeInstance`、`ModifyInstance`（均已在 vendored SDK `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket/v20230308/` 中）。
+- **No breaking change**: 纯新增 Optional 字段，向后兼容；不修改既有 Schema 字段，不影响已有 state。

--- a/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/specs/trocket-rocketmq-instance-params/spec.md
+++ b/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/specs/trocket-rocketmq-instance-params/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: TROcket Rocketmq Instance Billing and Deployment Schema
+
+The system SHALL define the following additional Optional fields on the `tencentcloud_trocket_rocketmq_instance` resource Schema:
+- `pay_mode` (Optional, TypeInt): 付费模式（0: 后付费；1: 预付费），默认值为 0。
+- `renew_flag` (Optional, TypeInt): 预付费集群是否自动续费（0: 不自动续费；1: 自动续费），默认值为 0。
+- `time_span` (Optional, TypeInt): 预付费集群的购买时长（单位：月），取值范围 1～60，默认值为 1。
+- `max_topic_num` (Optional, TypeInt): 最大可创建主题数。
+- `zone_ids` (Optional, TypeList with Elem TypeInt): 部署可用区列表。
+
+All new fields SHALL be Optional and backward compatible; no existing Schema field SHALL be modified or removed.
+
+#### Scenario: New fields are optional
+- **WHEN** a user creates a `tencentcloud_trocket_rocketmq_instance` without specifying `pay_mode`, `renew_flag`, `time_span`, `max_topic_num`, or `zone_ids`
+- **THEN** the system SHALL accept the configuration and rely on the cloud API defaults
+
+#### Scenario: zone_ids accepts a list of integers
+- **WHEN** a user sets `zone_ids = [100001, 100003]` in the Terraform configuration
+- **THEN** the schema SHALL accept the list of integers and mark each element as TypeInt
+
+### Requirement: TROcket Rocketmq Instance Create Operation
+
+The system SHALL, in the `Create` operation, fill the following `CreateInstanceRequest` fields when the corresponding Terraform fields are set:
+- `request.PayMode` from `pay_mode`
+- `request.RenewFlag` from `renew_flag`
+- `request.TimeSpan` from `time_span`
+- `request.MaxTopicNum` from `max_topic_num`
+- `request.ZoneIds` ([]*int64) from `zone_ids` list
+
+#### Scenario: Create with prepaid billing fields
+- **WHEN** the user sets `pay_mode = 1`, `renew_flag = 1`, `time_span = 12` in the Terraform configuration and creates the instance
+- **THEN** the system SHALL fill `request.PayMode = 1`, `request.RenewFlag = 1`, `request.TimeSpan = 12` in the `CreateInstance` request
+
+#### Scenario: Create without billing fields configured
+- **WHEN** the user does not set `pay_mode`, `renew_flag`, or `time_span` in the Terraform configuration
+- **THEN** the system SHALL NOT fill these fields in the `CreateInstance` request, preserving the cloud-side default
+
+#### Scenario: Create with max_topic_num configured
+- **WHEN** the user sets `max_topic_num = 500` in the Terraform configuration and creates the instance
+- **THEN** the system SHALL fill `request.MaxTopicNum = 500` in the `CreateInstance` request
+
+#### Scenario: Create with zone_ids configured
+- **WHEN** the user sets `zone_ids = [100001, 100003]` in the Terraform configuration and creates the instance
+- **THEN** the system SHALL convert each integer to `*int64` and fill `request.ZoneIds` in the `CreateInstance` request
+
+### Requirement: TROcket Rocketmq Instance Read Operation
+
+The system SHALL, in the `Read` operation, read the following fields from the `DescribeInstance` response (`rocketmqInstance` of type `Instance`):
+- `pay_mode`: SHALL be mapped from `rocketmqInstance.PayMode` (string enum `POSTPAID`/`PREPAID`) to int (`POSTPAID`→0, `PREPAID`→1). Before calling `d.Set`, the system SHALL check that `rocketmqInstance.PayMode` is not nil; if nil, skip the set.
+- `renew_flag`: SHALL be set from `rocketmqInstance.RenewFlag` (int64). Before calling `d.Set`, check non-nil; if nil, skip.
+- `zone_ids`: SHALL be set from `rocketmqInstance.ZoneIds` ([]*int64). Before calling `d.Set`, check non-nil; if nil, skip.
+
+The system SHALL NOT attempt to read `time_span` or `max_topic_num` from the `DescribeInstance` response (no corresponding field).
+
+#### Scenario: Read pay_mode from DescribeInstance
+- **WHEN** the Read operation calls `DescribeInstance` and the response `PayMode` is `"PREPAID"`
+- **THEN** the system SHALL set `pay_mode = 1` in Terraform state
+
+#### Scenario: Read pay_mode POSTPAID
+- **WHEN** the response `PayMode` is `"POSTPAID"`
+- **THEN** the system SHALL set `pay_mode = 0` in Terraform state
+
+#### Scenario: Read with nil response fields
+- **WHEN** the response `PayMode`, `RenewFlag`, or `ZoneIds` is nil
+- **THEN** the system SHALL skip the corresponding `d.Set` call to avoid nil pointer issues
+
+### Requirement: TROcket Rocketmq Instance Update Operation
+
+The system SHALL treat `pay_mode`, `renew_flag`, and `time_span` as immutable by adding them to the `immutableArgs` array in the Update operation. When any of these fields change, the system SHALL return an error `argument <name> cannot be changed`.
+
+The system SHALL support in-place update of `max_topic_num` and `zone_ids`:
+- When `max_topic_num` changes, the system SHALL fill `request1.MaxTopicNum` (int64) and call `ModifyInstance`.
+- When `zone_ids` changes, the system SHALL convert each integer to `*string` and fill `request1.ZoneIds` ([]*string), then call `ModifyInstance`.
+
+#### Scenario: Update pay_mode is rejected
+- **WHEN** `pay_mode` changes in the Terraform configuration
+- **THEN** the system SHALL return an error and NOT call any API
+
+#### Scenario: Update renew_flag is rejected
+- **WHEN** `renew_flag` changes in the Terraform configuration
+- **THEN** the system SHALL return an error and NOT call any API
+
+#### Scenario: Update time_span is rejected
+- **WHEN** `time_span` changes in the Terraform configuration
+- **THEN** the system SHALL return an error and NOT call any API
+
+#### Scenario: Update max_topic_num in-place
+- **WHEN** `max_topic_num` changes from 500 to 1000 in the Terraform configuration
+- **THEN** the system SHALL call `ModifyInstance` with `MaxTopicNum = 1000` and the update SHALL be performed in-place without resource recreation
+
+#### Scenario: Update zone_ids in-place
+- **WHEN** `zone_ids` changes in the Terraform configuration
+- **THEN** the system SHALL call `ModifyInstance` with `ZoneIds` ([]*string) converted from the new list and the update SHALL be performed in-place
+
+### Requirement: TROcket Rocketmq Instance Unit Tests
+
+The system SHALL provide unit tests in `resource_tc_trocket_rocketmq_instance_test.go` using the Terraform test suite (TF_ACC), covering the new parameters `pay_mode`, `renew_flag`, `time_span`, `max_topic_num`, and `zone_ids` in create and update scenarios.
+
+#### Scenario: Test covers new parameters
+- **WHEN** the test suite is run
+- **THEN** test cases SHALL cover creating an instance with the new fields and updating `max_topic_num`/`zone_ids`
+
+### Requirement: TROcket Rocketmq Instance Resource Documentation
+
+The system SHALL update the markdown documentation file `resource_tc_trocket_rocketmq_instance.md` to include example usage demonstrating the new `pay_mode`, `renew_flag`, `time_span`, `max_topic_num`, and `zone_ids` fields. The documentation SHALL NOT include `Argument Reference` or `Attribute Reference` sections (auto-generated).
+
+#### Scenario: Documentation updated
+- **WHEN** the resource parameters are added
+- **THEN** the `.md` file SHALL include example HCL demonstrating the new fields

--- a/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/tasks.md
+++ b/openspec/changes/archive/2026-07-28-add-trocket-rocketmq-instance-params/tasks.md
@@ -1,0 +1,40 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.go` 的 `ResourceTencentCloudTrocketRocketmqInstance()` Schema map 中新增五个 Optional 字段：`pay_mode` (TypeInt)、`renew_flag` (TypeInt)、`time_span` (TypeInt)、`max_topic_num` (TypeInt)、`zone_ids` (TypeList, Elem TypeInt)，均带 Description
+- [x] 1.2 确认新字段均为 Optional、不设 ForceNew、不修改任何既有字段，保证向后兼容
+
+## 2. Create 操作
+
+- [x] 2.1 在 `resourceTencentCloudTrocketRocketmqInstanceCreate` 中，当 `pay_mode` 设置时填充 `request.PayMode` (helper.IntInt64)
+- [x] 2.2 当 `renew_flag` 设置时填充 `request.RenewFlag`
+- [x] 2.3 当 `time_span` 设置时填充 `request.TimeSpan`
+- [x] 2.4 当 `max_topic_num` 设置时填充 `request.MaxTopicNum`
+- [x] 2.5 当 `zone_ids` 设置时遍历列表，将 int 转为 `*int64` 填充 `request.ZoneIds` ([]*int64)
+- [x] 2.6 确认 Create 调用后检查 response/InstanceId 非空，复用现有等待逻辑
+
+## 3. Read 操作
+
+- [x] 3.1 在 `resourceTencentCloudTrocketRocketmqInstanceRead` 中，当 `rocketmqInstance.PayMode` 非 nil 时做枚举映射（POSTPAID→0, PREPAID→1）并 `d.Set("pay_mode", ...)`
+- [x] 3.2 当 `rocketmqInstance.RenewFlag` 非 nil 时 `d.Set("renew_flag", ...)`
+- [x] 3.3 当 `rocketmqInstance.ZoneIds` 非 nil 时将 []*int64 转为 []interface{} int 并 `d.Set("zone_ids", ...)`
+- [x] 3.4 不回填 `time_span`、`max_topic_num`（无对应响应字段）
+
+## 4. Update 操作
+
+- [x] 4.1 将 `pay_mode`、`renew_flag`、`time_span` 加入 Update 方法的 `immutableArgs` 数组，变更时返回 `fmt.Errorf("argument %s cannot be changed", v)`
+- [x] 4.2 当 `max_topic_num` 变更时填充 `request1.MaxTopicNum` (helper.IntInt64) 并置 `needModifyInstance = true`
+- [x] 4.3 当 `zone_ids` 变更时遍历列表，将 int 转为 `*string` (helper.IntToStr) 填充 `request1.ZoneIds` ([]*string) 并置 `needModifyInstance = true`
+- [x] 4.4 确认 `needModifyInstance` 触发 `ModifyInstance` 调用并复用现有等待逻辑
+
+## 5. 单元测试
+
+- [x] 5.1 在 `tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance_test.go` 中补充测试用例，覆盖新增 `pay_mode`、`renew_flag`、`time_span`、`max_topic_num`、`zone_ids` 的 create 与 update（max_topic_num/zone_ids 原地更新）场景，使用 Terraform 测试套件（TF_ACC）
+
+## 6. 文档
+
+- [x] 6.1 更新 `tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.md`，在示例 HCL 中补充新字段演示（不添加 Argument Reference / Attribute Reference 段落）
+
+## 7. 验证
+
+- [x] 7.1 代码正确性检查：确认 Create 字段在 `CreateInstanceRequest` 中存在、Update 字段在 `ModifyInstanceRequest` 中存在、Read 字段在 `DescribeInstanceResponseParams` 中存在
+- [x] 7.2 最终由收尾阶段执行 `gofmt` 格式化与 `make doc` 文档生成（移交 tfpacer-finalize skill 执行）

--- a/openspec/specs/trocket-rocketmq-instance-params/spec.md
+++ b/openspec/specs/trocket-rocketmq-instance-params/spec.md
@@ -1,0 +1,114 @@
+# trocket-rocketmq-instance-params Specification
+
+## Purpose
+TBD - created by archiving change add-trocket-rocketmq-instance-params. Update Purpose after archive.
+## Requirements
+### Requirement: TROcket Rocketmq Instance Billing and Deployment Schema
+
+The system SHALL define the following additional Optional fields on the `tencentcloud_trocket_rocketmq_instance` resource Schema:
+- `pay_mode` (Optional, TypeInt): 付费模式（0: 后付费；1: 预付费），默认值为 0。
+- `renew_flag` (Optional, TypeInt): 预付费集群是否自动续费（0: 不自动续费；1: 自动续费），默认值为 0。
+- `time_span` (Optional, TypeInt): 预付费集群的购买时长（单位：月），取值范围 1～60，默认值为 1。
+- `max_topic_num` (Optional, TypeInt): 最大可创建主题数。
+- `zone_ids` (Optional, TypeList with Elem TypeInt): 部署可用区列表。
+
+All new fields SHALL be Optional and backward compatible; no existing Schema field SHALL be modified or removed.
+
+#### Scenario: New fields are optional
+- **WHEN** a user creates a `tencentcloud_trocket_rocketmq_instance` without specifying `pay_mode`, `renew_flag`, `time_span`, `max_topic_num`, or `zone_ids`
+- **THEN** the system SHALL accept the configuration and rely on the cloud API defaults
+
+#### Scenario: zone_ids accepts a list of integers
+- **WHEN** a user sets `zone_ids = [100001, 100003]` in the Terraform configuration
+- **THEN** the schema SHALL accept the list of integers and mark each element as TypeInt
+
+### Requirement: TROcket Rocketmq Instance Create Operation
+
+The system SHALL, in the `Create` operation, fill the following `CreateInstanceRequest` fields when the corresponding Terraform fields are set:
+- `request.PayMode` from `pay_mode`
+- `request.RenewFlag` from `renew_flag`
+- `request.TimeSpan` from `time_span`
+- `request.MaxTopicNum` from `max_topic_num`
+- `request.ZoneIds` ([]*int64) from `zone_ids` list
+
+#### Scenario: Create with prepaid billing fields
+- **WHEN** the user sets `pay_mode = 1`, `renew_flag = 1`, `time_span = 12` in the Terraform configuration and creates the instance
+- **THEN** the system SHALL fill `request.PayMode = 1`, `request.RenewFlag = 1`, `request.TimeSpan = 12` in the `CreateInstance` request
+
+#### Scenario: Create without billing fields configured
+- **WHEN** the user does not set `pay_mode`, `renew_flag`, or `time_span` in the Terraform configuration
+- **THEN** the system SHALL NOT fill these fields in the `CreateInstance` request, preserving the cloud-side default
+
+#### Scenario: Create with max_topic_num configured
+- **WHEN** the user sets `max_topic_num = 500` in the Terraform configuration and creates the instance
+- **THEN** the system SHALL fill `request.MaxTopicNum = 500` in the `CreateInstance` request
+
+#### Scenario: Create with zone_ids configured
+- **WHEN** the user sets `zone_ids = [100001, 100003]` in the Terraform configuration and creates the instance
+- **THEN** the system SHALL convert each integer to `*int64` and fill `request.ZoneIds` in the `CreateInstance` request
+
+### Requirement: TROcket Rocketmq Instance Read Operation
+
+The system SHALL, in the `Read` operation, read the following fields from the `DescribeInstance` response (`rocketmqInstance` of type `Instance`):
+- `pay_mode`: SHALL be mapped from `rocketmqInstance.PayMode` (string enum `POSTPAID`/`PREPAID`) to int (`POSTPAID`→0, `PREPAID`→1). Before calling `d.Set`, the system SHALL check that `rocketmqInstance.PayMode` is not nil; if nil, skip the set.
+- `renew_flag`: SHALL be set from `rocketmqInstance.RenewFlag` (int64). Before calling `d.Set`, check non-nil; if nil, skip.
+- `zone_ids`: SHALL be set from `rocketmqInstance.ZoneIds` ([]*int64). Before calling `d.Set`, check non-nil; if nil, skip.
+
+The system SHALL NOT attempt to read `time_span` or `max_topic_num` from the `DescribeInstance` response (no corresponding field).
+
+#### Scenario: Read pay_mode from DescribeInstance
+- **WHEN** the Read operation calls `DescribeInstance` and the response `PayMode` is `"PREPAID"`
+- **THEN** the system SHALL set `pay_mode = 1` in Terraform state
+
+#### Scenario: Read pay_mode POSTPAID
+- **WHEN** the response `PayMode` is `"POSTPAID"`
+- **THEN** the system SHALL set `pay_mode = 0` in Terraform state
+
+#### Scenario: Read with nil response fields
+- **WHEN** the response `PayMode`, `RenewFlag`, or `ZoneIds` is nil
+- **THEN** the system SHALL skip the corresponding `d.Set` call to avoid nil pointer issues
+
+### Requirement: TROcket Rocketmq Instance Update Operation
+
+The system SHALL treat `pay_mode`, `renew_flag`, and `time_span` as immutable by adding them to the `immutableArgs` array in the Update operation. When any of these fields change, the system SHALL return an error `argument <name> cannot be changed`.
+
+The system SHALL support in-place update of `max_topic_num` and `zone_ids`:
+- When `max_topic_num` changes, the system SHALL fill `request1.MaxTopicNum` (int64) and call `ModifyInstance`.
+- When `zone_ids` changes, the system SHALL convert each integer to `*string` and fill `request1.ZoneIds` ([]*string), then call `ModifyInstance`.
+
+#### Scenario: Update pay_mode is rejected
+- **WHEN** `pay_mode` changes in the Terraform configuration
+- **THEN** the system SHALL return an error and NOT call any API
+
+#### Scenario: Update renew_flag is rejected
+- **WHEN** `renew_flag` changes in the Terraform configuration
+- **THEN** the system SHALL return an error and NOT call any API
+
+#### Scenario: Update time_span is rejected
+- **WHEN** `time_span` changes in the Terraform configuration
+- **THEN** the system SHALL return an error and NOT call any API
+
+#### Scenario: Update max_topic_num in-place
+- **WHEN** `max_topic_num` changes from 500 to 1000 in the Terraform configuration
+- **THEN** the system SHALL call `ModifyInstance` with `MaxTopicNum = 1000` and the update SHALL be performed in-place without resource recreation
+
+#### Scenario: Update zone_ids in-place
+- **WHEN** `zone_ids` changes in the Terraform configuration
+- **THEN** the system SHALL call `ModifyInstance` with `ZoneIds` ([]*string) converted from the new list and the update SHALL be performed in-place
+
+### Requirement: TROcket Rocketmq Instance Unit Tests
+
+The system SHALL provide unit tests in `resource_tc_trocket_rocketmq_instance_test.go` using the Terraform test suite (TF_ACC), covering the new parameters `pay_mode`, `renew_flag`, `time_span`, `max_topic_num`, and `zone_ids` in create and update scenarios.
+
+#### Scenario: Test covers new parameters
+- **WHEN** the test suite is run
+- **THEN** test cases SHALL cover creating an instance with the new fields and updating `max_topic_num`/`zone_ids`
+
+### Requirement: TROcket Rocketmq Instance Resource Documentation
+
+The system SHALL update the markdown documentation file `resource_tc_trocket_rocketmq_instance.md` to include example usage demonstrating the new `pay_mode`, `renew_flag`, `time_span`, `max_topic_num`, and `zone_ids` fields. The documentation SHALL NOT include `Argument Reference` or `Attribute Reference` sections (auto-generated).
+
+#### Scenario: Documentation updated
+- **WHEN** the resource parameters are added
+- **THEN** the `.md` file SHALL include example HCL demonstrating the new fields
+

--- a/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.go
+++ b/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.go
@@ -30,81 +30,81 @@ func ResourceTencentCloudTrocketRocketmqInstance() *schema.Resource {
 			"instance_type": {
 				Required:    true,
 				Type:        schema.TypeString,
-				Description: "Instance type. Valid values: `EXPERIMENT`, `BASIC`, `PRO`, `PLATINUM`.",
+				Description: "Instance type. Valid values: `EXPERIMENT` (trial edition), `BASIC` (basic edition), `PRO` (professional edition), `PLATINUM` (platinum edition).",
 			},
 
 			"name": {
 				Required:    true,
 				Type:        schema.TypeString,
-				Description: "Instance name.",
+				Description: "Instance (cluster) name, 3-64 characters, can only contain digits, letters, hyphen '-' and underscore '_'.",
 			},
 
 			"sku_code": {
 				Required:    true,
 				Type:        schema.TypeString,
-				Description: "SKU code. Available specifications are as follows: experiment_500, basic_1k, basic_2k, basic_3k, basic_4k, basic_5k, basic_6k, basic_7k, basic_8k, basic_9k, basic_10k, pro_4k, pro_6k, pro_8k, pro_1w, pro_15k, pro_2w, pro_25k, pro_3w, pro_35k, pro_4w, pro_45k, pro_5w, pro_55k, pro_60k, pro_65k, pro_70k, pro_75k, pro_80k, pro_85k, pro_90k, pro_95k, pro_100k, platinum_1w, platinum_2w, platinum_3w, platinum_4w, platinum_5w, platinum_6w, platinum_7w, platinum_8w, platinum_9w, platinum_10w, platinum_12w, platinum_14w, platinum_16w, platinum_18w, platinum_20w, platinum_25w, platinum_30w, platinum_35w, platinum_40w, platinum_45w, platinum_50w, platinum_60w, platinum_70w, platinum_80w, platinum_90w, platinum_100w.",
+				Description: "SKU code, obtained from the ProductSKU output of the DescribeProductSKUs interface.",
 			},
 
 			"remark": {
 				Optional:    true,
 				Type:        schema.TypeString,
-				Description: "Remark.",
+				Description: "Remark information.",
 			},
 
 			"tags": {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Computed:    true,
-				Description: "Tag description list.",
+				Description: "Tag list.",
 			},
 
 			"vpc_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "VPC id.",
+				Description: "VPC ID that the instance binds to.",
 			},
 
 			"subnet_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Subnet id.",
+				Description: "Subnet ID that the instance binds to.",
 			},
 
 			"enable_public": {
 				Optional:    true,
 				Computed:    true,
 				Type:        schema.TypeBool,
-				Description: "Whether to enable the public network. Must set `bandwidth` when `enable_public` equal true.",
+				Description: "Whether to enable public network access, default false. When set to true, `bandwidth` must be set to a positive integer.",
 			},
 
 			"bandwidth": {
 				Optional:    true,
 				Computed:    true,
 				Type:        schema.TypeInt,
-				Description: "Public network bandwidth. `bandwidth` must be greater than zero when `enable_public` equal true.",
+				Description: "Public network bandwidth in Mbps, default 0. Must be a positive integer greater than 0 when public network is enabled.",
 			},
 
 			"ip_rules": {
 				Optional:    true,
 				Computed:    true,
 				Type:        schema.TypeList,
-				Description: "Public network access whitelist.",
+				Description: "Public network access whitelist. If left empty, all IP access is denied.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "IP.",
+							Description: "IP address.",
 						},
 						"allow": {
 							Type:        schema.TypeBool,
 							Required:    true,
-							Description: "Whether to allow release or not.",
+							Description: "Whether to allow access from this IP.",
 						},
 						"remark": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Remark.",
+							Description: "Remark information.",
 						},
 					},
 				},
@@ -114,42 +114,46 @@ func ResourceTencentCloudTrocketRocketmqInstance() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Type:        schema.TypeInt,
-				Description: "Message retention time in hours.",
+				Description: "Message retention time in hours. The value range and default are obtained from the DefaultRetention/RetentionLowerLimit/RetentionUpperLimit parameters in the ProductSKU output of the DescribeProductSKUs interface.",
 			},
 
 			"pay_mode": {
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeInt,
-				Description: "Billing mode (0: pay-as-you-go; 1: subscription). Default value is 0.",
+				Description: "Billing mode. `0`: pay-as-you-go (postpaid), `1`: subscription (prepaid). Default is `0`.",
 			},
 
 			"renew_flag": {
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeInt,
-				Description: "Whether to auto-renew a subscription instance (0: no auto-renewal; 1: auto-renewal). Default value is 0.",
+				Description: "Whether to auto-renew a prepaid instance. `0`: no auto-renewal, `1`: auto-renewal. Default is `0`.",
 			},
 
 			"time_span": {
 				Optional:    true,
 				Type:        schema.TypeInt,
-				Description: "Purchase duration of a subscription instance in months. Value range: 1-60. Default value is 1.",
+				Description: "Purchase duration of a prepaid instance in months. Value range: 1-60. Default is `1`.",
 			},
 
 			"max_topic_num": {
 				Optional:    true,
 				Type:        schema.TypeInt,
-				Description: "Maximum number of topics that can be created.",
+				Description: "Maximum number of topics that can be created. The default/minimum and maximum are obtained from the TopicNumLimit and TopicNumUpperLimit parameters in the ProductSKU output of the DescribeProductSKUs interface.",
 			},
 
 			"zone_ids": {
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeList,
-				Description: "List of deployment availability zones.",
+				Description: "List of deployment availability zones, obtained from the ZoneInfo structure returned by the DescribeZones interface.",
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,
 				},
 			},
 
+			// computed
 			"public_end_point": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -240,19 +244,19 @@ func resourceTencentCloudTrocketRocketmqInstanceCreate(d *schema.ResourceData, m
 		request.MessageRetention = helper.IntInt64(v.(int))
 	}
 
-	if v, ok := d.GetOk("pay_mode"); ok {
+	if v, ok := d.GetOkExists("pay_mode"); ok {
 		request.PayMode = helper.IntInt64(v.(int))
 	}
 
-	if v, ok := d.GetOk("renew_flag"); ok {
+	if v, ok := d.GetOkExists("renew_flag"); ok {
 		request.RenewFlag = helper.IntInt64(v.(int))
 	}
 
-	if v, ok := d.GetOk("time_span"); ok {
+	if v, ok := d.GetOkExists("time_span"); ok {
 		request.TimeSpan = helper.IntInt64(v.(int))
 	}
 
-	if v, ok := d.GetOk("max_topic_num"); ok {
+	if v, ok := d.GetOkExists("max_topic_num"); ok {
 		request.MaxTopicNum = helper.IntInt64(v.(int))
 	}
 
@@ -329,7 +333,7 @@ func resourceTencentCloudTrocketRocketmqInstanceRead(d *schema.ResourceData, met
 	}
 
 	if rocketmqInstance == nil {
-		log.Printf("[WARN]%s resource `TrocketRocketmqInstance` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		log.Printf("[WARN]%s resource `tencentcloud_trocket_rocketmq_instance` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.go
+++ b/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.go
@@ -117,6 +117,39 @@ func ResourceTencentCloudTrocketRocketmqInstance() *schema.Resource {
 				Description: "Message retention time in hours.",
 			},
 
+			"pay_mode": {
+				Optional:    true,
+				Type:        schema.TypeInt,
+				Description: "Billing mode (0: pay-as-you-go; 1: subscription). Default value is 0.",
+			},
+
+			"renew_flag": {
+				Optional:    true,
+				Type:        schema.TypeInt,
+				Description: "Whether to auto-renew a subscription instance (0: no auto-renewal; 1: auto-renewal). Default value is 0.",
+			},
+
+			"time_span": {
+				Optional:    true,
+				Type:        schema.TypeInt,
+				Description: "Purchase duration of a subscription instance in months. Value range: 1-60. Default value is 1.",
+			},
+
+			"max_topic_num": {
+				Optional:    true,
+				Type:        schema.TypeInt,
+				Description: "Maximum number of topics that can be created.",
+			},
+
+			"zone_ids": {
+				Optional:    true,
+				Type:        schema.TypeList,
+				Description: "List of deployment availability zones.",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+
 			"public_end_point": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -205,6 +238,31 @@ func resourceTencentCloudTrocketRocketmqInstanceCreate(d *schema.ResourceData, m
 
 	if v, ok := d.GetOkExists("message_retention"); ok {
 		request.MessageRetention = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOk("pay_mode"); ok {
+		request.PayMode = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOk("renew_flag"); ok {
+		request.RenewFlag = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOk("time_span"); ok {
+		request.TimeSpan = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_topic_num"); ok {
+		request.MaxTopicNum = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOk("zone_ids"); ok {
+		zoneIdsList := v.([]interface{})
+		zoneIds := make([]*int64, 0, len(zoneIdsList))
+		for _, zoneId := range zoneIdsList {
+			zoneIds = append(zoneIds, helper.IntInt64(zoneId.(int)))
+		}
+		request.ZoneIds = zoneIds
 	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
@@ -341,6 +399,30 @@ func resourceTencentCloudTrocketRocketmqInstanceRead(d *schema.ResourceData, met
 		_ = d.Set("message_retention", rocketmqInstance.MessageRetention)
 	}
 
+	if rocketmqInstance.PayMode != nil {
+		var payMode int
+		if *rocketmqInstance.PayMode == "PREPAID" {
+			payMode = 1
+		} else {
+			payMode = 0
+		}
+		_ = d.Set("pay_mode", payMode)
+	}
+
+	if rocketmqInstance.RenewFlag != nil {
+		_ = d.Set("renew_flag", rocketmqInstance.RenewFlag)
+	}
+
+	if rocketmqInstance.ZoneIds != nil {
+		zoneIds := make([]interface{}, 0, len(rocketmqInstance.ZoneIds))
+		for _, zoneId := range rocketmqInstance.ZoneIds {
+			if zoneId != nil {
+				zoneIds = append(zoneIds, int(*zoneId))
+			}
+		}
+		_ = d.Set("zone_ids", zoneIds)
+	}
+
 	tcClient := meta.(tccommon.ProviderMeta).GetAPIV3Conn()
 	tagService := svctag.NewTagService(meta.(tccommon.ProviderMeta).GetAPIV3Conn())
 	tags, err := tagService.DescribeResourceTags(ctx, "trocket", "instance", tcClient.Region, instanceId)
@@ -367,7 +449,7 @@ func resourceTencentCloudTrocketRocketmqInstanceUpdate(d *schema.ResourceData, m
 		needModifyInstanceEndpoint bool
 	)
 
-	immutableArgs := []string{"instance_type", "vpc_id", "subnet_id", "enable_public"}
+	immutableArgs := []string{"instance_type", "vpc_id", "subnet_id", "enable_public", "pay_mode", "renew_flag", "time_span"}
 	for _, v := range immutableArgs {
 		if d.HasChange(v) {
 			return fmt.Errorf("argument `%s` cannot be changed", v)
@@ -401,6 +483,27 @@ func resourceTencentCloudTrocketRocketmqInstanceUpdate(d *schema.ResourceData, m
 	if d.HasChange("message_retention") {
 		if v, ok := d.GetOkExists("message_retention"); ok {
 			request1.MessageRetention = helper.IntInt64(v.(int))
+		}
+
+		needModifyInstance = true
+	}
+
+	if d.HasChange("max_topic_num") {
+		if v, ok := d.GetOk("max_topic_num"); ok {
+			request1.MaxTopicNum = helper.IntInt64(v.(int))
+		}
+
+		needModifyInstance = true
+	}
+
+	if d.HasChange("zone_ids") {
+		if v, ok := d.GetOk("zone_ids"); ok {
+			zoneIdsList := v.([]interface{})
+			zoneIds := make([]*string, 0, len(zoneIdsList))
+			for _, zoneId := range zoneIdsList {
+				zoneIds = append(zoneIds, helper.String(helper.IntToStr(zoneId.(int))))
+			}
+			request1.ZoneIds = zoneIds
 		}
 
 		needModifyInstance = true

--- a/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.md
+++ b/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.md
@@ -84,6 +84,44 @@ resource "tencentcloud_trocket_rocketmq_instance" "example" {
 }
 ```
 
+Create Instance with Billing and Deployment Params
+
+```hcl
+# create vpc
+resource "tencentcloud_vpc" "vpc" {
+  name       = "vpc"
+  cidr_block = "10.0.0.0/16"
+}
+
+# create vpc subnet
+resource "tencentcloud_subnet" "subnet" {
+  name              = "subnet"
+  vpc_id            = tencentcloud_vpc.vpc.id
+  availability_zone = "ap-guangzhou-6"
+  cidr_block        = "10.0.20.0/28"
+  is_multicast      = false
+}
+
+# create rocketmq instance with billing and deployment params
+resource "tencentcloud_trocket_rocketmq_instance" "example" {
+  name          = "tf-example"
+  instance_type = "PRO"
+  sku_code      = "pro_4k"
+  remark        = "remark"
+  vpc_id        = tencentcloud_vpc.vpc.id
+  subnet_id     = tencentcloud_subnet.subnet.id
+  pay_mode      = 1
+  renew_flag    = 1
+  time_span     = 12
+  max_topic_num = 1000
+  zone_ids      = [100003]
+  tags = {
+    tag_key   = "rocketmq"
+    tag_value = "5.x"
+  }
+}
+```
+
 Import
 
 Trocket rocketmq instance can be imported using the id, e.g.

--- a/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.md
+++ b/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance.md
@@ -1,7 +1,5 @@
 Provides a resource to create a Trocket rocketmq instance
 
-~> **NOTE:** It only supports create postpaid rocketmq 5.x instance.
-
 Example Usage
 
 Create Basic Instance
@@ -114,7 +112,7 @@ resource "tencentcloud_trocket_rocketmq_instance" "example" {
   renew_flag    = 1
   time_span     = 12
   max_topic_num = 1000
-  zone_ids      = [100003]
+  zone_ids      = [100006, 100007]
   tags = {
     tag_key   = "rocketmq"
     tag_value = "5.x"

--- a/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance_test.go
+++ b/tencentcloud/services/trocket/resource_tc_trocket_rocketmq_instance_test.go
@@ -172,3 +172,112 @@ resource "tencentcloud_trocket_rocketmq_instance" "example" {
   }
 }
 `
+
+// go test -i; go test -test.run TestAccTencentCloudTrocketRocketmqInstanceResource_params -v
+func TestAccTencentCloudTrocketRocketmqInstanceResource_params(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { tcacctest.AccPreCheck(t) },
+		Providers: tcacctest.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrocketRocketmqInstanceParams,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tencentcloud_trocket_rocketmq_instance.example", "id"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "name", "tf-params"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "instance_type", "BASIC"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "sku_code", "basic_2k"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "pay_mode", "0"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "max_topic_num", "500"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "zone_ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccTrocketRocketmqInstanceParamsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tencentcloud_trocket_rocketmq_instance.example", "id"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "name", "tf-params-update"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "sku_code", "basic_4k"),
+					resource.TestCheckResourceAttr("tencentcloud_trocket_rocketmq_instance.example", "max_topic_num", "1000"),
+				),
+			},
+			{
+				ResourceName:      "tencentcloud_trocket_rocketmq_instance.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+const testAccTrocketRocketmqInstanceParams = `
+# create vpc
+resource "tencentcloud_vpc" "vpc" {
+  name       = "vpc"
+  cidr_block = "10.0.0.0/16"
+}
+
+# create vpc subnet
+resource "tencentcloud_subnet" "subnet" {
+  name              = "subnet"
+  vpc_id            = tencentcloud_vpc.vpc.id
+  availability_zone = "ap-guangzhou-6"
+  cidr_block        = "10.0.20.0/28"
+  is_multicast      = false
+}
+
+# create rocketmq instance with new params
+resource "tencentcloud_trocket_rocketmq_instance" "example" {
+  name          = "tf-params"
+  instance_type = "BASIC"
+  sku_code      = "basic_2k"
+  remark        = "remark"
+  vpc_id        = tencentcloud_vpc.vpc.id
+  subnet_id     = tencentcloud_subnet.subnet.id
+  pay_mode      = 0
+  renew_flag    = 0
+  time_span     = 1
+  max_topic_num = 500
+  zone_ids      = [100003]
+  tags = {
+    tag_key   = "rocketmq"
+    tag_value = "params"
+  }
+}
+`
+
+const testAccTrocketRocketmqInstanceParamsUpdate = `
+# create vpc
+resource "tencentcloud_vpc" "vpc" {
+  name       = "vpc"
+  cidr_block = "10.0.0.0/16"
+}
+
+# create vpc subnet
+resource "tencentcloud_subnet" "subnet" {
+  name              = "subnet"
+  vpc_id            = tencentcloud_vpc.vpc.id
+  availability_zone = "ap-guangzhou-6"
+  cidr_block        = "10.0.20.0/28"
+  is_multicast      = false
+}
+
+# update rocketmq instance max_topic_num and zone_ids in-place
+resource "tencentcloud_trocket_rocketmq_instance" "example" {
+  name          = "tf-params-update"
+  instance_type = "BASIC"
+  sku_code      = "basic_4k"
+  remark        = "remark"
+  vpc_id        = tencentcloud_vpc.vpc.id
+  subnet_id     = tencentcloud_subnet.subnet.id
+  pay_mode      = 0
+  renew_flag    = 0
+  time_span     = 1
+  max_topic_num = 1000
+  zone_ids      = [100003]
+  tags = {
+    tag_key   = "rocketmq"
+    tag_value = "params"
+  }
+}
+`

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket/v20230308/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket/v20230308/client.go
@@ -115,7 +115,9 @@ func NewCreateConsumerGroupResponse() (response *CreateConsumerGroupResponse) {
 }
 
 // CreateConsumerGroup
-// 创建消费组
+// 创建消费组。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的创建消费组接口文档见 [CreateRocketMQGroup](https://cloud.tencent.com/document/api/1179/63428)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -127,7 +129,9 @@ func (c *Client) CreateConsumerGroup(request *CreateConsumerGroupRequest) (respo
 }
 
 // CreateConsumerGroup
-// 创建消费组
+// 创建消费组。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的创建消费组接口文档见 [CreateRocketMQGroup](https://cloud.tencent.com/document/api/1179/63428)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -147,6 +151,62 @@ func (c *Client) CreateConsumerGroupWithContext(ctx context.Context, request *Cr
     request.SetContext(ctx)
     
     response = NewCreateConsumerGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateConsumerLabelRequest() (request *CreateConsumerLabelRequest) {
+    request = &CreateConsumerLabelRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "CreateConsumerLabel")
+    
+    
+    return
+}
+
+func NewCreateConsumerLabelResponse() (response *CreateConsumerLabelResponse) {
+    response = &CreateConsumerLabelResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateConsumerLabel
+// 创建消费组灰度标签
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  UNSUPPORTEDOPERATION_RESOURCEALREADYEXISTS = "UnsupportedOperation.ResourceAlreadyExists"
+func (c *Client) CreateConsumerLabel(request *CreateConsumerLabelRequest) (response *CreateConsumerLabelResponse, err error) {
+    return c.CreateConsumerLabelWithContext(context.Background(), request)
+}
+
+// CreateConsumerLabel
+// 创建消费组灰度标签
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  UNSUPPORTEDOPERATION_RESOURCEALREADYEXISTS = "UnsupportedOperation.ResourceAlreadyExists"
+func (c *Client) CreateConsumerLabelWithContext(ctx context.Context, request *CreateConsumerLabelRequest) (response *CreateConsumerLabelResponse, err error) {
+    if request == nil {
+        request = NewCreateConsumerLabelRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "CreateConsumerLabel")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateConsumerLabel require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateConsumerLabelResponse()
     err = c.Send(request, response)
     return
 }
@@ -171,7 +231,9 @@ func NewCreateInstanceResponse() (response *CreateInstanceResponse) {
 }
 
 // CreateInstance
-// 创建 RocketMQ 5.x 集群
+// 创建 RocketMQ 5.x 集群。
+//
+// 当前 API 适用集群：5.x 集群。创建 4.x 专享/通用集群的接口文档见 [CreateRocketMQVipInstance](https://cloud.tencent.com/document/product/1179/95721)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -180,7 +242,9 @@ func (c *Client) CreateInstance(request *CreateInstanceRequest) (response *Creat
 }
 
 // CreateInstance
-// 创建 RocketMQ 5.x 集群
+// 创建 RocketMQ 5.x 集群。
+//
+// 当前 API 适用集群：5.x 集群。创建 4.x 专享/通用集群的接口文档见 [CreateRocketMQVipInstance](https://cloud.tencent.com/document/product/1179/95721)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -201,222 +265,52 @@ func (c *Client) CreateInstanceWithContext(ctx context.Context, request *CreateI
     return
 }
 
-func NewCreateMQTTInsPublicEndpointRequest() (request *CreateMQTTInsPublicEndpointRequest) {
-    request = &CreateMQTTInsPublicEndpointRequest{
+func NewCreateMigrationTaskRequest() (request *CreateMigrationTaskRequest) {
+    request = &CreateMigrationTaskRequest{
         BaseRequest: &tchttp.BaseRequest{},
     }
     
-    request.Init().WithApiInfo("trocket", APIVersion, "CreateMQTTInsPublicEndpoint")
+    request.Init().WithApiInfo("trocket", APIVersion, "CreateMigrationTask")
     
     
     return
 }
 
-func NewCreateMQTTInsPublicEndpointResponse() (response *CreateMQTTInsPublicEndpointResponse) {
-    response = &CreateMQTTInsPublicEndpointResponse{
+func NewCreateMigrationTaskResponse() (response *CreateMigrationTaskResponse) {
+    response = &CreateMigrationTaskResponse{
         BaseResponse: &tchttp.BaseResponse{},
     } 
     return
 
 }
 
-// CreateMQTTInsPublicEndpoint
-// 为MQTT实例创建公网接入点
+// CreateMigrationTask
+// 创建元数据迁移上云任务
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
-func (c *Client) CreateMQTTInsPublicEndpoint(request *CreateMQTTInsPublicEndpointRequest) (response *CreateMQTTInsPublicEndpointResponse, err error) {
-    return c.CreateMQTTInsPublicEndpointWithContext(context.Background(), request)
+func (c *Client) CreateMigrationTask(request *CreateMigrationTaskRequest) (response *CreateMigrationTaskResponse, err error) {
+    return c.CreateMigrationTaskWithContext(context.Background(), request)
 }
 
-// CreateMQTTInsPublicEndpoint
-// 为MQTT实例创建公网接入点
+// CreateMigrationTask
+// 创建元数据迁移上云任务
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
-func (c *Client) CreateMQTTInsPublicEndpointWithContext(ctx context.Context, request *CreateMQTTInsPublicEndpointRequest) (response *CreateMQTTInsPublicEndpointResponse, err error) {
+func (c *Client) CreateMigrationTaskWithContext(ctx context.Context, request *CreateMigrationTaskRequest) (response *CreateMigrationTaskResponse, err error) {
     if request == nil {
-        request = NewCreateMQTTInsPublicEndpointRequest()
+        request = NewCreateMigrationTaskRequest()
     }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "CreateMQTTInsPublicEndpoint")
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "CreateMigrationTask")
     
     if c.GetCredential() == nil {
-        return nil, errors.New("CreateMQTTInsPublicEndpoint require credential")
+        return nil, errors.New("CreateMigrationTask require credential")
     }
 
     request.SetContext(ctx)
     
-    response = NewCreateMQTTInsPublicEndpointResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewCreateMQTTInstanceRequest() (request *CreateMQTTInstanceRequest) {
-    request = &CreateMQTTInstanceRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "CreateMQTTInstance")
-    
-    
-    return
-}
-
-func NewCreateMQTTInstanceResponse() (response *CreateMQTTInstanceResponse) {
-    response = &CreateMQTTInstanceResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// CreateMQTTInstance
-// 购买新的MQTT实例
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-func (c *Client) CreateMQTTInstance(request *CreateMQTTInstanceRequest) (response *CreateMQTTInstanceResponse, err error) {
-    return c.CreateMQTTInstanceWithContext(context.Background(), request)
-}
-
-// CreateMQTTInstance
-// 购买新的MQTT实例
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-func (c *Client) CreateMQTTInstanceWithContext(ctx context.Context, request *CreateMQTTInstanceRequest) (response *CreateMQTTInstanceResponse, err error) {
-    if request == nil {
-        request = NewCreateMQTTInstanceRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "CreateMQTTInstance")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("CreateMQTTInstance require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewCreateMQTTInstanceResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewCreateMQTTTopicRequest() (request *CreateMQTTTopicRequest) {
-    request = &CreateMQTTTopicRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "CreateMQTTTopic")
-    
-    
-    return
-}
-
-func NewCreateMQTTTopicResponse() (response *CreateMQTTTopicResponse) {
-    response = &CreateMQTTTopicResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// CreateMQTTTopic
-// 创建主题
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
-//  LIMITEXCEEDED_TOPICNUM = "LimitExceeded.TopicNum"
-//  OPERATIONDENIED = "OperationDenied"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  UNSUPPORTEDOPERATION_RESOURCEALREADYEXISTS = "UnsupportedOperation.ResourceAlreadyExists"
-func (c *Client) CreateMQTTTopic(request *CreateMQTTTopicRequest) (response *CreateMQTTTopicResponse, err error) {
-    return c.CreateMQTTTopicWithContext(context.Background(), request)
-}
-
-// CreateMQTTTopic
-// 创建主题
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
-//  LIMITEXCEEDED_TOPICNUM = "LimitExceeded.TopicNum"
-//  OPERATIONDENIED = "OperationDenied"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  UNSUPPORTEDOPERATION_RESOURCEALREADYEXISTS = "UnsupportedOperation.ResourceAlreadyExists"
-func (c *Client) CreateMQTTTopicWithContext(ctx context.Context, request *CreateMQTTTopicRequest) (response *CreateMQTTTopicResponse, err error) {
-    if request == nil {
-        request = NewCreateMQTTTopicRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "CreateMQTTTopic")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("CreateMQTTTopic require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewCreateMQTTTopicResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewCreateMQTTUserRequest() (request *CreateMQTTUserRequest) {
-    request = &CreateMQTTUserRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "CreateMQTTUser")
-    
-    
-    return
-}
-
-func NewCreateMQTTUserResponse() (response *CreateMQTTUserResponse) {
-    response = &CreateMQTTUserResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// CreateMQTTUser
-// 添加mqtt角色
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
-//  OPERATIONDENIED = "OperationDenied"
-//  RESOURCEINUSE = "ResourceInUse"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  UNSUPPORTEDOPERATION_RESOURCEALREADYEXISTS = "UnsupportedOperation.ResourceAlreadyExists"
-func (c *Client) CreateMQTTUser(request *CreateMQTTUserRequest) (response *CreateMQTTUserResponse, err error) {
-    return c.CreateMQTTUserWithContext(context.Background(), request)
-}
-
-// CreateMQTTUser
-// 添加mqtt角色
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
-//  OPERATIONDENIED = "OperationDenied"
-//  RESOURCEINUSE = "ResourceInUse"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  UNSUPPORTEDOPERATION_RESOURCEALREADYEXISTS = "UnsupportedOperation.ResourceAlreadyExists"
-func (c *Client) CreateMQTTUserWithContext(ctx context.Context, request *CreateMQTTUserRequest) (response *CreateMQTTUserResponse, err error) {
-    if request == nil {
-        request = NewCreateMQTTUserRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "CreateMQTTUser")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("CreateMQTTUser require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewCreateMQTTUserResponse()
+    response = NewCreateMigrationTaskResponse()
     err = c.Send(request, response)
     return
 }
@@ -441,7 +335,9 @@ func NewCreateRoleResponse() (response *CreateRoleResponse) {
 }
 
 // CreateRole
-// 添加角色
+// 添加角色。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的创建角色接口文档见 [CreateRocketMQRole](https://cloud.tencent.com/document/product/1179/107538)，给角色授权接口文档见 [CreateRocketMQEnvironmentRole](https://cloud.tencent.com/document/product/1179/107539)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -455,7 +351,9 @@ func (c *Client) CreateRole(request *CreateRoleRequest) (response *CreateRoleRes
 }
 
 // CreateRole
-// 添加角色
+// 添加角色。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的创建角色接口文档见 [CreateRocketMQRole](https://cloud.tencent.com/document/product/1179/107538)，给角色授权接口文档见 [CreateRocketMQEnvironmentRole](https://cloud.tencent.com/document/product/1179/107539)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -501,7 +399,9 @@ func NewCreateTopicResponse() (response *CreateTopicResponse) {
 }
 
 // CreateTopic
-// 创建主题
+// 创建 RocketMQ 主题。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的创建主题接口文档见 [CreateRocketMQTopic](https://cloud.tencent.com/document/api/1179/63426)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -515,7 +415,9 @@ func (c *Client) CreateTopic(request *CreateTopicRequest) (response *CreateTopic
 }
 
 // CreateTopic
-// 创建主题
+// 创建 RocketMQ 主题。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的创建主题接口文档见 [CreateRocketMQTopic](https://cloud.tencent.com/document/api/1179/63426)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -563,6 +465,8 @@ func NewDeleteConsumerGroupResponse() (response *DeleteConsumerGroupResponse) {
 // DeleteConsumerGroup
 // 删除消费组。消费者组删除后，消费者组的所有配置和相关数据都会被清空，且无法找回。删除后，在线的消费者客户端会出现报错，建议您提前下线客户端。
 //
+// 当前 API 适用集群：5.x 集群。4.x 集群的删除消费组接口文档见 [DeleteRocketMQGroup](https://cloud.tencent.com/document/api/1179/63424)。
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  RESOURCENOTFOUND_GROUP = "ResourceNotFound.Group"
@@ -572,6 +476,8 @@ func (c *Client) DeleteConsumerGroup(request *DeleteConsumerGroupRequest) (respo
 
 // DeleteConsumerGroup
 // 删除消费组。消费者组删除后，消费者组的所有配置和相关数据都会被清空，且无法找回。删除后，在线的消费者客户端会出现报错，建议您提前下线客户端。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的删除消费组接口文档见 [DeleteRocketMQGroup](https://cloud.tencent.com/document/api/1179/63424)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -589,6 +495,110 @@ func (c *Client) DeleteConsumerGroupWithContext(ctx context.Context, request *De
     request.SetContext(ctx)
     
     response = NewDeleteConsumerGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteConsumerLabelRequest() (request *DeleteConsumerLabelRequest) {
+    request = &DeleteConsumerLabelRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "DeleteConsumerLabel")
+    
+    
+    return
+}
+
+func NewDeleteConsumerLabelResponse() (response *DeleteConsumerLabelResponse) {
+    response = &DeleteConsumerLabelResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteConsumerLabel
+// 删除消费组灰度标签
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCENOTFOUND_GROUP = "ResourceNotFound.Group"
+func (c *Client) DeleteConsumerLabel(request *DeleteConsumerLabelRequest) (response *DeleteConsumerLabelResponse, err error) {
+    return c.DeleteConsumerLabelWithContext(context.Background(), request)
+}
+
+// DeleteConsumerLabel
+// 删除消费组灰度标签
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCENOTFOUND_GROUP = "ResourceNotFound.Group"
+func (c *Client) DeleteConsumerLabelWithContext(ctx context.Context, request *DeleteConsumerLabelRequest) (response *DeleteConsumerLabelResponse, err error) {
+    if request == nil {
+        request = NewDeleteConsumerLabelRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DeleteConsumerLabel")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteConsumerLabel require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteConsumerLabelResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteConsumerRouteConfigRequest() (request *DeleteConsumerRouteConfigRequest) {
+    request = &DeleteConsumerRouteConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "DeleteConsumerRouteConfig")
+    
+    
+    return
+}
+
+func NewDeleteConsumerRouteConfigResponse() (response *DeleteConsumerRouteConfigResponse) {
+    response = &DeleteConsumerRouteConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteConsumerRouteConfig
+// 删除消费组灰度路由配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCENOTFOUND_GROUP = "ResourceNotFound.Group"
+func (c *Client) DeleteConsumerRouteConfig(request *DeleteConsumerRouteConfigRequest) (response *DeleteConsumerRouteConfigResponse, err error) {
+    return c.DeleteConsumerRouteConfigWithContext(context.Background(), request)
+}
+
+// DeleteConsumerRouteConfig
+// 删除消费组灰度路由配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCENOTFOUND_GROUP = "ResourceNotFound.Group"
+func (c *Client) DeleteConsumerRouteConfigWithContext(ctx context.Context, request *DeleteConsumerRouteConfigRequest) (response *DeleteConsumerRouteConfigResponse, err error) {
+    if request == nil {
+        request = NewDeleteConsumerRouteConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DeleteConsumerRouteConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteConsumerRouteConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteConsumerRouteConfigResponse()
     err = c.Send(request, response)
     return
 }
@@ -615,6 +625,8 @@ func NewDeleteInstanceResponse() (response *DeleteInstanceResponse) {
 // DeleteInstance
 // 删除 RocketMQ 5.x 集群，删除前请先删除正在使用的主题、消费组和角色信息。
 //
+// 当前 API 适用集群：5.x 集群。删除 4.x 集群接口文档见 [DeleteRocketMQVipInstance](https://cloud.tencent.com/document/product/1179/95802)。
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  RESOURCEINUSE = "ResourceInUse"
@@ -625,6 +637,8 @@ func (c *Client) DeleteInstance(request *DeleteInstanceRequest) (response *Delet
 
 // DeleteInstance
 // 删除 RocketMQ 5.x 集群，删除前请先删除正在使用的主题、消费组和角色信息。
+//
+// 当前 API 适用集群：5.x 集群。删除 4.x 集群接口文档见 [DeleteRocketMQVipInstance](https://cloud.tencent.com/document/product/1179/95802)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -643,220 +657,6 @@ func (c *Client) DeleteInstanceWithContext(ctx context.Context, request *DeleteI
     request.SetContext(ctx)
     
     response = NewDeleteInstanceResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDeleteMQTTInsPublicEndpointRequest() (request *DeleteMQTTInsPublicEndpointRequest) {
-    request = &DeleteMQTTInsPublicEndpointRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DeleteMQTTInsPublicEndpoint")
-    
-    
-    return
-}
-
-func NewDeleteMQTTInsPublicEndpointResponse() (response *DeleteMQTTInsPublicEndpointResponse) {
-    response = &DeleteMQTTInsPublicEndpointResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DeleteMQTTInsPublicEndpoint
-// 删除MQTT实例的公网接入点
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  RESOURCEINUSE = "ResourceInUse"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DeleteMQTTInsPublicEndpoint(request *DeleteMQTTInsPublicEndpointRequest) (response *DeleteMQTTInsPublicEndpointResponse, err error) {
-    return c.DeleteMQTTInsPublicEndpointWithContext(context.Background(), request)
-}
-
-// DeleteMQTTInsPublicEndpoint
-// 删除MQTT实例的公网接入点
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  RESOURCEINUSE = "ResourceInUse"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DeleteMQTTInsPublicEndpointWithContext(ctx context.Context, request *DeleteMQTTInsPublicEndpointRequest) (response *DeleteMQTTInsPublicEndpointResponse, err error) {
-    if request == nil {
-        request = NewDeleteMQTTInsPublicEndpointRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DeleteMQTTInsPublicEndpoint")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DeleteMQTTInsPublicEndpoint require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDeleteMQTTInsPublicEndpointResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDeleteMQTTInstanceRequest() (request *DeleteMQTTInstanceRequest) {
-    request = &DeleteMQTTInstanceRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DeleteMQTTInstance")
-    
-    
-    return
-}
-
-func NewDeleteMQTTInstanceResponse() (response *DeleteMQTTInstanceResponse) {
-    response = &DeleteMQTTInstanceResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DeleteMQTTInstance
-// 删除MQTT实例
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  RESOURCEINUSE = "ResourceInUse"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DeleteMQTTInstance(request *DeleteMQTTInstanceRequest) (response *DeleteMQTTInstanceResponse, err error) {
-    return c.DeleteMQTTInstanceWithContext(context.Background(), request)
-}
-
-// DeleteMQTTInstance
-// 删除MQTT实例
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  RESOURCEINUSE = "ResourceInUse"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DeleteMQTTInstanceWithContext(ctx context.Context, request *DeleteMQTTInstanceRequest) (response *DeleteMQTTInstanceResponse, err error) {
-    if request == nil {
-        request = NewDeleteMQTTInstanceRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DeleteMQTTInstance")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DeleteMQTTInstance require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDeleteMQTTInstanceResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDeleteMQTTTopicRequest() (request *DeleteMQTTTopicRequest) {
-    request = &DeleteMQTTTopicRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DeleteMQTTTopic")
-    
-    
-    return
-}
-
-func NewDeleteMQTTTopicResponse() (response *DeleteMQTTTopicResponse) {
-    response = &DeleteMQTTTopicResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DeleteMQTTTopic
-// 删除MQTT主题
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
-func (c *Client) DeleteMQTTTopic(request *DeleteMQTTTopicRequest) (response *DeleteMQTTTopicResponse, err error) {
-    return c.DeleteMQTTTopicWithContext(context.Background(), request)
-}
-
-// DeleteMQTTTopic
-// 删除MQTT主题
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
-func (c *Client) DeleteMQTTTopicWithContext(ctx context.Context, request *DeleteMQTTTopicRequest) (response *DeleteMQTTTopicResponse, err error) {
-    if request == nil {
-        request = NewDeleteMQTTTopicRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DeleteMQTTTopic")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DeleteMQTTTopic require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDeleteMQTTTopicResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDeleteMQTTUserRequest() (request *DeleteMQTTUserRequest) {
-    request = &DeleteMQTTUserRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DeleteMQTTUser")
-    
-    
-    return
-}
-
-func NewDeleteMQTTUserResponse() (response *DeleteMQTTUserResponse) {
-    response = &DeleteMQTTUserResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DeleteMQTTUser
-// 删除MQTT访问用户
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  RESOURCENOTFOUND_ROLE = "ResourceNotFound.Role"
-func (c *Client) DeleteMQTTUser(request *DeleteMQTTUserRequest) (response *DeleteMQTTUserResponse, err error) {
-    return c.DeleteMQTTUserWithContext(context.Background(), request)
-}
-
-// DeleteMQTTUser
-// 删除MQTT访问用户
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  RESOURCENOTFOUND_ROLE = "ResourceNotFound.Role"
-func (c *Client) DeleteMQTTUserWithContext(ctx context.Context, request *DeleteMQTTUserRequest) (response *DeleteMQTTUserResponse, err error) {
-    if request == nil {
-        request = NewDeleteMQTTUserRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DeleteMQTTUser")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DeleteMQTTUser require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDeleteMQTTUserResponse()
     err = c.Send(request, response)
     return
 }
@@ -883,6 +683,8 @@ func NewDeleteRoleResponse() (response *DeleteRoleResponse) {
 // DeleteRole
 // 删除角色。请确保该角色相关信息不在当前代码中被使用。删除角色后，原先使用该角色进行生产或消费消息的密钥（AccessKey 和 SecretKey）将立即失效。
 //
+// 当前 API 适用集群：5.x 集群。4.x 集群的删除角色接口文档见 [DeleteRocketMQRoles](https://cloud.tencent.com/document/product/1179/107536)，删除角色授权接口文档见 [DeleteRocketMQEnvironmentRoles](https://cloud.tencent.com/document/product/1179/107537)。
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -893,6 +695,8 @@ func (c *Client) DeleteRole(request *DeleteRoleRequest) (response *DeleteRoleRes
 
 // DeleteRole
 // 删除角色。请确保该角色相关信息不在当前代码中被使用。删除角色后，原先使用该角色进行生产或消费消息的密钥（AccessKey 和 SecretKey）将立即失效。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的删除角色接口文档见 [DeleteRocketMQRoles](https://cloud.tencent.com/document/product/1179/107536)，删除角色授权接口文档见 [DeleteRocketMQEnvironmentRoles](https://cloud.tencent.com/document/product/1179/107537)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -991,6 +795,8 @@ func NewDeleteTopicResponse() (response *DeleteTopicResponse) {
 // DeleteTopic
 // 删除主题。主题删除后，主题的所有配置和相关数据都会被清空，且无法找回。
 //
+// 当前 API 适用集群：5.x 集群。4.x 集群的删除主题接口文档见 [DeleteRocketMQTopic](https://cloud.tencent.com/document/api/1179/63423)。
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
@@ -1000,6 +806,8 @@ func (c *Client) DeleteTopic(request *DeleteTopicRequest) (response *DeleteTopic
 
 // DeleteTopic
 // 删除主题。主题删除后，主题的所有配置和相关数据都会被清空，且无法找回。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的删除主题接口文档见 [DeleteRocketMQTopic](https://cloud.tencent.com/document/api/1179/63423)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1041,7 +849,9 @@ func NewDescribeConsumerClientResponse() (response *DescribeConsumerClientRespon
 }
 
 // DescribeConsumerClient
-// 查询消费者客户端详情
+// 查询消费者客户端详情。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消费者客户端详情接口文档见 [DescribeRocketMQConsumerConnectionDetail](https://cloud.tencent.com/document/product/1179/102490)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -1050,7 +860,9 @@ func (c *Client) DescribeConsumerClient(request *DescribeConsumerClientRequest) 
 }
 
 // DescribeConsumerClient
-// 查询消费者客户端详情
+// 查询消费者客户端详情。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消费者客户端详情接口文档见 [DescribeRocketMQConsumerConnectionDetail](https://cloud.tencent.com/document/product/1179/102490)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -1093,6 +905,8 @@ func NewDescribeConsumerClientListResponse() (response *DescribeConsumerClientLi
 // DescribeConsumerClientList
 // 查询消费组下的客户端连接列表。
 //
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消费组下的客户端列表接口文档见 [DescribeRocketMQConsumerConnections](https://cloud.tencent.com/document/product/1179/100460)。
+//
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
 func (c *Client) DescribeConsumerClientList(request *DescribeConsumerClientListRequest) (response *DescribeConsumerClientListResponse, err error) {
@@ -1101,6 +915,8 @@ func (c *Client) DescribeConsumerClientList(request *DescribeConsumerClientListR
 
 // DescribeConsumerClientList
 // 查询消费组下的客户端连接列表。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消费组下的客户端列表接口文档见 [DescribeRocketMQConsumerConnections](https://cloud.tencent.com/document/product/1179/100460)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -1141,7 +957,9 @@ func NewDescribeConsumerGroupResponse() (response *DescribeConsumerGroupResponse
 }
 
 // DescribeConsumerGroup
-// 查询消费组详情
+// 查询消费组详情。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消费组详情接口文档见 [DescribeRocketMQConsumerConnections](https://cloud.tencent.com/document/product/1179/100460)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_GROUP = "ResourceNotFound.Group"
@@ -1151,7 +969,9 @@ func (c *Client) DescribeConsumerGroup(request *DescribeConsumerGroupRequest) (r
 }
 
 // DescribeConsumerGroup
-// 查询消费组详情
+// 查询消费组详情。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消费组详情接口文档见 [DescribeRocketMQConsumerConnections](https://cloud.tencent.com/document/product/1179/100460)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_GROUP = "ResourceNotFound.Group"
@@ -1205,11 +1025,19 @@ func NewDescribeConsumerGroupListResponse() (response *DescribeConsumerGroupList
 //
 //     - false 并发投递
 //
+// - RetryPolicy，重试策略，枚举值如下：
+//
+//     - EXPONENTIAL：固定间隔
+//
+//     - CUSTOMIZED：阶梯退避
+//
 // 
 //
 // Filters示例： 
 //
 // [{ "Name": "ConsumeMessageOrderly", "Values": ["true"] }]
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的获取消费组列表接口文档见 [DescribeRocketMQGroups](https://cloud.tencent.com/document/api/1179/63420)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -1230,11 +1058,19 @@ func (c *Client) DescribeConsumerGroupList(request *DescribeConsumerGroupListReq
 //
 //     - false 并发投递
 //
+// - RetryPolicy，重试策略，枚举值如下：
+//
+//     - EXPONENTIAL：固定间隔
+//
+//     - CUSTOMIZED：阶梯退避
+//
 // 
 //
 // Filters示例： 
 //
 // [{ "Name": "ConsumeMessageOrderly", "Values": ["true"] }]
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的获取消费组列表接口文档见 [DescribeRocketMQGroups](https://cloud.tencent.com/document/api/1179/63420)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -1251,6 +1087,106 @@ func (c *Client) DescribeConsumerGroupListWithContext(ctx context.Context, reque
     request.SetContext(ctx)
     
     response = NewDescribeConsumerGroupListResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeConsumerLabelRequest() (request *DescribeConsumerLabelRequest) {
+    request = &DescribeConsumerLabelRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "DescribeConsumerLabel")
+    
+    
+    return
+}
+
+func NewDescribeConsumerLabelResponse() (response *DescribeConsumerLabelResponse) {
+    response = &DescribeConsumerLabelResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeConsumerLabel
+// 查询消费组某个灰度标签详情
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+func (c *Client) DescribeConsumerLabel(request *DescribeConsumerLabelRequest) (response *DescribeConsumerLabelResponse, err error) {
+    return c.DescribeConsumerLabelWithContext(context.Background(), request)
+}
+
+// DescribeConsumerLabel
+// 查询消费组某个灰度标签详情
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+func (c *Client) DescribeConsumerLabelWithContext(ctx context.Context, request *DescribeConsumerLabelRequest) (response *DescribeConsumerLabelResponse, err error) {
+    if request == nil {
+        request = NewDescribeConsumerLabelRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeConsumerLabel")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeConsumerLabel require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeConsumerLabelResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeConsumerLabelListRequest() (request *DescribeConsumerLabelListRequest) {
+    request = &DescribeConsumerLabelListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "DescribeConsumerLabelList")
+    
+    
+    return
+}
+
+func NewDescribeConsumerLabelListResponse() (response *DescribeConsumerLabelListResponse) {
+    response = &DescribeConsumerLabelListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeConsumerLabelList
+// 查询消费组下灰度标签列表
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+func (c *Client) DescribeConsumerLabelList(request *DescribeConsumerLabelListRequest) (response *DescribeConsumerLabelListResponse, err error) {
+    return c.DescribeConsumerLabelListWithContext(context.Background(), request)
+}
+
+// DescribeConsumerLabelList
+// 查询消费组下灰度标签列表
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+func (c *Client) DescribeConsumerLabelListWithContext(ctx context.Context, request *DescribeConsumerLabelListRequest) (response *DescribeConsumerLabelListResponse, err error) {
+    if request == nil {
+        request = NewDescribeConsumerLabelListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeConsumerLabelList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeConsumerLabelList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeConsumerLabelListResponse()
     err = c.Send(request, response)
     return
 }
@@ -1277,6 +1213,8 @@ func NewDescribeConsumerLagResponse() (response *DescribeConsumerLagResponse) {
 // DescribeConsumerLag
 // 查询指定消费组堆积数。
 //
+// 当前 API 适用集群：4.x 集群和 5.x 集群。
+//
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
 func (c *Client) DescribeConsumerLag(request *DescribeConsumerLagRequest) (response *DescribeConsumerLagResponse, err error) {
@@ -1285,6 +1223,8 @@ func (c *Client) DescribeConsumerLag(request *DescribeConsumerLagRequest) (respo
 
 // DescribeConsumerLag
 // 查询指定消费组堆积数。
+//
+// 当前 API 适用集群：4.x 集群和 5.x 集群。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -1301,6 +1241,106 @@ func (c *Client) DescribeConsumerLagWithContext(ctx context.Context, request *De
     request.SetContext(ctx)
     
     response = NewDescribeConsumerLagResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeConsumerRouteConfigRequest() (request *DescribeConsumerRouteConfigRequest) {
+    request = &DescribeConsumerRouteConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "DescribeConsumerRouteConfig")
+    
+    
+    return
+}
+
+func NewDescribeConsumerRouteConfigResponse() (response *DescribeConsumerRouteConfigResponse) {
+    response = &DescribeConsumerRouteConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeConsumerRouteConfig
+// 查询消费组当前生效的灰度路由配置
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+func (c *Client) DescribeConsumerRouteConfig(request *DescribeConsumerRouteConfigRequest) (response *DescribeConsumerRouteConfigResponse, err error) {
+    return c.DescribeConsumerRouteConfigWithContext(context.Background(), request)
+}
+
+// DescribeConsumerRouteConfig
+// 查询消费组当前生效的灰度路由配置
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+func (c *Client) DescribeConsumerRouteConfigWithContext(ctx context.Context, request *DescribeConsumerRouteConfigRequest) (response *DescribeConsumerRouteConfigResponse, err error) {
+    if request == nil {
+        request = NewDescribeConsumerRouteConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeConsumerRouteConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeConsumerRouteConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeConsumerRouteConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeConsumerRouteVersionListRequest() (request *DescribeConsumerRouteVersionListRequest) {
+    request = &DescribeConsumerRouteVersionListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "DescribeConsumerRouteVersionList")
+    
+    
+    return
+}
+
+func NewDescribeConsumerRouteVersionListResponse() (response *DescribeConsumerRouteVersionListResponse) {
+    response = &DescribeConsumerRouteVersionListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeConsumerRouteVersionList
+// 查询消费组灰度路由配置版本列表
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+func (c *Client) DescribeConsumerRouteVersionList(request *DescribeConsumerRouteVersionListRequest) (response *DescribeConsumerRouteVersionListResponse, err error) {
+    return c.DescribeConsumerRouteVersionListWithContext(context.Background(), request)
+}
+
+// DescribeConsumerRouteVersionList
+// 查询消费组灰度路由配置版本列表
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+func (c *Client) DescribeConsumerRouteVersionListWithContext(ctx context.Context, request *DescribeConsumerRouteVersionListRequest) (response *DescribeConsumerRouteVersionListResponse, err error) {
+    if request == nil {
+        request = NewDescribeConsumerRouteVersionListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeConsumerRouteVersionList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeConsumerRouteVersionList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeConsumerRouteVersionListResponse()
     err = c.Send(request, response)
     return
 }
@@ -1329,17 +1369,37 @@ func NewDescribeFusionInstanceListResponse() (response *DescribeFusionInstanceLi
 //
 // 
 //
-// - InstanceName 集群名称，支持模糊查询，从本接口返回值或控制台获得
+// - InstanceName: 集群名称，支持模糊查询，从本接口返回值或控制台获得
 //
-// - InstanceId 集群ID，精确查询，从当前接口或控制台获得
+// - InstanceId: 集群ID，精确查询，从当前接口或控制台获得
 //
-// - InstanceType 集群类型，可参考 [InstanceItem](https://cloud.tencent.com/document/api/1493/96031#InstanceItem) 数据结构，支持多选
+// - InstanceType: 集群类型，可参考 [InstanceItem](https://cloud.tencent.com/document/api/1493/96031#InstanceItem) 数据结构，支持多选
 //
-// - Version 集群版本，枚举值如下：
+// - Version: 集群版本，枚举值如下：
 //
 //     - 4 RocketMQ 4.x 集群
 //
 //     - 5 RocketMQ 5.x 集群
+//
+// -  InstanceStatus: 集群状态筛选条件，支持多选，枚举值如下：
+//
+//     - RUNNING：运行中
+//
+//     - ABNORMAL：异常
+//
+//     - OVERDUE：隔离中
+//
+//     - DESTROYED：已销毁
+//
+//     - CREATING：创建中
+//
+//     - MODIFYING：变配中
+//
+//     - CREATE_FAILURE：创建失败
+//
+//     - MODIFY_FAILURE：变配失败
+//
+//     - DELETING：删除中
 //
 // 
 //
@@ -1358,17 +1418,37 @@ func (c *Client) DescribeFusionInstanceList(request *DescribeFusionInstanceListR
 //
 // 
 //
-// - InstanceName 集群名称，支持模糊查询，从本接口返回值或控制台获得
+// - InstanceName: 集群名称，支持模糊查询，从本接口返回值或控制台获得
 //
-// - InstanceId 集群ID，精确查询，从当前接口或控制台获得
+// - InstanceId: 集群ID，精确查询，从当前接口或控制台获得
 //
-// - InstanceType 集群类型，可参考 [InstanceItem](https://cloud.tencent.com/document/api/1493/96031#InstanceItem) 数据结构，支持多选
+// - InstanceType: 集群类型，可参考 [InstanceItem](https://cloud.tencent.com/document/api/1493/96031#InstanceItem) 数据结构，支持多选
 //
-// - Version 集群版本，枚举值如下：
+// - Version: 集群版本，枚举值如下：
 //
 //     - 4 RocketMQ 4.x 集群
 //
 //     - 5 RocketMQ 5.x 集群
+//
+// -  InstanceStatus: 集群状态筛选条件，支持多选，枚举值如下：
+//
+//     - RUNNING：运行中
+//
+//     - ABNORMAL：异常
+//
+//     - OVERDUE：隔离中
+//
+//     - DESTROYED：已销毁
+//
+//     - CREATING：创建中
+//
+//     - MODIFYING：变配中
+//
+//     - CREATE_FAILURE：创建失败
+//
+//     - MODIFY_FAILURE：变配失败
+//
+//     - DELETING：删除中
 //
 // 
 //
@@ -1417,6 +1497,8 @@ func NewDescribeInstanceResponse() (response *DescribeInstanceResponse) {
 // DescribeInstance
 // 查询 RocketMQ 5.x 集群信息。
 //
+// 当前 API 适用集群：5.x 集群。查询 4.x 专享/通用集群信息的接口文档见 [DescribeRocketMQVipInstanceDetail](https://cloud.tencent.com/document/product/1179/86725)。
+//
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
 func (c *Client) DescribeInstance(request *DescribeInstanceRequest) (response *DescribeInstanceResponse, err error) {
@@ -1425,6 +1507,8 @@ func (c *Client) DescribeInstance(request *DescribeInstanceRequest) (response *D
 
 // DescribeInstance
 // 查询 RocketMQ 5.x 集群信息。
+//
+// 当前 API 适用集群：5.x 集群。查询 4.x 专享/通用集群信息的接口文档见 [DescribeRocketMQVipInstanceDetail](https://cloud.tencent.com/document/product/1179/86725)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -1539,654 +1623,6 @@ func (c *Client) DescribeInstanceListWithContext(ctx context.Context, request *D
     return
 }
 
-func NewDescribeMQTTClientRequest() (request *DescribeMQTTClientRequest) {
-    request = &DescribeMQTTClientRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTClient")
-    
-    
-    return
-}
-
-func NewDescribeMQTTClientResponse() (response *DescribeMQTTClientResponse) {
-    response = &DescribeMQTTClientResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTClient
-// 查询 MQTT 客户端详情
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_CLIENT = "ResourceNotFound.Client"
-func (c *Client) DescribeMQTTClient(request *DescribeMQTTClientRequest) (response *DescribeMQTTClientResponse, err error) {
-    return c.DescribeMQTTClientWithContext(context.Background(), request)
-}
-
-// DescribeMQTTClient
-// 查询 MQTT 客户端详情
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_CLIENT = "ResourceNotFound.Client"
-func (c *Client) DescribeMQTTClientWithContext(ctx context.Context, request *DescribeMQTTClientRequest) (response *DescribeMQTTClientResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTClientRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTClient")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTClient require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTClientResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTInsPublicEndpointsRequest() (request *DescribeMQTTInsPublicEndpointsRequest) {
-    request = &DescribeMQTTInsPublicEndpointsRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTInsPublicEndpoints")
-    
-    
-    return
-}
-
-func NewDescribeMQTTInsPublicEndpointsResponse() (response *DescribeMQTTInsPublicEndpointsResponse) {
-    response = &DescribeMQTTInsPublicEndpointsResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTInsPublicEndpoints
-// 查询MQTT实例公网接入点
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_CLIENT = "ResourceNotFound.Client"
-func (c *Client) DescribeMQTTInsPublicEndpoints(request *DescribeMQTTInsPublicEndpointsRequest) (response *DescribeMQTTInsPublicEndpointsResponse, err error) {
-    return c.DescribeMQTTInsPublicEndpointsWithContext(context.Background(), request)
-}
-
-// DescribeMQTTInsPublicEndpoints
-// 查询MQTT实例公网接入点
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_CLIENT = "ResourceNotFound.Client"
-func (c *Client) DescribeMQTTInsPublicEndpointsWithContext(ctx context.Context, request *DescribeMQTTInsPublicEndpointsRequest) (response *DescribeMQTTInsPublicEndpointsResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTInsPublicEndpointsRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTInsPublicEndpoints")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTInsPublicEndpoints require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTInsPublicEndpointsResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTInsVPCEndpointsRequest() (request *DescribeMQTTInsVPCEndpointsRequest) {
-    request = &DescribeMQTTInsVPCEndpointsRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTInsVPCEndpoints")
-    
-    
-    return
-}
-
-func NewDescribeMQTTInsVPCEndpointsResponse() (response *DescribeMQTTInsVPCEndpointsResponse) {
-    response = &DescribeMQTTInsVPCEndpointsResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTInsVPCEndpoints
-// 查询MQTT实例公网接入点
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_CLIENT = "ResourceNotFound.Client"
-func (c *Client) DescribeMQTTInsVPCEndpoints(request *DescribeMQTTInsVPCEndpointsRequest) (response *DescribeMQTTInsVPCEndpointsResponse, err error) {
-    return c.DescribeMQTTInsVPCEndpointsWithContext(context.Background(), request)
-}
-
-// DescribeMQTTInsVPCEndpoints
-// 查询MQTT实例公网接入点
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_CLIENT = "ResourceNotFound.Client"
-func (c *Client) DescribeMQTTInsVPCEndpointsWithContext(ctx context.Context, request *DescribeMQTTInsVPCEndpointsRequest) (response *DescribeMQTTInsVPCEndpointsResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTInsVPCEndpointsRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTInsVPCEndpoints")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTInsVPCEndpoints require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTInsVPCEndpointsResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTInstanceRequest() (request *DescribeMQTTInstanceRequest) {
-    request = &DescribeMQTTInstanceRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTInstance")
-    
-    
-    return
-}
-
-func NewDescribeMQTTInstanceResponse() (response *DescribeMQTTInstanceResponse) {
-    response = &DescribeMQTTInstanceResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTInstance
-// 查询实例信息
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTInstance(request *DescribeMQTTInstanceRequest) (response *DescribeMQTTInstanceResponse, err error) {
-    return c.DescribeMQTTInstanceWithContext(context.Background(), request)
-}
-
-// DescribeMQTTInstance
-// 查询实例信息
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTInstanceWithContext(ctx context.Context, request *DescribeMQTTInstanceRequest) (response *DescribeMQTTInstanceResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTInstanceRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTInstance")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTInstance require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTInstanceResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTInstanceCertRequest() (request *DescribeMQTTInstanceCertRequest) {
-    request = &DescribeMQTTInstanceCertRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTInstanceCert")
-    
-    
-    return
-}
-
-func NewDescribeMQTTInstanceCertResponse() (response *DescribeMQTTInstanceCertResponse) {
-    response = &DescribeMQTTInstanceCertResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTInstanceCert
-// 查询MQTT集群证书列表
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTInstanceCert(request *DescribeMQTTInstanceCertRequest) (response *DescribeMQTTInstanceCertResponse, err error) {
-    return c.DescribeMQTTInstanceCertWithContext(context.Background(), request)
-}
-
-// DescribeMQTTInstanceCert
-// 查询MQTT集群证书列表
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTInstanceCertWithContext(ctx context.Context, request *DescribeMQTTInstanceCertRequest) (response *DescribeMQTTInstanceCertResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTInstanceCertRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTInstanceCert")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTInstanceCert require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTInstanceCertResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTInstanceListRequest() (request *DescribeMQTTInstanceListRequest) {
-    request = &DescribeMQTTInstanceListRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTInstanceList")
-    
-    
-    return
-}
-
-func NewDescribeMQTTInstanceListResponse() (response *DescribeMQTTInstanceListResponse) {
-    response = &DescribeMQTTInstanceListResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTInstanceList
-// 获取实例列表，Filters参数使用说明如下：
-//
-// 1. InstanceName, 名称模糊查询
-//
-// 2. InstanceId，实例ID查询
-//
-// 3. InstanceType, 实例类型查询，支持多选
-//
-// 3. InstanceStatus，实例状态查询，支持多选
-//
-// 
-//
-// 当使用TagFilters查询时，Filters参数失效。
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-func (c *Client) DescribeMQTTInstanceList(request *DescribeMQTTInstanceListRequest) (response *DescribeMQTTInstanceListResponse, err error) {
-    return c.DescribeMQTTInstanceListWithContext(context.Background(), request)
-}
-
-// DescribeMQTTInstanceList
-// 获取实例列表，Filters参数使用说明如下：
-//
-// 1. InstanceName, 名称模糊查询
-//
-// 2. InstanceId，实例ID查询
-//
-// 3. InstanceType, 实例类型查询，支持多选
-//
-// 3. InstanceStatus，实例状态查询，支持多选
-//
-// 
-//
-// 当使用TagFilters查询时，Filters参数失效。
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-func (c *Client) DescribeMQTTInstanceListWithContext(ctx context.Context, request *DescribeMQTTInstanceListRequest) (response *DescribeMQTTInstanceListResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTInstanceListRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTInstanceList")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTInstanceList require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTInstanceListResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTMessageRequest() (request *DescribeMQTTMessageRequest) {
-    request = &DescribeMQTTMessageRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTMessage")
-    
-    
-    return
-}
-
-func NewDescribeMQTTMessageResponse() (response *DescribeMQTTMessageResponse) {
-    response = &DescribeMQTTMessageResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTMessage
-// 查询MQTT消息详情
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  RESOURCENOTFOUND_MESSAGE = "ResourceNotFound.Message"
-func (c *Client) DescribeMQTTMessage(request *DescribeMQTTMessageRequest) (response *DescribeMQTTMessageResponse, err error) {
-    return c.DescribeMQTTMessageWithContext(context.Background(), request)
-}
-
-// DescribeMQTTMessage
-// 查询MQTT消息详情
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  RESOURCENOTFOUND_MESSAGE = "ResourceNotFound.Message"
-func (c *Client) DescribeMQTTMessageWithContext(ctx context.Context, request *DescribeMQTTMessageRequest) (response *DescribeMQTTMessageResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTMessageRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTMessage")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTMessage require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTMessageResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTMessageListRequest() (request *DescribeMQTTMessageListRequest) {
-    request = &DescribeMQTTMessageListRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTMessageList")
-    
-    
-    return
-}
-
-func NewDescribeMQTTMessageListResponse() (response *DescribeMQTTMessageListResponse) {
-    response = &DescribeMQTTMessageListResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTMessageList
-// 查询消息列表，如查询死信，请设置ConsumerGroup参数
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTMessageList(request *DescribeMQTTMessageListRequest) (response *DescribeMQTTMessageListResponse, err error) {
-    return c.DescribeMQTTMessageListWithContext(context.Background(), request)
-}
-
-// DescribeMQTTMessageList
-// 查询消息列表，如查询死信，请设置ConsumerGroup参数
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTMessageListWithContext(ctx context.Context, request *DescribeMQTTMessageListRequest) (response *DescribeMQTTMessageListResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTMessageListRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTMessageList")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTMessageList require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTMessageListResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTProductSKUListRequest() (request *DescribeMQTTProductSKUListRequest) {
-    request = &DescribeMQTTProductSKUListRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTProductSKUList")
-    
-    
-    return
-}
-
-func NewDescribeMQTTProductSKUListResponse() (response *DescribeMQTTProductSKUListResponse) {
-    response = &DescribeMQTTProductSKUListResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTProductSKUList
-// 获取产品售卖规格
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTProductSKUList(request *DescribeMQTTProductSKUListRequest) (response *DescribeMQTTProductSKUListResponse, err error) {
-    return c.DescribeMQTTProductSKUListWithContext(context.Background(), request)
-}
-
-// DescribeMQTTProductSKUList
-// 获取产品售卖规格
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTProductSKUListWithContext(ctx context.Context, request *DescribeMQTTProductSKUListRequest) (response *DescribeMQTTProductSKUListResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTProductSKUListRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTProductSKUList")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTProductSKUList require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTProductSKUListResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTTopicRequest() (request *DescribeMQTTTopicRequest) {
-    request = &DescribeMQTTTopicRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTTopic")
-    
-    
-    return
-}
-
-func NewDescribeMQTTTopicResponse() (response *DescribeMQTTTopicResponse) {
-    response = &DescribeMQTTTopicResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTTopic
-// 查询mqtt主题详情
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
-func (c *Client) DescribeMQTTTopic(request *DescribeMQTTTopicRequest) (response *DescribeMQTTTopicResponse, err error) {
-    return c.DescribeMQTTTopicWithContext(context.Background(), request)
-}
-
-// DescribeMQTTTopic
-// 查询mqtt主题详情
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
-func (c *Client) DescribeMQTTTopicWithContext(ctx context.Context, request *DescribeMQTTTopicRequest) (response *DescribeMQTTTopicResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTTopicRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTTopic")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTTopic require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTTopicResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTTopicListRequest() (request *DescribeMQTTTopicListRequest) {
-    request = &DescribeMQTTTopicListRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTTopicList")
-    
-    
-    return
-}
-
-func NewDescribeMQTTTopicListResponse() (response *DescribeMQTTTopicListResponse) {
-    response = &DescribeMQTTTopicListResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTTopicList
-// 获取主题列表，Filter参数使用说明如下：
-//
-// 
-//
-// 1. TopicName，主题名称模糊搜索
-//
-// 2. TopicType，主题类型查询，支持多选，可选值：Normal,Order,Transaction,DelayScheduled
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTTopicList(request *DescribeMQTTTopicListRequest) (response *DescribeMQTTTopicListResponse, err error) {
-    return c.DescribeMQTTTopicListWithContext(context.Background(), request)
-}
-
-// DescribeMQTTTopicList
-// 获取主题列表，Filter参数使用说明如下：
-//
-// 
-//
-// 1. TopicName，主题名称模糊搜索
-//
-// 2. TopicType，主题类型查询，支持多选，可选值：Normal,Order,Transaction,DelayScheduled
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTTopicListWithContext(ctx context.Context, request *DescribeMQTTTopicListRequest) (response *DescribeMQTTTopicListResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTTopicListRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTTopicList")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTTopicList require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTTopicListResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewDescribeMQTTUserListRequest() (request *DescribeMQTTUserListRequest) {
-    request = &DescribeMQTTUserListRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "DescribeMQTTUserList")
-    
-    
-    return
-}
-
-func NewDescribeMQTTUserListResponse() (response *DescribeMQTTUserListResponse) {
-    response = &DescribeMQTTUserListResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// DescribeMQTTUserList
-// 查询用户列表，Filter参数使用说明如下：
-//
-// 
-//
-// 1. Username，用户名称模糊搜索
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTUserList(request *DescribeMQTTUserListRequest) (response *DescribeMQTTUserListResponse, err error) {
-    return c.DescribeMQTTUserListWithContext(context.Background(), request)
-}
-
-// DescribeMQTTUserList
-// 查询用户列表，Filter参数使用说明如下：
-//
-// 
-//
-// 1. Username，用户名称模糊搜索
-//
-// 可能返回的错误码:
-//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
-func (c *Client) DescribeMQTTUserListWithContext(ctx context.Context, request *DescribeMQTTUserListRequest) (response *DescribeMQTTUserListResponse, err error) {
-    if request == nil {
-        request = NewDescribeMQTTUserListRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeMQTTUserList")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("DescribeMQTTUserList require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewDescribeMQTTUserListResponse()
-    err = c.Send(request, response)
-    return
-}
-
 func NewDescribeMessageRequest() (request *DescribeMessageRequest) {
     request = &DescribeMessageRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -2207,7 +1643,9 @@ func NewDescribeMessageResponse() (response *DescribeMessageResponse) {
 }
 
 // DescribeMessage
-// 查询消息详情
+// 查询消息详情。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消息详情接口文档见 [DescribeRocketMQMsg](https://cloud.tencent.com/document/product/1179/91055)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -2217,7 +1655,9 @@ func (c *Client) DescribeMessage(request *DescribeMessageRequest) (response *Des
 }
 
 // DescribeMessage
-// 查询消息详情
+// 查询消息详情。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消息详情接口文档见 [DescribeRocketMQMsg](https://cloud.tencent.com/document/product/1179/91055)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -2261,6 +1701,8 @@ func NewDescribeMessageListResponse() (response *DescribeMessageListResponse) {
 // DescribeMessageList
 // 查询消息列表。如果查询死信消息，请设置ConsumerGroup参数。
 //
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消息列表接口文档见 [DescribeRocketMQTopicMsgs](https://cloud.tencent.com/document/product/1179/97761)。
+//
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
 func (c *Client) DescribeMessageList(request *DescribeMessageListRequest) (response *DescribeMessageListResponse, err error) {
@@ -2269,6 +1711,8 @@ func (c *Client) DescribeMessageList(request *DescribeMessageListRequest) (respo
 
 // DescribeMessageList
 // 查询消息列表。如果查询死信消息，请设置ConsumerGroup参数。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消息列表接口文档见 [DescribeRocketMQTopicMsgs](https://cloud.tencent.com/document/product/1179/97761)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -2311,6 +1755,8 @@ func NewDescribeMessageTraceResponse() (response *DescribeMessageTraceResponse) 
 // DescribeMessageTrace
 // 根据消息 ID 查询消息轨迹。
 //
+// 当前 API 适用集群：5.x 集群。4.x 集群查询消息轨迹接口文档见 [DescribeRocketMQMsgTrace](https://cloud.tencent.com/document/product/1179/97760)。
+//
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
 //  RESOURCENOTFOUND_MESSAGE = "ResourceNotFound.Message"
@@ -2320,6 +1766,8 @@ func (c *Client) DescribeMessageTrace(request *DescribeMessageTraceRequest) (res
 
 // DescribeMessageTrace
 // 根据消息 ID 查询消息轨迹。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群查询消息轨迹接口文档见 [DescribeRocketMQMsgTrace](https://cloud.tencent.com/document/product/1179/97760)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -2615,6 +2063,74 @@ func (c *Client) DescribeMigrationTaskListWithContext(ctx context.Context, reque
     return
 }
 
+func NewDescribeProducerListRequest() (request *DescribeProducerListRequest) {
+    request = &DescribeProducerListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "DescribeProducerList")
+    
+    
+    return
+}
+
+func NewDescribeProducerListResponse() (response *DescribeProducerListResponse) {
+    response = &DescribeProducerListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeProducerList
+// 查询主题关联的生产者列表信息，Filters支持以下筛选条件：
+//
+// - ClientIP，客户端IP
+//
+// - ClientID，客户端ID
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询生产者客户端列表接口文档见 [DescribeRocketMQProducers](https://cloud.tencent.com/document/api/1179/122749)。
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_MIGRATIONTASK = "ResourceNotFound.MigrationTask"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+func (c *Client) DescribeProducerList(request *DescribeProducerListRequest) (response *DescribeProducerListResponse, err error) {
+    return c.DescribeProducerListWithContext(context.Background(), request)
+}
+
+// DescribeProducerList
+// 查询主题关联的生产者列表信息，Filters支持以下筛选条件：
+//
+// - ClientIP，客户端IP
+//
+// - ClientID，客户端ID
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询生产者客户端列表接口文档见 [DescribeRocketMQProducers](https://cloud.tencent.com/document/api/1179/122749)。
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_MIGRATIONTASK = "ResourceNotFound.MigrationTask"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+func (c *Client) DescribeProducerListWithContext(ctx context.Context, request *DescribeProducerListRequest) (response *DescribeProducerListResponse, err error) {
+    if request == nil {
+        request = NewDescribeProducerListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeProducerList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeProducerList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeProducerListResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeProductSKUsRequest() (request *DescribeProductSKUsRequest) {
     request = &DescribeProductSKUsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -2705,6 +2221,8 @@ func NewDescribeRoleListResponse() (response *DescribeRoleListResponse) {
 //
 // [{ "Name": "RoleName", "Values": ["test_role"] }]
 //
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询角色列表接口文档见 [DescribeRocketMQRoles](https://cloud.tencent.com/document/product/1179/107534)，查询角色授权列表接口文档见 [DescribeRocketMQEnvironmentRoles](https://cloud.tencent.com/document/product/1179/107535)。
+//
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
 //  RESOURCENOTFOUND_MIGRATIONTASK = "ResourceNotFound.MigrationTask"
@@ -2728,6 +2246,8 @@ func (c *Client) DescribeRoleList(request *DescribeRoleListRequest) (response *D
 // Filters示例： 
 //
 // [{ "Name": "RoleName", "Values": ["test_role"] }]
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询角色列表接口文档见 [DescribeRocketMQRoles](https://cloud.tencent.com/document/product/1179/107534)，查询角色授权列表接口文档见 [DescribeRocketMQEnvironmentRoles](https://cloud.tencent.com/document/product/1179/107535)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -3065,6 +2585,8 @@ func NewDescribeTopicListResponse() (response *DescribeTopicListResponse) {
 //
 //  [{ "Name": "TopicName", "Values": ["test_topic"] }]
 //
+// 当前 API 适用集群：5.x 集群。4.x 集群的获取主题列表接口文档见 [DescribeRocketMQTopics](https://cloud.tencent.com/document/api/1179/63418)。
+//
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
 func (c *Client) DescribeTopicList(request *DescribeTopicListRequest) (response *DescribeTopicListResponse, err error) {
@@ -3085,6 +2607,8 @@ func (c *Client) DescribeTopicList(request *DescribeTopicListRequest) (response 
 // Filters示例：
 //
 //  [{ "Name": "TopicName", "Values": ["test_topic"] }]
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的获取主题列表接口文档见 [DescribeRocketMQTopics](https://cloud.tencent.com/document/api/1179/63418)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -3125,7 +2649,7 @@ func NewDescribeTopicListByGroupResponse() (response *DescribeTopicListByGroupRe
 }
 
 // DescribeTopicListByGroup
-// 根据消费组获取主题列表，Filter参数使用说明如下：
+// 查询消费组订阅的主题列表，Filter参数使用说明如下：
 //
 // 
 //
@@ -3136,6 +2660,8 @@ func NewDescribeTopicListByGroupResponse() (response *DescribeTopicListByGroupRe
 // Filters示例： 
 //
 // [{ "Name": "TopicName", "Values": ["test_topic"] }]
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消费组订阅的主题列表接口文档见 [DescribeRocketMQTopicsByGroup](https://cloud.tencent.com/document/product/1179/108863)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -3144,7 +2670,7 @@ func (c *Client) DescribeTopicListByGroup(request *DescribeTopicListByGroupReque
 }
 
 // DescribeTopicListByGroup
-// 根据消费组获取主题列表，Filter参数使用说明如下：
+// 查询消费组订阅的主题列表，Filter参数使用说明如下：
 //
 // 
 //
@@ -3155,6 +2681,8 @@ func (c *Client) DescribeTopicListByGroup(request *DescribeTopicListByGroupReque
 // Filters示例： 
 //
 // [{ "Name": "TopicName", "Values": ["test_topic"] }]
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的查询消费组订阅的主题列表接口文档见 [DescribeRocketMQTopicsByGroup](https://cloud.tencent.com/document/product/1179/108863)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
@@ -3171,6 +2699,64 @@ func (c *Client) DescribeTopicListByGroupWithContext(ctx context.Context, reques
     request.SetContext(ctx)
     
     response = NewDescribeTopicListByGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeTopicStatsRequest() (request *DescribeTopicStatsRequest) {
+    request = &DescribeTopicStatsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "DescribeTopicStats")
+    
+    
+    return
+}
+
+func NewDescribeTopicStatsResponse() (response *DescribeTopicStatsResponse) {
+    response = &DescribeTopicStatsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTopicStats
+// 获取主题队列级别的消费详情
+//
+// 当前 API 适用集群：5.x 铂金版集群
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) DescribeTopicStats(request *DescribeTopicStatsRequest) (response *DescribeTopicStatsResponse, err error) {
+    return c.DescribeTopicStatsWithContext(context.Background(), request)
+}
+
+// DescribeTopicStats
+// 获取主题队列级别的消费详情
+//
+// 当前 API 适用集群：5.x 铂金版集群
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) DescribeTopicStatsWithContext(ctx context.Context, request *DescribeTopicStatsRequest) (response *DescribeTopicStatsResponse, err error) {
+    if request == nil {
+        request = NewDescribeTopicStatsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "DescribeTopicStats")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTopicStats require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTopicStatsResponse()
     err = c.Send(request, response)
     return
 }
@@ -3199,6 +2785,8 @@ func NewDoHealthCheckOnMigratingTopicResponse() (response *DoHealthCheckOnMigrat
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) DoHealthCheckOnMigratingTopic(request *DoHealthCheckOnMigratingTopicRequest) (response *DoHealthCheckOnMigratingTopicResponse, err error) {
     return c.DoHealthCheckOnMigratingTopicWithContext(context.Background(), request)
 }
@@ -3208,6 +2796,8 @@ func (c *Client) DoHealthCheckOnMigratingTopic(request *DoHealthCheckOnMigrating
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) DoHealthCheckOnMigratingTopicWithContext(ctx context.Context, request *DoHealthCheckOnMigratingTopicRequest) (response *DoHealthCheckOnMigratingTopicResponse, err error) {
     if request == nil {
         request = NewDoHealthCheckOnMigratingTopicRequest()
@@ -3249,6 +2839,8 @@ func NewImportSourceClusterConsumerGroupsResponse() (response *ImportSourceClust
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) ImportSourceClusterConsumerGroups(request *ImportSourceClusterConsumerGroupsRequest) (response *ImportSourceClusterConsumerGroupsResponse, err error) {
     return c.ImportSourceClusterConsumerGroupsWithContext(context.Background(), request)
 }
@@ -3258,6 +2850,8 @@ func (c *Client) ImportSourceClusterConsumerGroups(request *ImportSourceClusterC
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) ImportSourceClusterConsumerGroupsWithContext(ctx context.Context, request *ImportSourceClusterConsumerGroupsRequest) (response *ImportSourceClusterConsumerGroupsResponse, err error) {
     if request == nil {
         request = NewImportSourceClusterConsumerGroupsRequest()
@@ -3299,6 +2893,8 @@ func NewImportSourceClusterTopicsResponse() (response *ImportSourceClusterTopics
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) ImportSourceClusterTopics(request *ImportSourceClusterTopicsRequest) (response *ImportSourceClusterTopicsResponse, err error) {
     return c.ImportSourceClusterTopicsWithContext(context.Background(), request)
 }
@@ -3308,6 +2904,8 @@ func (c *Client) ImportSourceClusterTopics(request *ImportSourceClusterTopicsReq
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) ImportSourceClusterTopicsWithContext(ctx context.Context, request *ImportSourceClusterTopicsRequest) (response *ImportSourceClusterTopicsResponse, err error) {
     if request == nil {
         request = NewImportSourceClusterTopicsRequest()
@@ -3345,19 +2943,27 @@ func NewModifyConsumerGroupResponse() (response *ModifyConsumerGroupResponse) {
 }
 
 // ModifyConsumerGroup
-// 修改消费组属性
+// 修改消费组属性。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的修改消费组属性接口文档见 [ModifyRocketMQGroup](https://cloud.tencent.com/document/api/1179/63416)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) ModifyConsumerGroup(request *ModifyConsumerGroupRequest) (response *ModifyConsumerGroupResponse, err error) {
     return c.ModifyConsumerGroupWithContext(context.Background(), request)
 }
 
 // ModifyConsumerGroup
-// 修改消费组属性
+// 修改消费组属性。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的修改消费组属性接口文档见 [ModifyRocketMQGroup](https://cloud.tencent.com/document/api/1179/63416)。
 //
 // 可能返回的错误码:
 //  RESOURCENOTFOUND_INSTANCE = "ResourceNotFound.Instance"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) ModifyConsumerGroupWithContext(ctx context.Context, request *ModifyConsumerGroupRequest) (response *ModifyConsumerGroupResponse, err error) {
     if request == nil {
         request = NewModifyConsumerGroupRequest()
@@ -3397,6 +3003,8 @@ func NewModifyInstanceResponse() (response *ModifyInstanceResponse) {
 // ModifyInstance
 // 修改 RocketMQ 5.x 集群属性，仅支持修改运行中的集群。
 //
+// 当前 API 适用集群：5.x 集群。修改 4.x 集群属性的接口文档见 [ModifyRocketMQInstance](https://cloud.tencent.com/document/product/1179/108862)。
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
@@ -3408,6 +3016,8 @@ func (c *Client) ModifyInstance(request *ModifyInstanceRequest) (response *Modif
 
 // ModifyInstance
 // 修改 RocketMQ 5.x 集群属性，仅支持修改运行中的集群。
+//
+// 当前 API 适用集群：5.x 集群。修改 4.x 集群属性的接口文档见 [ModifyRocketMQInstance](https://cloud.tencent.com/document/product/1179/108862)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -3485,272 +3095,6 @@ func (c *Client) ModifyInstanceEndpointWithContext(ctx context.Context, request 
     return
 }
 
-func NewModifyMQTTInsPublicEndpointRequest() (request *ModifyMQTTInsPublicEndpointRequest) {
-    request = &ModifyMQTTInsPublicEndpointRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "ModifyMQTTInsPublicEndpoint")
-    
-    
-    return
-}
-
-func NewModifyMQTTInsPublicEndpointResponse() (response *ModifyMQTTInsPublicEndpointResponse) {
-    response = &ModifyMQTTInsPublicEndpointResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// ModifyMQTTInsPublicEndpoint
-// 更新MQTT实例公网接入点
-//
-// 可能返回的错误码:
-//  OPERATIONDENIED = "OperationDenied"
-//  RESOURCENOTFOUND_ENDPOINT = "ResourceNotFound.Endpoint"
-//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
-func (c *Client) ModifyMQTTInsPublicEndpoint(request *ModifyMQTTInsPublicEndpointRequest) (response *ModifyMQTTInsPublicEndpointResponse, err error) {
-    return c.ModifyMQTTInsPublicEndpointWithContext(context.Background(), request)
-}
-
-// ModifyMQTTInsPublicEndpoint
-// 更新MQTT实例公网接入点
-//
-// 可能返回的错误码:
-//  OPERATIONDENIED = "OperationDenied"
-//  RESOURCENOTFOUND_ENDPOINT = "ResourceNotFound.Endpoint"
-//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
-func (c *Client) ModifyMQTTInsPublicEndpointWithContext(ctx context.Context, request *ModifyMQTTInsPublicEndpointRequest) (response *ModifyMQTTInsPublicEndpointResponse, err error) {
-    if request == nil {
-        request = NewModifyMQTTInsPublicEndpointRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "ModifyMQTTInsPublicEndpoint")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("ModifyMQTTInsPublicEndpoint require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewModifyMQTTInsPublicEndpointResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewModifyMQTTInstanceRequest() (request *ModifyMQTTInstanceRequest) {
-    request = &ModifyMQTTInstanceRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "ModifyMQTTInstance")
-    
-    
-    return
-}
-
-func NewModifyMQTTInstanceResponse() (response *ModifyMQTTInstanceResponse) {
-    response = &ModifyMQTTInstanceResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// ModifyMQTTInstance
-// 修改实例属性
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
-//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
-func (c *Client) ModifyMQTTInstance(request *ModifyMQTTInstanceRequest) (response *ModifyMQTTInstanceResponse, err error) {
-    return c.ModifyMQTTInstanceWithContext(context.Background(), request)
-}
-
-// ModifyMQTTInstance
-// 修改实例属性
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
-//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
-func (c *Client) ModifyMQTTInstanceWithContext(ctx context.Context, request *ModifyMQTTInstanceRequest) (response *ModifyMQTTInstanceResponse, err error) {
-    if request == nil {
-        request = NewModifyMQTTInstanceRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "ModifyMQTTInstance")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("ModifyMQTTInstance require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewModifyMQTTInstanceResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewModifyMQTTInstanceCertBindingRequest() (request *ModifyMQTTInstanceCertBindingRequest) {
-    request = &ModifyMQTTInstanceCertBindingRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "ModifyMQTTInstanceCertBinding")
-    
-    
-    return
-}
-
-func NewModifyMQTTInstanceCertBindingResponse() (response *ModifyMQTTInstanceCertBindingResponse) {
-    response = &ModifyMQTTInstanceCertBindingResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// ModifyMQTTInstanceCertBinding
-// 更新MQTT集群绑定证书
-//
-// 参数传空，则为删除证书
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
-//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
-func (c *Client) ModifyMQTTInstanceCertBinding(request *ModifyMQTTInstanceCertBindingRequest) (response *ModifyMQTTInstanceCertBindingResponse, err error) {
-    return c.ModifyMQTTInstanceCertBindingWithContext(context.Background(), request)
-}
-
-// ModifyMQTTInstanceCertBinding
-// 更新MQTT集群绑定证书
-//
-// 参数传空，则为删除证书
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_INSTANCENOTREADY = "FailedOperation.InstanceNotReady"
-//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
-func (c *Client) ModifyMQTTInstanceCertBindingWithContext(ctx context.Context, request *ModifyMQTTInstanceCertBindingRequest) (response *ModifyMQTTInstanceCertBindingResponse, err error) {
-    if request == nil {
-        request = NewModifyMQTTInstanceCertBindingRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "ModifyMQTTInstanceCertBinding")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("ModifyMQTTInstanceCertBinding require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewModifyMQTTInstanceCertBindingResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewModifyMQTTTopicRequest() (request *ModifyMQTTTopicRequest) {
-    request = &ModifyMQTTTopicRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "ModifyMQTTTopic")
-    
-    
-    return
-}
-
-func NewModifyMQTTTopicResponse() (response *ModifyMQTTTopicResponse) {
-    response = &ModifyMQTTTopicResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// ModifyMQTTTopic
-// 修改主题属性
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-func (c *Client) ModifyMQTTTopic(request *ModifyMQTTTopicRequest) (response *ModifyMQTTTopicResponse, err error) {
-    return c.ModifyMQTTTopicWithContext(context.Background(), request)
-}
-
-// ModifyMQTTTopic
-// 修改主题属性
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-func (c *Client) ModifyMQTTTopicWithContext(ctx context.Context, request *ModifyMQTTTopicRequest) (response *ModifyMQTTTopicResponse, err error) {
-    if request == nil {
-        request = NewModifyMQTTTopicRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "ModifyMQTTTopic")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("ModifyMQTTTopic require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewModifyMQTTTopicResponse()
-    err = c.Send(request, response)
-    return
-}
-
-func NewModifyMQTTUserRequest() (request *ModifyMQTTUserRequest) {
-    request = &ModifyMQTTUserRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("trocket", APIVersion, "ModifyMQTTUser")
-    
-    
-    return
-}
-
-func NewModifyMQTTUserResponse() (response *ModifyMQTTUserResponse) {
-    response = &ModifyMQTTUserResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// ModifyMQTTUser
-// 修改MQTT角色
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-func (c *Client) ModifyMQTTUser(request *ModifyMQTTUserRequest) (response *ModifyMQTTUserResponse, err error) {
-    return c.ModifyMQTTUserWithContext(context.Background(), request)
-}
-
-// ModifyMQTTUser
-// 修改MQTT角色
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-func (c *Client) ModifyMQTTUserWithContext(ctx context.Context, request *ModifyMQTTUserRequest) (response *ModifyMQTTUserResponse, err error) {
-    if request == nil {
-        request = NewModifyMQTTUserRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "ModifyMQTTUser")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("ModifyMQTTUser require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewModifyMQTTUserResponse()
-    err = c.Send(request, response)
-    return
-}
-
 func NewModifyRoleRequest() (request *ModifyRoleRequest) {
     request = &ModifyRoleRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -3771,7 +3115,9 @@ func NewModifyRoleResponse() (response *ModifyRoleResponse) {
 }
 
 // ModifyRole
-// 修改角色
+// 修改角色。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的修改角色接口文档见 [ModifyRocketMQRole](https://cloud.tencent.com/document/product/1179/107532)，修改角色的授权接口文档见 [ModifyRocketMQEnvironmentRole](https://cloud.tencent.com/document/product/1179/107533)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -3782,7 +3128,9 @@ func (c *Client) ModifyRole(request *ModifyRoleRequest) (response *ModifyRoleRes
 }
 
 // ModifyRole
-// 修改角色
+// 修改角色。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的修改角色接口文档见 [ModifyRocketMQRole](https://cloud.tencent.com/document/product/1179/107532)，修改角色的授权接口文档见 [ModifyRocketMQEnvironmentRole](https://cloud.tencent.com/document/product/1179/107533)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -3825,7 +3173,9 @@ func NewModifyTopicResponse() (response *ModifyTopicResponse) {
 }
 
 // ModifyTopic
-// 修改主题属性
+// 修改主题属性。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的修改主题属性接口文档见 [ModifyRocketMQTopic](https://cloud.tencent.com/document/api/1179/63414)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -3834,7 +3184,9 @@ func (c *Client) ModifyTopic(request *ModifyTopicRequest) (response *ModifyTopic
 }
 
 // ModifyTopic
-// 修改主题属性
+// 修改主题属性。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的修改主题属性接口文档见 [ModifyRocketMQTopic](https://cloud.tencent.com/document/api/1179/63414)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -3851,6 +3203,56 @@ func (c *Client) ModifyTopicWithContext(ctx context.Context, request *ModifyTopi
     request.SetContext(ctx)
     
     response = NewModifyTopicResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewPutConsumerRouteConfigRequest() (request *PutConsumerRouteConfigRequest) {
+    request = &PutConsumerRouteConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "PutConsumerRouteConfig")
+    
+    
+    return
+}
+
+func NewPutConsumerRouteConfigResponse() (response *PutConsumerRouteConfigResponse) {
+    response = &PutConsumerRouteConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// PutConsumerRouteConfig
+// 写入消费组灰度路由配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) PutConsumerRouteConfig(request *PutConsumerRouteConfigRequest) (response *PutConsumerRouteConfigResponse, err error) {
+    return c.PutConsumerRouteConfigWithContext(context.Background(), request)
+}
+
+// PutConsumerRouteConfig
+// 写入消费组灰度路由配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) PutConsumerRouteConfigWithContext(ctx context.Context, request *PutConsumerRouteConfigRequest) (response *PutConsumerRouteConfigResponse, err error) {
+    if request == nil {
+        request = NewPutConsumerRouteConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "PutConsumerRouteConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("PutConsumerRouteConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewPutConsumerRouteConfigResponse()
     err = c.Send(request, response)
     return
 }
@@ -3925,7 +3327,9 @@ func NewResendDeadLetterMessageResponse() (response *ResendDeadLetterMessageResp
 }
 
 // ResendDeadLetterMessage
-// 重新发送死信消息
+// 重新发送死信消息。
+//
+// 当前 API 适用集群：5.x集群。4.x 集群的重发死信消息接口文档见 [RetryRocketMQDlqMessage](https://cloud.tencent.com/document/api/1179/114595)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -3934,7 +3338,9 @@ func (c *Client) ResendDeadLetterMessage(request *ResendDeadLetterMessageRequest
 }
 
 // ResendDeadLetterMessage
-// 重新发送死信消息
+// 重新发送死信消息。
+//
+// 当前 API 适用集群：5.x集群。4.x 集群的重发死信消息接口文档见 [RetryRocketMQDlqMessage](https://cloud.tencent.com/document/api/1179/114595)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -3975,7 +3381,9 @@ func NewResetConsumerGroupOffsetResponse() (response *ResetConsumerGroupOffsetRe
 }
 
 // ResetConsumerGroupOffset
-// 重置消费位点
+// 重置消费位点。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的重置消费位点接口文档见 [ResetRocketMQConsumerOffSet](https://cloud.tencent.com/document/api/1179/71662)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -3984,7 +3392,9 @@ func (c *Client) ResetConsumerGroupOffset(request *ResetConsumerGroupOffsetReque
 }
 
 // ResetConsumerGroupOffset
-// 重置消费位点
+// 重置消费位点。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的重置消费位点接口文档见 [ResetRocketMQConsumerOffSet](https://cloud.tencent.com/document/api/1179/71662)。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -4051,6 +3461,118 @@ func (c *Client) RollbackMigratingTopicStageWithContext(ctx context.Context, req
     request.SetContext(ctx)
     
     response = NewRollbackMigratingTopicStageResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewSendMessageRequest() (request *SendMessageRequest) {
+    request = &SendMessageRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "SendMessage")
+    
+    
+    return
+}
+
+func NewSendMessageResponse() (response *SendMessageResponse) {
+    response = &SendMessageResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// SendMessage
+// 发送 RocketMQ 消息，该接口仅用于控制台发送少量测试消息，不保证 SLA，且云 API 存在限流，在真实业务场景下，请使用 RocketMQ SDK 发送消息。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的发送消息接口文档见 [SendRocketMQMessage](https://cloud.tencent.com/document/api/1179/94179)。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+func (c *Client) SendMessage(request *SendMessageRequest) (response *SendMessageResponse, err error) {
+    return c.SendMessageWithContext(context.Background(), request)
+}
+
+// SendMessage
+// 发送 RocketMQ 消息，该接口仅用于控制台发送少量测试消息，不保证 SLA，且云 API 存在限流，在真实业务场景下，请使用 RocketMQ SDK 发送消息。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的发送消息接口文档见 [SendRocketMQMessage](https://cloud.tencent.com/document/api/1179/94179)。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  RESOURCENOTFOUND_TOPIC = "ResourceNotFound.Topic"
+func (c *Client) SendMessageWithContext(ctx context.Context, request *SendMessageRequest) (response *SendMessageResponse, err error) {
+    if request == nil {
+        request = NewSendMessageRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "SendMessage")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("SendMessage require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewSendMessageResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewVerifyMessageConsumptionRequest() (request *VerifyMessageConsumptionRequest) {
+    request = &VerifyMessageConsumptionRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("trocket", APIVersion, "VerifyMessageConsumption")
+    
+    
+    return
+}
+
+func NewVerifyMessageConsumptionResponse() (response *VerifyMessageConsumptionResponse) {
+    response = &VerifyMessageConsumptionResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// VerifyMessageConsumption
+// 消息消费验证。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的消息消费验证接口文档见 [VerifyRocketMQConsume](https://cloud.tencent.com/document/api/1179/101061)。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  UNSUPPORTEDOPERATION_UNSUPPORTEDCONSUMERTYPE = "UnsupportedOperation.UnsupportedConsumerType"
+func (c *Client) VerifyMessageConsumption(request *VerifyMessageConsumptionRequest) (response *VerifyMessageConsumptionResponse, err error) {
+    return c.VerifyMessageConsumptionWithContext(context.Background(), request)
+}
+
+// VerifyMessageConsumption
+// 消息消费验证。
+//
+// 当前 API 适用集群：5.x 集群。4.x 集群的消息消费验证接口文档见 [VerifyRocketMQConsume](https://cloud.tencent.com/document/api/1179/101061)。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  UNSUPPORTEDOPERATION_UNSUPPORTEDCONSUMERTYPE = "UnsupportedOperation.UnsupportedConsumerType"
+func (c *Client) VerifyMessageConsumptionWithContext(ctx context.Context, request *VerifyMessageConsumptionRequest) (response *VerifyMessageConsumptionResponse, err error) {
+    if request == nil {
+        request = NewVerifyMessageConsumptionRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "trocket", APIVersion, "VerifyMessageConsumption")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("VerifyMessageConsumption require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewVerifyMessageConsumptionResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket/v20230308/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket/v20230308/errors.go
@@ -32,9 +32,6 @@ const (
 	// 资源被占用。
 	RESOURCEINUSE = "ResourceInUse"
 
-	// 客户端不存在。
-	RESOURCENOTFOUND_CLIENT = "ResourceNotFound.Client"
-
 	// 接入点不存在。
 	RESOURCENOTFOUND_ENDPOINT = "ResourceNotFound.Endpoint"
 
@@ -67,4 +64,7 @@ const (
 
 	// 资源已存在，请检查后重试。
 	UNSUPPORTEDOPERATION_RESOURCEALREADYEXISTS = "UnsupportedOperation.ResourceAlreadyExists"
+
+	// 当前消费者类型不支持此操作。
+	UNSUPPORTEDOPERATION_UNSUPPORTEDCONSUMERTYPE = "UnsupportedOperation.UnsupportedConsumerType"
 )

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket/v20230308/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket/v20230308/models.go
@@ -143,6 +143,19 @@ type ConsumeGroupItem struct {
 	// 4.x的完整命名空间
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	FullNamespaceV4 *string `json:"FullNamespaceV4,omitnil,omitempty" name:"FullNamespaceV4"`
+
+	// 订阅的主题个数
+	SubscribeTopicNum *int64 `json:"SubscribeTopicNum,omitnil,omitempty" name:"SubscribeTopicNum"`
+
+	// 创建时间
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 绑定的标签列表
+	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// 重试策略
+	RetryPolicy *RetryPolicy `json:"RetryPolicy,omitnil,omitempty" name:"RetryPolicy"`
 }
 
 type ConsumerClient struct {
@@ -171,29 +184,45 @@ type ConsumerClient struct {
 	ChannelProtocol *string `json:"ChannelProtocol,omitnil,omitempty" name:"ChannelProtocol"`
 }
 
+type ConsumerLabel struct {
+	// <p>标签</p>
+	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
+
+	// <p>标签状态</p><p>枚举值：</p><ul><li>ACTIVE： 生效中</li><li>DELETING： 删除中</li><li>UNKNOWN： 未知</li></ul>
+	State *string `json:"State,omitnil,omitempty" name:"State"`
+
+	// <p>更新时间</p><p>单位：毫秒(ms)</p>
+	UpdatedAt *int64 `json:"UpdatedAt,omitnil,omitempty" name:"UpdatedAt"`
+}
+
 // Predefined struct for user
 type CreateConsumerGroupRequestParams struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 最大重试次数，取值范围0～1000
+	// <p>最大重试次数，取值范围0～1000</p>
 	MaxRetryTimes *int64 `json:"MaxRetryTimes,omitnil,omitempty" name:"MaxRetryTimes"`
 
-	// 是否开启消费
+	// <p>是否开启消费</p>
 	ConsumeEnable *bool `json:"ConsumeEnable,omitnil,omitempty" name:"ConsumeEnable"`
 
-	// 顺序投递：true
-	// 并发投递：false
+	// <p>顺序投递：true<br>并发投递：false</p>
 	ConsumeMessageOrderly *bool `json:"ConsumeMessageOrderly,omitnil,omitempty" name:"ConsumeMessageOrderly"`
 
 	// 消费组名称，从 [DescribeConsumerGroupList](https://cloud.tencent.com/document/api/1493/101535) 接口返回的 [ConsumeGroupItem](https://cloud.tencent.com/document/api/1493/96031#ConsumeGroupItem) 或控制台获得。
 	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
 
-	// 备注信息，最多 128 个字符
+	// <p>备注信息，最多 128 个字符</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 标签列表
+	// <p>标签列表</p>
 	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// <p>重试策略</p>
+	RetryPolicy *RetryPolicy `json:"RetryPolicy,omitnil,omitempty" name:"RetryPolicy"`
+
+	// <p>轻量主题</p>
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
 }
 
 type CreateConsumerGroupRequest struct {
@@ -202,24 +231,29 @@ type CreateConsumerGroupRequest struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 最大重试次数，取值范围0～1000
+	// <p>最大重试次数，取值范围0～1000</p>
 	MaxRetryTimes *int64 `json:"MaxRetryTimes,omitnil,omitempty" name:"MaxRetryTimes"`
 
-	// 是否开启消费
+	// <p>是否开启消费</p>
 	ConsumeEnable *bool `json:"ConsumeEnable,omitnil,omitempty" name:"ConsumeEnable"`
 
-	// 顺序投递：true
-	// 并发投递：false
+	// <p>顺序投递：true<br>并发投递：false</p>
 	ConsumeMessageOrderly *bool `json:"ConsumeMessageOrderly,omitnil,omitempty" name:"ConsumeMessageOrderly"`
 
 	// 消费组名称，从 [DescribeConsumerGroupList](https://cloud.tencent.com/document/api/1493/101535) 接口返回的 [ConsumeGroupItem](https://cloud.tencent.com/document/api/1493/96031#ConsumeGroupItem) 或控制台获得。
 	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
 
-	// 备注信息，最多 128 个字符
+	// <p>备注信息，最多 128 个字符</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 标签列表
+	// <p>标签列表</p>
 	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// <p>重试策略</p>
+	RetryPolicy *RetryPolicy `json:"RetryPolicy,omitnil,omitempty" name:"RetryPolicy"`
+
+	// <p>轻量主题</p>
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
 }
 
 func (r *CreateConsumerGroupRequest) ToJsonString() string {
@@ -241,6 +275,8 @@ func (r *CreateConsumerGroupRequest) FromJsonString(s string) error {
 	delete(f, "ConsumerGroup")
 	delete(f, "Remark")
 	delete(f, "TagList")
+	delete(f, "RetryPolicy")
+	delete(f, "LiteTopic")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateConsumerGroupRequest has unknown keys!", "")
 	}
@@ -249,10 +285,10 @@ func (r *CreateConsumerGroupRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateConsumerGroupResponseParams struct {
-	// 集群ID
+	// <p>集群ID</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 消费组名称
+	// <p>消费组名称</p>
 	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -276,6 +312,83 @@ func (r *CreateConsumerGroupResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type CreateConsumerLabelRequestParams struct {
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>标签</p>
+	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+type CreateConsumerLabelRequest struct {
+	*tchttp.BaseRequest
+	
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>标签</p>
+	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+func (r *CreateConsumerLabelRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateConsumerLabelRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "Label")
+	delete(f, "Group")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateConsumerLabelRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateConsumerLabelResponseParams struct {
+	// <p>实例 ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+
+	// <p>标签</p>
+	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateConsumerLabelResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateConsumerLabelResponseParams `json:"Response"`
+}
+
+func (r *CreateConsumerLabelResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateConsumerLabelResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CreateInstanceRequestParams struct {
 	// 实例类型，枚举值如下：
 	// 
@@ -294,14 +407,14 @@ type CreateInstanceRequestParams struct {
 	// 商品规格，从 [DescribeProductSKUs](https://cloud.tencent.com/document/api/1493/107676) 接口中的 [ProductSKU](https://cloud.tencent.com/document/api/1493/96031#ProductSKU) 出参获得。
 	SkuCode *string `json:"SkuCode,omitnil,omitempty" name:"SkuCode"`
 
+	// 集群绑定的VPC信息
+	VpcList []*VpcInfo `json:"VpcList,omitnil,omitempty" name:"VpcList"`
+
 	// 备注信息
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
 	// 标签列表
 	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
-
-	// 集群绑定的VPC信息，必填
-	VpcList []*VpcInfo `json:"VpcList,omitnil,omitempty" name:"VpcList"`
 
 	// 是否开启公网，默认值为false表示不开启
 	EnablePublic *bool `json:"EnablePublic,omitnil,omitempty" name:"EnablePublic"`
@@ -361,14 +474,14 @@ type CreateInstanceRequest struct {
 	// 商品规格，从 [DescribeProductSKUs](https://cloud.tencent.com/document/api/1493/107676) 接口中的 [ProductSKU](https://cloud.tencent.com/document/api/1493/96031#ProductSKU) 出参获得。
 	SkuCode *string `json:"SkuCode,omitnil,omitempty" name:"SkuCode"`
 
+	// 集群绑定的VPC信息
+	VpcList []*VpcInfo `json:"VpcList,omitnil,omitempty" name:"VpcList"`
+
 	// 备注信息
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
 	// 标签列表
 	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
-
-	// 集群绑定的VPC信息，必填
-	VpcList []*VpcInfo `json:"VpcList,omitnil,omitempty" name:"VpcList"`
 
 	// 是否开启公网，默认值为false表示不开启
 	EnablePublic *bool `json:"EnablePublic,omitnil,omitempty" name:"EnablePublic"`
@@ -423,9 +536,9 @@ func (r *CreateInstanceRequest) FromJsonString(s string) error {
 	delete(f, "InstanceType")
 	delete(f, "Name")
 	delete(f, "SkuCode")
+	delete(f, "VpcList")
 	delete(f, "Remark")
 	delete(f, "TagList")
-	delete(f, "VpcList")
 	delete(f, "EnablePublic")
 	delete(f, "BillingFlow")
 	delete(f, "Bandwidth")
@@ -468,370 +581,86 @@ func (r *CreateInstanceResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
-type CreateMQTTInsPublicEndpointRequestParams struct {
-	// 实例ID
+type CreateMigrationTaskRequestParams struct {
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 带宽
-	Bandwidth *int64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
+	// 0 - 未指定（存量）
+	// 1 - 元数据导入
+	Type *int64 `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 公网访问规则
-	Rules []*PublicAccessRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+	// 待导入的消费组列表
+	Topics []*TopicItem `json:"Topics,omitnil,omitempty" name:"Topics"`
+
+	// 待导入的消费组列表
+	Groups []*ConsumeGroupItem `json:"Groups,omitnil,omitempty" name:"Groups"`
+
+	// 待导入的角色列表
+	Roles []*RoleItem `json:"Roles,omitnil,omitempty" name:"Roles"`
 }
 
-type CreateMQTTInsPublicEndpointRequest struct {
+type CreateMigrationTaskRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例ID
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 带宽
-	Bandwidth *int64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
+	// 0 - 未指定（存量）
+	// 1 - 元数据导入
+	Type *int64 `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 公网访问规则
-	Rules []*PublicAccessRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+	// 待导入的消费组列表
+	Topics []*TopicItem `json:"Topics,omitnil,omitempty" name:"Topics"`
+
+	// 待导入的消费组列表
+	Groups []*ConsumeGroupItem `json:"Groups,omitnil,omitempty" name:"Groups"`
+
+	// 待导入的角色列表
+	Roles []*RoleItem `json:"Roles,omitnil,omitempty" name:"Roles"`
 }
 
-func (r *CreateMQTTInsPublicEndpointRequest) ToJsonString() string {
+func (r *CreateMigrationTaskRequest) ToJsonString() string {
     b, _ := json.Marshal(r)
     return string(b)
 }
 
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
-func (r *CreateMQTTInsPublicEndpointRequest) FromJsonString(s string) error {
+func (r *CreateMigrationTaskRequest) FromJsonString(s string) error {
 	f := make(map[string]interface{})
 	if err := json.Unmarshal([]byte(s), &f); err != nil {
 		return err
 	}
 	delete(f, "InstanceId")
-	delete(f, "Bandwidth")
-	delete(f, "Rules")
+	delete(f, "Type")
+	delete(f, "Topics")
+	delete(f, "Groups")
+	delete(f, "Roles")
 	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateMQTTInsPublicEndpointRequest has unknown keys!", "")
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateMigrationTaskRequest has unknown keys!", "")
 	}
 	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
-type CreateMQTTInsPublicEndpointResponseParams struct {
+type CreateMigrationTaskResponseParams struct {
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
-type CreateMQTTInsPublicEndpointResponse struct {
+type CreateMigrationTaskResponse struct {
 	*tchttp.BaseResponse
-	Response *CreateMQTTInsPublicEndpointResponseParams `json:"Response"`
+	Response *CreateMigrationTaskResponseParams `json:"Response"`
 }
 
-func (r *CreateMQTTInsPublicEndpointResponse) ToJsonString() string {
+func (r *CreateMigrationTaskResponse) ToJsonString() string {
     b, _ := json.Marshal(r)
     return string(b)
 }
 
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
-func (r *CreateMQTTInsPublicEndpointResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type CreateMQTTInstanceRequestParams struct {
-	// 实例类型，
-	// EXPERIMENT 体验版
-	// BASIC 基础版
-	// PRO  专业版
-	// PLATINUM 铂金版
-	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
-
-	// 实例名称
-	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
-
-	// 商品规格，可用规格如下：
-	// basic_1k,
-	SkuCode *string `json:"SkuCode,omitnil,omitempty" name:"SkuCode"`
-
-	// 备注信息
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-
-	// 标签列表
-	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
-
-	// 实例绑定的VPC信息
-	VpcList []*VpcInfo `json:"VpcList,omitnil,omitempty" name:"VpcList"`
-
-	// 是否开启公网
-	EnablePublic *bool `json:"EnablePublic,omitnil,omitempty" name:"EnablePublic"`
-
-	// 公网带宽（单位：兆）
-	Bandwidth *int64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
-
-	// 公网访问白名单
-	IpRules []*IpRule `json:"IpRules,omitnil,omitempty" name:"IpRules"`
-
-	// 是否自动续费（0: 不自动续费；1: 自动续费）
-	RenewFlag *int64 `json:"RenewFlag,omitnil,omitempty" name:"RenewFlag"`
-
-	// 购买时长（单位：月）
-	TimeSpan *int64 `json:"TimeSpan,omitnil,omitempty" name:"TimeSpan"`
-}
-
-type CreateMQTTInstanceRequest struct {
-	*tchttp.BaseRequest
-	
-	// 实例类型，
-	// EXPERIMENT 体验版
-	// BASIC 基础版
-	// PRO  专业版
-	// PLATINUM 铂金版
-	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
-
-	// 实例名称
-	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
-
-	// 商品规格，可用规格如下：
-	// basic_1k,
-	SkuCode *string `json:"SkuCode,omitnil,omitempty" name:"SkuCode"`
-
-	// 备注信息
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-
-	// 标签列表
-	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
-
-	// 实例绑定的VPC信息
-	VpcList []*VpcInfo `json:"VpcList,omitnil,omitempty" name:"VpcList"`
-
-	// 是否开启公网
-	EnablePublic *bool `json:"EnablePublic,omitnil,omitempty" name:"EnablePublic"`
-
-	// 公网带宽（单位：兆）
-	Bandwidth *int64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
-
-	// 公网访问白名单
-	IpRules []*IpRule `json:"IpRules,omitnil,omitempty" name:"IpRules"`
-
-	// 是否自动续费（0: 不自动续费；1: 自动续费）
-	RenewFlag *int64 `json:"RenewFlag,omitnil,omitempty" name:"RenewFlag"`
-
-	// 购买时长（单位：月）
-	TimeSpan *int64 `json:"TimeSpan,omitnil,omitempty" name:"TimeSpan"`
-}
-
-func (r *CreateMQTTInstanceRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *CreateMQTTInstanceRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceType")
-	delete(f, "Name")
-	delete(f, "SkuCode")
-	delete(f, "Remark")
-	delete(f, "TagList")
-	delete(f, "VpcList")
-	delete(f, "EnablePublic")
-	delete(f, "Bandwidth")
-	delete(f, "IpRules")
-	delete(f, "RenewFlag")
-	delete(f, "TimeSpan")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateMQTTInstanceRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type CreateMQTTInstanceResponseParams struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type CreateMQTTInstanceResponse struct {
-	*tchttp.BaseResponse
-	Response *CreateMQTTInstanceResponseParams `json:"Response"`
-}
-
-func (r *CreateMQTTInstanceResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *CreateMQTTInstanceResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type CreateMQTTTopicRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 备注
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-type CreateMQTTTopicRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 备注
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-func (r *CreateMQTTTopicRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *CreateMQTTTopicRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Topic")
-	delete(f, "Remark")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateMQTTTopicRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type CreateMQTTTopicResponseParams struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type CreateMQTTTopicResponse struct {
-	*tchttp.BaseResponse
-	Response *CreateMQTTTopicResponseParams `json:"Response"`
-}
-
-func (r *CreateMQTTTopicResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *CreateMQTTTopicResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type CreateMQTTUserRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 备注
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-
-	// 是否开启生产权限
-	PermWrite *bool `json:"PermWrite,omitnil,omitempty" name:"PermWrite"`
-
-	// 是否开启消费权限
-	PermRead *bool `json:"PermRead,omitnil,omitempty" name:"PermRead"`
-
-	// 用户名
-	Username *string `json:"Username,omitnil,omitempty" name:"Username"`
-
-	// 密码，该字段为空时候则后端会默认生成
-	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
-}
-
-type CreateMQTTUserRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 备注
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-
-	// 是否开启生产权限
-	PermWrite *bool `json:"PermWrite,omitnil,omitempty" name:"PermWrite"`
-
-	// 是否开启消费权限
-	PermRead *bool `json:"PermRead,omitnil,omitempty" name:"PermRead"`
-
-	// 用户名
-	Username *string `json:"Username,omitnil,omitempty" name:"Username"`
-
-	// 密码，该字段为空时候则后端会默认生成
-	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
-}
-
-func (r *CreateMQTTUserRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *CreateMQTTUserRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Remark")
-	delete(f, "PermWrite")
-	delete(f, "PermRead")
-	delete(f, "Username")
-	delete(f, "Password")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateMQTTUserRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type CreateMQTTUserResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type CreateMQTTUserResponse struct {
-	*tchttp.BaseResponse
-	Response *CreateMQTTUserResponseParams `json:"Response"`
-}
-
-func (r *CreateMQTTUserResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *CreateMQTTUserResponse) FromJsonString(s string) error {
+func (r *CreateMigrationTaskResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -857,6 +686,15 @@ type CreateRoleRequestParams struct {
 
 	// Topic&Group维度权限配置，权限类型为 TopicAndGroup 时必填
 	DetailedPerms []*DetailedRolePerm `json:"DetailedPerms,omitnil,omitempty" name:"DetailedPerms"`
+
+	// AK、SK的生成方式，AUTO：后端自动生成，MANUAL：用户手动输入
+	RoleGenerateMode *string `json:"RoleGenerateMode,omitnil,omitempty" name:"RoleGenerateMode"`
+
+	// 选择MANUAL模式下，需要手动输入AK值
+	AccessKey *string `json:"AccessKey,omitnil,omitempty" name:"AccessKey"`
+
+	// 选择MANUAL模式下，需要手动输入SK值
+	SecretKey *string `json:"SecretKey,omitnil,omitempty" name:"SecretKey"`
 }
 
 type CreateRoleRequest struct {
@@ -882,6 +720,15 @@ type CreateRoleRequest struct {
 
 	// Topic&Group维度权限配置，权限类型为 TopicAndGroup 时必填
 	DetailedPerms []*DetailedRolePerm `json:"DetailedPerms,omitnil,omitempty" name:"DetailedPerms"`
+
+	// AK、SK的生成方式，AUTO：后端自动生成，MANUAL：用户手动输入
+	RoleGenerateMode *string `json:"RoleGenerateMode,omitnil,omitempty" name:"RoleGenerateMode"`
+
+	// 选择MANUAL模式下，需要手动输入AK值
+	AccessKey *string `json:"AccessKey,omitnil,omitempty" name:"AccessKey"`
+
+	// 选择MANUAL模式下，需要手动输入SK值
+	SecretKey *string `json:"SecretKey,omitnil,omitempty" name:"SecretKey"`
 }
 
 func (r *CreateRoleRequest) ToJsonString() string {
@@ -903,6 +750,9 @@ func (r *CreateRoleRequest) FromJsonString(s string) error {
 	delete(f, "Remark")
 	delete(f, "PermType")
 	delete(f, "DetailedPerms")
+	delete(f, "RoleGenerateMode")
+	delete(f, "AccessKey")
+	delete(f, "SecretKey")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateRoleRequest has unknown keys!", "")
 	}
@@ -948,6 +798,7 @@ type CreateTopicRequestParams struct {
 	// - FIFO: 顺序消息
 	// - DELAY: 延时消息
 	// - TRANSACTION: 事务消息
+	// - LITE: 轻量消息
 	TopicType *string `json:"TopicType,omitnil,omitempty" name:"TopicType"`
 
 	// 队列数量，取值范围3～16
@@ -961,6 +812,12 @@ type CreateTopicRequestParams struct {
 
 	// 标签列表
 	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// 是否过期自动删除（仅针对轻量主题类型）
+	AutoExpireDelete *bool `json:"AutoExpireDelete,omitnil,omitempty" name:"AutoExpireDelete"`
+
+	// 过期时间，单位：秒（仅针对轻量主题类型）
+	AutoExpireTime *int64 `json:"AutoExpireTime,omitnil,omitempty" name:"AutoExpireTime"`
 }
 
 type CreateTopicRequest struct {
@@ -978,6 +835,7 @@ type CreateTopicRequest struct {
 	// - FIFO: 顺序消息
 	// - DELAY: 延时消息
 	// - TRANSACTION: 事务消息
+	// - LITE: 轻量消息
 	TopicType *string `json:"TopicType,omitnil,omitempty" name:"TopicType"`
 
 	// 队列数量，取值范围3～16
@@ -991,6 +849,12 @@ type CreateTopicRequest struct {
 
 	// 标签列表
 	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// 是否过期自动删除（仅针对轻量主题类型）
+	AutoExpireDelete *bool `json:"AutoExpireDelete,omitnil,omitempty" name:"AutoExpireDelete"`
+
+	// 过期时间，单位：秒（仅针对轻量主题类型）
+	AutoExpireTime *int64 `json:"AutoExpireTime,omitnil,omitempty" name:"AutoExpireTime"`
 }
 
 func (r *CreateTopicRequest) ToJsonString() string {
@@ -1012,6 +876,8 @@ func (r *CreateTopicRequest) FromJsonString(s string) error {
 	delete(f, "Remark")
 	delete(f, "MsgTTL")
 	delete(f, "TagList")
+	delete(f, "AutoExpireDelete")
+	delete(f, "AutoExpireTime")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateTopicRequest has unknown keys!", "")
 	}
@@ -1044,16 +910,6 @@ func (r *CreateTopicResponse) ToJsonString() string {
 // because it has no param check, nor strict type check
 func (r *CreateTopicResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
-}
-
-type CustomMapEntry struct {
-	// key
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
-
-	// value
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
 }
 
 // Predefined struct for user
@@ -1118,6 +974,142 @@ func (r *DeleteConsumerGroupResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DeleteConsumerLabelRequestParams struct {
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+
+	// <p>标签</p>
+	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
+}
+
+type DeleteConsumerLabelRequest struct {
+	*tchttp.BaseRequest
+	
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+
+	// <p>标签</p>
+	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
+}
+
+func (r *DeleteConsumerLabelRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteConsumerLabelRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "Group")
+	delete(f, "Label")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteConsumerLabelRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteConsumerLabelResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteConsumerLabelResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteConsumerLabelResponseParams `json:"Response"`
+}
+
+func (r *DeleteConsumerLabelResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteConsumerLabelResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteConsumerRouteConfigRequestParams struct {
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+type DeleteConsumerRouteConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+func (r *DeleteConsumerRouteConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteConsumerRouteConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Topic")
+	delete(f, "InstanceId")
+	delete(f, "Group")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteConsumerRouteConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteConsumerRouteConfigResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteConsumerRouteConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteConsumerRouteConfigResponseParams `json:"Response"`
+}
+
+func (r *DeleteConsumerRouteConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteConsumerRouteConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DeleteInstanceRequestParams struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
@@ -1168,236 +1160,6 @@ func (r *DeleteInstanceResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteInstanceResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DeleteMQTTInsPublicEndpointRequestParams struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-type DeleteMQTTInsPublicEndpointRequest struct {
-	*tchttp.BaseRequest
-	
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-func (r *DeleteMQTTInsPublicEndpointRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DeleteMQTTInsPublicEndpointRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteMQTTInsPublicEndpointRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DeleteMQTTInsPublicEndpointResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DeleteMQTTInsPublicEndpointResponse struct {
-	*tchttp.BaseResponse
-	Response *DeleteMQTTInsPublicEndpointResponseParams `json:"Response"`
-}
-
-func (r *DeleteMQTTInsPublicEndpointResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DeleteMQTTInsPublicEndpointResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DeleteMQTTInstanceRequestParams struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-type DeleteMQTTInstanceRequest struct {
-	*tchttp.BaseRequest
-	
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-func (r *DeleteMQTTInstanceRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DeleteMQTTInstanceRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteMQTTInstanceRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DeleteMQTTInstanceResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DeleteMQTTInstanceResponse struct {
-	*tchttp.BaseResponse
-	Response *DeleteMQTTInstanceResponseParams `json:"Response"`
-}
-
-func (r *DeleteMQTTInstanceResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DeleteMQTTInstanceResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DeleteMQTTTopicRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-}
-
-type DeleteMQTTTopicRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-}
-
-func (r *DeleteMQTTTopicRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DeleteMQTTTopicRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Topic")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteMQTTTopicRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DeleteMQTTTopicResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DeleteMQTTTopicResponse struct {
-	*tchttp.BaseResponse
-	Response *DeleteMQTTTopicResponseParams `json:"Response"`
-}
-
-func (r *DeleteMQTTTopicResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DeleteMQTTTopicResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DeleteMQTTUserRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 用户名
-	Username *string `json:"Username,omitnil,omitempty" name:"Username"`
-}
-
-type DeleteMQTTUserRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 用户名
-	Username *string `json:"Username,omitnil,omitempty" name:"Username"`
-}
-
-func (r *DeleteMQTTUserRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DeleteMQTTUserRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Username")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteMQTTUserRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DeleteMQTTUserResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DeleteMQTTUserResponse struct {
-	*tchttp.BaseResponse
-	Response *DeleteMQTTUserResponseParams `json:"Response"`
-}
-
-func (r *DeleteMQTTUserResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DeleteMQTTUserResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -1767,6 +1529,9 @@ type DescribeConsumerGroupListRequestParams struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
+	// 标签过滤器
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
+
 	// 过滤查询条件列表，请在引用此参数的API说明中了解使用方法。
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
@@ -1778,6 +1543,16 @@ type DescribeConsumerGroupListRequestParams struct {
 
 	// 查询指定主题下的消费组
 	FromTopic *string `json:"FromTopic,omitnil,omitempty" name:"FromTopic"`
+
+	// 按照指定字段排序，枚举值如下：
+	// - subscribeNum：订阅 Topic 个数
+	SortedBy *string `json:"SortedBy,omitnil,omitempty" name:"SortedBy"`
+
+	// 按升序或降序排列，枚举值如下：
+	// 
+	// - asc：升序
+	// - desc：降序
+	SortOrder *string `json:"SortOrder,omitnil,omitempty" name:"SortOrder"`
 }
 
 type DescribeConsumerGroupListRequest struct {
@@ -1786,6 +1561,9 @@ type DescribeConsumerGroupListRequest struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
+	// 标签过滤器
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
+
 	// 过滤查询条件列表，请在引用此参数的API说明中了解使用方法。
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
@@ -1797,6 +1575,16 @@ type DescribeConsumerGroupListRequest struct {
 
 	// 查询指定主题下的消费组
 	FromTopic *string `json:"FromTopic,omitnil,omitempty" name:"FromTopic"`
+
+	// 按照指定字段排序，枚举值如下：
+	// - subscribeNum：订阅 Topic 个数
+	SortedBy *string `json:"SortedBy,omitnil,omitempty" name:"SortedBy"`
+
+	// 按升序或降序排列，枚举值如下：
+	// 
+	// - asc：升序
+	// - desc：降序
+	SortOrder *string `json:"SortOrder,omitnil,omitempty" name:"SortOrder"`
 }
 
 func (r *DescribeConsumerGroupListRequest) ToJsonString() string {
@@ -1812,10 +1600,13 @@ func (r *DescribeConsumerGroupListRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "InstanceId")
+	delete(f, "TagFilters")
 	delete(f, "Filters")
 	delete(f, "Offset")
 	delete(f, "Limit")
 	delete(f, "FromTopic")
+	delete(f, "SortedBy")
+	delete(f, "SortOrder")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeConsumerGroupListRequest has unknown keys!", "")
 	}
@@ -1891,42 +1682,44 @@ func (r *DescribeConsumerGroupRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeConsumerGroupResponseParams struct {
-	// 在线消费者数量
+	// <p>在线消费者数量</p>
 	ConsumerNum *int64 `json:"ConsumerNum,omitnil,omitempty" name:"ConsumerNum"`
 
-	// TPS
+	// <p>TPS</p>
 	Tps *int64 `json:"Tps,omitnil,omitempty" name:"Tps"`
 
-	// 消息堆积数量
+	// <p>消息堆积数量</p>
 	ConsumerLag *int64 `json:"ConsumerLag,omitnil,omitempty" name:"ConsumerLag"`
 
-	// 消费类型，枚举值如下：
-	// 
-	// - PULL：PULL 消费类型
-	// - PUSH：PUSH 消费类型
-	// - POP：POP 消费类型
+	// <p>消费类型，枚举值如下：</p><ul><li>PULL：PULL 消费类型</li><li>PUSH：PUSH 消费类型</li><li>POP：POP 消费类型</li></ul>
 	ConsumeType *string `json:"ConsumeType,omitnil,omitempty" name:"ConsumeType"`
 
-	// 创建时间，**Unix时间戳（毫秒）**
+	// <p>创建时间，<strong>Unix时间戳（毫秒）</strong></p>
 	CreatedTime *int64 `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
-	// 顺序投递：true
-	// 并发投递：false
+	// <p>顺序投递：true<br>并发投递：false</p>
 	ConsumeMessageOrderly *bool `json:"ConsumeMessageOrderly,omitnil,omitempty" name:"ConsumeMessageOrderly"`
 
-	// 是否开启消费
+	// <p>是否开启消费</p>
 	ConsumeEnable *bool `json:"ConsumeEnable,omitnil,omitempty" name:"ConsumeEnable"`
 
-	// 最大重试次数
+	// <p>最大重试次数</p>
 	MaxRetryTimes *int64 `json:"MaxRetryTimes,omitnil,omitempty" name:"MaxRetryTimes"`
 
-	// 备注
+	// <p>备注</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 消费模式：
-	// BROADCASTING 广播模式
-	// CLUSTERING 集群模式
+	// <p>消费模式：<br>BROADCASTING 广播模式<br>CLUSTERING 集群模式</p>
 	MessageModel *string `json:"MessageModel,omitnil,omitempty" name:"MessageModel"`
+
+	// <p>重试策略</p>
+	RetryPolicy *RetryPolicy `json:"RetryPolicy,omitnil,omitempty" name:"RetryPolicy"`
+
+	// <p>消费模式</p><p>枚举值：</p><ul><li>CLUSTERING： 集群/广播消费</li><li>LITE： LiteTopic消费</li></ul><p>默认值：CLUSTERING</p>
+	ConsumeModel *string `json:"ConsumeModel,omitnil,omitempty" name:"ConsumeModel"`
+
+	// <p>订阅的轻量主题（仅适用于轻量消费模式）</p>
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -1945,6 +1738,144 @@ func (r *DescribeConsumerGroupResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeConsumerGroupResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeConsumerLabelListRequestParams struct {
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+type DescribeConsumerLabelListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+func (r *DescribeConsumerLabelListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeConsumerLabelListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "Group")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeConsumerLabelListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeConsumerLabelListResponseParams struct {
+	// 查询总数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// <p>标签列表</p>
+	Labels []*ConsumerLabel `json:"Labels,omitnil,omitempty" name:"Labels"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeConsumerLabelListResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeConsumerLabelListResponseParams `json:"Response"`
+}
+
+func (r *DescribeConsumerLabelListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeConsumerLabelListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeConsumerLabelRequestParams struct {
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+
+	// <p>标签</p>
+	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
+}
+
+type DescribeConsumerLabelRequest struct {
+	*tchttp.BaseRequest
+	
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+
+	// <p>标签</p>
+	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
+}
+
+func (r *DescribeConsumerLabelRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeConsumerLabelRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "Group")
+	delete(f, "Label")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeConsumerLabelRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeConsumerLabelResponseParams struct {
+	// <p>标签详情</p>
+	Label *ConsumerLabel `json:"Label,omitnil,omitempty" name:"Label"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeConsumerLabelResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeConsumerLabelResponseParams `json:"Response"`
+}
+
+func (r *DescribeConsumerLabelResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeConsumerLabelResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2023,6 +1954,157 @@ func (r *DescribeConsumerLagResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeConsumerLagResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeConsumerRouteConfigRequestParams struct {
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+type DescribeConsumerRouteConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+func (r *DescribeConsumerRouteConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeConsumerRouteConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Topic")
+	delete(f, "InstanceId")
+	delete(f, "Group")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeConsumerRouteConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeConsumerRouteConfigResponseParams struct {
+	// <p>版本号</p>
+	Version *int64 `json:"Version,omitnil,omitempty" name:"Version"`
+
+	// <p>路由规格</p>
+	Rules []*RouteRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+
+	// <p>切流时间戳</p>
+	CutTimestamp *int64 `json:"CutTimestamp,omitnil,omitempty" name:"CutTimestamp"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeConsumerRouteConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeConsumerRouteConfigResponseParams `json:"Response"`
+}
+
+func (r *DescribeConsumerRouteConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeConsumerRouteConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeConsumerRouteVersionListRequestParams struct {
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+type DescribeConsumerRouteVersionListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+}
+
+func (r *DescribeConsumerRouteVersionListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeConsumerRouteVersionListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Topic")
+	delete(f, "InstanceId")
+	delete(f, "Group")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeConsumerRouteVersionListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeConsumerRouteVersionListResponseParams struct {
+	// 查询总数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// <p>版本列表</p>
+	Versions []*RouteRuleVersion `json:"Versions,omitnil,omitempty" name:"Versions"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeConsumerRouteVersionListResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeConsumerRouteVersionListResponseParams `json:"Response"`
+}
+
+func (r *DescribeConsumerRouteVersionListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeConsumerRouteVersionListResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2340,6 +2422,14 @@ type DescribeInstanceResponseParams struct {
 	// 所属可用区列表，参考 [DescribeZones](https://cloud.tencent.com/document/product/1596/77929) 接口返回中的 [ZoneInfo](https://cloud.tencent.com/document/api/1596/77932#ZoneInfo) 数据结构。
 	ZoneIds []*int64 `json:"ZoneIds,omitnil,omitempty" name:"ZoneIds"`
 
+	// proxy节点数量
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NodeCount *int64 `json:"NodeCount,omitnil,omitempty" name:"NodeCount"`
+
+	// proxy调度详情
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ZoneScheduledList []*ZoneScheduledItem `json:"ZoneScheduledList,omitnil,omitempty" name:"ZoneScheduledList"`
+
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
@@ -2357,966 +2447,6 @@ func (r *DescribeInstanceResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeInstanceResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTClientRequestParams struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 客户端详情
-	ClientId *string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
-}
-
-type DescribeMQTTClientRequest struct {
-	*tchttp.BaseRequest
-	
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 客户端详情
-	ClientId *string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
-}
-
-func (r *DescribeMQTTClientRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTClientRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "ClientId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTClientRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTClientResponseParams struct {
-	// 客户端唯一标识
-	ClientId *string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
-
-	// 客户端网络地址
-	ClientAddress *string `json:"ClientAddress,omitnil,omitempty" name:"ClientAddress"`
-
-	// MQTT 协议版本，4 表示 MQTT 3.1.1
-	ProtocolVersion *int64 `json:"ProtocolVersion,omitnil,omitempty" name:"ProtocolVersion"`
-
-	// 保持连接时间，单位：秒
-	Keepalive *int64 `json:"Keepalive,omitnil,omitempty" name:"Keepalive"`
-
-	// 连接状态，CONNECTED 已连接，DISCONNECTED 未连接
-	ConnectionStatus *string `json:"ConnectionStatus,omitnil,omitempty" name:"ConnectionStatus"`
-
-	// 客户端创建时间
-	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
-
-	// 上次建立连接时间
-	ConnectTime *int64 `json:"ConnectTime,omitnil,omitempty" name:"ConnectTime"`
-
-	// 上次断开连接时间，仅对持久会话（cleanSession=false）并且客户端当前未连接时有意义
-	DisconnectTime *int64 `json:"DisconnectTime,omitnil,omitempty" name:"DisconnectTime"`
-
-	// 客户端的订阅列表
-	MQTTClientSubscriptions []*MQTTClientSubscription `json:"MQTTClientSubscriptions,omitnil,omitempty" name:"MQTTClientSubscriptions"`
-
-	// 服务端到客户端的流量统计
-	Inbound *StatisticsReport `json:"Inbound,omitnil,omitempty" name:"Inbound"`
-
-	// 客户端到服务端的流量统计
-	OutBound *StatisticsReport `json:"OutBound,omitnil,omitempty" name:"OutBound"`
-
-	// cleansession标志
-	CleanSession *bool `json:"CleanSession,omitnil,omitempty" name:"CleanSession"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTClientResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTClientResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTClientResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTClientResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInsPublicEndpointsRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-type DescribeMQTTInsPublicEndpointsRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-func (r *DescribeMQTTInsPublicEndpointsRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInsPublicEndpointsRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTInsPublicEndpointsRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInsPublicEndpointsResponseParams struct {
-	// 接入点
-	Endpoints []*MQTTEndpointItem `json:"Endpoints,omitnil,omitempty" name:"Endpoints"`
-
-	// 实例id
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 带宽
-	Bandwidth *int64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
-
-	// 公网访问规则
-	Rules []*PublicAccessRule `json:"Rules,omitnil,omitempty" name:"Rules"`
-
-	// 公网状态：
-	//     NORMAL-正常
-	//     CLOSING-关闭中
-	//     MODIFYING-修改中
-	//     CREATING-开启中
-	//     CLOSE-关闭
-	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTInsPublicEndpointsResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTInsPublicEndpointsResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTInsPublicEndpointsResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInsPublicEndpointsResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInsVPCEndpointsRequestParams struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-type DescribeMQTTInsVPCEndpointsRequest struct {
-	*tchttp.BaseRequest
-	
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-func (r *DescribeMQTTInsVPCEndpointsRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInsVPCEndpointsRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTInsVPCEndpointsRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInsVPCEndpointsResponseParams struct {
-	// 接入点
-	Endpoints []*MQTTEndpointItem `json:"Endpoints,omitnil,omitempty" name:"Endpoints"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTInsVPCEndpointsResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTInsVPCEndpointsResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTInsVPCEndpointsResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInsVPCEndpointsResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInstanceCertRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-type DescribeMQTTInstanceCertRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-func (r *DescribeMQTTInstanceCertRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInstanceCertRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTInstanceCertRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInstanceCertResponseParams struct {
-	// 集群id
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 服务端证书id
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SSLServerCertId *string `json:"SSLServerCertId,omitnil,omitempty" name:"SSLServerCertId"`
-
-	// CA证书id
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SSLCaCertId *string `json:"SSLCaCertId,omitnil,omitempty" name:"SSLCaCertId"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTInstanceCertResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTInstanceCertResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTInstanceCertResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInstanceCertResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInstanceListRequestParams struct {
-	// 查询条件列表
-	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
-
-	// 查询起始位置
-	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
-
-	// 查询结果限制数量
-	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
-
-	// 是否包含新控制台集群：默认为包含
-	IncludeNew *bool `json:"IncludeNew,omitnil,omitempty" name:"IncludeNew"`
-}
-
-type DescribeMQTTInstanceListRequest struct {
-	*tchttp.BaseRequest
-	
-	// 查询条件列表
-	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
-
-	// 查询起始位置
-	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
-
-	// 查询结果限制数量
-	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
-
-	// 是否包含新控制台集群：默认为包含
-	IncludeNew *bool `json:"IncludeNew,omitnil,omitempty" name:"IncludeNew"`
-}
-
-func (r *DescribeMQTTInstanceListRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInstanceListRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "Filters")
-	delete(f, "Offset")
-	delete(f, "Limit")
-	delete(f, "IncludeNew")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTInstanceListRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInstanceListResponseParams struct {
-	// 查询总数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
-
-	// 实例列表
-	Data []*MQTTInstanceItem `json:"Data,omitnil,omitempty" name:"Data"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTInstanceListResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTInstanceListResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTInstanceListResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInstanceListResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInstanceRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-type DescribeMQTTInstanceRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-}
-
-func (r *DescribeMQTTInstanceRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInstanceRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTInstanceRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTInstanceResponseParams struct {
-	// 实例类型，
-	// EXPERIMENT 体验版
-	// BASIC 基础版
-	// PRO  专业版
-	// PLATINUM 铂金版
-	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
-
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 实例名称
-	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
-
-	// 主题数量
-	TopicNum *int64 `json:"TopicNum,omitnil,omitempty" name:"TopicNum"`
-
-	// 实例最大主题数量
-	TopicNumLimit *int64 `json:"TopicNumLimit,omitnil,omitempty" name:"TopicNumLimit"`
-
-	// TPS限流值
-	TpsLimit *int64 `json:"TpsLimit,omitnil,omitempty" name:"TpsLimit"`
-
-	// 创建时间，秒为单位
-	CreatedTime *int64 `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
-
-	// 备注信息
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-
-	// 实例状态
-	InstanceStatus *string `json:"InstanceStatus,omitnil,omitempty" name:"InstanceStatus"`
-
-	// 实例规格
-	SkuCode *string `json:"SkuCode,omitnil,omitempty" name:"SkuCode"`
-
-	// 订阅数上限
-	SubscriptionNumLimit *int64 `json:"SubscriptionNumLimit,omitnil,omitempty" name:"SubscriptionNumLimit"`
-
-	// 客户端数量上限
-	ClientNumLimit *int64 `json:"ClientNumLimit,omitnil,omitempty" name:"ClientNumLimit"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTInstanceResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTInstanceResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTInstanceResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTInstanceResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTMessageListRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 开始时间
-	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
-
-	// 结束时间
-	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
-
-	// 请求任务id
-	TaskRequestId *string `json:"TaskRequestId,omitnil,omitempty" name:"TaskRequestId"`
-
-	// 查询起始位置
-	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
-
-	// 查询结果限制数量
-	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
-}
-
-type DescribeMQTTMessageListRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 开始时间
-	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
-
-	// 结束时间
-	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
-
-	// 请求任务id
-	TaskRequestId *string `json:"TaskRequestId,omitnil,omitempty" name:"TaskRequestId"`
-
-	// 查询起始位置
-	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
-
-	// 查询结果限制数量
-	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
-}
-
-func (r *DescribeMQTTMessageListRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTMessageListRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Topic")
-	delete(f, "StartTime")
-	delete(f, "EndTime")
-	delete(f, "TaskRequestId")
-	delete(f, "Offset")
-	delete(f, "Limit")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTMessageListRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTMessageListResponseParams struct {
-	// 查询总数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
-
-	// 消息记录列表
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Data []*MQTTMessageItem `json:"Data,omitnil,omitempty" name:"Data"`
-
-	// 请求任务id
-	TaskRequestId *string `json:"TaskRequestId,omitnil,omitempty" name:"TaskRequestId"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTMessageListResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTMessageListResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTMessageListResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTMessageListResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTMessageRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 消息ID
-	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
-}
-
-type DescribeMQTTMessageRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 消息ID
-	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
-}
-
-func (r *DescribeMQTTMessageRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTMessageRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Topic")
-	delete(f, "MsgId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTMessageRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTMessageResponseParams struct {
-	// 消息体
-	Body *string `json:"Body,omitnil,omitempty" name:"Body"`
-
-	// 详情参数
-	Properties []*CustomMapEntry `json:"Properties,omitnil,omitempty" name:"Properties"`
-
-	// 生产时间
-	ProduceTime *string `json:"ProduceTime,omitnil,omitempty" name:"ProduceTime"`
-
-	// 消息ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	MessageId *string `json:"MessageId,omitnil,omitempty" name:"MessageId"`
-
-	// 生产者地址
-	ProducerAddr *string `json:"ProducerAddr,omitnil,omitempty" name:"ProducerAddr"`
-
-	// Topic
-	ShowTopicName *string `json:"ShowTopicName,omitnil,omitempty" name:"ShowTopicName"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTMessageResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTMessageResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTMessageResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTMessageResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTProductSKUListRequestParams struct {
-
-}
-
-type DescribeMQTTProductSKUListRequest struct {
-	*tchttp.BaseRequest
-	
-}
-
-func (r *DescribeMQTTProductSKUListRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTProductSKUListRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTProductSKUListRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTProductSKUListResponseParams struct {
-	// 查询总数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
-
-	// mqtt商品配置信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	MQTTProductSkuList []*MQTTProductSkuItem `json:"MQTTProductSkuList,omitnil,omitempty" name:"MQTTProductSkuList"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTProductSKUListResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTProductSKUListResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTProductSKUListResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTProductSKUListResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTTopicListRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 查询条件列表
-	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
-
-	// 查询起始位置
-	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
-
-	// 查询结果限制数量
-	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
-}
-
-type DescribeMQTTTopicListRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 查询条件列表
-	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
-
-	// 查询起始位置
-	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
-
-	// 查询结果限制数量
-	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
-}
-
-func (r *DescribeMQTTTopicListRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTTopicListRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Filters")
-	delete(f, "Offset")
-	delete(f, "Limit")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTTopicListRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTTopicListResponseParams struct {
-	// 查询总数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
-
-	// 主题列表
-	Data []*MQTTTopicItem `json:"Data,omitnil,omitempty" name:"Data"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTTopicListResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTTopicListResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTTopicListResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTTopicListResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTTopicRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-}
-
-type DescribeMQTTTopicRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-}
-
-func (r *DescribeMQTTTopicRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTTopicRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Topic")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTTopicRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTTopicResponseParams struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 备注
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-
-	// 创建时间，秒为单位
-	CreatedTime *int64 `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTTopicResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTTopicResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTTopicResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTTopicResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTUserListRequestParams struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 查询条件列表
-	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
-
-	// 查询起始位置
-	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
-
-	// 查询结果限制数量
-	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
-}
-
-type DescribeMQTTUserListRequest struct {
-	*tchttp.BaseRequest
-	
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 查询条件列表
-	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
-
-	// 查询起始位置
-	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
-
-	// 查询结果限制数量
-	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
-}
-
-func (r *DescribeMQTTUserListRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTUserListRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Filters")
-	delete(f, "Offset")
-	delete(f, "Limit")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMQTTUserListRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type DescribeMQTTUserListResponseParams struct {
-	// 查询总数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
-
-	// 角色信息列表
-	Data []*MQTTUserItem `json:"Data,omitnil,omitempty" name:"Data"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type DescribeMQTTUserListResponse struct {
-	*tchttp.BaseResponse
-	Response *DescribeMQTTUserListResponseParams `json:"Response"`
-}
-
-func (r *DescribeMQTTUserListResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *DescribeMQTTUserListResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -3360,6 +2490,9 @@ type DescribeMessageListRequestParams struct {
 
 	// 消息 Tag，从 [DescribeMessageList](https://cloud.tencent.com/document/api/1493/114593) 接口返回的 [MessageItem](https://cloud.tencent.com/document/api/1493/96031#MessageItem) 或业务日志中获得。
 	Tag *string `json:"Tag,omitnil,omitempty" name:"Tag"`
+
+	// 轻量主题
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
 }
 
 type DescribeMessageListRequest struct {
@@ -3403,6 +2536,9 @@ type DescribeMessageListRequest struct {
 
 	// 消息 Tag，从 [DescribeMessageList](https://cloud.tencent.com/document/api/1493/114593) 接口返回的 [MessageItem](https://cloud.tencent.com/document/api/1493/96031#MessageItem) 或业务日志中获得。
 	Tag *string `json:"Tag,omitnil,omitempty" name:"Tag"`
+
+	// 轻量主题
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
 }
 
 func (r *DescribeMessageListRequest) ToJsonString() string {
@@ -3430,6 +2566,7 @@ func (r *DescribeMessageListRequest) FromJsonString(s string) error {
 	delete(f, "RecentMessageNum")
 	delete(f, "QueryDeadLetterMessage")
 	delete(f, "Tag")
+	delete(f, "LiteTopic")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMessageListRequest has unknown keys!", "")
 	}
@@ -3477,7 +2614,7 @@ type DescribeMessageRequestParams struct {
 	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 
-	// 消息 ID，从 [DescribeMessageList](https://cloud.tencent.com/document/api/1493/114593) 接口或业务日志中获得。
+	// <p>消息 ID，从 <a href="https://cloud.tencent.com/document/api/1493/114593">DescribeMessageList</a> 接口或业务日志中获得。</p>
 	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
 
 	// 查询起始位置，默认为0。
@@ -3486,10 +2623,10 @@ type DescribeMessageRequestParams struct {
 	// 查询结果限制数量，默认20。
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否是死信消息，默认为false
+	// <p>是否是死信消息，默认为false</p>
 	QueryDeadLetterMessage *bool `json:"QueryDeadLetterMessage,omitnil,omitempty" name:"QueryDeadLetterMessage"`
 
-	// 是否是延时消息，默认为false
+	// <p>是否是延时消息，默认为false</p>
 	QueryDelayMessage *bool `json:"QueryDelayMessage,omitnil,omitempty" name:"QueryDelayMessage"`
 }
 
@@ -3502,7 +2639,7 @@ type DescribeMessageRequest struct {
 	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 
-	// 消息 ID，从 [DescribeMessageList](https://cloud.tencent.com/document/api/1493/114593) 接口或业务日志中获得。
+	// <p>消息 ID，从 <a href="https://cloud.tencent.com/document/api/1493/114593">DescribeMessageList</a> 接口或业务日志中获得。</p>
 	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
 
 	// 查询起始位置，默认为0。
@@ -3511,10 +2648,10 @@ type DescribeMessageRequest struct {
 	// 查询结果限制数量，默认20。
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否是死信消息，默认为false
+	// <p>是否是死信消息，默认为false</p>
 	QueryDeadLetterMessage *bool `json:"QueryDeadLetterMessage,omitnil,omitempty" name:"QueryDeadLetterMessage"`
 
-	// 是否是延时消息，默认为false
+	// <p>是否是延时消息，默认为false</p>
 	QueryDelayMessage *bool `json:"QueryDelayMessage,omitnil,omitempty" name:"QueryDelayMessage"`
 }
 
@@ -3545,30 +2682,33 @@ func (r *DescribeMessageRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeMessageResponseParams struct {
-	// 消息体
+	// <p>消息体</p>
 	Body *string `json:"Body,omitnil,omitempty" name:"Body"`
 
-	// 详情参数
+	// <p>详情参数</p>
 	Properties *string `json:"Properties,omitnil,omitempty" name:"Properties"`
 
-	// 生产时间
+	// <p>生产时间</p>
 	ProduceTime *string `json:"ProduceTime,omitnil,omitempty" name:"ProduceTime"`
 
-	// 消息ID
+	// <p>消息ID</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MessageId *string `json:"MessageId,omitnil,omitempty" name:"MessageId"`
 
-	// 生产者地址
+	// <p>生产者地址</p>
 	ProducerAddr *string `json:"ProducerAddr,omitnil,omitempty" name:"ProducerAddr"`
 
-	// 消息消费情况列表
+	// <p>消息消费情况列表</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MessageTracks []*MessageTrackItem `json:"MessageTracks,omitnil,omitempty" name:"MessageTracks"`
 
-	// 主题名称
+	// <p>主题名称</p>
 	ShowTopicName *string `json:"ShowTopicName,omitnil,omitempty" name:"ShowTopicName"`
 
-	// 消息消费情况列表总条数
+	// <p>轻量主题名称</p>
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
+
+	// <p>消息消费情况列表总条数</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MessageTracksCount *int64 `json:"MessageTracksCount,omitnil,omitempty" name:"MessageTracksCount"`
 
@@ -3600,13 +2740,13 @@ type DescribeMessageTraceRequestParams struct {
 	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 
-	// 消息 ID，从 [DescribeMessageList](https://cloud.tencent.com/document/api/1493/114593) 接口返回的 [MessageItem](https://cloud.tencent.com/document/api/1493/96031#MessageItem) 或业务日志中获得。
+	// <p>消息 ID，从 <a href="https://cloud.tencent.com/document/api/1493/114593">DescribeMessageList</a> 接口返回的 <a href="https://cloud.tencent.com/document/api/1493/96031#MessageItem">MessageItem</a> 或业务日志中获得。</p>
 	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
 
-	// 是否是死信消息，默认为false
+	// <p>是否是死信消息，默认为false</p>
 	QueryDeadLetterMessage *bool `json:"QueryDeadLetterMessage,omitnil,omitempty" name:"QueryDeadLetterMessage"`
 
-	// 是否是延时消息，默认为false
+	// <p>是否是延时消息，默认为false</p>
 	QueryDelayMessage *bool `json:"QueryDelayMessage,omitnil,omitempty" name:"QueryDelayMessage"`
 }
 
@@ -3619,13 +2759,13 @@ type DescribeMessageTraceRequest struct {
 	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 
-	// 消息 ID，从 [DescribeMessageList](https://cloud.tencent.com/document/api/1493/114593) 接口返回的 [MessageItem](https://cloud.tencent.com/document/api/1493/96031#MessageItem) 或业务日志中获得。
+	// <p>消息 ID，从 <a href="https://cloud.tencent.com/document/api/1493/114593">DescribeMessageList</a> 接口返回的 <a href="https://cloud.tencent.com/document/api/1493/96031#MessageItem">MessageItem</a> 或业务日志中获得。</p>
 	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
 
-	// 是否是死信消息，默认为false
+	// <p>是否是死信消息，默认为false</p>
 	QueryDeadLetterMessage *bool `json:"QueryDeadLetterMessage,omitnil,omitempty" name:"QueryDeadLetterMessage"`
 
-	// 是否是延时消息，默认为false
+	// <p>是否是延时消息，默认为false</p>
 	QueryDelayMessage *bool `json:"QueryDelayMessage,omitnil,omitempty" name:"QueryDelayMessage"`
 }
 
@@ -3654,10 +2794,13 @@ func (r *DescribeMessageTraceRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeMessageTraceResponseParams struct {
-	// 主题名称
+	// <p>主题名称</p>
 	ShowTopicName *string `json:"ShowTopicName,omitnil,omitempty" name:"ShowTopicName"`
 
-	// 轨迹详情
+	// <p>轻量主题名称</p>
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
+
+	// <p>轨迹详情</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Data []*MessageTraceItem `json:"Data,omitnil,omitempty" name:"Data"`
 
@@ -3924,26 +3067,26 @@ func (r *DescribeMigratingTopicStatsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeMigrationTaskListRequestParams struct {
-	// 查询条件列表
+	// 过滤查询条件列表，请在引用此参数的API说明中了解使用方法。
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 查询起始位置
+	// 查询起始位置，默认为0。
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 查询结果限制数量
+	// 查询结果限制数量，默认20。
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeMigrationTaskListRequest struct {
 	*tchttp.BaseRequest
 	
-	// 查询条件列表
+	// 过滤查询条件列表，请在引用此参数的API说明中了解使用方法。
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 查询起始位置
+	// 查询起始位置，默认为0。
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 查询结果限制数量
+	// 查询结果限制数量，默认20。
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
@@ -3994,6 +3137,94 @@ func (r *DescribeMigrationTaskListResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeMigrationTaskListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeProducerListRequestParams struct {
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 过滤查询条件列表，请在引用此参数的API说明中了解使用方法。
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 查询结果限制数量，默认20。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 查询起始位置，默认为0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+}
+
+type DescribeProducerListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 过滤查询条件列表，请在引用此参数的API说明中了解使用方法。
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 查询结果限制数量，默认20。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 查询起始位置，默认为0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+}
+
+func (r *DescribeProducerListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeProducerListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "Topic")
+	delete(f, "Filters")
+	delete(f, "Limit")
+	delete(f, "Offset")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeProducerListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeProducerListResponseParams struct {
+	// 查询总数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 生产者信息列表
+	ProducerList []*ProducerInfo `json:"ProducerList,omitnil,omitempty" name:"ProducerList"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeProducerListResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeProducerListResponseParams `json:"Response"`
+}
+
+func (r *DescribeProducerListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeProducerListResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -4382,6 +3613,9 @@ type DescribeTopicListRequestParams struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
+	// 标签过滤器
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
+
 	// 过滤查询条件列表，请在引用此参数的API说明中了解使用方法。
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
@@ -4390,6 +3624,9 @@ type DescribeTopicListRequestParams struct {
 
 	// 查询结果限制数量，默认20。
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 按照消费组查询订阅的主题
+	FromGroup *string `json:"FromGroup,omitnil,omitempty" name:"FromGroup"`
 }
 
 type DescribeTopicListRequest struct {
@@ -4398,6 +3635,9 @@ type DescribeTopicListRequest struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
+	// 标签过滤器
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
+
 	// 过滤查询条件列表，请在引用此参数的API说明中了解使用方法。
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
@@ -4406,6 +3646,9 @@ type DescribeTopicListRequest struct {
 
 	// 查询结果限制数量，默认20。
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 按照消费组查询订阅的主题
+	FromGroup *string `json:"FromGroup,omitnil,omitempty" name:"FromGroup"`
 }
 
 func (r *DescribeTopicListRequest) ToJsonString() string {
@@ -4421,9 +3664,11 @@ func (r *DescribeTopicListRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "InstanceId")
+	delete(f, "TagFilters")
 	delete(f, "Filters")
 	delete(f, "Offset")
 	delete(f, "Limit")
+	delete(f, "FromGroup")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTopicListRequest has unknown keys!", "")
 	}
@@ -4520,37 +3765,38 @@ func (r *DescribeTopicRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTopicResponseParams struct {
-	// 实例ID
+	// <p>实例ID</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 主题名称
+	// <p>主题名称</p>
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 
-	// 主题类型
-	// UNSPECIFIED:未指定,
-	// NORMAL:普通消息,
-	// FIFO:顺序消息,
-	// DELAY:延时消息,
-	// TRANSACTION:事务消息
+	// <p>主题类型<br>UNSPECIFIED:未指定,<br>NORMAL:普通消息,<br>FIFO:顺序消息,<br>DELAY:延时消息,<br>TRANSACTION:事务消息</p>
 	TopicType *string `json:"TopicType,omitnil,omitempty" name:"TopicType"`
 
-	// 备注
+	// <p>备注</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 创建时间，**Unix时间戳（毫秒）**
+	// <p>创建时间，<strong>Unix时间戳（毫秒）</strong></p>
 	CreatedTime *int64 `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
-	// 最后写入时间，**Unix时间戳（毫秒）**
+	// <p>最后写入时间，<strong>Unix时间戳（毫秒）</strong></p>
 	LastUpdateTime *int64 `json:"LastUpdateTime,omitnil,omitempty" name:"LastUpdateTime"`
 
-	// 订阅数量
+	// <p>订阅数量</p>
 	SubscriptionCount *int64 `json:"SubscriptionCount,omitnil,omitempty" name:"SubscriptionCount"`
 
-	// 订阅关系列表
+	// <p>订阅关系列表</p>
 	SubscriptionData []*SubscriptionData `json:"SubscriptionData,omitnil,omitempty" name:"SubscriptionData"`
 
-	// 消息保留时长，单位：小时
+	// <p>消息保留时长，单位：小时</p>
 	MsgTTL *int64 `json:"MsgTTL,omitnil,omitempty" name:"MsgTTL"`
+
+	// <p>是否自动删除</p><p>仅适用于轻量主题</p>
+	AutoExpireDelete *bool `json:"AutoExpireDelete,omitnil,omitempty" name:"AutoExpireDelete"`
+
+	// <p>自动过期时间</p><p>单位：分钟</p><p>仅适用于轻量主题</p>
+	AutoExpireTime *int64 `json:"AutoExpireTime,omitnil,omitempty" name:"AutoExpireTime"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -4569,6 +3815,94 @@ func (r *DescribeTopicResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeTopicResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTopicStatsRequestParams struct {
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组ID，可通过DescribeConsumerGroupList接口返回的ConsumerGroup字段或控制台查询</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// 查询起始位置，默认为0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 查询结果限制数量，默认20。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeTopicStatsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组ID，可通过DescribeConsumerGroupList接口返回的ConsumerGroup字段或控制台查询</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// 查询起始位置，默认为0。
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 查询结果限制数量，默认20。
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *DescribeTopicStatsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTopicStatsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Topic")
+	delete(f, "InstanceId")
+	delete(f, "GroupId")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTopicStatsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTopicStatsResponseParams struct {
+	// 查询总数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// <p>队列级别的消费详情</p>
+	Data []*TopicStatsDetail `json:"Data,omitnil,omitempty" name:"Data"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTopicStatsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTopicStatsResponseParams `json:"Response"`
+}
+
+func (r *DescribeTopicStatsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTopicStatsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -4599,7 +3933,7 @@ type DoHealthCheckOnMigratingTopicRequestParams struct {
 	// 主题名称，可在[DescribeMigratingTopicList](https://cloud.tencent.com/document/api/1493/118007)接口返回的[MigratingTopic](https://cloud.tencent.com/document/api/1493/96031#MigratingTopic)数据结构中获得。
 	TopicName *string `json:"TopicName,omitnil,omitempty" name:"TopicName"`
 
-	// 必填，是否忽略当前检查
+	// 是否忽略当前检查
 	IgnoreCheck *bool `json:"IgnoreCheck,omitnil,omitempty" name:"IgnoreCheck"`
 
 	// 命名空间，仅迁移至4.x集群有效，可在[DescribeMigratingTopicList](https://cloud.tencent.com/document/api/1493/118007)接口返回的[MigratingTopic](https://cloud.tencent.com/document/api/1493/96031#MigratingTopic)数据结构中获得。
@@ -4615,7 +3949,7 @@ type DoHealthCheckOnMigratingTopicRequest struct {
 	// 主题名称，可在[DescribeMigratingTopicList](https://cloud.tencent.com/document/api/1493/118007)接口返回的[MigratingTopic](https://cloud.tencent.com/document/api/1493/96031#MigratingTopic)数据结构中获得。
 	TopicName *string `json:"TopicName,omitnil,omitempty" name:"TopicName"`
 
-	// 必填，是否忽略当前检查
+	// 是否忽略当前检查
 	IgnoreCheck *bool `json:"IgnoreCheck,omitnil,omitempty" name:"IgnoreCheck"`
 
 	// 命名空间，仅迁移至4.x集群有效，可在[DescribeMigratingTopicList](https://cloud.tencent.com/document/api/1493/118007)接口返回的[MigratingTopic](https://cloud.tencent.com/document/api/1493/96031#MigratingTopic)数据结构中获得。
@@ -4841,6 +4175,14 @@ type FusionInstanceItem struct {
 
 	// 是否开启删除保护
 	EnableDeletionProtection *bool `json:"EnableDeletionProtection,omitnil,omitempty" name:"EnableDeletionProtection"`
+
+	// 实例创建时间
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 弹性TPS开关
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ScaledTpsEnabled *bool `json:"ScaledTpsEnabled,omitnil,omitempty" name:"ScaledTpsEnabled"`
 }
 
 // Predefined struct for user
@@ -5097,217 +4439,6 @@ type IpRule struct {
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 }
 
-type MQTTClientSubscription struct {
-	// topic 订阅
-	TopicFilter *string `json:"TopicFilter,omitnil,omitempty" name:"TopicFilter"`
-
-	// 服务质量等级
-	Qos *int64 `json:"Qos,omitnil,omitempty" name:"Qos"`
-}
-
-type MQTTEndpointItem struct {
-	// 类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
-
-	// 接入点
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Url *string `json:"Url,omitnil,omitempty" name:"Url"`
-
-	// vpc信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
-
-	// 子网信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
-
-	// 主机
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Host *string `json:"Host,omitnil,omitempty" name:"Host"`
-
-	// 端口
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Port *int64 `json:"Port,omitnil,omitempty" name:"Port"`
-
-	// 接入点ip
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Ip *string `json:"Ip,omitnil,omitempty" name:"Ip"`
-}
-
-type MQTTInstanceItem struct {
-	// 实例ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 实例名称
-	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
-
-	// 实例版本
-	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
-
-	// 实例类型，
-	// BASIC，基础版
-	// PRO，专业版
-	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
-
-	// 实例状态，
-	// RUNNING, 运行中
-	// MAINTAINING，维护中
-	// ABNORMAL，异常
-	// OVERDUE，欠费
-	// DESTROYED，已删除
-	// CREATING，创建中
-	// MODIFYING，变配中
-	// CREATE_FAILURE，创建失败
-	// MODIFY_FAILURE，变配失败
-	// DELETING，删除中
-	InstanceStatus *string `json:"InstanceStatus,omitnil,omitempty" name:"InstanceStatus"`
-
-	// 实例主题数上限
-	TopicNumLimit *int64 `json:"TopicNumLimit,omitnil,omitempty" name:"TopicNumLimit"`
-
-	// 备注信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-
-	// 主题数量
-	TopicNum *int64 `json:"TopicNum,omitnil,omitempty" name:"TopicNum"`
-
-	// 商品规格
-	SkuCode *string `json:"SkuCode,omitnil,omitempty" name:"SkuCode"`
-
-	// 弹性TPS限流值
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TpsLimit *int64 `json:"TpsLimit,omitnil,omitempty" name:"TpsLimit"`
-
-	// 创建时间
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
-
-	// 订阅关系上限
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SubscriptionNumLimit *int64 `json:"SubscriptionNumLimit,omitnil,omitempty" name:"SubscriptionNumLimit"`
-
-	// 客户端连接数上线
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ClientNumLimit *int64 `json:"ClientNumLimit,omitnil,omitempty" name:"ClientNumLimit"`
-}
-
-type MQTTMessageItem struct {
-	// 消息ID
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
-
-	// 消息tag
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Tags *string `json:"Tags,omitnil,omitempty" name:"Tags"`
-
-	// 消息key
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Keys *string `json:"Keys,omitnil,omitempty" name:"Keys"`
-
-	// 客户端地址	
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ProducerAddr *string `json:"ProducerAddr,omitnil,omitempty" name:"ProducerAddr"`
-
-	// 消息发送时间	
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ProduceTime *string `json:"ProduceTime,omitnil,omitempty" name:"ProduceTime"`
-
-	// 死信重发次数	
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	DeadLetterResendTimes *int64 `json:"DeadLetterResendTimes,omitnil,omitempty" name:"DeadLetterResendTimes"`
-
-	// 死信重发成功次数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	DeadLetterResendSuccessTimes *int64 `json:"DeadLetterResendSuccessTimes,omitnil,omitempty" name:"DeadLetterResendSuccessTimes"`
-
-	// 子topic
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SubTopic *string `json:"SubTopic,omitnil,omitempty" name:"SubTopic"`
-
-	// 消息质量等级
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Qos *string `json:"Qos,omitnil,omitempty" name:"Qos"`
-}
-
-type MQTTProductSkuItem struct {
-	// 类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
-
-	// cide
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SkuCode *string `json:"SkuCode,omitnil,omitempty" name:"SkuCode"`
-
-	// sale
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	OnSale *bool `json:"OnSale,omitnil,omitempty" name:"OnSale"`
-
-	// topic num限制
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TopicNumLimit *int64 `json:"TopicNumLimit,omitnil,omitempty" name:"TopicNumLimit"`
-
-	// tps
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TpsLimit *int64 `json:"TpsLimit,omitnil,omitempty" name:"TpsLimit"`
-
-	// 客户端连接数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ClientNumLimit *int64 `json:"ClientNumLimit,omitnil,omitempty" name:"ClientNumLimit"`
-
-	// 订阅数限制
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SubscriptionNumLimit *int64 `json:"SubscriptionNumLimit,omitnil,omitempty" name:"SubscriptionNumLimit"`
-
-	// 代理核
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ProxySpecCore *int64 `json:"ProxySpecCore,omitnil,omitempty" name:"ProxySpecCore"`
-
-	// 代理内存
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ProxySpecMemory *int64 `json:"ProxySpecMemory,omitnil,omitempty" name:"ProxySpecMemory"`
-
-	// 代理总数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ProxySpecCount *int64 `json:"ProxySpecCount,omitnil,omitempty" name:"ProxySpecCount"`
-}
-
-type MQTTTopicItem struct {
-	// 实例 ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 主题描述
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-type MQTTUserItem struct {
-	// 用户名
-	Username *string `json:"Username,omitnil,omitempty" name:"Username"`
-
-	// 密码
-	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
-
-	// 是否开启消费
-	PermRead *bool `json:"PermRead,omitnil,omitempty" name:"PermRead"`
-
-	// 是否开启生产
-	PermWrite *bool `json:"PermWrite,omitnil,omitempty" name:"PermWrite"`
-
-	// 备注信息
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-
-	// 创建时间，秒为单位
-	CreatedTime *int64 `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
-
-	// 修改时间，秒为单位
-	ModifiedTime *int64 `json:"ModifiedTime,omitnil,omitempty" name:"ModifiedTime"`
-}
-
 type MessageItem struct {
 	// 消息ID
 	// 注意：此字段可能返回 null，表示取不到有效值。
@@ -5367,6 +4498,12 @@ type MessageTrackItem struct {
 	// 异常信息
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ExceptionDesc *string `json:"ExceptionDesc,omitnil,omitempty" name:"ExceptionDesc"`
+
+	// 消费状态来源，枚举值如下：
+	// 
+	// - DIFF_OFFSET：通过服务端offset计算
+	// - TRACE_REPORT：通过上报的轨迹判断
+	ConsumeStatusSource *string `json:"ConsumeStatusSource,omitnil,omitempty" name:"ConsumeStatusSource"`
 }
 
 type MigratingTopic struct {
@@ -5435,9 +4572,6 @@ type ModifyConsumerGroupRequestParams struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 消费组名称，从 [DescribeConsumerGroupList](https://cloud.tencent.com/document/api/1493/101535) 接口返回的 [ConsumeGroupItem](https://cloud.tencent.com/document/api/1493/96031#ConsumeGroupItem) 或控制台获得。
-	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
-
 	// 是否开启消费
 	ConsumeEnable *bool `json:"ConsumeEnable,omitnil,omitempty" name:"ConsumeEnable"`
 
@@ -5445,11 +4579,17 @@ type ModifyConsumerGroupRequestParams struct {
 	// 并发投递：false
 	ConsumeMessageOrderly *bool `json:"ConsumeMessageOrderly,omitnil,omitempty" name:"ConsumeMessageOrderly"`
 
+	// 消费组名称，从 [DescribeConsumerGroupList](https://cloud.tencent.com/document/api/1493/101535) 接口返回的 [ConsumeGroupItem](https://cloud.tencent.com/document/api/1493/96031#ConsumeGroupItem) 或控制台获得。
+	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
+
 	// 最大重试次数，取值范围0～1000
 	MaxRetryTimes *int64 `json:"MaxRetryTimes,omitnil,omitempty" name:"MaxRetryTimes"`
 
 	// 备注信息，最多 128 个字符
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+
+	// 重试策略
+	RetryPolicy *RetryPolicy `json:"RetryPolicy,omitnil,omitempty" name:"RetryPolicy"`
 }
 
 type ModifyConsumerGroupRequest struct {
@@ -5458,9 +4598,6 @@ type ModifyConsumerGroupRequest struct {
 	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 消费组名称，从 [DescribeConsumerGroupList](https://cloud.tencent.com/document/api/1493/101535) 接口返回的 [ConsumeGroupItem](https://cloud.tencent.com/document/api/1493/96031#ConsumeGroupItem) 或控制台获得。
-	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
-
 	// 是否开启消费
 	ConsumeEnable *bool `json:"ConsumeEnable,omitnil,omitempty" name:"ConsumeEnable"`
 
@@ -5468,11 +4605,17 @@ type ModifyConsumerGroupRequest struct {
 	// 并发投递：false
 	ConsumeMessageOrderly *bool `json:"ConsumeMessageOrderly,omitnil,omitempty" name:"ConsumeMessageOrderly"`
 
+	// 消费组名称，从 [DescribeConsumerGroupList](https://cloud.tencent.com/document/api/1493/101535) 接口返回的 [ConsumeGroupItem](https://cloud.tencent.com/document/api/1493/96031#ConsumeGroupItem) 或控制台获得。
+	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
+
 	// 最大重试次数，取值范围0～1000
 	MaxRetryTimes *int64 `json:"MaxRetryTimes,omitnil,omitempty" name:"MaxRetryTimes"`
 
 	// 备注信息，最多 128 个字符
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+
+	// 重试策略
+	RetryPolicy *RetryPolicy `json:"RetryPolicy,omitnil,omitempty" name:"RetryPolicy"`
 }
 
 func (r *ModifyConsumerGroupRequest) ToJsonString() string {
@@ -5488,11 +4631,12 @@ func (r *ModifyConsumerGroupRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "InstanceId")
-	delete(f, "ConsumerGroup")
 	delete(f, "ConsumeEnable")
 	delete(f, "ConsumeMessageOrderly")
+	delete(f, "ConsumerGroup")
 	delete(f, "MaxRetryTimes")
 	delete(f, "Remark")
+	delete(f, "RetryPolicy")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyConsumerGroupRequest has unknown keys!", "")
 	}
@@ -5646,6 +4790,9 @@ type ModifyInstanceRequestParams struct {
 
 	// 是否开启删除保护
 	EnableDeletionProtection *bool `json:"EnableDeletionProtection,omitnil,omitempty" name:"EnableDeletionProtection"`
+
+	// 部署可用区列表
+	ZoneIds []*string `json:"ZoneIds,omitnil,omitempty" name:"ZoneIds"`
 }
 
 type ModifyInstanceRequest struct {
@@ -5690,6 +4837,9 @@ type ModifyInstanceRequest struct {
 
 	// 是否开启删除保护
 	EnableDeletionProtection *bool `json:"EnableDeletionProtection,omitnil,omitempty" name:"EnableDeletionProtection"`
+
+	// 部署可用区列表
+	ZoneIds []*string `json:"ZoneIds,omitnil,omitempty" name:"ZoneIds"`
 }
 
 func (r *ModifyInstanceRequest) ToJsonString() string {
@@ -5715,6 +4865,7 @@ func (r *ModifyInstanceRequest) FromJsonString(s string) error {
 	delete(f, "MaxTopicNum")
 	delete(f, "ExtraTopicNum")
 	delete(f, "EnableDeletionProtection")
+	delete(f, "ZoneIds")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyInstanceRequest has unknown keys!", "")
 	}
@@ -5740,360 +4891,6 @@ func (r *ModifyInstanceResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyInstanceResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTInsPublicEndpointRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 带宽
-	Bandwidth *int64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
-
-	// 公网访问规则
-	Rules []*PublicAccessRule `json:"Rules,omitnil,omitempty" name:"Rules"`
-}
-
-type ModifyMQTTInsPublicEndpointRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 带宽
-	Bandwidth *int64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
-
-	// 公网访问规则
-	Rules []*PublicAccessRule `json:"Rules,omitnil,omitempty" name:"Rules"`
-}
-
-func (r *ModifyMQTTInsPublicEndpointRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTInsPublicEndpointRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Bandwidth")
-	delete(f, "Rules")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyMQTTInsPublicEndpointRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTInsPublicEndpointResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type ModifyMQTTInsPublicEndpointResponse struct {
-	*tchttp.BaseResponse
-	Response *ModifyMQTTInsPublicEndpointResponseParams `json:"Response"`
-}
-
-func (r *ModifyMQTTInsPublicEndpointResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTInsPublicEndpointResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTInstanceCertBindingRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 服务端证书id
-	SSLServerCertId *string `json:"SSLServerCertId,omitnil,omitempty" name:"SSLServerCertId"`
-
-	// CA证书id
-	SSLCaCertId *string `json:"SSLCaCertId,omitnil,omitempty" name:"SSLCaCertId"`
-}
-
-type ModifyMQTTInstanceCertBindingRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 服务端证书id
-	SSLServerCertId *string `json:"SSLServerCertId,omitnil,omitempty" name:"SSLServerCertId"`
-
-	// CA证书id
-	SSLCaCertId *string `json:"SSLCaCertId,omitnil,omitempty" name:"SSLCaCertId"`
-}
-
-func (r *ModifyMQTTInstanceCertBindingRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTInstanceCertBindingRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "SSLServerCertId")
-	delete(f, "SSLCaCertId")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyMQTTInstanceCertBindingRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTInstanceCertBindingResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type ModifyMQTTInstanceCertBindingResponse struct {
-	*tchttp.BaseResponse
-	Response *ModifyMQTTInstanceCertBindingResponseParams `json:"Response"`
-}
-
-func (r *ModifyMQTTInstanceCertBindingResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTInstanceCertBindingResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTInstanceRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 实例名称
-	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
-
-	// 备注信息
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-type ModifyMQTTInstanceRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 实例名称
-	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
-
-	// 备注信息
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-func (r *ModifyMQTTInstanceRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTInstanceRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Name")
-	delete(f, "Remark")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyMQTTInstanceRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTInstanceResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type ModifyMQTTInstanceResponse struct {
-	*tchttp.BaseResponse
-	Response *ModifyMQTTInstanceResponseParams `json:"Response"`
-}
-
-func (r *ModifyMQTTInstanceResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTInstanceResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTTopicRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 备注信息
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-type ModifyMQTTTopicRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 主题名称
-	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
-
-	// 备注信息
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-func (r *ModifyMQTTTopicRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTTopicRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Topic")
-	delete(f, "Remark")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyMQTTTopicRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTTopicResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type ModifyMQTTTopicResponse struct {
-	*tchttp.BaseResponse
-	Response *ModifyMQTTTopicResponseParams `json:"Response"`
-}
-
-func (r *ModifyMQTTTopicResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTTopicResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTUserRequestParams struct {
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 用户名
-	Username *string `json:"Username,omitnil,omitempty" name:"Username"`
-
-	// 是否开启消费
-	PermRead *bool `json:"PermRead,omitnil,omitempty" name:"PermRead"`
-
-	// 是否开启生产
-	PermWrite *bool `json:"PermWrite,omitnil,omitempty" name:"PermWrite"`
-
-	// 备注
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-type ModifyMQTTUserRequest struct {
-	*tchttp.BaseRequest
-	
-	// 集群ID
-	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
-
-	// 用户名
-	Username *string `json:"Username,omitnil,omitempty" name:"Username"`
-
-	// 是否开启消费
-	PermRead *bool `json:"PermRead,omitnil,omitempty" name:"PermRead"`
-
-	// 是否开启生产
-	PermWrite *bool `json:"PermWrite,omitnil,omitempty" name:"PermWrite"`
-
-	// 备注
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
-}
-
-func (r *ModifyMQTTUserRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTUserRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "InstanceId")
-	delete(f, "Username")
-	delete(f, "PermRead")
-	delete(f, "PermWrite")
-	delete(f, "Remark")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyMQTTUserRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type ModifyMQTTUserResponseParams struct {
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type ModifyMQTTUserResponse struct {
-	*tchttp.BaseResponse
-	Response *ModifyMQTTUserResponseParams `json:"Response"`
-}
-
-func (r *ModifyMQTTUserResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *ModifyMQTTUserResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -6201,14 +4998,20 @@ type ModifyTopicRequestParams struct {
 	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 
-	// 队列数量，取值范围3～16
+	// <p>队列数量，取值范围3～16</p>
 	QueueNum *int64 `json:"QueueNum,omitnil,omitempty" name:"QueueNum"`
 
-	// 备注信息，最多 128 个字符
+	// <p>备注信息，最多 128 个字符</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 消息保留时长（单位：小时）
+	// <p>消息保留时长（单位：小时）</p>
 	MsgTTL *int64 `json:"MsgTTL,omitnil,omitempty" name:"MsgTTL"`
+
+	// <p>是否过期自动删除（仅针对轻量主题类型）</p>
+	AutoExpireDelete *bool `json:"AutoExpireDelete,omitnil,omitempty" name:"AutoExpireDelete"`
+
+	// <p>过期时间（仅针对轻量主题类型）</p><p>取值范围：[30, 720]</p><p>单位：分钟</p>
+	AutoExpireTime *int64 `json:"AutoExpireTime,omitnil,omitempty" name:"AutoExpireTime"`
 }
 
 type ModifyTopicRequest struct {
@@ -6220,14 +5023,20 @@ type ModifyTopicRequest struct {
 	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 
-	// 队列数量，取值范围3～16
+	// <p>队列数量，取值范围3～16</p>
 	QueueNum *int64 `json:"QueueNum,omitnil,omitempty" name:"QueueNum"`
 
-	// 备注信息，最多 128 个字符
+	// <p>备注信息，最多 128 个字符</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 消息保留时长（单位：小时）
+	// <p>消息保留时长（单位：小时）</p>
 	MsgTTL *int64 `json:"MsgTTL,omitnil,omitempty" name:"MsgTTL"`
+
+	// <p>是否过期自动删除（仅针对轻量主题类型）</p>
+	AutoExpireDelete *bool `json:"AutoExpireDelete,omitnil,omitempty" name:"AutoExpireDelete"`
+
+	// <p>过期时间（仅针对轻量主题类型）</p><p>取值范围：[30, 720]</p><p>单位：分钟</p>
+	AutoExpireTime *int64 `json:"AutoExpireTime,omitnil,omitempty" name:"AutoExpireTime"`
 }
 
 func (r *ModifyTopicRequest) ToJsonString() string {
@@ -6247,6 +5056,8 @@ func (r *ModifyTopicRequest) FromJsonString(s string) error {
 	delete(f, "QueueNum")
 	delete(f, "Remark")
 	delete(f, "MsgTTL")
+	delete(f, "AutoExpireDelete")
+	delete(f, "AutoExpireTime")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyTopicRequest has unknown keys!", "")
 	}
@@ -6275,20 +5086,6 @@ func (r *ModifyTopicResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type PacketStatistics struct {
-	// 类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	MessageType *string `json:"MessageType,omitnil,omitempty" name:"MessageType"`
-
-	// 服务质量
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Qos *int64 `json:"Qos,omitnil,omitempty" name:"Qos"`
-
-	// 指标值
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Count *int64 `json:"Count,omitnil,omitempty" name:"Count"`
-}
-
 type PriceTag struct {
 	// 计价名称（枚举值：tps：TPS基础价；stepTps：TPS步长）
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
@@ -6296,6 +5093,48 @@ type PriceTag struct {
 	// 计费项对应的步长数
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Step *int64 `json:"Step,omitnil,omitempty" name:"Step"`
+}
+
+type ProducerInfo struct {
+	// 客户端ID	
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ClientId *string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
+
+	// 客户端IP	
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ClientIp *string `json:"ClientIp,omitnil,omitempty" name:"ClientIp"`
+
+	// 客户端语言 
+	// - JAVA((byte) 0)
+	// - CPP((byte) 1) 
+	// - DOTNET((byte) 2) 
+	// - PYTHON((byte) 3)
+	// - DELPHI((byte) 4)
+	// - ERLANG((byte) 5)
+	// - RUBY((byte) 6)
+	// - OTHER((byte) 7)
+	// - HTTP((byte) 8)
+	// - GO((byte) 9)
+	// - PHP((byte) 10)
+	// - OMS((byte) 11)
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Language *string `json:"Language,omitnil,omitempty" name:"Language"`
+
+	// 客户端版本	
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
+
+	// 最后生产时间，**Unix时间戳（秒）**
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	LastUpdateTimestamp *uint64 `json:"LastUpdateTimestamp,omitnil,omitempty" name:"LastUpdateTimestamp"`
+
+	// 生产者客户端协议类型，枚举如下：
+	// 
+	// - grpc：GRpc协议
+	// - remoting：Remoting协议
+	// - http：HTTP协议
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ChannelProtocol *string `json:"ChannelProtocol,omitnil,omitempty" name:"ChannelProtocol"`
 }
 
 type ProductSKU struct {
@@ -6343,18 +5182,91 @@ type ProductSKU struct {
 	TopicNumUpperLimit *int64 `json:"TopicNumUpperLimit,omitnil,omitempty" name:"TopicNumUpperLimit"`
 }
 
-type PublicAccessRule struct {
-	// ip网段信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	IpRule *string `json:"IpRule,omitnil,omitempty" name:"IpRule"`
+// Predefined struct for user
+type PutConsumerRouteConfigRequestParams struct {
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 
-	// 允许或者拒绝
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Allow *bool `json:"Allow,omitnil,omitempty" name:"Allow"`
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 备注信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+
+	// <p>路由规则</p>
+	Rules []*RouteRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+}
+
+type PutConsumerRouteConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+
+	// <p>路由规则</p>
+	Rules []*RouteRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+}
+
+func (r *PutConsumerRouteConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *PutConsumerRouteConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Topic")
+	delete(f, "InstanceId")
+	delete(f, "Group")
+	delete(f, "Rules")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "PutConsumerRouteConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type PutConsumerRouteConfigResponseParams struct {
+	// <p>实例 ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>主题</p>
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// <p>消费组</p>
+	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
+
+	// <p>版本号</p>
+	Version *int64 `json:"Version,omitnil,omitempty" name:"Version"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type PutConsumerRouteConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *PutConsumerRouteConfigResponseParams `json:"Response"`
+}
+
+func (r *PutConsumerRouteConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *PutConsumerRouteConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
@@ -6572,6 +5484,17 @@ func (r *ResetConsumerGroupOffsetResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type RetryPolicy struct {
+	// 重试策略类型，枚举值如下：
+	// 
+	// - EXPONENTIAL：固定间隔
+	// - CUSTOMIZED：阶梯退避
+	PolicyType *string `json:"PolicyType,omitnil,omitempty" name:"PolicyType"`
+
+	// 固定重试间隔，仅在重试策略为固定间隔时生效
+	RetryInterval *int64 `json:"RetryInterval,omitnil,omitempty" name:"RetryInterval"`
+}
+
 type RoleItem struct {
 	// 角色名称
 	RoleName *string `json:"RoleName,omitnil,omitempty" name:"RoleName"`
@@ -6670,6 +5593,120 @@ func (r *RollbackMigratingTopicStageResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *RollbackMigratingTopicStageResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+type RouteRule struct {
+	// <p>路由匹配条件</p>
+	MatchCondition *string `json:"MatchCondition,omitnil,omitempty" name:"MatchCondition"`
+
+	// <p>标签</p>
+	TargetConsumerLabel *string `json:"TargetConsumerLabel,omitnil,omitempty" name:"TargetConsumerLabel"`
+}
+
+type RouteRuleVersion struct {
+	// <p>版本号</p>
+	Version *int64 `json:"Version,omitnil,omitempty" name:"Version"`
+
+	// <p>切流时间戳</p><p>单位：毫秒（ms）</p>
+	CutTimestamp *int64 `json:"CutTimestamp,omitnil,omitempty" name:"CutTimestamp"`
+
+	// <p>更新时间戳</p><p>单位：毫秒（ms）</p>
+	UpdatedAt *int64 `json:"UpdatedAt,omitnil,omitempty" name:"UpdatedAt"`
+
+	// <p>路由规则列表</p>
+	Rules []*RouteRule `json:"Rules,omitnil,omitempty" name:"Rules"`
+}
+
+// Predefined struct for user
+type SendMessageRequestParams struct {
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 消息内容
+	MsgBody *string `json:"MsgBody,omitnil,omitempty" name:"MsgBody"`
+
+	// 消息Key
+	MsgKey *string `json:"MsgKey,omitnil,omitempty" name:"MsgKey"`
+
+	// 消息Tag
+	MsgTag *string `json:"MsgTag,omitnil,omitempty" name:"MsgTag"`
+
+	// 轻量主题
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
+}
+
+type SendMessageRequest struct {
+	*tchttp.BaseRequest
+	
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 消息内容
+	MsgBody *string `json:"MsgBody,omitnil,omitempty" name:"MsgBody"`
+
+	// 消息Key
+	MsgKey *string `json:"MsgKey,omitnil,omitempty" name:"MsgKey"`
+
+	// 消息Tag
+	MsgTag *string `json:"MsgTag,omitnil,omitempty" name:"MsgTag"`
+
+	// 轻量主题
+	LiteTopic *string `json:"LiteTopic,omitnil,omitempty" name:"LiteTopic"`
+}
+
+func (r *SendMessageRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *SendMessageRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "Topic")
+	delete(f, "MsgBody")
+	delete(f, "MsgKey")
+	delete(f, "MsgTag")
+	delete(f, "LiteTopic")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "SendMessageRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type SendMessageResponseParams struct {
+	// 消息ID
+	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type SendMessageResponse struct {
+	*tchttp.BaseResponse
+	Response *SendMessageResponseParams `json:"Response"`
+}
+
+func (r *SendMessageResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *SendMessageResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -6811,16 +5848,6 @@ type SourceClusterTopicConfig struct {
 
 	// 4.x的完整命名空间，出参使用
 	FullNamespaceV4 *string `json:"FullNamespaceV4,omitnil,omitempty" name:"FullNamespaceV4"`
-}
-
-type StatisticsReport struct {
-	// 字节数
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Bytes *int64 `json:"Bytes,omitnil,omitempty" name:"Bytes"`
-
-	// 监控指标
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Items []*PacketStatistics `json:"Items,omitnil,omitempty" name:"Items"`
 }
 
 type SubscriptionData struct {
@@ -6980,6 +6007,9 @@ type TopicItem struct {
 
 	// 消息保留时长
 	MsgTTL *int64 `json:"MsgTTL,omitnil,omitempty" name:"MsgTTL"`
+
+	// 绑定的标签列表
+	TagList []*Tag `json:"TagList,omitnil,omitempty" name:"TagList"`
 }
 
 type TopicStageChangeResult struct {
@@ -6993,10 +6023,126 @@ type TopicStageChangeResult struct {
 	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
 }
 
+type TopicStatsDetail struct {
+	// <p>Broker节点名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	BrokerName *string `json:"BrokerName,omitnil,omitempty" name:"BrokerName"`
+
+	// <p>队列编号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	QueueId *int64 `json:"QueueId,omitnil,omitempty" name:"QueueId"`
+
+	// <p>生产消息位点</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	BrokerOffset *int64 `json:"BrokerOffset,omitnil,omitempty" name:"BrokerOffset"`
+
+	// <p>最新消费位点</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CommitOffset *int64 `json:"CommitOffset,omitnil,omitempty" name:"CommitOffset"`
+
+	// <p>堆积总数</p><p>单位：条</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MessageCount *int64 `json:"MessageCount,omitnil,omitempty" name:"MessageCount"`
+
+	// <p>最后消费时间</p><p>单位：毫秒</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	LastUpdateTimestamp *int64 `json:"LastUpdateTimestamp,omitnil,omitempty" name:"LastUpdateTimestamp"`
+}
+
+// Predefined struct for user
+type VerifyMessageConsumptionRequestParams struct {
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 消息ID
+	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
+
+	// 客户端 ID，不指定该参数时消息将被发送到对应消费组内任意客户端
+	ClientId *string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
+
+	// 消费组名称，从 [DescribeConsumerGroupList](https://cloud.tencent.com/document/api/1493/101535) 接口返回的 [ConsumeGroupItem](https://cloud.tencent.com/document/api/1493/96031#ConsumeGroupItem) 或控制台获得。
+	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
+}
+
+type VerifyMessageConsumptionRequest struct {
+	*tchttp.BaseRequest
+	
+	// 腾讯云 RocketMQ 实例 ID，从 [DescribeFusionInstanceList](https://cloud.tencent.com/document/api/1493/106745) 接口或控制台获得。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// 主题名称，从 [DescribeTopicList](https://cloud.tencent.com/document/api/1493/96030) 接口返回的 [TopicItem](https://cloud.tencent.com/document/api/1493/96031#TopicItem) 或控制台获得。
+	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
+
+	// 消息ID
+	MsgId *string `json:"MsgId,omitnil,omitempty" name:"MsgId"`
+
+	// 客户端 ID，不指定该参数时消息将被发送到对应消费组内任意客户端
+	ClientId *string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
+
+	// 消费组名称，从 [DescribeConsumerGroupList](https://cloud.tencent.com/document/api/1493/101535) 接口返回的 [ConsumeGroupItem](https://cloud.tencent.com/document/api/1493/96031#ConsumeGroupItem) 或控制台获得。
+	ConsumerGroup *string `json:"ConsumerGroup,omitnil,omitempty" name:"ConsumerGroup"`
+}
+
+func (r *VerifyMessageConsumptionRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *VerifyMessageConsumptionRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "Topic")
+	delete(f, "MsgId")
+	delete(f, "ClientId")
+	delete(f, "ConsumerGroup")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "VerifyMessageConsumptionRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type VerifyMessageConsumptionResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type VerifyMessageConsumptionResponse struct {
+	*tchttp.BaseResponse
+	Response *VerifyMessageConsumptionResponseParams `json:"Response"`
+}
+
+func (r *VerifyMessageConsumptionResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *VerifyMessageConsumptionResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type VpcInfo struct {
 	// VPC ID
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
 	// 子网ID
 	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
+}
+
+type ZoneScheduledItem struct {
+	// 可用区ID
+	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
+
+	// 有剔除的调度任务且没有切回的可用区时，该值为true，反之为false
+	NodePermWipeFlag *bool `json:"NodePermWipeFlag,omitnil,omitempty" name:"NodePermWipeFlag"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1452,7 +1452,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc/v20230321
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke/v20180525
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke/v20220501
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.1.0
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.3.129
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket/v20230308
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tse v1.0.857

--- a/website/docs/r/trocket_rocketmq_instance.html.markdown
+++ b/website/docs/r/trocket_rocketmq_instance.html.markdown
@@ -11,8 +11,6 @@ description: |-
 
 Provides a resource to create a Trocket rocketmq instance
 
-~> **NOTE:** It only supports create postpaid rocketmq 5.x instance.
-
 ## Example Usage
 
 ### Create Basic Instance
@@ -125,7 +123,7 @@ resource "tencentcloud_trocket_rocketmq_instance" "example" {
   renew_flag    = 1
   time_span     = 12
   max_topic_num = 1000
-  zone_ids      = [100003]
+  zone_ids      = [100006, 100007]
   tags = {
     tag_key   = "rocketmq"
     tag_value = "5.x"
@@ -137,28 +135,28 @@ resource "tencentcloud_trocket_rocketmq_instance" "example" {
 
 The following arguments are supported:
 
-* `instance_type` - (Required, String) Instance type. Valid values: `EXPERIMENT`, `BASIC`, `PRO`, `PLATINUM`.
-* `name` - (Required, String) Instance name.
-* `sku_code` - (Required, String) SKU code. Available specifications are as follows: experiment_500, basic_1k, basic_2k, basic_3k, basic_4k, basic_5k, basic_6k, basic_7k, basic_8k, basic_9k, basic_10k, pro_4k, pro_6k, pro_8k, pro_1w, pro_15k, pro_2w, pro_25k, pro_3w, pro_35k, pro_4w, pro_45k, pro_5w, pro_55k, pro_60k, pro_65k, pro_70k, pro_75k, pro_80k, pro_85k, pro_90k, pro_95k, pro_100k, platinum_1w, platinum_2w, platinum_3w, platinum_4w, platinum_5w, platinum_6w, platinum_7w, platinum_8w, platinum_9w, platinum_10w, platinum_12w, platinum_14w, platinum_16w, platinum_18w, platinum_20w, platinum_25w, platinum_30w, platinum_35w, platinum_40w, platinum_45w, platinum_50w, platinum_60w, platinum_70w, platinum_80w, platinum_90w, platinum_100w.
-* `subnet_id` - (Required, String) Subnet id.
-* `vpc_id` - (Required, String) VPC id.
-* `bandwidth` - (Optional, Int) Public network bandwidth. `bandwidth` must be greater than zero when `enable_public` equal true.
-* `enable_public` - (Optional, Bool) Whether to enable the public network. Must set `bandwidth` when `enable_public` equal true.
-* `ip_rules` - (Optional, List) Public network access whitelist.
-* `max_topic_num` - (Optional, Int) Maximum number of topics that can be created.
-* `message_retention` - (Optional, Int) Message retention time in hours.
-* `pay_mode` - (Optional, Int) Billing mode (0: pay-as-you-go; 1: subscription). Default value is 0.
-* `remark` - (Optional, String) Remark.
-* `renew_flag` - (Optional, Int) Whether to auto-renew a subscription instance (0: no auto-renewal; 1: auto-renewal). Default value is 0.
-* `tags` - (Optional, Map) Tag description list.
-* `time_span` - (Optional, Int) Purchase duration of a subscription instance in months. Value range: 1-60. Default value is 1.
-* `zone_ids` - (Optional, List: [`Int`]) List of deployment availability zones.
+* `instance_type` - (Required, String) Instance type. Valid values: `EXPERIMENT` (trial edition), `BASIC` (basic edition), `PRO` (professional edition), `PLATINUM` (platinum edition).
+* `name` - (Required, String) Instance (cluster) name, 3-64 characters, can only contain digits, letters, hyphen '-' and underscore '_'.
+* `sku_code` - (Required, String) SKU code, obtained from the ProductSKU output of the DescribeProductSKUs interface.
+* `subnet_id` - (Required, String) Subnet ID that the instance binds to.
+* `vpc_id` - (Required, String) VPC ID that the instance binds to.
+* `bandwidth` - (Optional, Int) Public network bandwidth in Mbps, default 0. Must be a positive integer greater than 0 when public network is enabled.
+* `enable_public` - (Optional, Bool) Whether to enable public network access, default false. When set to true, `bandwidth` must be set to a positive integer.
+* `ip_rules` - (Optional, List) Public network access whitelist. If left empty, all IP access is denied.
+* `max_topic_num` - (Optional, Int) Maximum number of topics that can be created. The default/minimum and maximum are obtained from the TopicNumLimit and TopicNumUpperLimit parameters in the ProductSKU output of the DescribeProductSKUs interface.
+* `message_retention` - (Optional, Int) Message retention time in hours. The value range and default are obtained from the DefaultRetention/RetentionLowerLimit/RetentionUpperLimit parameters in the ProductSKU output of the DescribeProductSKUs interface.
+* `pay_mode` - (Optional, Int) Billing mode. `0`: pay-as-you-go (postpaid), `1`: subscription (prepaid). Default is `0`.
+* `remark` - (Optional, String) Remark information.
+* `renew_flag` - (Optional, Int) Whether to auto-renew a prepaid instance. `0`: no auto-renewal, `1`: auto-renewal. Default is `0`.
+* `tags` - (Optional, Map) Tag list.
+* `time_span` - (Optional, Int) Purchase duration of a prepaid instance in months. Value range: 1-60. Default is `1`.
+* `zone_ids` - (Optional, List: [`Int`]) List of deployment availability zones, obtained from the ZoneInfo structure returned by the DescribeZones interface.
 
 The `ip_rules` object supports the following:
 
-* `allow` - (Required, Bool) Whether to allow release or not.
-* `ip` - (Required, String) IP.
-* `remark` - (Required, String) Remark.
+* `allow` - (Required, Bool) Whether to allow access from this IP.
+* `ip` - (Required, String) IP address.
+* `remark` - (Required, String) Remark information.
 
 ## Attributes Reference
 

--- a/website/docs/r/trocket_rocketmq_instance.html.markdown
+++ b/website/docs/r/trocket_rocketmq_instance.html.markdown
@@ -95,6 +95,44 @@ resource "tencentcloud_trocket_rocketmq_instance" "example" {
 }
 ```
 
+### Create Instance with Billing and Deployment Params
+
+```hcl
+# create vpc
+resource "tencentcloud_vpc" "vpc" {
+  name       = "vpc"
+  cidr_block = "10.0.0.0/16"
+}
+
+# create vpc subnet
+resource "tencentcloud_subnet" "subnet" {
+  name              = "subnet"
+  vpc_id            = tencentcloud_vpc.vpc.id
+  availability_zone = "ap-guangzhou-6"
+  cidr_block        = "10.0.20.0/28"
+  is_multicast      = false
+}
+
+# create rocketmq instance with billing and deployment params
+resource "tencentcloud_trocket_rocketmq_instance" "example" {
+  name          = "tf-example"
+  instance_type = "PRO"
+  sku_code      = "pro_4k"
+  remark        = "remark"
+  vpc_id        = tencentcloud_vpc.vpc.id
+  subnet_id     = tencentcloud_subnet.subnet.id
+  pay_mode      = 1
+  renew_flag    = 1
+  time_span     = 12
+  max_topic_num = 1000
+  zone_ids      = [100003]
+  tags = {
+    tag_key   = "rocketmq"
+    tag_value = "5.x"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -107,9 +145,14 @@ The following arguments are supported:
 * `bandwidth` - (Optional, Int) Public network bandwidth. `bandwidth` must be greater than zero when `enable_public` equal true.
 * `enable_public` - (Optional, Bool) Whether to enable the public network. Must set `bandwidth` when `enable_public` equal true.
 * `ip_rules` - (Optional, List) Public network access whitelist.
+* `max_topic_num` - (Optional, Int) Maximum number of topics that can be created.
 * `message_retention` - (Optional, Int) Message retention time in hours.
+* `pay_mode` - (Optional, Int) Billing mode (0: pay-as-you-go; 1: subscription). Default value is 0.
 * `remark` - (Optional, String) Remark.
+* `renew_flag` - (Optional, Int) Whether to auto-renew a subscription instance (0: no auto-renewal; 1: auto-renewal). Default value is 0.
 * `tags` - (Optional, Map) Tag description list.
+* `time_span` - (Optional, Int) Purchase duration of a subscription instance in months. Value range: 1-60. Default value is 1.
+* `zone_ids` - (Optional, List: [`Int`]) List of deployment availability zones.
 
 The `ip_rules` object supports the following:
 


### PR DESCRIPTION
## What does this PR do?

Add five new optional parameters to the `tencentcloud_trocket_rocketmq_instance` resource to align with the cloud API `CreateInstance` / `ModifyInstance` capabilities:

- `pay_mode` (TypeInt): Billing mode (0: pay-as-you-go; 1: subscription).
- `renew_flag` (TypeInt): Whether to auto-renew a subscription instance (0: no; 1: yes).
- `time_span` (TypeInt): Purchase duration in months for subscription instances (1-60).
- `max_topic_num` (TypeInt): Maximum number of topics that can be created.
- `zone_ids` (TypeList of TypeInt): List of deployment availability zones.

## Changes

- `resource_tc_trocket_rocketmq_instance.go`: Add the five new schema fields; populate them in Create/Read/Update. `pay_mode`, `renew_flag`, `time_span` are immutable after creation (added to immutableArgs); `max_topic_num` and `zone_ids` support in-place update via ModifyInstance.
- `resource_tc_trocket_rocketmq_instance_test.go`: Add acceptance test covering create and in-place update of the new params.
- `resource_tc_trocket_rocketmq_instance.md`: Add example usage for the new params.

## Backward Compatibility

Purely additive optional fields; no breaking change to existing schema or state.