### PR TITLE
feat(dbdc): add new params to dbdc_db_custom_node resource

### DIFF
--- a/.changelog/4366.txt
+++ b/.changelog/4366.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_dbdc_db_custom_node: support charge_type, network_mode, system_disk, data_disks, host_name, and security_group_ids parameters
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -123,7 +123,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/csip v1.0.860
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.118
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2 v1.3.144
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/gwlb v1.0.1127
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/igtm v1.3.29

--- a/go.sum
+++ b/go.sum
@@ -992,7 +992,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.110/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.112/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.113/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.115/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.118/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.121/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.122/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.124/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1003,8 +1002,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.135/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144 h1:3ZXz4f/y5gvBlS0cJ99nZFq6l8o5KSTcf9BsgSswS1k=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149 h1:rIoeeQt8842sJj/UQuZmSrQqPuXYvy1LeS9O6BN20T8=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1023,8 +1023,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335 h1:D8qrel
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335/go.mod h1:pz4s3nOhoB9cY0+uWzifuwr7lfh/Gvi1rv0ADxpPzD4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26 h1:UrEmrF2rVN7JxMZqamx0tU/fUx/6Ip++uX09NlNb/KM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26/go.mod h1:1MPBiJ3+3Guw6SDZbZ0smrO6ENIV63qMhJq24nU50gY=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.118 h1:klaFn5rg5T2HAxVZXxcR9NqTi8WU6GfM4Xs6KuAwycs=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.118/go.mod h1:sa5ke5zY+bdxT+YweqNYbwIztJ2hKIA4B063zk/D4g8=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149 h1:VRt5qgAdcyDZKrzNV6Y2TeCTkIOf5iR8MuVyHpREi3g=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149/go.mod h1:qLRT2AtZhjc1VJUivRKud+hSFW4jrBZ58Fj3TfySYog=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633 h1:Ul5iNhXoBrrzguMdbFzTDf3lfl15QrKbvOhvVBiqxDI=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633/go.mod h1:tc6Hvf03M1cBtMC1IKSa5mlOn3kpxWOwhWU1fRy+KEE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673 h1:YyjGLjvPDKNlpbGt89WLFif7TjId0fHzcrGOaHSQRNQ=

--- a/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/design.md
+++ b/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The `tencentcloud_dbdc_db_custom_node` resource (`tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go`) wraps the `CreateDBCustomNodes` API of the `dbdc` service (SDK package `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029`).
+
+**Current state:**
+- The resource schema exposes `zone`, `image_id`, `vpc_id`, `subnet_id`, `node_type`, `period`, `node_name`, `login_settings`, `auto_voucher`, `voucher_ids`, `auto_renew`, `tags`, plus a set of Computed-only fields (`charge_type`, `system_disk`, `data_disks`, `node_id`, `cluster_id`, etc.).
+- Create builds a `CreateDBCustomNodesRequest` from the schema and polls the returned `TaskId` via the existing `waitDBCustomTaskSucceeded` helper.
+- Read calls the existing service helper `DescribeDBCustomNodeById` (wraps `DescribeDBCustomNodes`, returns `*dbdcv20201029.DBCustomNode`).
+- Update handles `tags` (via `ModifyDBCustomNodeTags`) and `period`/`auto_renew` (via `RenewDBCustomNode`).
+- Delete isolates then destroys the node.
+
+**API behavior analysis** (verified against the vendored SDK structs):
+
+| API | Field in Request | Field in Response (`DBCustomNode`) | Modify API available? |
+|-----|------------------|------------------------------------|------------------------|
+| `CreateDBCustomNodes` | `ChargeType` | `ChargeType` | No |
+| `CreateDBCustomNodes` | `NetworkMode` | `NetworkMode` | No |
+| `CreateDBCustomNodes` | `SystemDisk` (`DiskType`,`DiskSize`) | `SystemDisk` | No |
+| `CreateDBCustomNodes` | `DataDisks` (`DiskType`,`DiskSize`,`DiskName`) | `DataDisks` | No |
+| `CreateDBCustomNodes` | `HostName` | **(not returned)** | No |
+| `CreateDBCustomNodes` | `SecurityGroupIds` | **(not in `DBCustomNode`)** | Yes: `ModifyDBCustomNodeSecurityGroups` |
+| `DescribeDBCustomNodeSecurityGroups` | `NodeId` | `Groups[]` (`SecurityGroupId`) | (read API) |
+
+**Key constraints:**
+- `ChargeType`, `NetworkMode`, `SystemDisk`, `DataDisks`, `HostName` have no Modify API → they must be `ForceNew`.
+- `HostName` is not returned by `DescribeDBCustomNodes` → it cannot be refreshed on Read (write-only).
+- `SecurityGroupIds` is mutable: `ModifyDBCustomNodeSecurityGroups` accepts `NodeId` + `SecurityGroupIds[]` and performs a full overwrite (set semantic). Read must use the separate `DescribeDBCustomNodeSecurityGroups` API because `DBCustomNode` does not carry security groups.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Promote `charge_type` from Computed to Optional+Computed (ForceNew) and pass it to `CreateDBCustomNodesRequest.ChargeType`.
+- Add `network_mode` (Optional, ForceNew) → `CreateDBCustomNodesRequest.NetworkMode`.
+- Promote `system_disk` block (Optional+Computed, ForceNew) → `CreateDBCustomNodesRequest.SystemDisk` (`DiskType`, `DiskSize`).
+- Promote `data_disks` block (Optional+Computed, ForceNew) → `CreateDBCustomNodesRequest.DataDisks` (`DiskType`, `DiskSize`, `DiskName`).
+- Add `host_name` (Optional, ForceNew) → `CreateDBCustomNodesRequest.HostName`.
+- Add `security_group_ids` (Optional, mutable) → `CreateDBCustomNodesRequest.SecurityGroupIds` on Create, `ModifyDBCustomNodeSecurityGroups` on Update, `DescribeDBCustomNodeSecurityGroups` on Read.
+- Maintain full backward compatibility (existing configs/state unchanged).
+- Update `.md` example and add test coverage.
+
+**Non-Goals:**
+- Adding an update path for `charge_type`, `network_mode`, `system_disk`, `data_disks`, `host_name` (no Modify API exists).
+- Exposing `host_name` as a readable/computed field (API does not return it).
+- Changes to the `tencentcloud_dbdc_db_custom_nodes` data source.
+
+## Decisions
+
+### Decision 1: ForceNew for parameters without a Modify API
+
+`ChargeType`, `NetworkMode`, `SystemDisk`, `DataDisks`, `HostName` are accepted only by `CreateDBCustomNodes`. There is no Modify API to change them on an existing node. Setting `ForceNew: true` makes Terraform destroy+recreate the node when any of these change, which matches the API reality.
+
+**Alternatives considered:** An `immutableArgs` array that returns a clear error (used by the cvm placement-group resource). That pattern is preferable when ForceNew would be silently destructive and an explicit error is friendlier. Here, however, these are genuine lifecycle-affecting inputs (disk size, charge type) where rebuild is the only valid response, so ForceNew is the conventional Terraform behavior and is consistent with the other already-ForceNew fields in this resource (`zone`, `image_id`, `node_type`, etc.).
+
+### Decision 2: Promote Computed fields to Optional+Computed (not plain Optional)
+
+`charge_type`, `system_disk`, `data_disks` are currently Computed (populated from the Describe response). To allow user input while preserving state refresh for resources created without these arguments (and for imports), they are promoted to `Optional: true, Computed: true`. This keeps backward compatibility: if the user omits them, the API defaults apply and the values are still read back into state.
+
+### Decision 3: `host_name` is write-only (Optional, ForceNew, NOT Computed)
+
+`DescribeDBCustomNodes` does not return `HostName`. If `host_name` were Computed, the Read would always overwrite the user's value with an empty string, causing a perpetual diff. Marking it Optional+ForceNew (without Computed) means Terraform keeps the configured value in state and never tries to reconcile it from the API. Import verification must ignore `host_name` (it cannot be repopulated).
+
+### Decision 4: `security_group_ids` is mutable; Read via a dedicated service helper
+
+`SecurityGroupIds` is not part of the `DBCustomNode` response. To refresh it, Read calls the new service helper `DescribeDBCustomNodeSecurityGroupsById(ctx, nodeId)`, which wraps `DescribeDBCustomNodeSecurityGroups` and returns `[]string` (the `SecurityGroupId` values from `Groups[]`). Update calls `ModifyDBCustomNodeSecurityGroups` with the full new list (set/overwrite semantic — the API replaces the node's security groups with the provided array). `d.HasChange("security_group_ids")` gates the Update call so it only fires when the list changes.
+
+### Decision 5: Create reads new arguments with nil-guards, consistent with existing code
+
+The existing Create builds the request field-by-field using `d.GetOk` / `helper.InterfacesHeadMap`. The new arguments follow the same pattern:
+- `charge_type`, `network_mode`, `host_name`: `d.GetOk` → `helper.String`.
+- `system_disk`: `helper.InterfacesHeadMap(d, "system_disk")` → build `dbdcv20201029.SystemDisk{DiskType, DiskSize}`.
+- `data_disks`: iterate `d.Get("data_disks").([]interface{})` → build `[]*dbdcv20201029.DataDisk`.
+- `security_group_ids`: iterate the list → `[]*string`.
+
+### Decision 6: No SDK upgrade required
+
+All required structs (`SystemDisk`, `DataDisk`), request fields (`ChargeType`, `NetworkMode`, `SystemDisk`, `DataDisks`, `HostName`, `SecurityGroupIds`), and client methods (`DescribeDBCustomNodeSecurityGroupsWithContext`, `ModifyDBCustomNodeSecurityGroupsWithContext`) already exist in the vendored SDK. No `go.mod`/vendor change is needed.
+
+## Risks / Trade-offs
+
+- **[Risk] ForceNew destroys nodes when an immutable field changes.** → Mitigation: This is the intended Terraform behavior for lifecycle-affecting inputs; descriptions will document that changes require recreation. Users are protected by `terraform plan` showing the destroy/create.
+- **[Risk] `host_name` cannot be refreshed on Read/import.** → Mitigation: `host_name` is Optional+ForceNew (not Computed); the configured value stays in state. Import verification ignores `host_name`.
+- **[Risk] `security_group_ids` Update overwrites the full list.** → Mitigation: This matches the `ModifyDBCustomNodeSecurityGroups` set semantic. Terraform computes the diff and sends the complete desired list, which is the correct behavior.
+- **[Risk] Promoting Computed fields to Optional+Computed could surprise users who relied on the API default.** → Mitigation: Backward compatible — when omitted, nothing is sent to the API (gated by `d.GetOk`), so the API default still applies and the value is read back.

--- a/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/proposal.md
+++ b/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The `tencentcloud_dbdc_db_custom_node` resource currently exposes only a subset of the `CreateDBCustomNodes` API parameters. The API supports specifying the charge type, network mode, system/data disk configuration, host name, and security groups at node creation time, but none of these are configurable through Terraform. Users who need cloud-disk node types (e.g. `DB.SA5`), custom host names, or bound security groups must fall back to the console or raw API calls, breaking the declarative workflow.
+
+## What Changes
+
+- Add `charge_type` as an **Optional + Computed, ForceNew** parameter (promote the existing Computed field) mapped to `CreateDBCustomNodesRequest.ChargeType`. Valid values: `PREPAID`, `POSTPAID`. Immutable after creation because no Modify API exists.
+- Add `network_mode` as an **Optional, ForceNew** parameter mapped to `CreateDBCustomNodesRequest.NetworkMode`. Valid values: `privatelink`, `cross_tenant_eni`. Immutable after creation.
+- Promote the existing `system_disk` block from **Computed-only** to **Optional + Computed, ForceNew** so users can pass `disk_type`/`disk_size` (mapped to `CreateDBCustomNodesRequest.SystemDisk`). Immutable after creation.
+- Promote the existing `data_disks` block from **Computed-only** to **Optional + Computed, ForceNew** so users can pass `disk_type`/`disk_size`/`disk_name` (mapped to `CreateDBCustomNodesRequest.DataDisks`). Immutable after creation.
+- Add `host_name` as an **Optional, ForceNew** parameter mapped to `CreateDBCustomNodesRequest.HostName`. Immutable after creation; not returned by `DescribeDBCustomNodes`, so it is write-only (imported resources will not repopulate it).
+- Add `security_group_ids` as an **Optional** (mutable, not ForceNew) parameter mapped to `CreateDBCustomNodesRequest.SecurityGroupIds` on Create and to the `ModifyDBCustomNodeSecurityGroups` API on Update. Read refreshes it via the separate `DescribeDBCustomNodeSecurityGroups` API because `DBCustomNode` does not return security groups.
+- Wire the new arguments through the Create flow, add Read support (from `DescribeDBCustomNodes` where available, plus a new service helper for security groups), and add Update handling for `security_group_ids`.
+- Update `resource_tc_dbdc_db_custom_node.md` example and add test coverage.
+
+## Capabilities
+
+### New Capabilities
+- `dbdc-db-custom-node-create-params`: New optional creation parameters on the `tencentcloud_dbdc_db_custom_node` resource — charge type, network mode, system disk, data disks, host name, and security group ids — including mutable update support for security group ids.
+
+### Modified Capabilities
+<!-- No existing specs require modification. The dbdc-db-custom-node resource has no prior spec; this change creates the capability spec. -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go` — extend schema (promote `charge_type`, `system_disk`, `data_disks` to Optional+Computed; add `network_mode`, `host_name`, `security_group_ids`), wire Create, extend Read, extend Update for `security_group_ids`.
+  - `tencentcloud/services/dbdc/service_tencentcloud_dbdc.go` — add `DescribeDBCustomNodeSecurityGroupsById(ctx, nodeId)` helper wrapping `DescribeDBCustomNodeSecurityGroups`.
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.md` — update example usage.
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node_test.go` — extend acceptance tests for new parameters.
+- **APIs used:** `CreateDBCustomNodes` (already used, new request fields), `DescribeDBCustomNodes` (already used, reads `ChargeType`/`NetworkMode`/`SystemDisk`/`DataDisks`), `DescribeDBCustomNodeSecurityGroups` (new, for `security_group_ids` Read), `ModifyDBCustomNodeSecurityGroups` (new, for `security_group_ids` Update).
+- **SDK dependency:** No SDK upgrade required. All referenced request/response structs and client methods already exist in the vendored `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029` package.
+- **Backward compatibility:** Fully backward compatible. Every changed field is promoted from Computed to Optional+Computed or added as Optional, so existing configurations and state continue to work unchanged.
+- **API constraints:**
+  - `ChargeType`, `NetworkMode`, `SystemDisk`, `DataDisks`, `HostName` are accepted only by `CreateDBCustomNodes`; no Modify API exists, so they are `ForceNew` (rebuild on change).
+  - `HostName` is not returned by `DescribeDBCustomNodes`, so it cannot be refreshed on Read/import (write-only).
+  - `SecurityGroupIds` is accepted by `CreateDBCustomNodes` and updatable via `ModifyDBCustomNodeSecurityGroups`; it is not part of the `DBCustomNode` response, so Read uses `DescribeDBCustomNodeSecurityGroups`.

--- a/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/specs/dbdc-db-custom-node-create-params/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/specs/dbdc-db-custom-node-create-params/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Charge type on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `charge_type` parameter (TypeString, Optional, Computed, ForceNew) that is passed to the `CreateDBCustomNodes` API as `ChargeType`. Valid values are `PREPAID` and `POSTPAID`. When omitted, the provider SHALL NOT set `ChargeType` in the request (the API defaults to `PREPAID`). The value SHALL be refreshed from `DescribeDBCustomNodes` (`DBCustomNode.ChargeType`) on Read.
+
+#### Scenario: Create node with explicit charge_type
+- **WHEN** a user specifies `charge_type = "PREPAID"` in the resource configuration
+- **THEN** the provider SHALL pass `ChargeType=PREPAID` in the `CreateDBCustomNodes` request
+
+#### Scenario: Create node without charge_type
+- **WHEN** a user does NOT specify `charge_type`
+- **THEN** the provider SHALL NOT set `ChargeType` in the request, and SHALL read the API-applied value back into state
+
+#### Scenario: Changing charge_type forces recreation
+- **WHEN** a user changes `charge_type` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew) because no Modify API exists
+
+### Requirement: Network mode on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `network_mode` parameter (TypeString, Optional, ForceNew) passed to the `CreateDBCustomNodes` API as `NetworkMode`. Valid values are `privatelink` and `cross_tenant_eni`. When omitted, the provider SHALL NOT set `NetworkMode` (API defaults to `privatelink`). The value SHALL be refreshed from `DescribeDBCustomNodes` (`DBCustomNode.NetworkMode`) on Read.
+
+#### Scenario: Create node with cross_tenant_eni network mode
+- **WHEN** a user specifies `network_mode = "cross_tenant_eni"`
+- **THEN** the provider SHALL pass `NetworkMode=cross_tenant_eni` in the request
+
+#### Scenario: Create node without network_mode
+- **WHEN** a user does NOT specify `network_mode`
+- **THEN** the provider SHALL NOT set `NetworkMode`, and SHALL read the API-applied value back into state
+
+#### Scenario: Changing network_mode forces recreation
+- **WHEN** a user changes `network_mode` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew)
+
+### Requirement: System disk configuration on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `system_disk` block (TypeList, MaxItems 1, Optional, Computed, ForceNew) whose `disk_type` and `disk_size` are passed to the `CreateDBCustomNodes` API as `SystemDisk.DiskType` and `SystemDisk.DiskSize`. When omitted, the provider SHALL NOT set `SystemDisk` (API applies its default). The value SHALL be refreshed from `DescribeDBCustomNodes` (`DBCustomNode.SystemDisk`) on Read.
+
+#### Scenario: Create node with explicit system disk
+- **WHEN** a user specifies a `system_disk` block with `disk_type = "CLOUD_HSSD"` and `disk_size = 100`
+- **THEN** the provider SHALL set `SystemDisk={DiskType:"CLOUD_HSSD", DiskSize:100}` in the request
+
+#### Scenario: Create node without system_disk
+- **WHEN** a user does NOT specify `system_disk`
+- **THEN** the provider SHALL NOT set `SystemDisk`, and SHALL read the API-applied value back into state
+
+#### Scenario: Changing system_disk forces recreation
+- **WHEN** a user changes `system_disk` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew)
+
+### Requirement: Data disks configuration on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `data_disks` block (TypeList, Optional, Computed, ForceNew) whose entries' `disk_type`, `disk_size`, and `disk_name` are passed to the `CreateDBCustomNodes` API as `DataDisks[]`. When omitted, the provider SHALL NOT set `DataDisks` (API applies its default). The value SHALL be refreshed from `DescribeDBCustomNodes` (`DBCustomNode.DataDisks`) on Read.
+
+#### Scenario: Create node with explicit data disks
+- **WHEN** a user specifies a `data_disks` block with `disk_type`, `disk_size`, and `disk_name`
+- **THEN** the provider SHALL build the `DataDisks` array and pass it in the request
+
+#### Scenario: Create node without data_disks
+- **WHEN** a user does NOT specify `data_disks`
+- **THEN** the provider SHALL NOT set `DataDisks`, and SHALL read the API-applied value back into state
+
+#### Scenario: Changing data_disks forces recreation
+- **WHEN** a user changes `data_disks` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew)
+
+### Requirement: Host name on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `host_name` parameter (TypeString, Optional, ForceNew) passed to the `CreateDBCustomNodes` API as `HostName`. Because `DescribeDBCustomNodes` does NOT return `HostName`, `host_name` SHALL NOT be Computed; the configured value SHALL be retained in state on Read (write-only). Import verification SHALL ignore `host_name`.
+
+#### Scenario: Create node with host_name
+- **WHEN** a user specifies `host_name = "my-node-1"`
+- **THEN** the provider SHALL pass `HostName=my-node-1` in the request
+
+#### Scenario: Read does not clear host_name
+- **WHEN** the provider reads an existing node that was created with `host_name`
+- **THEN** the provider SHALL leave the configured `host_name` value in state (it is not overwritten, because the API does not return it)
+
+#### Scenario: Changing host_name forces recreation
+- **WHEN** a user changes `host_name` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew)
+
+### Requirement: Security group ids on db custom node
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `security_group_ids` parameter (TypeList of String, Optional, mutable — NOT ForceNew) passed to the `CreateDBCustomNodes` API as `SecurityGroupIds` on Create. On Update, when `security_group_ids` changes, the provider SHALL call `ModifyDBCustomNodeSecurityGroups` with the full new list (set/overwrite semantic). On Read, the provider SHALL refresh `security_group_ids` from the `DescribeDBCustomNodeSecurityGroups` API (`Groups[].SecurityGroupId`), because `DBCustomNode` does not return security groups.
+
+#### Scenario: Create node with security group ids
+- **WHEN** a user specifies `security_group_ids = ["sg-xxx", "sg-yyy"]`
+- **THEN** the provider SHALL set `SecurityGroupIds=["sg-xxx","sg-yyy"]` in the `CreateDBCustomNodes` request
+
+#### Scenario: Create node without security_group_ids
+- **WHEN** a user does NOT specify `security_group_ids`
+- **THEN** the provider SHALL NOT set `SecurityGroupIds` in the request
+
+#### Scenario: Update security group ids in place
+- **WHEN** a user changes `security_group_ids` on an existing node
+- **THEN** the provider SHALL call `ModifyDBCustomNodeSecurityGroups` with the full new list and SHALL NOT recreate the node
+
+#### Scenario: Read refreshes security group ids
+- **WHEN** the provider reads an existing node
+- **THEN** the provider SHALL call `DescribeDBCustomNodeSecurityGroups` and populate `security_group_ids` from `Groups[].SecurityGroupId`

--- a/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/tasks.md
+++ b/openspec/changes/archive/2026-07-31-add-dbdc-db-custom-node-params/tasks.md
@@ -1,0 +1,49 @@
+## 1. Service Layer
+
+- [x] 1.1 Add `DescribeDBCustomNodeSecurityGroupsById(ctx, nodeId)` to `tencentcloud/services/dbdc/service_tencentcloud_dbdc.go` — wraps `DescribeDBCustomNodeSecurityGroups` (`NodeId`, `resource.Retry` + `ratelimit.Check`), returns `[]string` of `SecurityGroupId` from `Response.Groups` (nil/length-safe)
+- [x] 1.2 (No other service-layer changes needed; `DescribeDBCustomNodeById` already returns `*DBCustomNode` carrying `ChargeType`, `NetworkMode`, `SystemDisk`, `DataDisks`)
+
+## 2. Schema Changes
+
+- [x] 2.1 Promote `charge_type` from Computed to Optional+Computed, ForceNew in `ResourceTencentCloudDbdcDbCustomNode()` (keep description; note valid values `PREPAID`/`POSTPAID`)
+- [x] 2.2 Add `network_mode` (TypeString, Optional, ForceNew) — valid values `privatelink`, `cross_tenant_eni`
+- [x] 2.3 Promote `system_disk` block from Computed to Optional+Computed, ForceNew (MaxItems 1; keep `disk_type`/`disk_size` sub-fields)
+- [x] 2.4 Promote `data_disks` block from Computed to Optional+Computed, ForceNew (keep `disk_type`/`disk_size`/`disk_name` sub-fields)
+- [x] 2.5 Add `host_name` (TypeString, Optional, ForceNew; NOT Computed — write-only)
+- [x] 2.6 Add `security_group_ids` (TypeList of String, Optional; mutable — NOT ForceNew)
+
+## 3. Create Function Changes
+
+- [x] 3.1 Pass `charge_type` to `request.ChargeType` when set (`d.GetOk`)
+- [x] 3.2 Pass `network_mode` to `request.NetworkMode` when set (`d.GetOk`)
+- [x] 3.3 Build `request.SystemDisk` (`DiskType`, `DiskSize`) from the `system_disk` block when present (`helper.InterfacesHeadMap`)
+- [x] 3.4 Build `request.DataDisks` (`[]*DataDisk{DiskType, DiskSize, DiskName}`) from the `data_disks` list when present
+- [x] 3.5 Pass `host_name` to `request.HostName` when set (`d.GetOk`)
+- [x] 3.6 Pass `security_group_ids` to `request.SecurityGroupIds` (`[]*string`) when set
+
+## 4. Read Function Changes
+
+- [x] 4.1 Set `charge_type` from `respData.ChargeType` (existing nil-guard) — already present, keep
+- [x] 4.2 Add setting `network_mode` from `respData.NetworkMode` with nil-guard
+- [x] 4.3 Keep existing `system_disk` read (from `respData.SystemDisk`) — now also reflects user input on refresh
+- [x] 4.4 Keep existing `data_disks` read (from `respData.DataDisks`) — now also reflects user input on refresh
+- [x] 4.5 Do NOT read `host_name` from the API (write-only); leave configured value in state untouched
+- [x] 4.6 Read `security_group_ids` via the new `DescribeDBCustomNodeSecurityGroupsById` service helper; set into state with nil-guard (empty list when no groups)
+
+## 5. Update Function Changes
+
+- [x] 5.1 Add `d.HasChange("security_group_ids")` branch: call `ModifyDBCustomNodeSecurityGroups` with `NodeId` + full new `SecurityGroupIds` list, wrapped in `resource.Retry(WriteRetryTimeout)` + `tccommon.RetryError`, nil-guard the response
+- [x] 5.2 Confirm `charge_type`, `network_mode`, `system_disk`, `data_disks`, `host_name` are ForceNew (no Update handling required — Terraform recreates)
+
+## 6. Documentation
+
+- [x] 6.1 Update `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.md` example usage to illustrate the new parameters (`charge_type`, `network_mode`, `system_disk`, `data_disks`, `host_name`, `security_group_ids`)
+
+## 7. Tests
+
+- [x] 7.1 Extend `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node_test.go` acceptance tests to cover the new parameters (basic create with new args, update of `security_group_ids`, import with `ImportStateVerifyIgnore` for write-only `host_name`)
+
+## 8. Verification
+
+- [x] 8.1 Verify the code compiles successfully
+- [x] 8.2 Verify no lint errors

--- a/openspec/specs/dbdc-db-custom-node-create-params/spec.md
+++ b/openspec/specs/dbdc-db-custom-node-create-params/spec.md
@@ -1,0 +1,99 @@
+# dbdc-db-custom-node-create-params Specification
+
+## Purpose
+TBD - created by archiving change add-dbdc-db-custom-node-params. Update Purpose after archive.
+## Requirements
+### Requirement: Charge type on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `charge_type` parameter (TypeString, Optional, Computed, ForceNew) that is passed to the `CreateDBCustomNodes` API as `ChargeType`. Valid values are `PREPAID` and `POSTPAID`. When omitted, the provider SHALL NOT set `ChargeType` in the request (the API defaults to `PREPAID`). The value SHALL be refreshed from `DescribeDBCustomNodes` (`DBCustomNode.ChargeType`) on Read.
+
+#### Scenario: Create node with explicit charge_type
+- **WHEN** a user specifies `charge_type = "PREPAID"` in the resource configuration
+- **THEN** the provider SHALL pass `ChargeType=PREPAID` in the `CreateDBCustomNodes` request
+
+#### Scenario: Create node without charge_type
+- **WHEN** a user does NOT specify `charge_type`
+- **THEN** the provider SHALL NOT set `ChargeType` in the request, and SHALL read the API-applied value back into state
+
+#### Scenario: Changing charge_type forces recreation
+- **WHEN** a user changes `charge_type` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew) because no Modify API exists
+
+### Requirement: Network mode on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `network_mode` parameter (TypeString, Optional, ForceNew) passed to the `CreateDBCustomNodes` API as `NetworkMode`. Valid values are `privatelink` and `cross_tenant_eni`. When omitted, the provider SHALL NOT set `NetworkMode` (API defaults to `privatelink`). The value SHALL be refreshed from `DescribeDBCustomNodes` (`DBCustomNode.NetworkMode`) on Read.
+
+#### Scenario: Create node with cross_tenant_eni network mode
+- **WHEN** a user specifies `network_mode = "cross_tenant_eni"`
+- **THEN** the provider SHALL pass `NetworkMode=cross_tenant_eni` in the request
+
+#### Scenario: Create node without network_mode
+- **WHEN** a user does NOT specify `network_mode`
+- **THEN** the provider SHALL NOT set `NetworkMode`, and SHALL read the API-applied value back into state
+
+#### Scenario: Changing network_mode forces recreation
+- **WHEN** a user changes `network_mode` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew)
+
+### Requirement: System disk configuration on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `system_disk` block (TypeList, MaxItems 1, Optional, Computed, ForceNew) whose `disk_type` and `disk_size` are passed to the `CreateDBCustomNodes` API as `SystemDisk.DiskType` and `SystemDisk.DiskSize`. When omitted, the provider SHALL NOT set `SystemDisk` (API applies its default). The value SHALL be refreshed from `DescribeDBCustomNodes` (`DBCustomNode.SystemDisk`) on Read.
+
+#### Scenario: Create node with explicit system disk
+- **WHEN** a user specifies a `system_disk` block with `disk_type = "CLOUD_HSSD"` and `disk_size = 100`
+- **THEN** the provider SHALL set `SystemDisk={DiskType:"CLOUD_HSSD", DiskSize:100}` in the request
+
+#### Scenario: Create node without system_disk
+- **WHEN** a user does NOT specify `system_disk`
+- **THEN** the provider SHALL NOT set `SystemDisk`, and SHALL read the API-applied value back into state
+
+#### Scenario: Changing system_disk forces recreation
+- **WHEN** a user changes `system_disk` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew)
+
+### Requirement: Data disks configuration on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `data_disks` block (TypeList, Optional, Computed, ForceNew) whose entries' `disk_type`, `disk_size`, and `disk_name` are passed to the `CreateDBCustomNodes` API as `DataDisks[]`. When omitted, the provider SHALL NOT set `DataDisks` (API applies its default). The value SHALL be refreshed from `DescribeDBCustomNodes` (`DBCustomNode.DataDisks`) on Read.
+
+#### Scenario: Create node with explicit data disks
+- **WHEN** a user specifies a `data_disks` block with `disk_type`, `disk_size`, and `disk_name`
+- **THEN** the provider SHALL build the `DataDisks` array and pass it in the request
+
+#### Scenario: Create node without data_disks
+- **WHEN** a user does NOT specify `data_disks`
+- **THEN** the provider SHALL NOT set `DataDisks`, and SHALL read the API-applied value back into state
+
+#### Scenario: Changing data_disks forces recreation
+- **WHEN** a user changes `data_disks` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew)
+
+### Requirement: Host name on db custom node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `host_name` parameter (TypeString, Optional, ForceNew) passed to the `CreateDBCustomNodes` API as `HostName`. Because `DescribeDBCustomNodes` does NOT return `HostName`, `host_name` SHALL NOT be Computed; the configured value SHALL be retained in state on Read (write-only). Import verification SHALL ignore `host_name`.
+
+#### Scenario: Create node with host_name
+- **WHEN** a user specifies `host_name = "my-node-1"`
+- **THEN** the provider SHALL pass `HostName=my-node-1` in the request
+
+#### Scenario: Read does not clear host_name
+- **WHEN** the provider reads an existing node that was created with `host_name`
+- **THEN** the provider SHALL leave the configured `host_name` value in state (it is not overwritten, because the API does not return it)
+
+#### Scenario: Changing host_name forces recreation
+- **WHEN** a user changes `host_name` on an existing node
+- **THEN** the provider SHALL recreate the resource (ForceNew)
+
+### Requirement: Security group ids on db custom node
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `security_group_ids` parameter (TypeList of String, Optional, mutable — NOT ForceNew) passed to the `CreateDBCustomNodes` API as `SecurityGroupIds` on Create. On Update, when `security_group_ids` changes, the provider SHALL call `ModifyDBCustomNodeSecurityGroups` with the full new list (set/overwrite semantic). On Read, the provider SHALL refresh `security_group_ids` from the `DescribeDBCustomNodeSecurityGroups` API (`Groups[].SecurityGroupId`), because `DBCustomNode` does not return security groups.
+
+#### Scenario: Create node with security group ids
+- **WHEN** a user specifies `security_group_ids = ["sg-xxx", "sg-yyy"]`
+- **THEN** the provider SHALL set `SecurityGroupIds=["sg-xxx","sg-yyy"]` in the `CreateDBCustomNodes` request
+
+#### Scenario: Create node without security_group_ids
+- **WHEN** a user does NOT specify `security_group_ids`
+- **THEN** the provider SHALL NOT set `SecurityGroupIds` in the request
+
+#### Scenario: Update security group ids in place
+- **WHEN** a user changes `security_group_ids` on an existing node
+- **THEN** the provider SHALL call `ModifyDBCustomNodeSecurityGroups` with the full new list and SHALL NOT recreate the node
+
+#### Scenario: Read refreshes security group ids
+- **WHEN** the provider reads an existing node
+- **THEN** the provider SHALL call `DescribeDBCustomNodeSecurityGroups` and populate `security_group_ids` from `Groups[].SecurityGroupId`
+

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go
@@ -194,8 +194,17 @@ func ResourceTencentCloudDbdcDbCustomNode() *schema.Resource {
 
 			"charge_type": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
-				Description: "Charge type. Valid values: `PREPAID`.",
+				ForceNew:    true,
+				Description: "Charge type. Valid values: `PREPAID`, `POSTPAID`.",
+			},
+
+			"network_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Network mode of the node. Valid values: `privatelink`, `cross_tenant_eni`. Default value is `privatelink`.",
 			},
 
 			"expire_time": {
@@ -218,17 +227,22 @@ func ResourceTencentCloudDbdcDbCustomNode() *schema.Resource {
 
 			"system_disk": {
 				Type:        schema.TypeList,
+				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
+				MaxItems:    1,
 				Description: "System disk information.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"disk_type": {
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
-							Description: "Disk type.",
+							Description: "Disk type. Valid values: `CLOUD_HSSD`.",
 						},
 						"disk_size": {
 							Type:        schema.TypeInt,
+							Optional:    true,
 							Computed:    true,
 							Description: "Disk size, unit: GiB.",
 						},
@@ -238,26 +252,47 @@ func ResourceTencentCloudDbdcDbCustomNode() *schema.Resource {
 
 			"data_disks": {
 				Type:        schema.TypeList,
+				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Description: "Data disk information.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"disk_type": {
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
-							Description: "Disk type.",
+							Description: "Disk type. Valid values: `CLOUD_HSSD`, `LOCAL_NVME`.",
 						},
 						"disk_size": {
 							Type:        schema.TypeInt,
+							Optional:    true,
 							Computed:    true,
 							Description: "Disk size, unit: GiB.",
 						},
 						"disk_name": {
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "Disk name.",
 						},
 					},
+				},
+			},
+
+			"host_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Host name of the node. Write-only: the API does not return it, so the configured value is retained in state and cannot be refreshed on import.",
+			},
+
+			"security_group_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Security group IDs bound to the node. Mutable: updating this list calls the ModifyDBCustomNodeSecurityGroups API.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
 				},
 			},
 		},
@@ -352,6 +387,60 @@ func resourceTencentCloudDbdcDbCustomNodeCreate(d *schema.ResourceData, meta int
 			}
 
 			request.Tags = append(request.Tags, &tag)
+		}
+	}
+
+	if v, ok := d.GetOk("charge_type"); ok {
+		request.ChargeType = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("network_mode"); ok {
+		request.NetworkMode = helper.String(v.(string))
+	}
+
+	if dMap, ok := helper.InterfacesHeadMap(d, "system_disk"); ok {
+		systemDisk := dbdcv20201029.SystemDisk{}
+		if v, ok := dMap["disk_type"]; ok && v.(string) != "" {
+			systemDisk.DiskType = helper.String(v.(string))
+		}
+
+		if v, ok := dMap["disk_size"]; ok {
+			systemDisk.DiskSize = helper.IntInt64(v.(int))
+		}
+
+		request.SystemDisk = &systemDisk
+	}
+
+	if v, ok := d.GetOk("data_disks"); ok {
+		dataDisksList := v.([]interface{})
+		for i := range dataDisksList {
+			dataDiskMap := dataDisksList[i].(map[string]interface{})
+			dataDisk := dbdcv20201029.DataDisk{}
+			if v, ok := dataDiskMap["disk_type"]; ok && v.(string) != "" {
+				dataDisk.DiskType = helper.String(v.(string))
+			}
+
+			if v, ok := dataDiskMap["disk_size"]; ok {
+				dataDisk.DiskSize = helper.IntInt64(v.(int))
+			}
+
+			if v, ok := dataDiskMap["disk_name"]; ok && v.(string) != "" {
+				dataDisk.DiskName = helper.String(v.(string))
+			}
+
+			request.DataDisks = append(request.DataDisks, &dataDisk)
+		}
+	}
+
+	if v, ok := d.GetOk("host_name"); ok {
+		request.HostName = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("security_group_ids"); ok {
+		securityGroupIdsList := v.([]interface{})
+		for i := range securityGroupIdsList {
+			securityGroupId := securityGroupIdsList[i].(string)
+			request.SecurityGroupIds = append(request.SecurityGroupIds, &securityGroupId)
 		}
 	}
 
@@ -496,6 +585,10 @@ func resourceTencentCloudDbdcDbCustomNodeRead(d *schema.ResourceData, meta inter
 		_ = d.Set("charge_type", respData.ChargeType)
 	}
 
+	if respData.NetworkMode != nil {
+		_ = d.Set("network_mode", respData.NetworkMode)
+	}
+
 	if respData.ExpireTime != nil {
 		_ = d.Set("expire_time", respData.ExpireTime)
 	}
@@ -546,6 +639,13 @@ func resourceTencentCloudDbdcDbCustomNodeRead(d *schema.ResourceData, meta inter
 
 		_ = d.Set("data_disks", dataDisksList)
 	}
+
+	securityGroupIds, err := service.DescribeDBCustomNodeSecurityGroupsById(ctx, nodeId)
+	if err != nil {
+		return err
+	}
+
+	_ = d.Set("security_group_ids", securityGroupIds)
 
 	return nil
 }
@@ -600,6 +700,39 @@ func resourceTencentCloudDbdcDbCustomNodeUpdate(d *schema.ResourceData, meta int
 
 		if reqErr != nil {
 			log.Printf("[CRITAL]%s update dbdc db custom node tags failed, reason:%+v", logId, reqErr)
+			return reqErr
+		}
+	}
+
+	if d.HasChange("security_group_ids") {
+		request := dbdcv20201029.NewModifyDBCustomNodeSecurityGroupsRequest()
+		request.NodeId = helper.String(nodeId)
+
+		if v, ok := d.GetOk("security_group_ids"); ok {
+			securityGroupIdsList := v.([]interface{})
+			for i := range securityGroupIdsList {
+				securityGroupId := securityGroupIdsList[i].(string)
+				request.SecurityGroupIds = append(request.SecurityGroupIds, &securityGroupId)
+			}
+		}
+
+		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDbdcV20201029Client().ModifyDBCustomNodeSecurityGroupsWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify dbdc db custom node security groups failed, Response is nil."))
+			}
+
+			return nil
+		})
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s update dbdc db custom node security group ids failed, reason:%+v", logId, reqErr)
 			return reqErr
 		}
 	}

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.md
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.md
@@ -8,10 +8,26 @@ resource "tencentcloud_dbdc_db_custom_node" "example" {
   image_id   = "img-rm13akp3"
   vpc_id     = "vpc-py7mlxqm"
   subnet_id  = "subnet-qd4upp83"
-  node_type  = "DB.AT5.8XLARGE128"
+  node_type  = "DB.SA5.8XLARGE128"
   period     = 1
   auto_renew = 1
   node_name  = "tf-example"
+
+  charge_type   = "PREPAID"
+  network_mode  = "privatelink"
+  host_name     = "tf-example-node"
+  security_group_ids = ["sg-xxxxxxxx"]
+
+  system_disk {
+    disk_type = "CLOUD_HSSD"
+    disk_size = 100
+  }
+
+  data_disks {
+    disk_type = "CLOUD_HSSD"
+    disk_size = 500
+    disk_name = "tf-example-data"
+  }
 
   login_settings {
     password = "Password@2026"

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node_test.go
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node_test.go
@@ -38,7 +38,43 @@ func TestAccTencentCloudDbdcDbCustomNodeResource_basic(t *testing.T) {
 				ResourceName:            "tencentcloud_dbdc_db_custom_node.example",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"login_settings", "period", "node_count", "auto_voucher", "voucher_ids"},
+				ImportStateVerifyIgnore: []string{"login_settings", "period", "node_count", "auto_voucher", "voucher_ids", "host_name"},
+			},
+		},
+	})
+}
+
+func TestAccTencentCloudDbdcDbCustomNodeResource_createParams(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			tcacctest.AccPreCheck(t)
+		},
+		Providers: tcacctest.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDbdcDbCustomNodeCreateParams,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tencentcloud_dbdc_db_custom_node.example", "id"),
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_node.example", "charge_type", "PREPAID"),
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_node.example", "network_mode", "privatelink"),
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_node.example", "host_name", "tf-example-host"),
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_node.example", "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_node.example", "system_disk.#", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_node.example", "data_disks.#", "1"),
+				),
+			},
+			{
+				Config: testAccDbdcDbCustomNodeCreateParamsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_node.example", "security_group_ids.#", "2"),
+				),
+			},
+			{
+				ResourceName:            "tencentcloud_dbdc_db_custom_node.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"login_settings", "period", "node_count", "auto_voucher", "voucher_ids", "host_name"},
 			},
 		},
 	})
@@ -84,6 +120,82 @@ resource "tencentcloud_dbdc_db_custom_node" "example" {
 
   tags = {
     createBy = "TerraformUpdate"
+  }
+}
+`
+
+const testAccDbdcDbCustomNodeCreateParams = `
+resource "tencentcloud_dbdc_db_custom_node" "example" {
+  zone       = "ap-shanghai-5"
+  image_id   = "img-xxxxxxxx"
+  vpc_id     = "vpc-xxxxxxxx"
+  subnet_id  = "subnet-xxxxxxxx"
+  node_type  = "DB.SA5.8XLARGE128"
+  period     = 1
+  node_name  = "tf-example"
+
+  charge_type   = "PREPAID"
+  network_mode  = "privatelink"
+  host_name     = "tf-example-host"
+  security_group_ids = ["sg-xxxxxxxx"]
+
+  system_disk {
+    disk_type = "CLOUD_HSSD"
+    disk_size = 100
+  }
+
+  data_disks {
+    disk_type = "CLOUD_HSSD"
+    disk_size = 500
+    disk_name = "tf-example-data"
+  }
+
+  login_settings {
+    password = "Passw0rd@2024"
+  }
+
+  auto_renew = 0
+
+  tags = {
+    createBy = "Terraform"
+  }
+}
+`
+
+const testAccDbdcDbCustomNodeCreateParamsUpdate = `
+resource "tencentcloud_dbdc_db_custom_node" "example" {
+  zone       = "ap-shanghai-5"
+  image_id   = "img-xxxxxxxx"
+  vpc_id     = "vpc-xxxxxxxx"
+  subnet_id  = "subnet-xxxxxxxx"
+  node_type  = "DB.SA5.8XLARGE128"
+  period     = 1
+  node_name  = "tf-example"
+
+  charge_type   = "PREPAID"
+  network_mode  = "privatelink"
+  host_name     = "tf-example-host"
+  security_group_ids = ["sg-xxxxxxxx", "sg-yyyyyyyy"]
+
+  system_disk {
+    disk_type = "CLOUD_HSSD"
+    disk_size = 100
+  }
+
+  data_disks {
+    disk_type = "CLOUD_HSSD"
+    disk_size = 500
+    disk_name = "tf-example-data"
+  }
+
+  login_settings {
+    password = "Passw0rd@2024"
+  }
+
+  auto_renew = 0
+
+  tags = {
+    createBy = "Terraform"
   }
 }
 `

--- a/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
+++ b/tencentcloud/services/dbdc/service_tencentcloud_dbdc.go
@@ -406,6 +406,53 @@ func (me *DbdcService) DescribeDBCustomNodeById(ctx context.Context, nodeId stri
 	return
 }
 
+func (me *DbdcService) DescribeDBCustomNodeSecurityGroupsById(ctx context.Context, nodeId string) (sgIds []string, errRet error) {
+	var (
+		logId   = tccommon.GetLogId(ctx)
+		request = dbdcv20201029.NewDescribeDBCustomNodeSecurityGroupsRequest()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	request.NodeId = &nodeId
+
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, e := me.client.UseDbdcV20201029Client().DescribeDBCustomNodeSecurityGroupsWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe dbdc db custom node security groups failed, Response is nil."))
+		}
+
+		if result.Response.Groups != nil {
+			for _, group := range result.Response.Groups {
+				if group == nil || group.SecurityGroupId == nil {
+					continue
+				}
+				sgIds = append(sgIds, *group.SecurityGroupId)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		errRet = err
+		return
+	}
+
+	return
+}
+
 func (me *DbdcService) DescribeDBCustomClusterNodeById(ctx context.Context, clusterId, nodeId string) (ret *dbdcv20201029.DBCustomClusterNode, errRet error) {
 	var (
 		logId   = tccommon.GetLogId(ctx)

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.144"
+	params["RequestClient"] = "SDK_GO_1.3.149"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/client.go
@@ -65,7 +65,7 @@ func NewAddNodesToDBCustomClusterResponse() (response *AddNodesToDBCustomCluster
 }
 
 // AddNodesToDBCustomCluster
-// 该接口（AddNodesToDBCustomCluster）用于为 DB Custom 集群上架节点。
+// 该接口（AddNodesToDBCustomCluster）用于为 DB Custom 集群添加已存在的节点。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -77,7 +77,7 @@ func (c *Client) AddNodesToDBCustomCluster(request *AddNodesToDBCustomClusterReq
 }
 
 // AddNodesToDBCustomCluster
-// 该接口（AddNodesToDBCustomCluster）用于为 DB Custom 集群上架节点。
+// 该接口（AddNodesToDBCustomCluster）用于为 DB Custom 集群添加已存在的节点。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -381,6 +381,118 @@ func (c *Client) DescribeDBCustomClusterKubeconfigWithContext(ctx context.Contex
     return
 }
 
+func NewDescribeDBCustomClusterNodeConfigRequest() (request *DescribeDBCustomClusterNodeConfigRequest) {
+    request = &DescribeDBCustomClusterNodeConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomClusterNodeConfig")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomClusterNodeConfigResponse() (response *DescribeDBCustomClusterNodeConfigResponse) {
+    response = &DescribeDBCustomClusterNodeConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomClusterNodeConfig
+// 该接口（DescribeDBCustomClusterNodeConfig）用于查询 DB Custom 集群内节点的配置信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomClusterNodeConfig(request *DescribeDBCustomClusterNodeConfigRequest) (response *DescribeDBCustomClusterNodeConfigResponse, err error) {
+    return c.DescribeDBCustomClusterNodeConfigWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomClusterNodeConfig
+// 该接口（DescribeDBCustomClusterNodeConfig）用于查询 DB Custom 集群内节点的配置信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomClusterNodeConfigWithContext(ctx context.Context, request *DescribeDBCustomClusterNodeConfigRequest) (response *DescribeDBCustomClusterNodeConfigResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomClusterNodeConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomClusterNodeConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomClusterNodeConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomClusterNodeConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeDBCustomClusterNodeResourcesRequest() (request *DescribeDBCustomClusterNodeResourcesRequest) {
+    request = &DescribeDBCustomClusterNodeResourcesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomClusterNodeResources")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomClusterNodeResourcesResponse() (response *DescribeDBCustomClusterNodeResourcesResponse) {
+    response = &DescribeDBCustomClusterNodeResourcesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomClusterNodeResources
+// 该接口（DescribeDBCustomClusterNodeResources）用于查询 DB Custom 集群内节点的资源信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomClusterNodeResources(request *DescribeDBCustomClusterNodeResourcesRequest) (response *DescribeDBCustomClusterNodeResourcesResponse, err error) {
+    return c.DescribeDBCustomClusterNodeResourcesWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomClusterNodeResources
+// 该接口（DescribeDBCustomClusterNodeResources）用于查询 DB Custom 集群内节点的资源信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomClusterNodeResourcesWithContext(ctx context.Context, request *DescribeDBCustomClusterNodeResourcesRequest) (response *DescribeDBCustomClusterNodeResourcesResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomClusterNodeResourcesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomClusterNodeResources")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomClusterNodeResources require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomClusterNodeResourcesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeDBCustomClusterNodesRequest() (request *DescribeDBCustomClusterNodesRequest) {
     request = &DescribeDBCustomClusterNodesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -437,6 +549,62 @@ func (c *Client) DescribeDBCustomClusterNodesWithContext(ctx context.Context, re
     return
 }
 
+func NewDescribeDBCustomClusterResourcesRequest() (request *DescribeDBCustomClusterResourcesRequest) {
+    request = &DescribeDBCustomClusterResourcesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomClusterResources")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomClusterResourcesResponse() (response *DescribeDBCustomClusterResourcesResponse) {
+    response = &DescribeDBCustomClusterResourcesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomClusterResources
+// 该接口（DescribeDBCustomClusterResources）用于查询 DB Custom 集群的资源信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomClusterResources(request *DescribeDBCustomClusterResourcesRequest) (response *DescribeDBCustomClusterResourcesResponse, err error) {
+    return c.DescribeDBCustomClusterResourcesWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomClusterResources
+// 该接口（DescribeDBCustomClusterResources）用于查询 DB Custom 集群的资源信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomClusterResourcesWithContext(ctx context.Context, request *DescribeDBCustomClusterResourcesRequest) (response *DescribeDBCustomClusterResourcesResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomClusterResourcesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomClusterResources")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomClusterResources require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomClusterResourcesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeDBCustomClustersRequest() (request *DescribeDBCustomClustersRequest) {
     request = &DescribeDBCustomClustersRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -457,7 +625,7 @@ func NewDescribeDBCustomClustersResponse() (response *DescribeDBCustomClustersRe
 }
 
 // DescribeDBCustomClusters
-// 该接口（DescribeDBCustomClusters）为DB Custom 集群列表查询接口。
+// 该接口（DescribeDBCustomClusters）为 DB Custom 集群列表查询接口。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -469,7 +637,7 @@ func (c *Client) DescribeDBCustomClusters(request *DescribeDBCustomClustersReque
 }
 
 // DescribeDBCustomClusters
-// 该接口（DescribeDBCustomClusters）为DB Custom 集群列表查询接口。
+// 该接口（DescribeDBCustomClusters）为 DB Custom 集群列表查询接口。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -549,6 +717,118 @@ func (c *Client) DescribeDBCustomImagesWithContext(ctx context.Context, request 
     return
 }
 
+func NewDescribeDBCustomNodeSecurityGroupsRequest() (request *DescribeDBCustomNodeSecurityGroupsRequest) {
+    request = &DescribeDBCustomNodeSecurityGroupsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomNodeSecurityGroups")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomNodeSecurityGroupsResponse() (response *DescribeDBCustomNodeSecurityGroupsResponse) {
+    response = &DescribeDBCustomNodeSecurityGroupsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomNodeSecurityGroups
+// 该接口（DescribeDBCustomNodeSecurityGroups）用于查询 DB Custom 节点安全组信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomNodeSecurityGroups(request *DescribeDBCustomNodeSecurityGroupsRequest) (response *DescribeDBCustomNodeSecurityGroupsResponse, err error) {
+    return c.DescribeDBCustomNodeSecurityGroupsWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomNodeSecurityGroups
+// 该接口（DescribeDBCustomNodeSecurityGroups）用于查询 DB Custom 节点安全组信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomNodeSecurityGroupsWithContext(ctx context.Context, request *DescribeDBCustomNodeSecurityGroupsRequest) (response *DescribeDBCustomNodeSecurityGroupsResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomNodeSecurityGroupsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomNodeSecurityGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomNodeSecurityGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomNodeSecurityGroupsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeDBCustomNodeTypesRequest() (request *DescribeDBCustomNodeTypesRequest) {
+    request = &DescribeDBCustomNodeTypesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomNodeTypes")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomNodeTypesResponse() (response *DescribeDBCustomNodeTypesResponse) {
+    response = &DescribeDBCustomNodeTypesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomNodeTypes
+// 该接口(DescribeDBCustomNodeTypes) 用于查询 DB Custom 节点支持的机型信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomNodeTypes(request *DescribeDBCustomNodeTypesRequest) (response *DescribeDBCustomNodeTypesResponse, err error) {
+    return c.DescribeDBCustomNodeTypesWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomNodeTypes
+// 该接口(DescribeDBCustomNodeTypes) 用于查询 DB Custom 节点支持的机型信息。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomNodeTypesWithContext(ctx context.Context, request *DescribeDBCustomNodeTypesRequest) (response *DescribeDBCustomNodeTypesResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomNodeTypesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomNodeTypes")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomNodeTypes require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomNodeTypesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeDBCustomNodesRequest() (request *DescribeDBCustomNodesRequest) {
     request = &DescribeDBCustomNodesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -605,6 +885,62 @@ func (c *Client) DescribeDBCustomNodesWithContext(ctx context.Context, request *
     return
 }
 
+func NewDescribeDBCustomRegionsRequest() (request *DescribeDBCustomRegionsRequest) {
+    request = &DescribeDBCustomRegionsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomRegions")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomRegionsResponse() (response *DescribeDBCustomRegionsResponse) {
+    response = &DescribeDBCustomRegionsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomRegions
+// 该接口(DescribeDBCustomRegions) 用于查询 DB Custom 支持的地域列表。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomRegions(request *DescribeDBCustomRegionsRequest) (response *DescribeDBCustomRegionsResponse, err error) {
+    return c.DescribeDBCustomRegionsWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomRegions
+// 该接口(DescribeDBCustomRegions) 用于查询 DB Custom 支持的地域列表。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomRegionsWithContext(ctx context.Context, request *DescribeDBCustomRegionsRequest) (response *DescribeDBCustomRegionsResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomRegionsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomRegions")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomRegions require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomRegionsResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeDBCustomTaskStatusRequest() (request *DescribeDBCustomTaskStatusRequest) {
     request = &DescribeDBCustomTaskStatusRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -657,6 +993,62 @@ func (c *Client) DescribeDBCustomTaskStatusWithContext(ctx context.Context, requ
     request.SetContext(ctx)
     
     response = NewDescribeDBCustomTaskStatusResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeDBCustomZonesRequest() (request *DescribeDBCustomZonesRequest) {
+    request = &DescribeDBCustomZonesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomZones")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomZonesResponse() (response *DescribeDBCustomZonesResponse) {
+    response = &DescribeDBCustomZonesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomZones
+// 该接口(DescribeDBCustomZones) 用于查询指定地域的 DB Custom 可用区列表。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomZones(request *DescribeDBCustomZonesRequest) (response *DescribeDBCustomZonesResponse, err error) {
+    return c.DescribeDBCustomZonesWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomZones
+// 该接口(DescribeDBCustomZones) 用于查询指定地域的 DB Custom 可用区列表。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomZonesWithContext(ctx context.Context, request *DescribeDBCustomZonesRequest) (response *DescribeDBCustomZonesResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomZonesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomZones")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomZones require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomZonesResponse()
     err = c.Send(request, response)
     return
 }
@@ -1123,6 +1515,62 @@ func (c *Client) IsolateDBCustomNodeWithContext(ctx context.Context, request *Is
     return
 }
 
+func NewModifyDBCustomClusterNodeConfigRequest() (request *ModifyDBCustomClusterNodeConfigRequest) {
+    request = &ModifyDBCustomClusterNodeConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomClusterNodeConfig")
+    
+    
+    return
+}
+
+func NewModifyDBCustomClusterNodeConfigResponse() (response *ModifyDBCustomClusterNodeConfigResponse) {
+    response = &ModifyDBCustomClusterNodeConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomClusterNodeConfig
+// 该接口（ModifyDBCustomClusterNodeConfig）用于修改 DB Custom 集群中节点的配置。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomClusterNodeConfig(request *ModifyDBCustomClusterNodeConfigRequest) (response *ModifyDBCustomClusterNodeConfigResponse, err error) {
+    return c.ModifyDBCustomClusterNodeConfigWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomClusterNodeConfig
+// 该接口（ModifyDBCustomClusterNodeConfig）用于修改 DB Custom 集群中节点的配置。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomClusterNodeConfigWithContext(ctx context.Context, request *ModifyDBCustomClusterNodeConfigRequest) (response *ModifyDBCustomClusterNodeConfigResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomClusterNodeConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomClusterNodeConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomClusterNodeConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomClusterNodeConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyDBCustomClusterTagsRequest() (request *ModifyDBCustomClusterTagsRequest) {
     request = &ModifyDBCustomClusterTagsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1143,7 +1591,7 @@ func NewModifyDBCustomClusterTagsResponse() (response *ModifyDBCustomClusterTags
 }
 
 // ModifyDBCustomClusterTags
-// 该接口（ModifyDBCustomClusterTags）用于修改 DB Custom 集群的标签配置。
+// 该接口（ModifyDBCustomClusterTags）用于修改 DB Custom 集群绑定的标签。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -1155,7 +1603,7 @@ func (c *Client) ModifyDBCustomClusterTags(request *ModifyDBCustomClusterTagsReq
 }
 
 // ModifyDBCustomClusterTags
-// 该接口（ModifyDBCustomClusterTags）用于修改 DB Custom 集群的标签配置。
+// 该接口（ModifyDBCustomClusterTags）用于修改 DB Custom 集群绑定的标签。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -1175,6 +1623,62 @@ func (c *Client) ModifyDBCustomClusterTagsWithContext(ctx context.Context, reque
     request.SetContext(ctx)
     
     response = NewModifyDBCustomClusterTagsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyDBCustomNodeSecurityGroupsRequest() (request *ModifyDBCustomNodeSecurityGroupsRequest) {
+    request = &ModifyDBCustomNodeSecurityGroupsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomNodeSecurityGroups")
+    
+    
+    return
+}
+
+func NewModifyDBCustomNodeSecurityGroupsResponse() (response *ModifyDBCustomNodeSecurityGroupsResponse) {
+    response = &ModifyDBCustomNodeSecurityGroupsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomNodeSecurityGroups
+// 该接口（ModifyDBCustomNodeSecurityGroups）用于修改 DB Custom 节点安全组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodeSecurityGroups(request *ModifyDBCustomNodeSecurityGroupsRequest) (response *ModifyDBCustomNodeSecurityGroupsResponse, err error) {
+    return c.ModifyDBCustomNodeSecurityGroupsWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomNodeSecurityGroups
+// 该接口（ModifyDBCustomNodeSecurityGroups）用于修改 DB Custom 节点安全组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodeSecurityGroupsWithContext(ctx context.Context, request *ModifyDBCustomNodeSecurityGroupsRequest) (response *ModifyDBCustomNodeSecurityGroupsResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomNodeSecurityGroupsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomNodeSecurityGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomNodeSecurityGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomNodeSecurityGroupsResponse()
     err = c.Send(request, response)
     return
 }
@@ -1199,7 +1703,7 @@ func NewModifyDBCustomNodeTagsResponse() (response *ModifyDBCustomNodeTagsRespon
 }
 
 // ModifyDBCustomNodeTags
-// 该接口（ModifyDBCustomNodeTags）用于修改 DB Custom 节点的标签配置。
+// 该接口（ModifyDBCustomNodeTags）用于修改 DB Custom 节点绑定的标签。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -1211,7 +1715,7 @@ func (c *Client) ModifyDBCustomNodeTags(request *ModifyDBCustomNodeTagsRequest) 
 }
 
 // ModifyDBCustomNodeTags
-// 该接口（ModifyDBCustomNodeTags）用于修改 DB Custom 节点的标签配置。
+// 该接口（ModifyDBCustomNodeTags）用于修改 DB Custom 节点绑定的标签。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -1313,7 +1817,7 @@ func NewRemoveNodesFromDBCustomClusterResponse() (response *RemoveNodesFromDBCus
 }
 
 // RemoveNodesFromDBCustomCluster
-// 该接口（RemoveNodesFromDBCustomCluster）用于从 DB Custom 集群移除节点。
+// 该接口（RemoveNodesFromDBCustomCluster）用于从 DB Custom 集群移出节点。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -1325,7 +1829,7 @@ func (c *Client) RemoveNodesFromDBCustomCluster(request *RemoveNodesFromDBCustom
 }
 
 // RemoveNodesFromDBCustomCluster
-// 该接口（RemoveNodesFromDBCustomCluster）用于从 DB Custom 集群移除节点。
+// 该接口（RemoveNodesFromDBCustomCluster）用于从 DB Custom 集群移出节点。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -1369,7 +1873,7 @@ func NewRenewDBCustomNodeResponse() (response *RenewDBCustomNodeResponse) {
 }
 
 // RenewDBCustomNode
-// 该接口（RenewDBCustomNode）用于给 DB Custom 节点续费。
+// 该接口（RenewDBCustomNode）用于给 DB Custom 节点续费，或者给已经隔离的实例解除隔离。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"
@@ -1381,7 +1885,7 @@ func (c *Client) RenewDBCustomNode(request *RenewDBCustomNodeRequest) (response 
 }
 
 // RenewDBCustomNode
-// 该接口（RenewDBCustomNode）用于给 DB Custom 节点续费。
+// 该接口（RenewDBCustomNode）用于给 DB Custom 节点续费，或者给已经隔离的实例解除隔离。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE = "AuthFailure"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/models.go
@@ -33,6 +33,21 @@ type AddNodesToDBCustomClusterRequestParams struct {
 
 	// <p>实例登录设置。通过该参数可以设置实例的登录方式密码、密钥或保持镜像的原始登录设置。</p><p>入参限制：若选择密钥方式，KeyIds 仅支持单个 ID。三种方式必须且仅可以设置其中一种。</p>
 	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
+
+	// <p>节点上架成功后初始化新增的自定义 Label</p><p>入参限制：单次 ≤ 20 对</p>
+	Labels []*Label `json:"Labels,omitnil,omitempty" name:"Labels"`
+
+	// <p>节点上架成功后初始化下发的Taint</p><p>入参限制：单次 ≤ 5 对</p>
+	Taints []*Taint `json:"Taints,omitnil,omitempty" name:"Taints"`
+
+	// <p>主机hostname ，仅 HostNameType=1 时必填，其余情况忽略；不支持大写字母</p><p>入参限制：- 点号（.）和短横线（-）不能作为 HostName 的首尾字符，不能连续使用。不允许使用下划线(_)。</p><ul><li>Windows 节点：主机名名字符长度为[2, 15]，允许字母（不限制大小写）、数字和短横线（-）组成，不支持点号（.），不能全是数字。</li><li>其他类型（Linux 等）节点：主机名字符长度为[2, 60]，允许支持多个点号，点之间为一段，每段允许字母（不限制大小写）、数字和短横线（-）组成。</li><li>上架多台节点时：</li><li>指定模式串 {R:x}：表示生成数字序列 [x, x+n-1]，其中 n为购买节点的数量。例如：输入 server_{R:3}，购买1台时，节点主机名为 server_3；购买2台时，主机名分别为 server_3、server_4。</li><li>指定模式串 {R:x,F:y}：y表示固定位数（可选），取值范围为 [0,8]，默认值 0表示不固定位数（等效于 {R:x}）。不足位时自动补零，例如：输入server_{R:3,F:3}，购买2台时，节点主机名为 server_003、server_004。若数字位数超过 y（如 {R:99,F:2}），以实际位数为准，例如：app_{R:99,F:2}，购买2台时，节点主机名为 app_99、app_100。</li><li>指定模式串 {IP}：自动替换为节点的内网IP地址。例如：输入 node-{IP}，节点主机名为 node-10.0.12.8；支持与序号模式串混合使用，例如：输入 web-{IP}-{R:1}，购买2台时，节点主机名分别为 web-10.0.12.8-1、web-10.0.12.9-2。</li><li>模式串需严格遵循 {R:x,F:y}、{R:x} 或 {IP} 格式，无效格式（如 {}）视为普通文本。支持多个模式串。</li><li>未指定模式串：节点主机名添加后缀 1、2...n，其中n表示购买节点的数量，例如 server_购买2台时生成 server_1、server_2。</li></ul>
+	HostName *string `json:"HostName,omitnil,omitempty" name:"HostName"`
+
+	// <p>HostName 来源类型</p><p>枚举值：</p><ul><li>0： 复用节点创建时设置的 hostname，为空则报错</li><li>1： 重新指定 HostName，需同时传 HostName 字段（支持模式串 {R:x}、{R:x,F:y}、{IP}）</li><li>2： 系统自动分配，用 NodeId 作为 HostName</li></ul>
+	HostNameType *int64 `json:"HostNameType,omitnil,omitempty" name:"HostNameType"`
+
+	// <p>试运行开关，true 时只执行参数校验，不发起上架流程</p><p>默认值：false</p>
+	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
 }
 
 type AddNodesToDBCustomClusterRequest struct {
@@ -49,6 +64,21 @@ type AddNodesToDBCustomClusterRequest struct {
 
 	// <p>实例登录设置。通过该参数可以设置实例的登录方式密码、密钥或保持镜像的原始登录设置。</p><p>入参限制：若选择密钥方式，KeyIds 仅支持单个 ID。三种方式必须且仅可以设置其中一种。</p>
 	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
+
+	// <p>节点上架成功后初始化新增的自定义 Label</p><p>入参限制：单次 ≤ 20 对</p>
+	Labels []*Label `json:"Labels,omitnil,omitempty" name:"Labels"`
+
+	// <p>节点上架成功后初始化下发的Taint</p><p>入参限制：单次 ≤ 5 对</p>
+	Taints []*Taint `json:"Taints,omitnil,omitempty" name:"Taints"`
+
+	// <p>主机hostname ，仅 HostNameType=1 时必填，其余情况忽略；不支持大写字母</p><p>入参限制：- 点号（.）和短横线（-）不能作为 HostName 的首尾字符，不能连续使用。不允许使用下划线(_)。</p><ul><li>Windows 节点：主机名名字符长度为[2, 15]，允许字母（不限制大小写）、数字和短横线（-）组成，不支持点号（.），不能全是数字。</li><li>其他类型（Linux 等）节点：主机名字符长度为[2, 60]，允许支持多个点号，点之间为一段，每段允许字母（不限制大小写）、数字和短横线（-）组成。</li><li>上架多台节点时：</li><li>指定模式串 {R:x}：表示生成数字序列 [x, x+n-1]，其中 n为购买节点的数量。例如：输入 server_{R:3}，购买1台时，节点主机名为 server_3；购买2台时，主机名分别为 server_3、server_4。</li><li>指定模式串 {R:x,F:y}：y表示固定位数（可选），取值范围为 [0,8]，默认值 0表示不固定位数（等效于 {R:x}）。不足位时自动补零，例如：输入server_{R:3,F:3}，购买2台时，节点主机名为 server_003、server_004。若数字位数超过 y（如 {R:99,F:2}），以实际位数为准，例如：app_{R:99,F:2}，购买2台时，节点主机名为 app_99、app_100。</li><li>指定模式串 {IP}：自动替换为节点的内网IP地址。例如：输入 node-{IP}，节点主机名为 node-10.0.12.8；支持与序号模式串混合使用，例如：输入 web-{IP}-{R:1}，购买2台时，节点主机名分别为 web-10.0.12.8-1、web-10.0.12.9-2。</li><li>模式串需严格遵循 {R:x,F:y}、{R:x} 或 {IP} 格式，无效格式（如 {}）视为普通文本。支持多个模式串。</li><li>未指定模式串：节点主机名添加后缀 1、2...n，其中n表示购买节点的数量，例如 server_购买2台时生成 server_1、server_2。</li></ul>
+	HostName *string `json:"HostName,omitnil,omitempty" name:"HostName"`
+
+	// <p>HostName 来源类型</p><p>枚举值：</p><ul><li>0： 复用节点创建时设置的 hostname，为空则报错</li><li>1： 重新指定 HostName，需同时传 HostName 字段（支持模式串 {R:x}、{R:x,F:y}、{IP}）</li><li>2： 系统自动分配，用 NodeId 作为 HostName</li></ul>
+	HostNameType *int64 `json:"HostNameType,omitnil,omitempty" name:"HostNameType"`
+
+	// <p>试运行开关，true 时只执行参数校验，不发起上架流程</p><p>默认值：false</p>
+	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
 }
 
 func (r *AddNodesToDBCustomClusterRequest) ToJsonString() string {
@@ -67,6 +97,11 @@ func (r *AddNodesToDBCustomClusterRequest) FromJsonString(s string) error {
 	delete(f, "NodeIds")
 	delete(f, "ImageId")
 	delete(f, "LoginSettings")
+	delete(f, "Labels")
+	delete(f, "Taints")
+	delete(f, "HostName")
+	delete(f, "HostNameType")
+	delete(f, "DryRun")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "AddNodesToDBCustomClusterRequest has unknown keys!", "")
 	}
@@ -179,7 +214,7 @@ type CreateDBCustomClusterRequestParams struct {
 	// <p>容器网络，在此集群的所有 POD 与此网络连通</p>
 	ContainerNetwork *ContainerNetwork `json:"ContainerNetwork,omitnil,omitempty" name:"ContainerNetwork"`
 
-	// <p>集群名称</p><p>入参限制：最长128个字符，只能为中文，英文，下划线。</p>
+	// <p>集群名称</p><p>入参限制：最长128个字符。</p>
 	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 
 	// <p>集群的API Server的网络信息</p><p>入参限制：必须为此账号下拥有的网络地址，可以与容器网络保持一致。</p>
@@ -193,6 +228,9 @@ type CreateDBCustomClusterRequestParams struct {
 
 	// <p>客户端Token</p>
 	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+
+	// <p>试运行开关，true 时只执行参数校验，不发起创建流程，默认 false</p>
+	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
 }
 
 type CreateDBCustomClusterRequest struct {
@@ -201,7 +239,7 @@ type CreateDBCustomClusterRequest struct {
 	// <p>容器网络，在此集群的所有 POD 与此网络连通</p>
 	ContainerNetwork *ContainerNetwork `json:"ContainerNetwork,omitnil,omitempty" name:"ContainerNetwork"`
 
-	// <p>集群名称</p><p>入参限制：最长128个字符，只能为中文，英文，下划线。</p>
+	// <p>集群名称</p><p>入参限制：最长128个字符。</p>
 	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 
 	// <p>集群的API Server的网络信息</p><p>入参限制：必须为此账号下拥有的网络地址，可以与容器网络保持一致。</p>
@@ -215,6 +253,9 @@ type CreateDBCustomClusterRequest struct {
 
 	// <p>客户端Token</p>
 	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+
+	// <p>试运行开关，true 时只执行参数校验，不发起创建流程，默认 false</p>
+	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
 }
 
 func (r *CreateDBCustomClusterRequest) ToJsonString() string {
@@ -235,6 +276,7 @@ func (r *CreateDBCustomClusterRequest) FromJsonString(s string) error {
 	delete(f, "ClusterDescription")
 	delete(f, "Tags")
 	delete(f, "ClientToken")
+	delete(f, "DryRun")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBCustomClusterRequest has unknown keys!", "")
 	}
@@ -283,17 +325,17 @@ type CreateDBCustomNodesRequestParams struct {
 	// <p>为节点打通SSH连接的VPC 子网 ID。 </p><p>参数格式：subnet-t13dtest</p><p>入参限制：必须是VPC之下的子网，子网必须与可用区对应。</p><p>取值参考：可通过【查询子网列表】接口获取：https://cloud.tencent.com/document/product/215/15784</p>
 	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
-	// <p>购买时长(月): 1/2/3/4/5/6/7/8/9/10/11/12/24/36</p><p>取值范围：[1, 36]</p><p>单位：月</p><p>默认值：1</p>
-	Period *int64 `json:"Period,omitnil,omitempty" name:"Period"`
-
 	// <p>节点机型</p><p>枚举值：</p><ul><li>DB.AT5.32XLARGE512： 高IO型服务器：128核心512GB内存，8*7180GB本地NvME SSDB。</li><li>DB.AT5.64XLARGE1152： 高IO型服务器：256核心1152GB内存，12*7180GB本地NvME SSDB。</li><li>DB.AT5.128XLARGE2304： 高IO型服务器：512核心2304GB内存，24*7180GB本地NvME SSDB。</li><li>DB.AT5.16XLARGE256： 高IO型服务器：64核心256GB内存，4*7180GB本地NvME SSDB。</li><li>DB.AT5.8XLARGE128： 高IO型服务器：32核心128GB内存，2*7180GB本地NvME SSDB。</li></ul>
 	NodeType *string `json:"NodeType,omitnil,omitempty" name:"NodeType"`
 
 	// <p>购买的节点数量</p><p>取值范围：[1, 20]</p>
 	NodeCount *int64 `json:"NodeCount,omitnil,omitempty" name:"NodeCount"`
 
-	// <p>实例登录设置。通过该参数可以设置实例的登录方式密码、密钥或保持镜像的原始登录设置。</p><p>入参限制：若选择密钥方式，KeyIds 仅支持单个 ID。三种方式必须且仅可以设置其中一种。</p>
+	// <p>节点登录设置。通过该参数可以设置节点的登录方式密码、密钥或保持镜像的原始登录设置。</p><p>入参限制：若选择密钥方式，KeyIds 仅支持单个 ID。三种方式必须且仅可以设置其中一种。</p>
 	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
+
+	// <p>购买时长(月): 1/2/3/4/5/6/7/8/9/10/11/12/24/36</p><p>取值范围：[1, 36]</p><p>单位：月</p><p>默认值：1</p>
+	Period *int64 `json:"Period,omitnil,omitempty" name:"Period"`
 
 	// <p>自动续费配置</p><p>枚举值：</p><ul><li>1： 自动续费</li><li>2： 不自动续费</li></ul><p>默认值：不自动续费</p>
 	AutoRenew *int64 `json:"AutoRenew,omitnil,omitempty" name:"AutoRenew"`
@@ -312,6 +354,27 @@ type CreateDBCustomNodesRequestParams struct {
 
 	// <p>用于保证请求幂等性的字符串。该字符串由客户生成，需保证不同请求之间唯一，最大值不超过64个ASCII字符。若不指定该参数，则无法保证请求的幂等性。</p>
 	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+
+	// <p>计费模式</p><p>枚举值：</p><ul><li>PREPAID： 包年包月</li><li>POSTPAID： 按量付费</li></ul><p>默认值：默认为包年包月(PREPAID)</p>
+	ChargeType *string `json:"ChargeType,omitnil,omitempty" name:"ChargeType"`
+
+	// <p>访问主机的网络模式</p><p>枚举值：</p><ul><li>privatelink： 四层网络联通，放通SSH 通路</li><li>cross_tenant_eni： 三层网络联通，双网卡模式</li></ul><p>默认值：默认值为：privatelink</p>
+	NetworkMode *string `json:"NetworkMode,omitnil,omitempty" name:"NetworkMode"`
+
+	// <p>系统盘配置</p><p>入参限制：仅云盘版机型支持，如DB.SA5机型。本地盘机型DB.AT5机型不支持设置</p>
+	SystemDisk *SystemDisk `json:"SystemDisk,omitnil,omitempty" name:"SystemDisk"`
+
+	// <p>数据库盘配置</p><p>入参限制：仅云盘版机型支持，如DB.SA5机型。本地盘机型DB.AT5机型不支持设置</p>
+	DataDisks []*DataDisk `json:"DataDisks,omitnil,omitempty" name:"DataDisks"`
+
+	// <p>主机的hostname。</p><p>参数格式：字符串或者指定模式串</p><p>入参限制：- 点号（.）和短横线（-）不能作为 HostName 的首尾字符，不能连续使用。不允许使用下划线(_)。</p><ul><li>Windows 节点：主机名名字符长度为[2, 15]，允许字母（不限制大小写）、数字和短横线（-）组成，不支持点号（.），不能全是数字。</li><li>其他类型（Linux 等）节点：主机名字符长度为[2, 60]，允许支持多个点号，点之间为一段，每段允许字母（不限制大小写）、数字和短横线（-）组成。</li><li>购买多台节点时：</li><li>指定模式串 {R:x}：表示生成数字序列 [x, x+n-1]，其中 n为购买节点的数量。例如：输入 server_{R:3}，购买1台时，节点主机名为 server_3；购买2台时，主机名分别为 server_3、server_4。</li><li>指定模式串 {R:x,F:y}：y表示固定位数（可选），取值范围为 [0,8]，默认值 0表示不固定位数（等效于 {R:x}）。不足位时自动补零，例如：输入server_{R:3,F:3}，购买2台时，节点主机名为 server_003、server_004。若数字位数超过 y（如 {R:99,F:2}），以实际位数为准，例如：app_{R:99,F:2}，购买2台时，节点主机名为 app_99、app_100。</li><li>指定模式串 {IP}：自动替换为节点的内网IP地址。例如：输入 node-{IP}，节点主机名为 node-10.0.12.8；支持与序号模式串混合使用，例如：输入 web-{IP}-{R:1}，购买2台时，节点主机名分别为 web-10.0.12.8-1、web-10.0.12.9-2。</li><li>模式串需严格遵循 {R:x,F:y}、{R:x} 或 {IP} 格式，无效格式（如 {}）视为普通文本。支持多个模式串。</li><li>未指定模式串：节点主机名添加后缀 1、2...n，其中n表示购买节点的数量，例如 server_购买2台时生成 server_1、server_2。</li></ul>
+	HostName *string `json:"HostName,omitnil,omitempty" name:"HostName"`
+
+	// <p>试运行开关。</p><p>枚举值：</p><ul><li>true： 为 true 时接口只执行参数校验与资源申请检查（库存、配额、网络等），完成后立即返回空响应，不会真正下单，也不会创建节点记录。用于调用方在真正下单前做一次可行性预检。</li><li>false： 不预检查</li></ul><p>默认值：false</p>
+	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
+
+	// <p>设置节点安全组</p><p>参数格式：设置需要与节点绑定的多个安全组ID，以数组形式配置。</p>
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
 }
 
 type CreateDBCustomNodesRequest struct {
@@ -329,17 +392,17 @@ type CreateDBCustomNodesRequest struct {
 	// <p>为节点打通SSH连接的VPC 子网 ID。 </p><p>参数格式：subnet-t13dtest</p><p>入参限制：必须是VPC之下的子网，子网必须与可用区对应。</p><p>取值参考：可通过【查询子网列表】接口获取：https://cloud.tencent.com/document/product/215/15784</p>
 	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
-	// <p>购买时长(月): 1/2/3/4/5/6/7/8/9/10/11/12/24/36</p><p>取值范围：[1, 36]</p><p>单位：月</p><p>默认值：1</p>
-	Period *int64 `json:"Period,omitnil,omitempty" name:"Period"`
-
 	// <p>节点机型</p><p>枚举值：</p><ul><li>DB.AT5.32XLARGE512： 高IO型服务器：128核心512GB内存，8*7180GB本地NvME SSDB。</li><li>DB.AT5.64XLARGE1152： 高IO型服务器：256核心1152GB内存，12*7180GB本地NvME SSDB。</li><li>DB.AT5.128XLARGE2304： 高IO型服务器：512核心2304GB内存，24*7180GB本地NvME SSDB。</li><li>DB.AT5.16XLARGE256： 高IO型服务器：64核心256GB内存，4*7180GB本地NvME SSDB。</li><li>DB.AT5.8XLARGE128： 高IO型服务器：32核心128GB内存，2*7180GB本地NvME SSDB。</li></ul>
 	NodeType *string `json:"NodeType,omitnil,omitempty" name:"NodeType"`
 
 	// <p>购买的节点数量</p><p>取值范围：[1, 20]</p>
 	NodeCount *int64 `json:"NodeCount,omitnil,omitempty" name:"NodeCount"`
 
-	// <p>实例登录设置。通过该参数可以设置实例的登录方式密码、密钥或保持镜像的原始登录设置。</p><p>入参限制：若选择密钥方式，KeyIds 仅支持单个 ID。三种方式必须且仅可以设置其中一种。</p>
+	// <p>节点登录设置。通过该参数可以设置节点的登录方式密码、密钥或保持镜像的原始登录设置。</p><p>入参限制：若选择密钥方式，KeyIds 仅支持单个 ID。三种方式必须且仅可以设置其中一种。</p>
 	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
+
+	// <p>购买时长(月): 1/2/3/4/5/6/7/8/9/10/11/12/24/36</p><p>取值范围：[1, 36]</p><p>单位：月</p><p>默认值：1</p>
+	Period *int64 `json:"Period,omitnil,omitempty" name:"Period"`
 
 	// <p>自动续费配置</p><p>枚举值：</p><ul><li>1： 自动续费</li><li>2： 不自动续费</li></ul><p>默认值：不自动续费</p>
 	AutoRenew *int64 `json:"AutoRenew,omitnil,omitempty" name:"AutoRenew"`
@@ -358,6 +421,27 @@ type CreateDBCustomNodesRequest struct {
 
 	// <p>用于保证请求幂等性的字符串。该字符串由客户生成，需保证不同请求之间唯一，最大值不超过64个ASCII字符。若不指定该参数，则无法保证请求的幂等性。</p>
 	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+
+	// <p>计费模式</p><p>枚举值：</p><ul><li>PREPAID： 包年包月</li><li>POSTPAID： 按量付费</li></ul><p>默认值：默认为包年包月(PREPAID)</p>
+	ChargeType *string `json:"ChargeType,omitnil,omitempty" name:"ChargeType"`
+
+	// <p>访问主机的网络模式</p><p>枚举值：</p><ul><li>privatelink： 四层网络联通，放通SSH 通路</li><li>cross_tenant_eni： 三层网络联通，双网卡模式</li></ul><p>默认值：默认值为：privatelink</p>
+	NetworkMode *string `json:"NetworkMode,omitnil,omitempty" name:"NetworkMode"`
+
+	// <p>系统盘配置</p><p>入参限制：仅云盘版机型支持，如DB.SA5机型。本地盘机型DB.AT5机型不支持设置</p>
+	SystemDisk *SystemDisk `json:"SystemDisk,omitnil,omitempty" name:"SystemDisk"`
+
+	// <p>数据库盘配置</p><p>入参限制：仅云盘版机型支持，如DB.SA5机型。本地盘机型DB.AT5机型不支持设置</p>
+	DataDisks []*DataDisk `json:"DataDisks,omitnil,omitempty" name:"DataDisks"`
+
+	// <p>主机的hostname。</p><p>参数格式：字符串或者指定模式串</p><p>入参限制：- 点号（.）和短横线（-）不能作为 HostName 的首尾字符，不能连续使用。不允许使用下划线(_)。</p><ul><li>Windows 节点：主机名名字符长度为[2, 15]，允许字母（不限制大小写）、数字和短横线（-）组成，不支持点号（.），不能全是数字。</li><li>其他类型（Linux 等）节点：主机名字符长度为[2, 60]，允许支持多个点号，点之间为一段，每段允许字母（不限制大小写）、数字和短横线（-）组成。</li><li>购买多台节点时：</li><li>指定模式串 {R:x}：表示生成数字序列 [x, x+n-1]，其中 n为购买节点的数量。例如：输入 server_{R:3}，购买1台时，节点主机名为 server_3；购买2台时，主机名分别为 server_3、server_4。</li><li>指定模式串 {R:x,F:y}：y表示固定位数（可选），取值范围为 [0,8]，默认值 0表示不固定位数（等效于 {R:x}）。不足位时自动补零，例如：输入server_{R:3,F:3}，购买2台时，节点主机名为 server_003、server_004。若数字位数超过 y（如 {R:99,F:2}），以实际位数为准，例如：app_{R:99,F:2}，购买2台时，节点主机名为 app_99、app_100。</li><li>指定模式串 {IP}：自动替换为节点的内网IP地址。例如：输入 node-{IP}，节点主机名为 node-10.0.12.8；支持与序号模式串混合使用，例如：输入 web-{IP}-{R:1}，购买2台时，节点主机名分别为 web-10.0.12.8-1、web-10.0.12.9-2。</li><li>模式串需严格遵循 {R:x,F:y}、{R:x} 或 {IP} 格式，无效格式（如 {}）视为普通文本。支持多个模式串。</li><li>未指定模式串：节点主机名添加后缀 1、2...n，其中n表示购买节点的数量，例如 server_购买2台时生成 server_1、server_2。</li></ul>
+	HostName *string `json:"HostName,omitnil,omitempty" name:"HostName"`
+
+	// <p>试运行开关。</p><p>枚举值：</p><ul><li>true： 为 true 时接口只执行参数校验与资源申请检查（库存、配额、网络等），完成后立即返回空响应，不会真正下单，也不会创建节点记录。用于调用方在真正下单前做一次可行性预检。</li><li>false： 不预检查</li></ul><p>默认值：false</p>
+	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
+
+	// <p>设置节点安全组</p><p>参数格式：设置需要与节点绑定的多个安全组ID，以数组形式配置。</p>
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
 }
 
 func (r *CreateDBCustomNodesRequest) ToJsonString() string {
@@ -376,16 +460,23 @@ func (r *CreateDBCustomNodesRequest) FromJsonString(s string) error {
 	delete(f, "ImageId")
 	delete(f, "VpcId")
 	delete(f, "SubnetId")
-	delete(f, "Period")
 	delete(f, "NodeType")
 	delete(f, "NodeCount")
 	delete(f, "LoginSettings")
+	delete(f, "Period")
 	delete(f, "AutoRenew")
 	delete(f, "NodeName")
 	delete(f, "AutoVoucher")
 	delete(f, "VoucherIds")
 	delete(f, "Tags")
 	delete(f, "ClientToken")
+	delete(f, "ChargeType")
+	delete(f, "NetworkMode")
+	delete(f, "SystemDisk")
+	delete(f, "DataDisks")
+	delete(f, "HostName")
+	delete(f, "DryRun")
+	delete(f, "SecurityGroupIds")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBCustomNodesRequest has unknown keys!", "")
 	}
@@ -474,6 +565,52 @@ type DBCustomClusterNode struct {
 
 	// <p>节点类型</p><p>枚举值：</p><ul><li>DB.AT5.32XLARGE512： 高IO型服务器：128核心512GB内存，8*7180GB本地NvME SSDB。</li><li>DB.AT5.64XLARGE1152： 高IO型服务器：256核心1152GB内存，12*7180GB本地NvME SSDB。</li><li>DB.AT5.128XLARGE2304： 高IO型服务器：512核心2304GB内存，24*7180GB本地NvME SSDB。</li><li>DB.AT5.16XLARGE256： 高IO型服务器：64核心256GB内存，4*7180GB本地NvME SSDB。</li><li>DB.AT5.8XLARGE128： 高IO型服务器：32核心128GB内存，2*7180GB本地NvME SSDB。</li></ul>
 	NodeType *string `json:"NodeType,omitnil,omitempty" name:"NodeType"`
+
+	// <p>网络模式</p><p>枚举值：</p><ul><li>privatelink： 四层网络联通，放通SSH 通路</li><li>cross_tenant_eni： 三层网络联通，双网卡模式</li></ul>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NetworkMode *string `json:"NetworkMode,omitnil,omitempty" name:"NetworkMode"`
+
+	// <p>当选择网络模式为三层网络联通模式时，此处的IP地址则为用户可访问的地址。</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EniIP *string `json:"EniIP,omitnil,omitempty" name:"EniIP"`
+}
+
+type DBCustomClusterNodeConfig struct {
+	// <p>节点ID</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+
+	// <p>节点的标签信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Labels []*Label `json:"Labels,omitnil,omitempty" name:"Labels"`
+
+	// <p>节点的污点信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Taints []*Taint `json:"Taints,omitnil,omitempty" name:"Taints"`
+}
+
+type DBCustomClusterNodeResource struct {
+	// <p>节点ID</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+
+	// <p>节点物理资源总容量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Capacity *MetaResource `json:"Capacity,omitnil,omitempty" name:"Capacity"`
+
+	// <p>节点可分配容量= Capacity - 系统预留</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Allocatable *MetaResource `json:"Allocatable,omitnil,omitempty" name:"Allocatable"`
+
+	// <p>节点上所有非终态 Pod 的 requests 申请量之和（含系统 Pod）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Requests *MetaResource `json:"Requests,omitnil,omitempty" name:"Requests"`
+
+	// <p>节点上所有非终态 Pod 的 limits 上限之和（含系统 Pod）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Limits *MetaResource `json:"Limits,omitnil,omitempty" name:"Limits"`
+
+	// <p>节点可再调度余量 = max(0, Allocatable - Requests)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Available *MetaResource `json:"Available,omitnil,omitempty" name:"Available"`
 }
 
 type DBCustomImage struct {
@@ -488,6 +625,9 @@ type DBCustomImage struct {
 
 	// <p>操作系统架构</p><p>枚举值：</p><ul><li>x86_64： X86 64位架构</li><li>arm64： ARM 64位机构</li></ul>
 	Architecture *string `json:"Architecture,omitnil,omitempty" name:"Architecture"`
+
+	// <p>操作系统类型</p><p>枚举值：</p><ul><li>windows： windows</li><li>linux： linux</li></ul>
+	OsType *string `json:"OsType,omitnil,omitempty" name:"OsType"`
 }
 
 type DBCustomNode struct {
@@ -557,7 +697,7 @@ type DBCustomNode struct {
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// <p>节点是否自动续费标记</p><p>枚举值：</p><ul><li>1： 自动续费</li><li>0： 不自动续费</li></ul>
+	// <p>节点是否自动续费标记</p><p>枚举值：</p><ul><li>1： 自动续费</li><li>2： 不自动续费</li></ul>
 	AutoRenew *int64 `json:"AutoRenew,omitnil,omitempty" name:"AutoRenew"`
 
 	// <p>交换机ID（已加密）</p>
@@ -568,6 +708,38 @@ type DBCustomNode struct {
 
 	// <p>底层物理机IP（已加密）</p>
 	HostIp *string `json:"HostIp,omitnil,omitempty" name:"HostIp"`
+
+	// <p>网络模式</p><p>枚举值：</p><ul><li>NetworkModePrivateLink： 四层 SSH 服务联通模式</li><li>NetworkModeCrossTenantENI：  三层双网卡访问方式</li></ul>
+	NetworkMode *string `json:"NetworkMode,omitnil,omitempty" name:"NetworkMode"`
+
+	// <p>当选择NetworkModeCrossTenantENI模式时，节点的访问IP地址</p>
+	EniIP *string `json:"EniIP,omitnil,omitempty" name:"EniIP"`
+}
+
+type DBCustomNodeTypeInfo struct {
+	// <p>可用区标识，如 ap-guangzhou-6</p>
+	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
+
+	// <p>机型标识</p><p>枚举值：</p><ul><li>DB.SA5.2XLARGE32： DB.SA5机型</li><li>DB.AT5.8XLARGE128： DB.AT5机型</li></ul>
+	NodeType *string `json:"NodeType,omitnil,omitempty" name:"NodeType"`
+
+	// <p>机型系列，如 DB.AT5、DB.SA5</p>
+	NodeFamily *string `json:"NodeFamily,omitnil,omitempty" name:"NodeFamily"`
+
+	// <p>CPU 核数</p><p>单位：核</p>
+	CPU *uint64 `json:"CPU,omitnil,omitempty" name:"CPU"`
+
+	// <p>内存大小</p><p>单位：GiB</p>
+	Memory *uint64 `json:"Memory,omitnil,omitempty" name:"Memory"`
+
+	// <p>机型售卖状态</p><p>枚举值：</p><ul><li>SELL： 正常售卖</li><li>SOLD_OUT： 售罄</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>该机型允许的系统盘类型列表（如 CLOUD_BSSD、CLOUD_HSSD）；</p>
+	SystemDiskTypes []*string `json:"SystemDiskTypes,omitnil,omitempty" name:"SystemDiskTypes"`
+
+	// <p>该机型允许的数据盘类型列表（如 CLOUD_BSSD、CLOUD_HSSD）；</p>
+	DataDiskTypes []*string `json:"DataDiskTypes,omitnil,omitempty" name:"DataDiskTypes"`
 }
 
 type DBInstanceDetail struct {
@@ -645,7 +817,7 @@ type DataDisk struct {
 	// <p>磁盘大小</p><p>单位：GiB</p>
 	DiskSize *int64 `json:"DiskSize,omitnil,omitempty" name:"DiskSize"`
 
-	// <p>磁盘名称</p>
+	// <p>磁盘名称</p><p>DataDisk 作为输入参数时，DiskName 无效。</p>
 	DiskName *string `json:"DiskName,omitnil,omitempty" name:"DiskName"`
 }
 
@@ -695,7 +867,7 @@ type DescribeDBCustomClusterDetailResponseParams struct {
 	// <p>集群所属地域</p><p>枚举值：</p><ul><li>ap-shanghai： 上海地域</li><li>ap-nanjing： 南京地域</li></ul>
 	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// <p>DB Custom 集群状态</p><p>枚举值：</p><ul><li>Creating： 创建中</li><li>Running： 运行中</li><li>Destroying： 销毁中</li></ul>
+	// <p>DB Custom 集群状态</p><p>枚举值：</p><ul><li>Creating： 创建中</li><li>Running： 运行中</li><li>Destroying： 销毁中</li><li>Initializing： 初始化中</li></ul>
 	ClusterStatus *string `json:"ClusterStatus,omitnil,omitempty" name:"ClusterStatus"`
 
 	// <p>集群版本</p><p>枚举值：</p><ul><li>1.34.1： 集群版本1.34.1</li></ul><p>默认值：1.34.1</p>
@@ -800,6 +972,135 @@ func (r *DescribeDBCustomClusterKubeconfigResponse) FromJsonString(s string) err
 }
 
 // Predefined struct for user
+type DescribeDBCustomClusterNodeConfigRequestParams struct {
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>按照一个或者多个 NodeId 查询。</p><p>入参限制：每次请求的数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+}
+
+type DescribeDBCustomClusterNodeConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>按照一个或者多个 NodeId 查询。</p><p>入参限制：每次请求的数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+}
+
+func (r *DescribeDBCustomClusterNodeConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomClusterNodeConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "NodeIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomClusterNodeConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomClusterNodeConfigResponseParams struct {
+	// <p>当前账号下拥有的DB Custom 节点列表信息</p>
+	NodeSet []*DBCustomClusterNodeConfig `json:"NodeSet,omitnil,omitempty" name:"NodeSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomClusterNodeConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomClusterNodeConfigResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomClusterNodeConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomClusterNodeConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomClusterNodeResourcesRequestParams struct {
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>按照一个或者多个 NodeId 查询。</p><p>入参限制：每次请求的数量上限为50</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+}
+
+type DescribeDBCustomClusterNodeResourcesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>按照一个或者多个 NodeId 查询。</p><p>入参限制：每次请求的数量上限为50</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+}
+
+func (r *DescribeDBCustomClusterNodeResourcesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomClusterNodeResourcesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "NodeIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomClusterNodeResourcesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomClusterNodeResourcesResponseParams struct {
+	// <p>当前账号下拥有的DB Custom 节点列表信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NodeSet []*DBCustomClusterNodeResource `json:"NodeSet,omitnil,omitempty" name:"NodeSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomClusterNodeResourcesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomClusterNodeResourcesResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomClusterNodeResourcesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomClusterNodeResourcesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeDBCustomClusterNodesRequestParams struct {
 	// <p>DB Custom 集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -877,6 +1178,78 @@ func (r *DescribeDBCustomClusterNodesResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeDBCustomClusterNodesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomClusterResourcesRequestParams struct {
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+type DescribeDBCustomClusterResourcesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+func (r *DescribeDBCustomClusterResourcesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomClusterResourcesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomClusterResourcesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomClusterResourcesResponseParams struct {
+	// <p>参与汇总的工作节点总数（不含控制面节点）</p><p>单位：台</p>
+	NodeCount *uint64 `json:"NodeCount,omitnil,omitempty" name:"NodeCount"`
+
+	// <p>集群所有节点的资源物理总容量之和</p>
+	Capacity *MetaResource `json:"Capacity,omitnil,omitempty" name:"Capacity"`
+
+	// <p>集群所有节点的可分配容量之和（= Capacity - 系统预留）</p>
+	Allocatable *MetaResource `json:"Allocatable,omitnil,omitempty" name:"Allocatable"`
+
+	// <p>集群所有非终态 Pod 的 requests 申请量之和（含系统 Pod）</p>
+	Requests *MetaResource `json:"Requests,omitnil,omitempty" name:"Requests"`
+
+	// <p>集群所有非终态 Pod 的 limits 上限之和（含系统 Pod，Pods 字段无语义，固定为 0）</p>
+	Limits *MetaResource `json:"Limits,omitnil,omitempty" name:"Limits"`
+
+	// <p>集群可再调度余量（所有节点 max(0, Allocatable - Requests) 累加求和）</p>
+	Available *MetaResource `json:"Available,omitnil,omitempty" name:"Available"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomClusterResourcesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomClusterResourcesResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomClusterResourcesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomClusterResourcesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -970,6 +1343,9 @@ func (r *DescribeDBCustomClustersResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeDBCustomImagesRequestParams struct {
+	// <p>支持镜像过滤的选项</p><p>取值参考：</p><ul><li>image-id,按镜像 ID 过滤    </li><li>os-type,按操作系统类型过滤(linux / windows)</li><li>image-type，按镜像类型过滤（PUBLIC_IMAGE（公共镜像）/ PRIVATE_IMAGE（私有镜像））</li><li>architecture，按架构过滤（x86_64 / arm64）</li></ul>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
 	// <p>偏移量</p><p>默认值：0</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
@@ -980,6 +1356,9 @@ type DescribeDBCustomImagesRequestParams struct {
 type DescribeDBCustomImagesRequest struct {
 	*tchttp.BaseRequest
 	
+	// <p>支持镜像过滤的选项</p><p>取值参考：</p><ul><li>image-id,按镜像 ID 过滤    </li><li>os-type,按操作系统类型过滤(linux / windows)</li><li>image-type，按镜像类型过滤（PUBLIC_IMAGE（公共镜像）/ PRIVATE_IMAGE（私有镜像））</li><li>architecture，按架构过滤（x86_64 / arm64）</li></ul>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
 	// <p>偏移量</p><p>默认值：0</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
@@ -999,6 +1378,7 @@ func (r *DescribeDBCustomImagesRequest) FromJsonString(s string) error {
 	if err := json.Unmarshal([]byte(s), &f); err != nil {
 		return err
 	}
+	delete(f, "Filters")
 	delete(f, "Offset")
 	delete(f, "Limit")
 	if len(f) > 0 {
@@ -1032,6 +1412,122 @@ func (r *DescribeDBCustomImagesResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeDBCustomImagesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomNodeSecurityGroupsRequestParams struct {
+	// <p>节点id</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+}
+
+type DescribeDBCustomNodeSecurityGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>节点id</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+}
+
+func (r *DescribeDBCustomNodeSecurityGroupsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomNodeSecurityGroupsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NodeId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomNodeSecurityGroupsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomNodeSecurityGroupsResponseParams struct {
+	// <p>与节点绑定的安全组id，数组格式，根据内部安全组ID的顺序来确认优先级。</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Groups []*SecurityGroup `json:"Groups,omitnil,omitempty" name:"Groups"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomNodeSecurityGroupsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomNodeSecurityGroupsResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomNodeSecurityGroupsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomNodeSecurityGroupsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomNodeTypesRequestParams struct {
+	// <p>支持通过地域，可用区，机型系列，机型标识进行过滤</p><p>入参限制：region、zone、node-family、node-type</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+type DescribeDBCustomNodeTypesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>支持通过地域，可用区，机型系列，机型标识进行过滤</p><p>入参限制：region、zone、node-family、node-type</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+func (r *DescribeDBCustomNodeTypesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomNodeTypesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Filters")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomNodeTypesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomNodeTypesResponseParams struct {
+	// <p>节点机型详细信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NodeTypeSet []*DBCustomNodeTypeInfo `json:"NodeTypeSet,omitnil,omitempty" name:"NodeTypeSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomNodeTypesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomNodeTypesResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomNodeTypesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomNodeTypesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -1124,6 +1620,61 @@ func (r *DescribeDBCustomNodesResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeDBCustomRegionsRequestParams struct {
+
+}
+
+type DescribeDBCustomRegionsRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *DescribeDBCustomRegionsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomRegionsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomRegionsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomRegionsResponseParams struct {
+	// <p>支持售卖的地域列表信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RegionSet []*RegionInfo `json:"RegionSet,omitnil,omitempty" name:"RegionSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomRegionsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomRegionsResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomRegionsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomRegionsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeDBCustomTaskStatusRequestParams struct {
 	// <p>DB Custom 任务ID</p>
 	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
@@ -1177,6 +1728,61 @@ func (r *DescribeDBCustomTaskStatusResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeDBCustomTaskStatusResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomZonesRequestParams struct {
+
+}
+
+type DescribeDBCustomZonesRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *DescribeDBCustomZonesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomZonesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomZonesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomZonesResponseParams struct {
+	// <p>查询支持售卖的地域对应的可用区，State字段值如为SELL则代表正常售卖。</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ZoneSet []*ZoneInfo `json:"ZoneSet,omitnil,omitempty" name:"ZoneSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomZonesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomZonesResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomZonesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomZonesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2194,6 +2800,14 @@ func (r *IsolateDBCustomNodeResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type Label struct {
+	// <p>在集群内的节点Label键</p>
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// <p>在集群内的节点Label键值</p>
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
 type LoginSettings struct {
 	// <p>实例登录密码。不同操作系统类型密码复杂度限制不一样，具体如下： Linux实例密码必须8到30位，至少包括两项[a-z]，[A-Z]、[0-9] 和 [( ) <code>~ ! @ # $ % ^ &amp; * - + = | { } [ ] : ; &#39; , . ? / ]中的特殊符号。 Windows实例密码必须12到30位，至少包括三项[a-z]，[A-Z]，[0-9] 和 [( )</code> ~ ! @ # $ % ^ &amp; * - + = | { } [ ] : ; &#39; , . ? /]中的特殊符号。</p>
 	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
@@ -2203,6 +2817,109 @@ type LoginSettings struct {
 
 	// <p>保持镜像的原始设置。该参数与Password或KeyIds.N不能同时指定。只有使用自定义镜像、共享镜像或外部导入镜像创建实例时才能指定该参数为true。</p><p>枚举值：</p><ul><li>true： 表示保持镜像的登录设置</li><li>false： 表示不保持镜像的登录设置</li></ul>
 	KeepImageLogin *string `json:"KeepImageLogin,omitnil,omitempty" name:"KeepImageLogin"`
+}
+
+type MetaResource struct {
+	// <p>CPU核心</p><p>单位：核</p>
+	Cpu *float64 `json:"Cpu,omitnil,omitempty" name:"Cpu"`
+
+	// <p>内存</p><p>单位：GiB</p>
+	Memory *float64 `json:"Memory,omitnil,omitempty" name:"Memory"`
+
+	// <p>POD数量</p><p>单位：个</p>
+	Pods *uint64 `json:"Pods,omitnil,omitempty" name:"Pods"`
+}
+
+// Predefined struct for user
+type ModifyDBCustomClusterNodeConfigRequestParams struct {
+	// <p>目标集群 ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>要修改的节点 ID 列表</p><p>入参限制：数量范围 1~50 个</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>新增或覆盖的集群 Label</p><p>入参限制：- 单次 ≤ 20 对；合并后节点总量不超过 20</p><ul><li>Key 格式对齐 K8s 原生（两段式，prefix DNS 子域 ≤ 253 字符，name ≤ 63 字符）</li><li>Value ≤ 63 字符，可为空</li><li>不可操作系统保留前缀</li></ul>
+	UpsertLabels []*Label `json:"UpsertLabels,omitnil,omitempty" name:"UpsertLabels"`
+
+	// <p>要删除的 Label key 列表，按 key 精确匹配，key 不存在时幂等放行。</p><p>入参限制：- Key 格式对齐 K8s 原生（两段式，prefix DNS 子域 ≤ 253 字符，name ≤ 63 字符）</p><ul><li>Value ≤ 63 字符，可为空</li><li>不可操作系统保留前缀</li></ul>
+	DeleteLabelKeys []*string `json:"DeleteLabelKeys,omitnil,omitempty" name:"DeleteLabelKeys"`
+
+	// <p>新增或覆盖的 Taint。</p><p>入参限制：- 单次 ≤ 5 对；合并后节点总量不超过 5。</p><ul><li>唯一性键为 (Key, Effect)，匹配到已有 (Key, Effect) 时覆盖 Value，否则新增</li><li>Effect 合法值：NoSchedule / PreferNoSchedule / NoExecute</li><li>同一 Key 允许多个不同 Effect 的 Taint 并存</li></ul>
+	UpsertTaints []*Taint `json:"UpsertTaints,omitnil,omitempty" name:"UpsertTaints"`
+
+	// <p>要删除的 Taint 过滤器列表</p><p>入参限制：- 唯一性键为 (Key, Effect)，匹配到已有 (Key, Effect) 时覆盖 Value，否则新增</p><ul><li>Effect 合法值：NoSchedule / PreferNoSchedule / NoExecute</li><li>同一 Key 允许多个不同 Effect 的 Taint 并存</li></ul>
+	DeleteTaints []*Taint `json:"DeleteTaints,omitnil,omitempty" name:"DeleteTaints"`
+}
+
+type ModifyDBCustomClusterNodeConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>目标集群 ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>要修改的节点 ID 列表</p><p>入参限制：数量范围 1~50 个</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>新增或覆盖的集群 Label</p><p>入参限制：- 单次 ≤ 20 对；合并后节点总量不超过 20</p><ul><li>Key 格式对齐 K8s 原生（两段式，prefix DNS 子域 ≤ 253 字符，name ≤ 63 字符）</li><li>Value ≤ 63 字符，可为空</li><li>不可操作系统保留前缀</li></ul>
+	UpsertLabels []*Label `json:"UpsertLabels,omitnil,omitempty" name:"UpsertLabels"`
+
+	// <p>要删除的 Label key 列表，按 key 精确匹配，key 不存在时幂等放行。</p><p>入参限制：- Key 格式对齐 K8s 原生（两段式，prefix DNS 子域 ≤ 253 字符，name ≤ 63 字符）</p><ul><li>Value ≤ 63 字符，可为空</li><li>不可操作系统保留前缀</li></ul>
+	DeleteLabelKeys []*string `json:"DeleteLabelKeys,omitnil,omitempty" name:"DeleteLabelKeys"`
+
+	// <p>新增或覆盖的 Taint。</p><p>入参限制：- 单次 ≤ 5 对；合并后节点总量不超过 5。</p><ul><li>唯一性键为 (Key, Effect)，匹配到已有 (Key, Effect) 时覆盖 Value，否则新增</li><li>Effect 合法值：NoSchedule / PreferNoSchedule / NoExecute</li><li>同一 Key 允许多个不同 Effect 的 Taint 并存</li></ul>
+	UpsertTaints []*Taint `json:"UpsertTaints,omitnil,omitempty" name:"UpsertTaints"`
+
+	// <p>要删除的 Taint 过滤器列表</p><p>入参限制：- 唯一性键为 (Key, Effect)，匹配到已有 (Key, Effect) 时覆盖 Value，否则新增</p><ul><li>Effect 合法值：NoSchedule / PreferNoSchedule / NoExecute</li><li>同一 Key 允许多个不同 Effect 的 Taint 并存</li></ul>
+	DeleteTaints []*Taint `json:"DeleteTaints,omitnil,omitempty" name:"DeleteTaints"`
+}
+
+func (r *ModifyDBCustomClusterNodeConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomClusterNodeConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "NodeIds")
+	delete(f, "UpsertLabels")
+	delete(f, "DeleteLabelKeys")
+	delete(f, "UpsertTaints")
+	delete(f, "DeleteTaints")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomClusterNodeConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomClusterNodeConfigResponseParams struct {
+	// <p>任务ID</p>
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomClusterNodeConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomClusterNodeConfigResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomClusterNodeConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomClusterNodeConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
@@ -2270,6 +2987,67 @@ func (r *ModifyDBCustomClusterTagsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyDBCustomClusterTagsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodeSecurityGroupsRequestParams struct {
+	// <p>节点id</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+
+	// <p>安全组id，数组格式，根据内部安全组ID的顺序来确认优先级。</p>
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+}
+
+type ModifyDBCustomNodeSecurityGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>节点id</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+
+	// <p>安全组id，数组格式，根据内部安全组ID的顺序来确认优先级。</p>
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+}
+
+func (r *ModifyDBCustomNodeSecurityGroupsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodeSecurityGroupsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NodeId")
+	delete(f, "SecurityGroupIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomNodeSecurityGroupsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodeSecurityGroupsResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomNodeSecurityGroupsResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomNodeSecurityGroupsResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomNodeSecurityGroupsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodeSecurityGroupsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2402,6 +3180,40 @@ func (r *ModifyInstanceNameResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type PolicyRule struct {
+	// <p>规则动作，</p><p>枚举值：</p><ul><li>ACCEPT： 允许</li><li>DROP： 拒绝</li></ul>
+	Action *string `json:"Action,omitnil,omitempty" name:"Action"`
+
+	// <p>来源/目标 IP 或 CIDR，如 0.0.0.0/0</p>
+	CidrIp *string `json:"CidrIp,omitnil,omitempty" name:"CidrIp"`
+
+	// <p>端口范围，如 80、8080-8090、ALL</p>
+	PortRange *string `json:"PortRange,omitnil,omitempty" name:"PortRange"`
+
+	// <p>协议类型，如 tcp、udp、icmp、ALL</p>
+	IpProtocol *string `json:"IpProtocol,omitnil,omitempty" name:"IpProtocol"`
+
+	// <p>协议端口模板 ID</p>
+	ServiceModule *string `json:"ServiceModule,omitnil,omitempty" name:"ServiceModule"`
+
+	// <p>IP 地址模板 ID</p>
+	AddressModule *string `json:"AddressModule,omitnil,omitempty" name:"AddressModule"`
+
+	// <p>安全组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>规则备注描述</p>
+	Desc *string `json:"Desc,omitnil,omitempty" name:"Desc"`
+}
+
+type RegionInfo struct {
+	// <p>地域</p>
+	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
+
+	// <p>售卖状态</p><p>枚举值：</p><ul><li>SELL： 正常售卖</li><li>SOLD_OUT： 售罄</li></ul>
+	RegionState *string `json:"RegionState,omitnil,omitempty" name:"RegionState"`
+}
+
 // Predefined struct for user
 type RemoveNodesFromDBCustomClusterRequestParams struct {
 	// <p>DB Custom 集群ID</p>
@@ -2409,6 +3221,9 @@ type RemoveNodesFromDBCustomClusterRequestParams struct {
 
 	// <p>要下架的 DB Custom 节点ID列表</p>
 	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>节点的登录参数</p>
+	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
 }
 
 type RemoveNodesFromDBCustomClusterRequest struct {
@@ -2419,6 +3234,9 @@ type RemoveNodesFromDBCustomClusterRequest struct {
 
 	// <p>要下架的 DB Custom 节点ID列表</p>
 	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>节点的登录参数</p>
+	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
 }
 
 func (r *RemoveNodesFromDBCustomClusterRequest) ToJsonString() string {
@@ -2435,6 +3253,7 @@ func (r *RemoveNodesFromDBCustomClusterRequest) FromJsonString(s string) error {
 	}
 	delete(f, "ClusterId")
 	delete(f, "NodeIds")
+	delete(f, "LoginSettings")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RemoveNodesFromDBCustomClusterRequest has unknown keys!", "")
 	}
@@ -2556,6 +3375,29 @@ type ResourceTag struct {
 	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
+type SecurityGroup struct {
+	// <p>安全组ID</p>
+	SecurityGroupId *string `json:"SecurityGroupId,omitnil,omitempty" name:"SecurityGroupId"`
+
+	// <p>所属项目 ID</p>
+	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
+
+	// <p>安全组创建时间</p>
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>安全组入方向规则列表</p>
+	Inbound []*PolicyRule `json:"Inbound,omitnil,omitempty" name:"Inbound"`
+
+	// <p>安全组出方向规则列表</p>
+	Outbound []*PolicyRule `json:"Outbound,omitnil,omitempty" name:"Outbound"`
+
+	// <p>安全组名称</p>
+	SecurityGroupName *string `json:"SecurityGroupName,omitnil,omitempty" name:"SecurityGroupName"`
+
+	// <p>安全组备注说明</p>
+	SecurityGroupRemark *string `json:"SecurityGroupRemark,omitnil,omitempty" name:"SecurityGroupRemark"`
+}
+
 type SystemDisk struct {
 	// <p>磁盘类型</p><p>枚举值：</p><ul><li>CLOUD_HSSD： 增强型云硬盘</li></ul>
 	DiskType *string `json:"DiskType,omitnil,omitempty" name:"DiskType"`
@@ -2570,4 +3412,23 @@ type Tag struct {
 
 	// <p>标签值</p>
 	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
+type Taint struct {
+	// <p>Taint 的键，格式对齐 K8s 原生约束（prefix DNS 子域 ≤ 253 字符，name ≤ 63 字符），不可使用系统保留前缀</p>
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// <p>污点效果</p><p>枚举值：</p><ul><li>NoSchedule： 不允许新 Pod 调度到该节点（已运行 Pod 不受影响）</li><li>PreferNoSchedule： 尽量不调度，无法满足时仍可调度</li><li>NoExecute： 不允许调度，且会驱逐已在节点上运行的不容忍该 Taint 的 Pod</li></ul>
+	Effect *string `json:"Effect,omitnil,omitempty" name:"Effect"`
+
+	// <p>Taint 的值，≤ 63 字符，可为空</p>
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
+type ZoneInfo struct {
+	// <p>支持的可用区</p>
+	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
+
+	// <p>可用区状态</p><p>枚举值：</p><ul><li>SELL： 正常售卖</li><li>SOLD_OUT： 售罄</li></ul>
+	ZoneState *string `json:"ZoneState,omitnil,omitempty" name:"ZoneState"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1297,7 +1297,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu/v20180709
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain/v20210527
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.118
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633

--- a/website/docs/r/dbdc_db_custom_node.html.markdown
+++ b/website/docs/r/dbdc_db_custom_node.html.markdown
@@ -19,10 +19,26 @@ resource "tencentcloud_dbdc_db_custom_node" "example" {
   image_id   = "img-rm13akp3"
   vpc_id     = "vpc-py7mlxqm"
   subnet_id  = "subnet-qd4upp83"
-  node_type  = "DB.AT5.8XLARGE128"
+  node_type  = "DB.SA5.8XLARGE128"
   period     = 1
   auto_renew = 1
   node_name  = "tf-example"
+
+  charge_type        = "PREPAID"
+  network_mode       = "privatelink"
+  host_name          = "tf-example-node"
+  security_group_ids = ["sg-xxxxxxxx"]
+
+  system_disk {
+    disk_type = "CLOUD_HSSD"
+    disk_size = 100
+  }
+
+  data_disks {
+    disk_type = "CLOUD_HSSD"
+    disk_size = 500
+    disk_name = "tf-example-data"
+  }
 
   login_settings {
     password = "Password@2026"
@@ -45,11 +61,23 @@ The following arguments are supported:
 * `zone` - (Required, String, ForceNew) Availability zone supported by the product, e.g. `ap-shanghai-5`, `ap-shanghai-8`, `ap-nanjing-3`.
 * `auto_renew` - (Optional, Int) Auto-renew flag. Valid values: `1` (auto-renew), `2` (not auto-renew). Mutable via the renew API.
 * `auto_voucher` - (Optional, Int) Whether to use voucher to deduct automatically. Valid values: `1` (use), `0` (not use). Default value is `0`.
+* `charge_type` - (Optional, String, ForceNew) Charge type. Valid values: `PREPAID`, `POSTPAID`.
+* `data_disks` - (Optional, List, ForceNew) Data disk information.
+* `host_name` - (Optional, String, ForceNew) Host name of the node. Write-only: the API does not return it, so the configured value is retained in state and cannot be refreshed on import.
 * `login_settings` - (Optional, List, ForceNew) Instance login settings. You can set the login method to password, key, or keep the original image login settings. Only one method can be set.
+* `network_mode` - (Optional, String, ForceNew) Network mode of the node. Valid values: `privatelink`, `cross_tenant_eni`. Default value is `privatelink`.
 * `node_name` - (Optional, String, ForceNew) Node name. Up to 128 characters.
 * `period` - (Optional, Int) Purchase duration in months. Valid values: 1/2/3/4/5/6/7/8/9/10/11/12/24/36. Default value is `1`.
+* `security_group_ids` - (Optional, List: [`String`]) Security group IDs bound to the node. Mutable: updating this list calls the ModifyDBCustomNodeSecurityGroups API.
+* `system_disk` - (Optional, List, ForceNew) System disk information.
 * `tags` - (Optional, Map) Node tags.
 * `voucher_ids` - (Optional, List: [`String`]) Voucher ID list. Must be undeducted voucher IDs owned by the current account.
+
+The `data_disks` object supports the following:
+
+* `disk_name` - (Optional, String) Disk name.
+* `disk_size` - (Optional, Int) Disk size, unit: GiB.
+* `disk_type` - (Optional, String) Disk type. Valid values: `CLOUD_HSSD`, `LOCAL_NVME`.
 
 The `login_settings` object supports the following:
 
@@ -57,19 +85,19 @@ The `login_settings` object supports the following:
 * `key_ids` - (Optional, List, ForceNew) Key pair ID list. Only a single ID is supported currently. Password and key cannot be specified at the same time.
 * `password` - (Optional, String, ForceNew) Instance login password. Password complexity limits vary by operating system type.
 
+The `system_disk` object supports the following:
+
+* `disk_size` - (Optional, Int) Disk size, unit: GiB.
+* `disk_type` - (Optional, String) Disk type. Valid values: `CLOUD_HSSD`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-* `charge_type` - Charge type. Valid values: `PREPAID`.
 * `cluster_id` - Cluster ID that the node belongs to.
 * `cpu` - Node CPU size, unit: core.
 * `created_time` - Node creation time.
-* `data_disks` - Data disk information.
-  * `disk_name` - Disk name.
-  * `disk_size` - Disk size, unit: GiB.
-  * `disk_type` - Disk type.
 * `expire_time` - Node expiration time.
 * `isolated_time` - Node isolation time.
 * `lan_ip` - Intranet communication IP address of the node.
@@ -78,9 +106,6 @@ In addition to all arguments above, the following attributes are exported:
 * `os_name` - Operating system name of the node.
 * `ssh_endpoint` - SSH endpoint to access this node, in the format `IP:Port`.
 * `status` - Node status. Valid values: `Creating`, `Running`, `Isolating`, `Isolated`, `Activating`, `Destroying`.
-* `system_disk` - System disk information.
-  * `disk_size` - Disk size, unit: GiB.
-  * `disk_type` - Disk type.
 
 ## Timeouts
 


### PR DESCRIPTION
Add new optional creation parameters to the tencentcloud_dbdc_db_custom_node resource: charge_type, network_mode, system_disk, data_disks, host_name, and security_group_ids. Includes Create/Read/Update wiring, service helper for DescribeDBCustomNodeSecurityGroups, documentation update, and test coverage.