### PR TITLE
fix(cdb): [120811674] `tencentcloud_mysql_instance` support timeouts for `update`

### DIFF
--- a/.changelog/4382.txt
+++ b/.changelog/4382.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_mysql_instance: support timeouts for update
+```

--- a/tencentcloud/services/cdb/resource_tc_mysql_instance.go
+++ b/tencentcloud/services/cdb/resource_tc_mysql_instance.go
@@ -409,6 +409,7 @@ func ResourceTencentCloudMysqlInstance() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(6 * time.Hour),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 	}
@@ -1263,7 +1264,7 @@ func mysqlAllInstanceRoleUpdate(ctx context.Context, d *schema.ResourceData, met
 			}
 
 			if waitSwitch != InWindow {
-				err = resource.Retry(6*time.Hour, func() *resource.RetryError {
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 					taskStatus, message, err := mysqlService.DescribeAsyncRequestInfo(ctx, asyncRequestId)
 
 					if err != nil {
@@ -1372,7 +1373,7 @@ func mysqlAllInstanceRoleUpdate(ctx context.Context, d *schema.ResourceData, met
 			}
 
 			if waitSwitch != InWindow {
-				err = resource.Retry(6*time.Hour, func() *resource.RetryError {
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 					taskStatus, message, err := mysqlService.DescribeAsyncRequestInfo(ctx, asyncRequestId)
 
 					if err != nil {
@@ -1479,7 +1480,7 @@ func mysqlAllInstanceRoleUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 
 		if waitSwitch != InWindow {
-			err = resource.Retry(6*time.Hour, func() *resource.RetryError {
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 				taskStatus, message, err := mysqlService.DescribeAsyncRequestInfo(ctx, asyncRequestId)
 
 				if err != nil {
@@ -1626,7 +1627,7 @@ func mysqlAllInstanceRoleUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		asyncRequestId = *response.Response.AsyncRequestId
 		if waitSwitch != InWindow {
-			err = resource.Retry(6*time.Hour, func() *resource.RetryError {
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 				taskStatus, message, err := mysqlService.DescribeAsyncRequestInfo(ctx, asyncRequestId)
 				if err != nil {
 					if _, ok := err.(*errors.TencentCloudSDKError); !ok {

--- a/website/docs/r/mysql_instance.html.markdown
+++ b/website/docs/r/mysql_instance.html.markdown
@@ -276,6 +276,7 @@ In addition to all arguments above, the following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to `20m`) Used when creating the resource.
+* `update` - (Defaults to `6h0m`) Used when updating the resource.
 * `delete` - (Defaults to `20m`) Used when deleting the resource.
 
 ## Import


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
