### PR TITLE
fix(tke): [120924921] `tencentcloud_kubernetes_cluster` update code logic for `auth_options`

### DIFF
--- a/.changelog/4383.txt
+++ b/.changelog/4383.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_kubernetes_cluster: update code logic for `auth_options`
+```

--- a/tencentcloud/services/tke/resource_tc_kubernetes_cluster.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_cluster.go
@@ -1284,12 +1284,14 @@ func ResourceTencentCloudKubernetesCluster() *schema.Resource {
 						"jwks_uri": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Specify service-account-jwks-uri. If use_tke_default is set to `true`, please do not set this field, it will be ignored anyway.",
+							Computed:    true,
+							Description: "Specify service-account-jwks-uri. If use_tke_default is set to `true`, please do not set this field, it will be ignored anyway. This field is also computed: when use_tke_default is `true`, TKE will auto-generate the value and it will be read back into state.",
 						},
 						"issuer": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Specify service-account-issuer. If use_tke_default is set to `true`, please do not set this field, it will be ignored anyway.",
+							Computed:    true,
+							Description: "Specify service-account-issuer. If use_tke_default is set to `true`, please do not set this field, it will be ignored anyway. This field is also computed: when use_tke_default is `true`, TKE will auto-generate the value and it will be read back into state.",
 						},
 						"auto_create_discovery_anonymous_auth": {
 							Type:        schema.TypeBool,

--- a/tencentcloud/services/tke/resource_tc_kubernetes_cluster_extension.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_cluster_extension.go
@@ -931,10 +931,12 @@ func resourceTencentCloudKubernetesClusterReadPostHandleResponse0(ctx context.Co
 				authOptions := make(map[string]interface{}, 0)
 				if helper.PBool(options.UseTKEDefault) {
 					authOptions["use_tke_default"] = helper.PBool(options.UseTKEDefault)
-				} else {
-					authOptions["jwks_uri"] = helper.PString(options.JWKSURI)
-					authOptions["issuer"] = helper.PString(options.Issuer)
 				}
+				// Always read back issuer and jwks_uri from the API so that users can
+				// see the auto-generated values when use_tke_default=true. These fields
+				// are Optional+Computed, so reading them back does not produce drift.
+				authOptions["jwks_uri"] = helper.PString(options.JWKSURI)
+				authOptions["issuer"] = helper.PString(options.Issuer)
 				authOptions["auto_create_discovery_anonymous_auth"] = helper.PBool(options.AutoCreateDiscoveryAnonymousAuth)
 				_ = d.Set("auth_options", []map[string]interface{}{authOptions})
 			}

--- a/tencentcloud/services/tke/resource_tc_kubernetes_log_config_extension.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_log_config_extension.go
@@ -11,7 +11,7 @@ import (
 func resourceTencentCloudKubernetesLogConfigReadRequestOnSuccess0(ctx context.Context, resp *v20180525.DescribeLogConfigsResponseParams) *resource.RetryError {
 	if resp != nil {
 		if resp.Message != nil && *resp.Message != "" {
-			e := fmt.Errorf(*resp.Message)
+			e := fmt.Errorf("%s", *resp.Message)
 			return resource.NonRetryableError(e)
 		}
 	}
@@ -23,7 +23,7 @@ func resourceTencentCloudKubernetesLogConfigDeletePostRequest0(ctx context.Conte
 	if resp != nil && resp.Response != nil {
 		message := resp.Response.Message
 		if message != nil && *message != "" {
-			e := fmt.Errorf(*message)
+			e := fmt.Errorf("%s", *message)
 			return resource.NonRetryableError(e)
 		}
 	}

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -855,8 +855,8 @@ The following arguments are supported:
 The `auth_options` object supports the following:
 
 * `auto_create_discovery_anonymous_auth` - (Optional, Bool) If set to `true`, the rbac rule will be created automatically which allow anonymous user to access '/.well-known/openid-configuration' and '/openid/v1/jwks'.
-* `issuer` - (Optional, String) Specify service-account-issuer. If use_tke_default is set to `true`, please do not set this field, it will be ignored anyway.
-* `jwks_uri` - (Optional, String) Specify service-account-jwks-uri. If use_tke_default is set to `true`, please do not set this field, it will be ignored anyway.
+* `issuer` - (Optional, String) Specify service-account-issuer. If use_tke_default is set to `true`, please do not set this field, it will be ignored anyway. This field is also computed: when use_tke_default is `true`, TKE will auto-generate the value and it will be read back into state.
+* `jwks_uri` - (Optional, String) Specify service-account-jwks-uri. If use_tke_default is set to `true`, please do not set this field, it will be ignored anyway. This field is also computed: when use_tke_default is `true`, TKE will auto-generate the value and it will be read back into state.
 * `use_tke_default` - (Optional, Bool) If set to `true`, the issuer and jwks_uri will be generated automatically by tke, please do not set issuer and jwks_uri, and they will be ignored.
 
 The `cluster_audit` object supports the following:


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
