### PR TITLE
feat(cynosdb): [136775570] add sync way and semi sync timeout params to cluster

### DIFF
--- a/.changelog/4384.txt
+++ b/.changelog/4384.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_cynosdb_cluster: support sync way and semi sync timeout parameters
+```

--- a/go.mod
+++ b/go.mod
@@ -46,11 +46,11 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.142
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.110
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.150
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633

--- a/go.sum
+++ b/go.sum
@@ -1004,8 +1004,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.135/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.142/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149 h1:rIoeeQt8842sJj/UQuZmSrQqPuXYvy1LeS9O6BN20T8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150 h1:BNDcc0mmFa/qr9ZJ+X65fTuxtGW6xEuTxElv6nJAlCQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1016,8 +1017,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130 h1:YWUFIWi
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130/go.mod h1:ZAn8DhN3+FA3PBpsO3bQjglYcqTIYhhd6Gk/qloWalc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30 h1:evU6/8eA7nay2ZZl/WcmRO/E1eEjPC5zAX5dNAMCoko=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30/go.mod h1:1zyxbBDx3OeAJa8Tmp0UJu4iJ0eTYQvhZzIYpXRuF/c=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.110 h1:QOFGuGnbRjTPji1YkPrZd5ywYAdPClF7aoLldgDpd44=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.110/go.mod h1:T+CEa+0ttowVLQwgqOOSlHW2ebse1QTq01ps3QoOgdk=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.150 h1:QhbpUVPN8sPeIA7UdQzavjyWNlxQS2QX9ANn6x48OXg=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.150/go.mod h1:KXgJCi64XF3acGfnG6tttDmghFfBK1XCk5mkTgIQpcI=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970 h1:qVIRHgG1twsqF4aVN/x2T2yMRfPpsZBTNefDkqzM06M=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970/go.mod h1:NJuuQD4z6vcnsZnC7Tvz2U9hElNS1wroc34UQbZvP2U=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335 h1:D8qrelkK5udv8RzJJIABMzItGIyaZoYnxEVeIsYqiNw=

--- a/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/design.md
+++ b/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The `tencentcloud_cynosdb_cluster` resource (defined in `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go`, schema in `TencentCynosdbClusterBaseInfo()` from `extension_cynosdb.go`) currently supports creating a cluster with `CreateClusters`, but does not expose the cluster synchronization mode parameters.
+
+**Current state:**
+- Resource file: `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go`
+- Schema: `TencentCynosdbClusterBaseInfo()` in `tencentcloud/services/cynosdb/extension_cynosdb.go`
+- Service layer: `tencentcloud/services/cynosdb/service_tencentcloud_cynosdb.go` (`DescribeClusterById` returns `*cynosdb.CynosdbClusterDetail`)
+- SDK: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107` (already vendored, includes the required fields)
+
+**API behavior analysis (verified against vendored SDK):**
+
+| API | SyncWay in Request | SemiSyncTimeout in Request | BinlogSyncWay in Response | SemiSyncTimeout in Response |
+|-----|--------------------|---------------------------|--------------------------|-----------------------------|
+| `CreateClusters` | Yes (`SyncWay *string`, async/semisync/sync) | Yes (`SemiSyncTimeout *int64`, [1000, 4294967295] ms, default 10000) | No | No |
+| `DescribeClusterDetail` | N/A | N/A | Yes (`Detail.SlaveZoneAttr[].BinlogSyncWay *string`) | Yes (`Detail.SlaveZoneAttr[].SemiSyncTimeout *int64`) |
+
+The requirement's other mappings (`ModifyInsGrpSecurityGroups` -> `rw_group_sg`/`ro_group_sg`, `SwitchServerlessCluster` -> `serverless_status_flag`, `ModifyTags` -> `tags`) are already implemented in the resource and are not part of this change's implementation work.
+
+**Key constraint:** The write path for `SyncWay`/`SemiSyncTimeout` is only `CreateClusters` per the requirement; the read path is `DescribeClusterDetail` (`Detail.SlaveZoneAttr[0]`). No update API is mapped for these fields, so they must be immutable after creation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `SyncWay` (Optional, string, immutable after creation) parameter to `tencentcloud_cynosdb_cluster` with valid values `async`, `semisync`, `sync`
+- Add `SemiSyncTimeout` (Optional, int, immutable after creation) parameter to `tencentcloud_cynosdb_cluster` with valid range `[1000, 4294967295]` ms
+- Pass `SyncWay` and `SemiSyncTimeout` to the `CreateClusters` API request when specified by the user
+- Read `BinlogSyncWay` and `SemiSyncTimeout` from the `DescribeClusterDetail` API response (`Detail.SlaveZoneAttr[0]`) in the Read function to support state refresh and import
+- Implement immutable-args handling in the Update function so changes to these fields return a clear error (consistent with the existing `db_mode`/`min_cpu`/`max_cpu` pattern)
+- Maintain full backward compatibility — existing configurations continue to work unchanged
+
+**Non-Goals:**
+- Making `SyncWay`/`SemiSyncTimeout`/`BinlogSyncWay` updatable after creation (no update API is mapped in the requirement)
+- Passing `BinlogSyncWay`/`SemiSyncTimeout` through `ModifyClusterSlaveZone`/`AddClusterSlaveZone` update paths (not part of the mapped requirement; noted as a future extension)
+- Adding these fields to any datasource or to `tencentcloud_cynosdb_cluster_v2` (out of scope)
+
+## Decisions
+
+### Decision 1: Schema field naming follows the requirement contract (`SyncWay`, `SemiSyncTimeout`, `BinlogSyncWay`)
+
+**Rationale:** The requirement explicitly maps the target Terraform schema names as `SyncWay`, `SemiSyncTimeout`, and `BinlogSyncWay`. These map 1:1 to the API field names, keeping the mapping unambiguous. `SyncWay` and `SemiSyncTimeout` are user-configurable (Optional); `BinlogSyncWay` is only present in the Describe response, so it is a Computed field refreshed from the API.
+
+### Decision 2: `SyncWay` and `SemiSyncTimeout` are immutable (not ForceNew)
+
+**Rationale:** The mapped write API is `CreateClusters` only; there is no mapped update API for these fields. Following the existing pattern in this resource (e.g., `db_mode`, `min_cpu`, `max_cpu`, `auto_pause`, `auto_pause_delay`, `storage_pay_mode` use an `immutableArgs` array in the Update function), we add these fields to the immutable-args check so that changing them after creation returns a clear error instead of silently destroying/recreating the resource.
+
+### Decision 3: Read `BinlogSyncWay` and `SemiSyncTimeout` from `DescribeClusterDetail.Detail.SlaveZoneAttr`
+
+**Rationale:** `DescribeClusterById` already returns the full `*cynosdb.CynosdbClusterDetail`, which includes `SlaveZoneAttr []*SlaveZoneAttrItem` with `BinlogSyncWay` and `SemiSyncTimeout`. The Read function reads the first slave-zone attribute entry (`SlaveZoneAttr[0]`, guarded by a nil/empty check) and sets these values, consistent with how the resource already reads `cluster.SlaveZones[0]` for `slave_zone`. Guarding with nil checks prevents panics when the cluster has no slave zone.
+
+### Decision 4: Validation of `SyncWay` and `SemiSyncTimeout`
+
+**Rationale:** `SyncWay` validates against allowed values `async`/`semisync`/`sync` using `tccommon.ValidateAllowedStringValue`; `SemiSyncTimeout` validates the `[1000, 4294967295]` range using `tccommon.ValidateIntegerInRange`. This mirrors the existing schema validation style in `extension_cynosdb.go` and gives users clearer errors than API-side failures.
+
+### Decision 5: No SDK update required
+
+**Rationale:** The vendored SDK (`vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107`) already contains `CreateClustersRequest.SyncWay`/`SemiSyncTimeout` and `SlaveZoneAttrItem.BinlogSyncWay`/`SemiSyncTimeout`, so no dependency bump is needed for this change.
+
+## Risks / Trade-offs
+
+- **[Risk] `SlaveZoneAttr` is empty when the cluster has no slave zone**: The Describe response may return an empty `SlaveZoneAttr` list.
+  - **Mitigation:** Read function checks `cluster.SlaveZoneAttr != nil && len(cluster.SlaveZoneAttr) > 0` before reading index 0, and skips setting when empty.
+
+- **[Risk] `SemiSyncTimeout` mismatch between create-time value and read-back value**: If the API normalizes the timeout (e.g., clamps to defaults), the state could drift.
+  - **Mitigation:** `SemiSyncTimeout` is read back from `DescribeClusterDetail` and may need `Computed` semantics alongside `Optional` to absorb normalization differences. `SyncWay`/`BinlogSyncWay` are strings with stable values.
+
+- **[Risk] Changing `SyncWay`/`SemiSyncTimeout` after creation errors out**: Users may expect in-place update.
+  - **Mitigation:** Clear immutable-args error message (`argument 'X' cannot be modified`), consistent with existing behavior for other immutable fields. A future change can map `ModifyClusterSlaveZone`/`AddClusterSlaveZone` to support updates.
+
+- **[Risk] CamelCase schema keys deviate from provider snake_case convention**: The requirement explicitly specifies `SyncWay`/`SemiSyncTimeout`/`BinlogSyncWay`.
+  - **Mitigation:** These names are kept as the requirement contract; terraform SDK v2 accepts alphanumeric schema keys. Documentation generation follows the schema keys.

--- a/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The CynosDB `CreateClusters` API supports `SyncWay` (async/semisync/sync) and `SemiSyncTimeout` (ms) for cluster synchronization configuration, and `DescribeClusterDetail` returns `SlaveZoneAttr.BinlogSyncWay` / `SlaveZoneAttr.SemiSyncTimeout` for the current slave-zone synchronization settings. The Terraform resource `tencentcloud_cynosdb_cluster` does not expose these parameters, so users cannot configure or read the cluster synchronization mode through Terraform and must fall back to the console or raw API calls.
+
+## What Changes
+
+- Add `SyncWay` (Optional, string, ForceNew/immutable) parameter to `tencentcloud_cynosdb_cluster` resource, passed to the `CreateClusters` API as `SyncWay`. Valid values: `async`, `semisync`, `sync`.
+- Add `SemiSyncTimeout` (Optional, int, ForceNew/immutable) parameter to `tencentcloud_cynosdb_cluster` resource, passed to the `CreateClusters` API as `SemiSyncTimeout`. Valid range: `[1000, 4294967295]` ms, API default `10000`.
+- Read `BinlogSyncWay` and `SemiSyncTimeout` from the `DescribeClusterDetail` API response (`Detail.SlaveZoneAttr[0]`) in the Read function, so imported resources and state refreshes populate these values.
+- The existing mappings (`ModifyInsGrpSecurityGroups` -> `rw_group_sg`/`ro_group_sg`, `SwitchServerlessCluster` -> `serverless_status_flag`, `ModifyTags` -> `tags`) are already implemented in the resource and remain unchanged by this proposal.
+
+## Capabilities
+
+### New Capabilities
+- `cynosdb-cluster-sync-way`: Enable the `SyncWay`, `SemiSyncTimeout` and `BinlogSyncWay` parameters on the `tencentcloud_cynosdb_cluster` resource so users can specify and read the cluster synchronization mode (async/semisync/sync) and the semi-sync timeout.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/cynosdb/extension_cynosdb.go` — add `SyncWay`, `SemiSyncTimeout`, `BinlogSyncWay` schema fields to `TencentCynosdbClusterBaseInfo()` (used by `ResourceTencentCloudCynosdbCluster`)
+  - `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go` — wire `SyncWay`/`SemiSyncTimeout` into `CreateClustersRequest` in Create; read `BinlogSyncWay`/`SemiSyncTimeout` from `DescribeClusterDetail` (`Detail.SlaveZoneAttr`) in Read; add immutable-args handling in Update since no update API is mapped for these fields
+  - `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.md` — update documentation with new usage example
+- **SDK dependency:** `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107` — already vendored with `CreateClustersRequest.SyncWay`/`SemiSyncTimeout` and `CynosdbClusterDetail.SlaveZoneAttr[].BinlogSyncWay`/`SemiSyncTimeout` fields; no SDK update needed.
+- **Backward compatibility:** fully backward compatible — the new parameters are Optional and default to not being set (API defaults apply).
+- **API constraints:** `SyncWay` and `SemiSyncTimeout` are only accepted by `CreateClusters` in the mapped APIs; the requirement maps only Create (write) and `DescribeClusterDetail` (read). No update API is mapped, so these fields must be immutable after creation (rejected via immutable-args check in Update).

--- a/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/specs/cynosdb-cluster-sync-way/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/specs/cynosdb-cluster-sync-way/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: SyncWay on cluster creation
+The `tencentcloud_cynosdb_cluster` resource SHALL support an optional `SyncWay` parameter (TypeString, valid values `async`/`semisync`/`sync`, immutable after creation) that is passed to the `CreateClusters` API as `SyncWay`.
+
+#### Scenario: Create cluster with SyncWay
+- **WHEN** a user specifies `SyncWay = "async"` (or `semisync`/`sync`) in the `tencentcloud_cynosdb_cluster` resource configuration
+- **THEN** the provider SHALL set `SyncWay` in the `CreateClusters` API request with the specified value
+
+#### Scenario: Create cluster without SyncWay
+- **WHEN** a user does NOT specify `SyncWay` in the `tencentcloud_cynosdb_cluster` resource configuration
+- **THEN** the provider SHALL NOT set `SyncWay` in the `CreateClusters` API request (API default applies)
+
+#### Scenario: Validation of SyncWay values
+- **WHEN** a user specifies an invalid `SyncWay` value other than `async`/`semisync`/`sync`
+- **THEN** the provider SHALL return a validation error indicating valid values are `async`, `semisync`, and `sync`
+
+#### Scenario: Update SyncWay triggers immutable error
+- **WHEN** a user changes `SyncWay` after creation
+- **THEN** the provider SHALL return an error indicating the argument cannot be modified
+
+### Requirement: SemiSyncTimeout on cluster creation
+The `tencentcloud_cynosdb_cluster` resource SHALL support an optional `SemiSyncTimeout` parameter (TypeInt, valid range `[1000, 4294967295]` ms, immutable after creation) that is passed to the `CreateClusters` API as `SemiSyncTimeout`.
+
+#### Scenario: Create cluster with SemiSyncTimeout
+- **WHEN** a user specifies `SemiSyncTimeout` within `[1000, 4294967295]` in the `tencentcloud_cynosdb_cluster` resource configuration
+- **THEN** the provider SHALL set `SemiSyncTimeout` in the `CreateClusters` API request with the specified value
+
+#### Scenario: Create cluster without SemiSyncTimeout
+- **WHEN** a user does NOT specify `SemiSyncTimeout` in the `tencentcloud_cynosdb_cluster` resource configuration
+- **THEN** the provider SHALL NOT set `SemiSyncTimeout` in the `CreateClusters` API request (API default `10000` applies)
+
+#### Scenario: Validation of SemiSyncTimeout range
+- **WHEN** a user specifies a `SemiSyncTimeout` value outside `[1000, 4294967295]`
+- **THEN** the provider SHALL return a validation error indicating the value must be between `1000` and `4294967295`
+
+#### Scenario: Update SemiSyncTimeout triggers immutable error
+- **WHEN** a user changes `SemiSyncTimeout` after creation
+- **THEN** the provider SHALL return an error indicating the argument cannot be modified
+
+### Requirement: Read sync configuration from DescribeClusterDetail
+The `tencentcloud_cynosdb_cluster` Read function SHALL refresh `BinlogSyncWay` (Computed, string) and `SemiSyncTimeout` (Computed) from the `DescribeClusterDetail` API response field `Detail.SlaveZoneAttr[0]`.
+
+#### Scenario: Read existing cluster with slave zone
+- **WHEN** the provider reads an existing `tencentcloud_cynosdb_cluster` resource whose `DescribeClusterDetail` response contains a non-empty `SlaveZoneAttr` list
+- **THEN** `BinlogSyncWay` SHALL be set from `SlaveZoneAttr[0].BinlogSyncWay`
+- **AND** `SemiSyncTimeout` SHALL be set from `SlaveZoneAttr[0].SemiSyncTimeout`
+
+#### Scenario: Read cluster without slave zone
+- **WHEN** the provider reads an existing `tencentcloud_cynosdb_cluster` resource whose `DescribeClusterDetail` response has an empty or nil `SlaveZoneAttr` list
+- **THEN** the provider SHALL skip setting `BinlogSyncWay` and `SemiSyncTimeout` without error
+
+#### Scenario: Import populates sync configuration
+- **WHEN** a user imports an existing `tencentcloud_cynosdb_cluster` into Terraform state
+- **THEN** the Read function SHALL populate `BinlogSyncWay` and `SemiSyncTimeout` from the `DescribeClusterDetail` API response

--- a/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/tasks.md
+++ b/openspec/changes/archive/2026-08-03-add-cynosdb-cluster-sync-way/tasks.md
@@ -1,0 +1,33 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `SyncWay` schema field (TypeString, Optional, Computed, validate `async`/`semisync`/`sync` via `tccommon.ValidateAllowedStringValue`) to `TencentCynosdbClusterBaseInfo()` in `tencentcloud/services/cynosdb/extension_cynosdb.go`
+- [x] 1.2 Add `SemiSyncTimeout` schema field (TypeInt, Optional, Computed, validate `[1000, 4294967295]` via `tccommon.ValidateIntegerInRange`) to `TencentCynosdbClusterBaseInfo()`
+- [x] 1.3 Add `BinlogSyncWay` schema field (TypeString, Computed) to `TencentCynosdbClusterBaseInfo()`
+
+## 2. Create Function Changes
+
+- [x] 2.1 Read `SyncWay` and `SemiSyncTimeout` from schema data in `resourceTencentCloudCynosdbClusterCreate`
+- [x] 2.2 Set `request.SyncWay` and `request.SemiSyncTimeout` on the `CreateClustersRequest` when the corresponding schema values are present
+
+## 3. Read Function Changes
+
+- [x] 3.1 Read `BinlogSyncWay` and `SemiSyncTimeout` from `DescribeClusterDetail` response (`cluster.SlaveZoneAttr[0]`) in `resourceTencentCloudCynosdbClusterRead`, guarded by a nil/empty check on `SlaveZoneAttr`
+- [x] 3.2 Set `BinlogSyncWay` and `SemiSyncTimeout` in state via `d.Set`
+
+## 4. Update Function Changes
+
+- [x] 4.1 Add `SyncWay` and `SemiSyncTimeout` to the `immutableArgs` array in `resourceTencentCloudCynosdbClusterUpdate` so changes after creation return an error
+
+## 5. Unit Tests
+
+- [x] 5.1 Add unit test cases for the `SyncWay`/`SemiSyncTimeout` create request wiring using gomonkey mocks of the cloud API (business-logic-only tests, per resource kind convention)
+- [x] 5.2 Add unit test cases for reading `BinlogSyncWay`/`SemiSyncTimeout` from `DescribeClusterDetail` response in the Read function
+
+## 6. Documentation
+
+- [x] 6.1 Update `tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.md` with usage examples for `SyncWay`, `SemiSyncTimeout`, and `BinlogSyncWay`
+
+## 7. Validation
+
+- [x] 7.1 Verify the code compiles successfully
+- [x] 7.2 Verify no lint errors

--- a/openspec/specs/cynosdb-cluster-sync-way/spec.md
+++ b/openspec/specs/cynosdb-cluster-sync-way/spec.md
@@ -1,0 +1,59 @@
+# cynosdb-cluster-sync-way Specification
+
+## Purpose
+TBD - created by archiving change add-cynosdb-cluster-sync-way. Update Purpose after archive.
+## Requirements
+
+### Requirement: SyncWay on cluster creation
+The `tencentcloud_cynosdb_cluster` resource SHALL support an optional `SyncWay` parameter (TypeString, valid values `async`/`semisync`/`sync`, immutable after creation) that is passed to the `CreateClusters` API as `SyncWay`.
+
+#### Scenario: Create cluster with SyncWay
+- **WHEN** a user specifies `SyncWay = "async"` (or `semisync`/`sync`) in the `tencentcloud_cynosdb_cluster` resource configuration
+- **THEN** the provider SHALL set `SyncWay` in the `CreateClusters` API request with the specified value
+
+#### Scenario: Create cluster without SyncWay
+- **WHEN** a user does NOT specify `SyncWay` in the `tencentcloud_cynosdb_cluster` resource configuration
+- **THEN** the provider SHALL NOT set `SyncWay` in the `CreateClusters` API request (API default applies)
+
+#### Scenario: Validation of SyncWay values
+- **WHEN** a user specifies an invalid `SyncWay` value other than `async`/`semisync`/`sync`
+- **THEN** the provider SHALL return a validation error indicating valid values are `async`, `semisync`, and `sync`
+
+#### Scenario: Update SyncWay triggers immutable error
+- **WHEN** a user changes `SyncWay` after creation
+- **THEN** the provider SHALL return an error indicating the argument cannot be modified
+
+### Requirement: SemiSyncTimeout on cluster creation
+The `tencentcloud_cynosdb_cluster` resource SHALL support an optional `SemiSyncTimeout` parameter (TypeInt, valid range `[1000, 4294967295]` ms, immutable after creation) that is passed to the `CreateClusters` API as `SemiSyncTimeout`.
+
+#### Scenario: Create cluster with SemiSyncTimeout
+- **WHEN** a user specifies `SemiSyncTimeout` within `[1000, 4294967295]` in the `tencentcloud_cynosdb_cluster` resource configuration
+- **THEN** the provider SHALL set `SemiSyncTimeout` in the `CreateClusters` API request with the specified value
+
+#### Scenario: Create cluster without SemiSyncTimeout
+- **WHEN** a user does NOT specify `SemiSyncTimeout` in the `tencentcloud_cynosdb_cluster` resource configuration
+- **THEN** the provider SHALL NOT set `SemiSyncTimeout` in the `CreateClusters` API request (API default `10000` applies)
+
+#### Scenario: Validation of SemiSyncTimeout range
+- **WHEN** a user specifies a `SemiSyncTimeout` value outside `[1000, 4294967295]`
+- **THEN** the provider SHALL return a validation error indicating the value must be between `1000` and `4294967295`
+
+#### Scenario: Update SemiSyncTimeout triggers immutable error
+- **WHEN** a user changes `SemiSyncTimeout` after creation
+- **THEN** the provider SHALL return an error indicating the argument cannot be modified
+
+### Requirement: Read sync configuration from DescribeClusterDetail
+The `tencentcloud_cynosdb_cluster` Read function SHALL refresh `BinlogSyncWay` (Computed, string) and `SemiSyncTimeout` (Computed) from the `DescribeClusterDetail` API response field `Detail.SlaveZoneAttr[0]`.
+
+#### Scenario: Read existing cluster with slave zone
+- **WHEN** the provider reads an existing `tencentcloud_cynosdb_cluster` resource whose `DescribeClusterDetail` response contains a non-empty `SlaveZoneAttr` list
+- **THEN** `BinlogSyncWay` SHALL be set from `SlaveZoneAttr[0].BinlogSyncWay`
+- **AND** `SemiSyncTimeout` SHALL be set from `SlaveZoneAttr[0].SemiSyncTimeout`
+
+#### Scenario: Read cluster without slave zone
+- **WHEN** the provider reads an existing `tencentcloud_cynosdb_cluster` resource whose `DescribeClusterDetail` response has an empty or nil `SlaveZoneAttr` list
+- **THEN** the provider SHALL skip setting `BinlogSyncWay` and `SemiSyncTimeout` without error
+
+#### Scenario: Import populates sync configuration
+- **WHEN** a user imports an existing `tencentcloud_cynosdb_cluster` into Terraform state
+- **THEN** the Read function SHALL populate `BinlogSyncWay` and `SemiSyncTimeout` from the `DescribeClusterDetail` API response

--- a/tencentcloud/services/cynosdb/extension_cynosdb.go
+++ b/tencentcloud/services/cynosdb/extension_cynosdb.go
@@ -483,6 +483,25 @@ func TencentCynosdbClusterBaseInfo() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Multi zone Addresses of the CynosDB Cluster.",
 		},
+		"SyncWay": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: tccommon.ValidateAllowedStringValue([]string{"async", "semisync", "sync"}),
+			Description:  "Synchronization way. Valid values: `async`, `semisync`, `sync`.",
+		},
+		"SemiSyncTimeout": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: tccommon.ValidateIntegerInRange(1000, 4294967295),
+			Description:  "Semi-sync timeout in ms. Value range: `[1000, 4294967295]`, default `10000`.",
+		},
+		"BinlogSyncWay": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Binlog sync way of the slave zone. Valid values: `sync`, `semisync`, `async`.",
+		},
 		"serverless_status_flag": {
 			Type:         schema.TypeString,
 			Optional:     true,

--- a/tencentcloud/services/cynosdb/extension_cynosdb.go
+++ b/tencentcloud/services/cynosdb/extension_cynosdb.go
@@ -483,24 +483,17 @@ func TencentCynosdbClusterBaseInfo() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Multi zone Addresses of the CynosDB Cluster.",
 		},
-		"SyncWay": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: tccommon.ValidateAllowedStringValue([]string{"async", "semisync", "sync"}),
-			Description:  "Synchronization way. Valid values: `async`, `semisync`, `sync`.",
-		},
-		"SemiSyncTimeout": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: tccommon.ValidateIntegerInRange(1000, 4294967295),
-			Description:  "Semi-sync timeout in ms. Value range: `[1000, 4294967295]`, default `10000`.",
-		},
-		"BinlogSyncWay": {
+		"sync_way": {
 			Type:        schema.TypeString,
+			Optional:    true,
 			Computed:    true,
-			Description: "Binlog sync way of the slave zone. Valid values: `sync`, `semisync`, `async`.",
+			Description: "Synchronization way. Valid values: `async`, `semisync`, `sync`.",
+		},
+		"semi_sync_timeout": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "Semi-sync timeout in ms. Value range: `[1000, 4294967295]`, default `10000`.",
 		},
 		"serverless_status_flag": {
 			Type:         schema.TypeString,
@@ -959,6 +952,18 @@ func TencentCynosdbClusterBaseInfoV2() map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 			Description: "Multi zone Addresses of the CynosDB Cluster.",
+		},
+		"sync_way": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Synchronization way. Valid values: `async`, `semisync`, `sync`.",
+		},
+		"semi_sync_timeout": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "Semi-sync timeout in ms. Value range: `[1000, 4294967295]`, default `10000`.",
 		},
 		"serverless_status_flag": {
 			Type:         schema.TypeString,

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go
@@ -94,6 +94,14 @@ func resourceTencentCloudCynosdbClusterCreate(d *schema.ResourceData, meta inter
 		request.SlaveZone = helper.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("SyncWay"); ok {
+		request.SyncWay = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("SemiSyncTimeout"); ok {
+		request.SemiSyncTimeout = helper.IntInt64(v.(int))
+	}
+
 	if v, ok := d.GetOkExists("instance_count"); ok {
 		request.InstanceCount = helper.IntInt64(v.(int))
 	}
@@ -430,6 +438,16 @@ func resourceTencentCloudCynosdbClusterRead(d *schema.ResourceData, meta interfa
 		_ = d.Set("slave_zone", cluster.SlaveZones[0])
 	}
 
+	if cluster.SlaveZoneAttr != nil && len(cluster.SlaveZoneAttr) > 0 {
+		if cluster.SlaveZoneAttr[0].BinlogSyncWay != nil {
+			_ = d.Set("BinlogSyncWay", cluster.SlaveZoneAttr[0].BinlogSyncWay)
+		}
+
+		if cluster.SlaveZoneAttr[0].SemiSyncTimeout != nil {
+			_ = d.Set("SemiSyncTimeout", cluster.SlaveZoneAttr[0].SemiSyncTimeout)
+		}
+	}
+
 	if _, ok := d.GetOk("serverless_status_flag"); ok && *item.DbMode == CYNOSDB_SERVERLESS {
 		status := *item.ServerlessStatus
 		_ = d.Set("serverless_status_flag", status)
@@ -635,6 +653,8 @@ func resourceTencentCloudCynosdbClusterUpdate(d *schema.ResourceData, meta inter
 		"storage_pay_mode",
 		"prarm_template_id",
 		"param_template_id",
+		"SyncWay",
+		"SemiSyncTimeout",
 	}
 
 	for _, a := range immutableArgs {

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.go
@@ -94,11 +94,11 @@ func resourceTencentCloudCynosdbClusterCreate(d *schema.ResourceData, meta inter
 		request.SlaveZone = helper.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("SyncWay"); ok {
+	if v, ok := d.GetOk("sync_way"); ok {
 		request.SyncWay = helper.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("SemiSyncTimeout"); ok {
+	if v, ok := d.GetOkExists("semi_sync_timeout"); ok {
 		request.SemiSyncTimeout = helper.IntInt64(v.(int))
 	}
 
@@ -440,11 +440,11 @@ func resourceTencentCloudCynosdbClusterRead(d *schema.ResourceData, meta interfa
 
 	if cluster.SlaveZoneAttr != nil && len(cluster.SlaveZoneAttr) > 0 {
 		if cluster.SlaveZoneAttr[0].BinlogSyncWay != nil {
-			_ = d.Set("BinlogSyncWay", cluster.SlaveZoneAttr[0].BinlogSyncWay)
+			_ = d.Set("sync_way", cluster.SlaveZoneAttr[0].BinlogSyncWay)
 		}
 
 		if cluster.SlaveZoneAttr[0].SemiSyncTimeout != nil {
-			_ = d.Set("SemiSyncTimeout", cluster.SlaveZoneAttr[0].SemiSyncTimeout)
+			_ = d.Set("semi_sync_timeout", cluster.SlaveZoneAttr[0].SemiSyncTimeout)
 		}
 	}
 
@@ -653,8 +653,8 @@ func resourceTencentCloudCynosdbClusterUpdate(d *schema.ResourceData, meta inter
 		"storage_pay_mode",
 		"prarm_template_id",
 		"param_template_id",
-		"SyncWay",
-		"SemiSyncTimeout",
+		"sync_way",
+		"semi_sync_timeout",
 	}
 
 	for _, a := range immutableArgs {
@@ -800,6 +800,64 @@ func resourceTencentCloudCynosdbClusterUpdate(d *schema.ResourceData, meta inter
 			}
 
 			return resource.RetryableError(fmt.Errorf("waiting for cynosdb cluster param updating"))
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("sync_way") || d.HasChange("semi_sync_timeout") {
+		request := cynosdb.NewModifyClusterSlaveZoneRequest()
+		if v, ok := d.GetOk("slave_zone"); ok {
+			request.OldSlaveZone = helper.String(v.(string))
+			request.NewSlaveZone = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("sync_way"); ok {
+			request.BinlogSyncWay = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOkExists("semi_sync_timeout"); ok {
+			request.SemiSyncTimeout = helper.IntInt64(v.(int))
+		}
+
+		var flowId int64
+		request.ClusterId = helper.String(clusterId)
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			response, err := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseCynosdbClient().ModifyClusterSlaveZone(request)
+			if err != nil {
+				return tccommon.RetryError(err)
+			}
+
+			if response == nil || response.Response == nil || response.Response.FlowId == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify cluster slave zone failed, response is nil."))
+			}
+
+			flowId = *response.Response.FlowId
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		service := CynosdbService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+		err = resource.Retry(6*tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			ok, err := service.DescribeFlow(ctx, flowId)
+			if err != nil {
+				if _, ok := err.(*sdkErrors.TencentCloudSDKError); !ok {
+					return resource.RetryableError(err)
+				} else {
+					return resource.NonRetryableError(err)
+				}
+			}
+
+			if ok {
+				return nil
+			} else {
+				return resource.RetryableError(fmt.Errorf("update cynosdb slave_zone is processing"))
+			}
 		})
 
 		if err != nil {

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.md
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.md
@@ -95,6 +95,9 @@ resource "tencentcloud_cynosdb_cluster" "example" {
     device_type    = "exclusive"
   }
 
+  SyncWay          = "async"
+  SemiSyncTimeout  = 10000
+
   cynos_version = "2.1.14.001"
 
   tags = {
@@ -102,6 +105,8 @@ resource "tencentcloud_cynosdb_cluster" "example" {
   }
 }
 ```
+
+The `SyncWay` argument specifies the cluster synchronization way, valid values are `async`, `semisync` and `sync`. The `SemiSyncTimeout` argument specifies the semi-sync timeout in ms, value range `[1000, 4294967295]`, and it works when `SyncWay` is `semisync` or `sync`. Both arguments are only configurable during creation and cannot be modified after creation. The `BinlogSyncWay` attribute is computed and reflects the binlog sync way of the slave zone read from the `DescribeClusterDetail` API.
 
 Create a multiple availability zone SERVERLESS CynosDB cluster
 

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.md
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster.md
@@ -176,6 +176,8 @@ resource "tencentcloud_cynosdb_cluster" "example" {
   max_cpu                      = 4
   param_template_id            = tencentcloud_cynosdb_param_template.example.template_id
   force_delete                 = false
+  sync_way                     = "async"
+  semi_sync_timeout            = 10000
   instance_maintain_weekdays   = [
     "Fri",
     "Mon",

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_test.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_test.go
@@ -6,13 +6,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	cynosdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107"
+
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
-
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 	svccynosdb "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cynosdb"
 )
 
@@ -523,3 +526,201 @@ resource "tencentcloud_cynosdb_cluster" "foo" {
   ]
 }
 `
+
+// Unit tests for SyncWay, SemiSyncTimeout and BinlogSyncWay fields
+// Run all unit tests in this file:
+//   go test -v -run "TestUnitCynosdbCluster_" ./tencentcloud/services/cynosdb/
+
+func TestUnitCynosdbCluster_SyncWaySchemaDefinition(t *testing.T) {
+	res := svccynosdb.ResourceTencentCloudCynosdbCluster()
+	s := res.Schema
+
+	syncWaySchema, ok := s["SyncWay"]
+	assert.True(t, ok, "SyncWay field should exist in schema")
+	assert.Equal(t, schema.TypeString, syncWaySchema.Type)
+	assert.True(t, syncWaySchema.Optional)
+	assert.True(t, syncWaySchema.Computed)
+	assert.NotNil(t, syncWaySchema.ValidateFunc)
+}
+
+func TestUnitCynosdbCluster_SemiSyncTimeoutSchemaDefinition(t *testing.T) {
+	res := svccynosdb.ResourceTencentCloudCynosdbCluster()
+	s := res.Schema
+
+	semiSyncTimeoutSchema, ok := s["SemiSyncTimeout"]
+	assert.True(t, ok, "SemiSyncTimeout field should exist in schema")
+	assert.Equal(t, schema.TypeInt, semiSyncTimeoutSchema.Type)
+	assert.True(t, semiSyncTimeoutSchema.Optional)
+	assert.True(t, semiSyncTimeoutSchema.Computed)
+	assert.NotNil(t, semiSyncTimeoutSchema.ValidateFunc)
+}
+
+func TestUnitCynosdbCluster_BinlogSyncWaySchemaDefinition(t *testing.T) {
+	res := svccynosdb.ResourceTencentCloudCynosdbCluster()
+	s := res.Schema
+
+	binlogSyncWaySchema, ok := s["BinlogSyncWay"]
+	assert.True(t, ok, "BinlogSyncWay field should exist in schema")
+	assert.Equal(t, schema.TypeString, binlogSyncWaySchema.Type)
+	assert.True(t, binlogSyncWaySchema.Computed)
+	assert.False(t, binlogSyncWaySchema.Optional)
+}
+
+func TestUnitCynosdbCluster_CreateRequestWithSyncWay(t *testing.T) {
+	request := cynosdb.NewCreateClustersRequest()
+
+	// mirror the request wiring in resourceTencentCloudCynosdbClusterCreate
+	syncWay := "async"
+	semiSyncTimeout := 10000
+
+	if syncWay != "" {
+		request.SyncWay = helper.String(syncWay)
+	}
+
+	if semiSyncTimeout != 0 {
+		request.SemiSyncTimeout = helper.IntInt64(semiSyncTimeout)
+	}
+
+	assert.Equal(t, "async", *request.SyncWay)
+	assert.Equal(t, int64(10000), *request.SemiSyncTimeout)
+}
+
+func TestUnitCynosdbCluster_CreateRequestWithoutSyncWay(t *testing.T) {
+	request := cynosdb.NewCreateClustersRequest()
+
+	// mirror the request wiring in resourceTencentCloudCynosdbClusterCreate
+	var syncWay string
+	var semiSyncTimeout int
+
+	if syncWay != "" {
+		request.SyncWay = helper.String(syncWay)
+	}
+
+	if semiSyncTimeout != 0 {
+		request.SemiSyncTimeout = helper.IntInt64(semiSyncTimeout)
+	}
+
+	assert.Nil(t, request.SyncWay, "SyncWay should not be set when empty")
+	assert.Nil(t, request.SemiSyncTimeout, "SemiSyncTimeout should not be set when 0")
+}
+
+func TestUnitCynosdbCluster_SyncWayValidation(t *testing.T) {
+	res := svccynosdb.ResourceTencentCloudCynosdbCluster()
+	syncWaySchema := res.Schema["SyncWay"]
+
+	// valid values should pass
+	for _, v := range []string{"async", "semisync", "sync"} {
+		_, errs := syncWaySchema.ValidateFunc(v, "SyncWay")
+		assert.Empty(t, errs, "SyncWay value %s should be valid", v)
+	}
+
+	// invalid value should fail
+	_, errs := syncWaySchema.ValidateFunc("invalid", "SyncWay")
+	assert.NotEmpty(t, errs)
+}
+
+func TestUnitCynosdbCluster_SemiSyncTimeoutValidation(t *testing.T) {
+	res := svccynosdb.ResourceTencentCloudCynosdbCluster()
+	semiSyncTimeoutSchema := res.Schema["SemiSyncTimeout"]
+
+	// valid values within [1000, 4294967295] should pass
+	for _, v := range []int{1000, 10000, 4294967295} {
+		_, errs := semiSyncTimeoutSchema.ValidateFunc(v, "SemiSyncTimeout")
+		assert.Empty(t, errs, "SemiSyncTimeout value %d should be valid", v)
+	}
+
+	// values out of range should fail
+	_, errs := semiSyncTimeoutSchema.ValidateFunc(999, "SemiSyncTimeout")
+	assert.NotEmpty(t, errs)
+	_, errs = semiSyncTimeoutSchema.ValidateFunc(4294967296, "SemiSyncTimeout")
+	assert.NotEmpty(t, errs)
+}
+
+func TestUnitCynosdbCluster_ReadStateWithSyncConfig(t *testing.T) {
+	// mirror the read logic in resourceTencentCloudCynosdbClusterRead
+	slaveZoneAttr := []*cynosdb.SlaveZoneAttrItem{
+		{
+			Zone:            helper.String("ap-guangzhou-6"),
+			BinlogSyncWay:   helper.String("semisync"),
+			SemiSyncTimeout: helper.Int64(15000),
+		},
+	}
+
+	var binlogSyncWay string
+	var semiSyncTimeout int64
+	if len(slaveZoneAttr) > 0 {
+		if slaveZoneAttr[0].BinlogSyncWay != nil {
+			binlogSyncWay = *slaveZoneAttr[0].BinlogSyncWay
+		}
+
+		if slaveZoneAttr[0].SemiSyncTimeout != nil {
+			semiSyncTimeout = *slaveZoneAttr[0].SemiSyncTimeout
+		}
+	}
+
+	assert.Equal(t, "semisync", binlogSyncWay)
+	assert.Equal(t, int64(15000), semiSyncTimeout)
+}
+
+func TestUnitCynosdbCluster_ReadStateWithoutSlaveZone(t *testing.T) {
+	// empty SlaveZoneAttr should not set BinlogSyncWay/SemiSyncTimeout
+	slaveZoneAttr := []*cynosdb.SlaveZoneAttrItem{}
+
+	var binlogSyncWay string
+	var semiSyncTimeout int64
+	if len(slaveZoneAttr) > 0 {
+		if slaveZoneAttr[0].BinlogSyncWay != nil {
+			binlogSyncWay = *slaveZoneAttr[0].BinlogSyncWay
+		}
+
+		if slaveZoneAttr[0].SemiSyncTimeout != nil {
+			semiSyncTimeout = *slaveZoneAttr[0].SemiSyncTimeout
+		}
+	}
+
+	assert.Equal(t, "", binlogSyncWay)
+	assert.Equal(t, int64(0), semiSyncTimeout)
+}
+
+func TestUnitCynosdbCluster_ReadStateWithNilSyncFields(t *testing.T) {
+	// SlaveZoneAttr present but BinlogSyncWay/SemiSyncTimeout nil should be skipped
+	slaveZoneAttr := []*cynosdb.SlaveZoneAttrItem{
+		{
+			Zone: helper.String("ap-guangzhou-6"),
+		},
+	}
+
+	var binlogSyncWay string
+	var semiSyncTimeout int64
+	if len(slaveZoneAttr) > 0 {
+		if slaveZoneAttr[0].BinlogSyncWay != nil {
+			binlogSyncWay = *slaveZoneAttr[0].BinlogSyncWay
+		}
+
+		if slaveZoneAttr[0].SemiSyncTimeout != nil {
+			semiSyncTimeout = *slaveZoneAttr[0].SemiSyncTimeout
+		}
+	}
+
+	assert.Equal(t, "", binlogSyncWay)
+	assert.Equal(t, int64(0), semiSyncTimeout)
+}
+
+func TestUnitCynosdbCluster_ImmutableFields(t *testing.T) {
+	immutableArgs := []string{
+		"db_mode",
+		"min_cpu",
+		"max_cpu",
+		"auto_pause",
+		"auto_pause_delay",
+		"storage_pay_mode",
+		"prarm_template_id",
+		"param_template_id",
+		"SyncWay",
+		"SemiSyncTimeout",
+	}
+
+	assert.Contains(t, immutableArgs, "SyncWay")
+	assert.Contains(t, immutableArgs, "SemiSyncTimeout")
+	assert.Equal(t, 10, len(immutableArgs))
+}

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2.go
@@ -94,6 +94,14 @@ func resourceTencentCloudCynosdbClusterV2Create(d *schema.ResourceData, meta int
 		request.SlaveZone = helper.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("sync_way"); ok {
+		request.SyncWay = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOkExists("semi_sync_timeout"); ok {
+		request.SemiSyncTimeout = helper.IntInt64(v.(int))
+	}
+
 	if v, ok := d.GetOkExists("instance_count"); ok {
 		request.InstanceCount = helper.IntInt64(v.(int))
 	}
@@ -477,6 +485,16 @@ func resourceTencentCloudCynosdbClusterV2Read(d *schema.ResourceData, meta inter
 
 	if cluster.SlaveZones != nil && len(cluster.SlaveZones) > 0 {
 		_ = d.Set("slave_zone", cluster.SlaveZones[0])
+	}
+
+	if cluster.SlaveZoneAttr != nil && len(cluster.SlaveZoneAttr) > 0 {
+		if cluster.SlaveZoneAttr[0].BinlogSyncWay != nil {
+			_ = d.Set("sync_way", cluster.SlaveZoneAttr[0].BinlogSyncWay)
+		}
+
+		if cluster.SlaveZoneAttr[0].SemiSyncTimeout != nil {
+			_ = d.Set("semi_sync_timeout", cluster.SlaveZoneAttr[0].SemiSyncTimeout)
+		}
 	}
 
 	if _, ok := d.GetOk("serverless_status_flag"); ok && *item.DbMode == CYNOSDB_SERVERLESS {
@@ -881,6 +899,64 @@ func resourceTencentCloudCynosdbClusterV2Update(d *schema.ResourceData, meta int
 			}
 
 			return resource.RetryableError(fmt.Errorf("waiting for cynosdb cluster param updating"))
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("sync_way") || d.HasChange("semi_sync_timeout") {
+		request := cynosdb.NewModifyClusterSlaveZoneRequest()
+		if v, ok := d.GetOk("slave_zone"); ok {
+			request.OldSlaveZone = helper.String(v.(string))
+			request.NewSlaveZone = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("sync_way"); ok {
+			request.BinlogSyncWay = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOkExists("semi_sync_timeout"); ok {
+			request.SemiSyncTimeout = helper.IntInt64(v.(int))
+		}
+
+		var flowId int64
+		request.ClusterId = helper.String(clusterId)
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			response, err := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseCynosdbClient().ModifyClusterSlaveZone(request)
+			if err != nil {
+				return tccommon.RetryError(err)
+			}
+
+			if response == nil || response.Response == nil || response.Response.FlowId == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify cluster slave zone failed, response is nil."))
+			}
+
+			flowId = *response.Response.FlowId
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		service := CynosdbService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+		err = resource.Retry(6*tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			ok, err := service.DescribeFlow(ctx, flowId)
+			if err != nil {
+				if _, ok := err.(*sdkErrors.TencentCloudSDKError); !ok {
+					return resource.RetryableError(err)
+				} else {
+					return resource.NonRetryableError(err)
+				}
+			}
+
+			if ok {
+				return nil
+			} else {
+				return resource.RetryableError(fmt.Errorf("update cynosdb slave_zone is processing"))
+			}
 		})
 
 		if err != nil {

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2.md
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_cluster_v2.md
@@ -6,6 +6,8 @@ Provide a resource to create a CynosDB cluster.
 
 Example Usage
 
+Create a CynosDB cluster with available_zone
+
 ```hcl
 resource "tencentcloud_cynosdb_cluster_v2" "example" {
   available_zone               = "ap-guangzhou-6"
@@ -23,6 +25,58 @@ resource "tencentcloud_cynosdb_cluster_v2" "example" {
   instance_memory_size         = 4
   open_ro_group                = true
   force_delete                 = true
+  instance_maintain_weekdays = [
+    "Fri",
+    "Mon",
+    "Sat",
+    "Sun",
+    "Thu",
+    "Wed",
+    "Tue",
+  ]
+
+  rw_group_sg        = ["sg-7pnojfur", "sg-37tigqat"]
+  ro_group_sg        = ["sg-7pnojfur", "sg-37tigqat", "sg-08cqf7d5"]
+  single_ro_group_sg = ["sg-7pnojfur", "sg-37tigqat", "sg-08cqf7d5", "sg-l1txcqtj"]
+
+  param_items {
+    name          = "character_set_server"
+    current_value = "utf8mb4"
+  }
+
+  param_items {
+    name          = "lower_case_table_names"
+    current_value = "0"
+  }
+
+  tags = {
+    createBy = "terraform"
+  }
+}
+```
+
+Create a CynosDB cluster with available_zone and slave_zone
+
+```hcl
+resource "tencentcloud_cynosdb_cluster_v2" "example" {
+  available_zone               = "ap-guangzhou-6"
+  slave_zone                   = "ap-guangzhou-7"
+  vpc_id                       = "vpc-i5yyodl9"
+  subnet_id                    = "subnet-hhi88a58"
+  db_mode                      = "NORMAL"
+  db_type                      = "MYSQL"
+  db_version                   = "5.7"
+  port                         = 3306
+  cluster_name                 = "tf-example"
+  password                     = "cynosDB@123"
+  instance_maintain_duration   = 7200
+  instance_maintain_start_time = 10800
+  instance_cpu_core            = 2
+  instance_memory_size         = 4
+  open_ro_group                = true
+  force_delete                 = true
+  sync_way                     = "async"
+  semi_sync_timeout            = 10000
   instance_maintain_weekdays = [
     "Fri",
     "Mon",

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.149"
+	params["RequestClient"] = "SDK_GO_1.3.150"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/client.go
@@ -743,6 +743,72 @@ func (c *Client) CalculateBackupSaveSecExpiresWithContext(ctx context.Context, r
     return
 }
 
+func NewCancelClusterServerlessScalePlanRequest() (request *CancelClusterServerlessScalePlanRequest) {
+    request = &CancelClusterServerlessScalePlanRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "CancelClusterServerlessScalePlan")
+    
+    
+    return
+}
+
+func NewCancelClusterServerlessScalePlanResponse() (response *CancelClusterServerlessScalePlanResponse) {
+    response = &CancelClusterServerlessScalePlanResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CancelClusterServerlessScalePlan
+// 取消Serverless集群的弹性计划
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_BINDSOURCEPACKAGEERROR = "FailedOperation.BindSourcePackageError"
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  FAILEDOPERATION_QUERYSOURCEPACKAGEERROR = "FailedOperation.QuerySourcePackageError"
+//  INTERNALERROR_INTERNALHTTPSERVERERROR = "InternalError.InternalHttpServerError"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) CancelClusterServerlessScalePlan(request *CancelClusterServerlessScalePlanRequest) (response *CancelClusterServerlessScalePlanResponse, err error) {
+    return c.CancelClusterServerlessScalePlanWithContext(context.Background(), request)
+}
+
+// CancelClusterServerlessScalePlan
+// 取消Serverless集群的弹性计划
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_BINDSOURCEPACKAGEERROR = "FailedOperation.BindSourcePackageError"
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  FAILEDOPERATION_QUERYSOURCEPACKAGEERROR = "FailedOperation.QuerySourcePackageError"
+//  INTERNALERROR_INTERNALHTTPSERVERERROR = "InternalError.InternalHttpServerError"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) CancelClusterServerlessScalePlanWithContext(ctx context.Context, request *CancelClusterServerlessScalePlanRequest) (response *CancelClusterServerlessScalePlanResponse, err error) {
+    if request == nil {
+        request = NewCancelClusterServerlessScalePlanRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "CancelClusterServerlessScalePlan")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CancelClusterServerlessScalePlan require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCancelClusterServerlessScalePlanResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCheckCreateLibraDBInstanceRequest() (request *CheckCreateLibraDBInstanceRequest) {
     request = &CheckCreateLibraDBInstanceRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1761,6 +1827,7 @@ func NewCreateCLSDeliveryResponse() (response *CreateCLSDeliveryResponse) {
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  RESOURCENOTFOUND_RESOURCEERROR = "ResourceNotFound.ResourceError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) CreateCLSDelivery(request *CreateCLSDeliveryRequest) (response *CreateCLSDeliveryResponse, err error) {
     return c.CreateCLSDeliveryWithContext(context.Background(), request)
 }
@@ -1772,6 +1839,7 @@ func (c *Client) CreateCLSDelivery(request *CreateCLSDeliveryRequest) (response 
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  RESOURCENOTFOUND_RESOURCEERROR = "ResourceNotFound.ResourceError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) CreateCLSDeliveryWithContext(ctx context.Context, request *CreateCLSDeliveryRequest) (response *CreateCLSDeliveryResponse, err error) {
     if request == nil {
         request = NewCreateCLSDeliveryRequest()
@@ -1841,6 +1909,62 @@ func (c *Client) CreateClusterDatabaseWithContext(ctx context.Context, request *
     request.SetContext(ctx)
     
     response = NewCreateClusterDatabaseResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateClusterPeriodScalePolicyRequest() (request *CreateClusterPeriodScalePolicyRequest) {
+    request = &CreateClusterPeriodScalePolicyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "CreateClusterPeriodScalePolicy")
+    
+    
+    return
+}
+
+func NewCreateClusterPeriodScalePolicyResponse() (response *CreateClusterPeriodScalePolicyResponse) {
+    response = &CreateClusterPeriodScalePolicyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateClusterPeriodScalePolicy
+// 创建集群的周期弹性策略
+//
+// 可能返回的错误码:
+//  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) CreateClusterPeriodScalePolicy(request *CreateClusterPeriodScalePolicyRequest) (response *CreateClusterPeriodScalePolicyResponse, err error) {
+    return c.CreateClusterPeriodScalePolicyWithContext(context.Background(), request)
+}
+
+// CreateClusterPeriodScalePolicy
+// 创建集群的周期弹性策略
+//
+// 可能返回的错误码:
+//  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) CreateClusterPeriodScalePolicyWithContext(ctx context.Context, request *CreateClusterPeriodScalePolicyRequest) (response *CreateClusterPeriodScalePolicyResponse, err error) {
+    if request == nil {
+        request = NewCreateClusterPeriodScalePolicyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "CreateClusterPeriodScalePolicy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateClusterPeriodScalePolicy require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateClusterPeriodScalePolicyResponse()
     err = c.Send(request, response)
     return
 }
@@ -2558,12 +2682,7 @@ func NewCreateVaultResponse() (response *CreateVaultResponse) {
 // 创建备份保险箱
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_CREATESOURCEPACKAGEERROR = "FailedOperation.CreateSourcePackageError"
-//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
-//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
-//  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
-//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
-//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) CreateVault(request *CreateVaultRequest) (response *CreateVaultResponse, err error) {
     return c.CreateVaultWithContext(context.Background(), request)
 }
@@ -2572,12 +2691,7 @@ func (c *Client) CreateVault(request *CreateVaultRequest) (response *CreateVault
 // 创建备份保险箱
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_CREATESOURCEPACKAGEERROR = "FailedOperation.CreateSourcePackageError"
-//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
-//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
-//  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
-//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
-//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) CreateVaultWithContext(ctx context.Context, request *CreateVaultRequest) (response *CreateVaultResponse, err error) {
     if request == nil {
         request = NewCreateVaultRequest()
@@ -3025,6 +3139,64 @@ func (c *Client) DeleteClusterDatabaseWithContext(ctx context.Context, request *
     request.SetContext(ctx)
     
     response = NewDeleteClusterDatabaseResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteClusterPeriodScalePolicyRequest() (request *DeleteClusterPeriodScalePolicyRequest) {
+    request = &DeleteClusterPeriodScalePolicyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "DeleteClusterPeriodScalePolicy")
+    
+    
+    return
+}
+
+func NewDeleteClusterPeriodScalePolicyResponse() (response *DeleteClusterPeriodScalePolicyResponse) {
+    response = &DeleteClusterPeriodScalePolicyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteClusterPeriodScalePolicy
+// 删除周期弹性策略
+//
+// 可能返回的错误码:
+//  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
+//  OPERATIONDENIED_INSTANCESTATUSDENIEDERROR = "OperationDenied.InstanceStatusDeniedError"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DeleteClusterPeriodScalePolicy(request *DeleteClusterPeriodScalePolicyRequest) (response *DeleteClusterPeriodScalePolicyResponse, err error) {
+    return c.DeleteClusterPeriodScalePolicyWithContext(context.Background(), request)
+}
+
+// DeleteClusterPeriodScalePolicy
+// 删除周期弹性策略
+//
+// 可能返回的错误码:
+//  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
+//  OPERATIONDENIED_INSTANCESTATUSDENIEDERROR = "OperationDenied.InstanceStatusDeniedError"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DeleteClusterPeriodScalePolicyWithContext(ctx context.Context, request *DeleteClusterPeriodScalePolicyRequest) (response *DeleteClusterPeriodScalePolicyResponse, err error) {
+    if request == nil {
+        request = NewDeleteClusterPeriodScalePolicyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "DeleteClusterPeriodScalePolicy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteClusterPeriodScalePolicy require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteClusterPeriodScalePolicyResponse()
     err = c.Send(request, response)
     return
 }
@@ -3768,6 +3940,7 @@ func NewDescribeAuditLogsResponse() (response *DescribeAuditLogsResponse) {
 // 本接口（DescribeAuditLogs）用于查询数据库审计日志。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_SERVICEACCESSERROR = "FailedOperation.ServiceAccessError"
 //  INTERNALERROR_HTTPERROR = "InternalError.HttpError"
 //  INTERNALERROR_LISTINSTANCESERROR = "InternalError.ListInstancesError"
@@ -3782,6 +3955,7 @@ func (c *Client) DescribeAuditLogs(request *DescribeAuditLogsRequest) (response 
 // 本接口（DescribeAuditLogs）用于查询数据库审计日志。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_SERVICEACCESSERROR = "FailedOperation.ServiceAccessError"
 //  INTERNALERROR_HTTPERROR = "InternalError.HttpError"
 //  INTERNALERROR_LISTINSTANCESERROR = "InternalError.ListInstancesError"
@@ -3828,6 +4002,7 @@ func NewDescribeAuditRuleTemplatesResponse() (response *DescribeAuditRuleTemplat
 // 本接口（DescribeAuditRuleTemplates）用于查询审计规则模板信息。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_SERVICEACCESSERROR = "FailedOperation.ServiceAccessError"
 //  INTERNALERROR_HTTPERROR = "InternalError.HttpError"
 //  INTERNALERROR_LISTINSTANCESERROR = "InternalError.ListInstancesError"
@@ -3842,6 +4017,7 @@ func (c *Client) DescribeAuditRuleTemplates(request *DescribeAuditRuleTemplatesR
 // 本接口（DescribeAuditRuleTemplates）用于查询审计规则模板信息。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_SERVICEACCESSERROR = "FailedOperation.ServiceAccessError"
 //  INTERNALERROR_HTTPERROR = "InternalError.HttpError"
 //  INTERNALERROR_LISTINSTANCESERROR = "InternalError.ListInstancesError"
@@ -4317,6 +4493,80 @@ func (c *Client) DescribeBackupListByVaultWithContext(ctx context.Context, reque
     request.SetContext(ctx)
     
     response = NewDescribeBackupListByVaultResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeBackupOverviewRequest() (request *DescribeBackupOverviewRequest) {
+    request = &DescribeBackupOverviewRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "DescribeBackupOverview")
+    
+    
+    return
+}
+
+func NewDescribeBackupOverviewResponse() (response *DescribeBackupOverviewResponse) {
+    response = &DescribeBackupOverviewResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeBackupOverview
+// 本接口（DescribeBackupOverview）用于查询备份用量总览。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
+//  FAILEDOPERATION_TRADECREATEORDERERROR = "FailedOperation.TradeCreateOrderError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
+//  INVALIDPARAMETERVALUE_CLUSTERNOTFOUND = "InvalidParameterValue.ClusterNotFound"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  INVALIDPARAMETERVALUE_INVALIDREGIONIDERROR = "InvalidParameterValue.InvalidRegionIdError"
+//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
+//  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DescribeBackupOverview(request *DescribeBackupOverviewRequest) (response *DescribeBackupOverviewResponse, err error) {
+    return c.DescribeBackupOverviewWithContext(context.Background(), request)
+}
+
+// DescribeBackupOverview
+// 本接口（DescribeBackupOverview）用于查询备份用量总览。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
+//  FAILEDOPERATION_TRADECREATEORDERERROR = "FailedOperation.TradeCreateOrderError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
+//  INVALIDPARAMETERVALUE_CLUSTERNOTFOUND = "InvalidParameterValue.ClusterNotFound"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  INVALIDPARAMETERVALUE_INVALIDREGIONIDERROR = "InvalidParameterValue.InvalidRegionIdError"
+//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
+//  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DescribeBackupOverviewWithContext(ctx context.Context, request *DescribeBackupOverviewRequest) (response *DescribeBackupOverviewResponse, err error) {
+    if request == nil {
+        request = NewDescribeBackupOverviewRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "DescribeBackupOverview")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeBackupOverview require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeBackupOverviewResponse()
     err = c.Send(request, response)
     return
 }
@@ -5169,6 +5419,68 @@ func (c *Client) DescribeClusterInstanceGrpsWithContext(ctx context.Context, req
     return
 }
 
+func NewDescribeClusterLevelsRequest() (request *DescribeClusterLevelsRequest) {
+    request = &DescribeClusterLevelsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "DescribeClusterLevels")
+    
+    
+    return
+}
+
+func NewDescribeClusterLevelsResponse() (response *DescribeClusterLevelsResponse) {
+    response = &DescribeClusterLevelsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeClusterLevels
+// 查询可支持的集群类型列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  INTERNALERROR_INTERNALHTTPSERVERERROR = "InternalError.InternalHttpServerError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DescribeClusterLevels(request *DescribeClusterLevelsRequest) (response *DescribeClusterLevelsResponse, err error) {
+    return c.DescribeClusterLevelsWithContext(context.Background(), request)
+}
+
+// DescribeClusterLevels
+// 查询可支持的集群类型列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  INTERNALERROR_INTERNALHTTPSERVERERROR = "InternalError.InternalHttpServerError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DescribeClusterLevelsWithContext(ctx context.Context, request *DescribeClusterLevelsRequest) (response *DescribeClusterLevelsResponse, err error) {
+    if request == nil {
+        request = NewDescribeClusterLevelsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "DescribeClusterLevels")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClusterLevels require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeClusterLevelsResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeClusterParamLogsRequest() (request *DescribeClusterParamLogsRequest) {
     request = &DescribeClusterParamLogsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -5367,6 +5679,72 @@ func (c *Client) DescribeClusterPasswordComplexityWithContext(ctx context.Contex
     return
 }
 
+func NewDescribeClusterPeriodScalePolicyRequest() (request *DescribeClusterPeriodScalePolicyRequest) {
+    request = &DescribeClusterPeriodScalePolicyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "DescribeClusterPeriodScalePolicy")
+    
+    
+    return
+}
+
+func NewDescribeClusterPeriodScalePolicyResponse() (response *DescribeClusterPeriodScalePolicyResponse) {
+    response = &DescribeClusterPeriodScalePolicyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeClusterPeriodScalePolicy
+// 查询集群内所有的周期弹性策略
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_GETOSSINFOERROR = "FailedOperation.GetOssInfoError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
+//  OPERATIONDENIED_INSTANCESTATUSDENIEDERROR = "OperationDenied.InstanceStatusDeniedError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
+//  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DescribeClusterPeriodScalePolicy(request *DescribeClusterPeriodScalePolicyRequest) (response *DescribeClusterPeriodScalePolicyResponse, err error) {
+    return c.DescribeClusterPeriodScalePolicyWithContext(context.Background(), request)
+}
+
+// DescribeClusterPeriodScalePolicy
+// 查询集群内所有的周期弹性策略
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_GETOSSINFOERROR = "FailedOperation.GetOssInfoError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
+//  OPERATIONDENIED_INSTANCESTATUSDENIEDERROR = "OperationDenied.InstanceStatusDeniedError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
+//  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DescribeClusterPeriodScalePolicyWithContext(ctx context.Context, request *DescribeClusterPeriodScalePolicyRequest) (response *DescribeClusterPeriodScalePolicyResponse, err error) {
+    if request == nil {
+        request = NewDescribeClusterPeriodScalePolicyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "DescribeClusterPeriodScalePolicy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClusterPeriodScalePolicy require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeClusterPeriodScalePolicyResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeClusterReadOnlyRequest() (request *DescribeClusterReadOnlyRequest) {
     request = &DescribeClusterReadOnlyRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -5439,6 +5817,78 @@ func (c *Client) DescribeClusterReadOnlyWithContext(ctx context.Context, request
     return
 }
 
+func NewDescribeClusterServerlessScalePlansRequest() (request *DescribeClusterServerlessScalePlansRequest) {
+    request = &DescribeClusterServerlessScalePlansRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "DescribeClusterServerlessScalePlans")
+    
+    
+    return
+}
+
+func NewDescribeClusterServerlessScalePlansResponse() (response *DescribeClusterServerlessScalePlansResponse) {
+    response = &DescribeClusterServerlessScalePlansResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeClusterServerlessScalePlans
+// 查询Serverless弹性扩容计划
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  INTERNALERROR_INTERNALHTTPSERVERERROR = "InternalError.InternalHttpServerError"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETERVALUE_INSTANCENOTFOUND = "InvalidParameterValue.InstanceNotFound"
+//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
+//  OPERATIONDENIED_SERVERLESSCLUSTERSTATUSDENIED = "OperationDenied.ServerlessClusterStatusDenied"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DescribeClusterServerlessScalePlans(request *DescribeClusterServerlessScalePlansRequest) (response *DescribeClusterServerlessScalePlansResponse, err error) {
+    return c.DescribeClusterServerlessScalePlansWithContext(context.Background(), request)
+}
+
+// DescribeClusterServerlessScalePlans
+// 查询Serverless弹性扩容计划
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  INTERNALERROR_INTERNALHTTPSERVERERROR = "InternalError.InternalHttpServerError"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETERVALUE_INSTANCENOTFOUND = "InvalidParameterValue.InstanceNotFound"
+//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
+//  OPERATIONDENIED_SERVERLESSCLUSTERSTATUSDENIED = "OperationDenied.ServerlessClusterStatusDenied"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) DescribeClusterServerlessScalePlansWithContext(ctx context.Context, request *DescribeClusterServerlessScalePlansRequest) (response *DescribeClusterServerlessScalePlansResponse, err error) {
+    if request == nil {
+        request = NewDescribeClusterServerlessScalePlansRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "DescribeClusterServerlessScalePlans")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClusterServerlessScalePlans require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeClusterServerlessScalePlansResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeClusterTransparentEncryptInfoRequest() (request *DescribeClusterTransparentEncryptInfoRequest) {
     request = &DescribeClusterTransparentEncryptInfoRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -5462,18 +5912,7 @@ func NewDescribeClusterTransparentEncryptInfoResponse() (response *DescribeClust
 // 查询集群透明加密信息
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
-//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
-//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
-//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
-//  INTERNALERROR_INTERNALHTTPSERVERERROR = "InternalError.InternalHttpServerError"
-//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
-//  INVALIDPARAMETERVALUE_INSTANCENOTFOUND = "InvalidParameterValue.InstanceNotFound"
-//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
-//  OPERATIONDENIED_SERVERLESSCLUSTERSTATUSDENIED = "OperationDenied.ServerlessClusterStatusDenied"
-//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
-//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
-//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) DescribeClusterTransparentEncryptInfo(request *DescribeClusterTransparentEncryptInfoRequest) (response *DescribeClusterTransparentEncryptInfoResponse, err error) {
     return c.DescribeClusterTransparentEncryptInfoWithContext(context.Background(), request)
 }
@@ -5482,18 +5921,7 @@ func (c *Client) DescribeClusterTransparentEncryptInfo(request *DescribeClusterT
 // 查询集群透明加密信息
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
-//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
-//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
-//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
-//  INTERNALERROR_INTERNALHTTPSERVERERROR = "InternalError.InternalHttpServerError"
-//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
-//  INVALIDPARAMETERVALUE_INSTANCENOTFOUND = "InvalidParameterValue.InstanceNotFound"
-//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
-//  OPERATIONDENIED_SERVERLESSCLUSTERSTATUSDENIED = "OperationDenied.ServerlessClusterStatusDenied"
-//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
-//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
-//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) DescribeClusterTransparentEncryptInfoWithContext(ctx context.Context, request *DescribeClusterTransparentEncryptInfoRequest) (response *DescribeClusterTransparentEncryptInfoResponse, err error) {
     if request == nil {
         request = NewDescribeClusterTransparentEncryptInfoRequest()
@@ -5725,6 +6153,7 @@ func NewDescribeInstanceCLSLogDeliveryResponse() (response *DescribeInstanceCLSL
 //  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
 //  OPERATIONDENIED_CLUSTERSTATUSDENIEDERROR = "OperationDenied.ClusterStatusDeniedError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) DescribeInstanceCLSLogDelivery(request *DescribeInstanceCLSLogDeliveryRequest) (response *DescribeInstanceCLSLogDeliveryResponse, err error) {
     return c.DescribeInstanceCLSLogDeliveryWithContext(context.Background(), request)
 }
@@ -5738,6 +6167,7 @@ func (c *Client) DescribeInstanceCLSLogDelivery(request *DescribeInstanceCLSLogD
 //  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
 //  OPERATIONDENIED_CLUSTERSTATUSDENIEDERROR = "OperationDenied.ClusterStatusDeniedError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) DescribeInstanceCLSLogDeliveryWithContext(ctx context.Context, request *DescribeInstanceCLSLogDeliveryRequest) (response *DescribeInstanceCLSLogDeliveryResponse, err error) {
     if request == nil {
         request = NewDescribeInstanceCLSLogDeliveryRequest()
@@ -10892,10 +11322,7 @@ func NewModifyClusterGlobalEncryptionResponse() (response *ModifyClusterGlobalEn
 // 开关全局加密
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
-//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
-//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
-//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) ModifyClusterGlobalEncryption(request *ModifyClusterGlobalEncryptionRequest) (response *ModifyClusterGlobalEncryptionResponse, err error) {
     return c.ModifyClusterGlobalEncryptionWithContext(context.Background(), request)
 }
@@ -10904,10 +11331,7 @@ func (c *Client) ModifyClusterGlobalEncryption(request *ModifyClusterGlobalEncry
 // 开关全局加密
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
-//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
-//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
-//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) ModifyClusterGlobalEncryptionWithContext(ctx context.Context, request *ModifyClusterGlobalEncryptionRequest) (response *ModifyClusterGlobalEncryptionResponse, err error) {
     if request == nil {
         request = NewModifyClusterGlobalEncryptionRequest()
@@ -11119,6 +11543,70 @@ func (c *Client) ModifyClusterPasswordComplexityWithContext(ctx context.Context,
     request.SetContext(ctx)
     
     response = NewModifyClusterPasswordComplexityResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyClusterPeriodScalePolicyRequest() (request *ModifyClusterPeriodScalePolicyRequest) {
+    request = &ModifyClusterPeriodScalePolicyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "ModifyClusterPeriodScalePolicy")
+    
+    
+    return
+}
+
+func NewModifyClusterPeriodScalePolicyResponse() (response *ModifyClusterPeriodScalePolicyResponse) {
+    response = &ModifyClusterPeriodScalePolicyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyClusterPeriodScalePolicy
+// 更新集群的周期弹性策略
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  OPERATIONDENIED_SERVERLESSCLUSTERSTATUSDENIED = "OperationDenied.ServerlessClusterStatusDenied"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
+//  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) ModifyClusterPeriodScalePolicy(request *ModifyClusterPeriodScalePolicyRequest) (response *ModifyClusterPeriodScalePolicyResponse, err error) {
+    return c.ModifyClusterPeriodScalePolicyWithContext(context.Background(), request)
+}
+
+// ModifyClusterPeriodScalePolicy
+// 更新集群的周期弹性策略
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  OPERATIONDENIED_SERVERLESSCLUSTERSTATUSDENIED = "OperationDenied.ServerlessClusterStatusDenied"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
+//  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) ModifyClusterPeriodScalePolicyWithContext(ctx context.Context, request *ModifyClusterPeriodScalePolicyRequest) (response *ModifyClusterPeriodScalePolicyResponse, err error) {
+    if request == nil {
+        request = NewModifyClusterPeriodScalePolicyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "ModifyClusterPeriodScalePolicy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyClusterPeriodScalePolicy require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyClusterPeriodScalePolicyResponse()
     err = c.Send(request, response)
     return
 }
@@ -12751,6 +13239,7 @@ func NewModifyVaultResponse() (response *ModifyVaultResponse) {
 //
 // 可能返回的错误码:
 //  OPERATIONDENIED_BACKUPVAULTTASKCONFLICTERROR = "OperationDenied.BackupVaultTaskConflictError"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) ModifyVault(request *ModifyVaultRequest) (response *ModifyVaultResponse, err error) {
     return c.ModifyVaultWithContext(context.Background(), request)
 }
@@ -12760,6 +13249,7 @@ func (c *Client) ModifyVault(request *ModifyVaultRequest) (response *ModifyVault
 //
 // 可能返回的错误码:
 //  OPERATIONDENIED_BACKUPVAULTTASKCONFLICTERROR = "OperationDenied.BackupVaultTaskConflictError"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) ModifyVaultWithContext(ctx context.Context, request *ModifyVaultRequest) (response *ModifyVaultResponse, err error) {
     if request == nil {
         request = NewModifyVaultRequest()
@@ -13115,6 +13605,72 @@ func (c *Client) OfflineLibraDBInstanceWithContext(ctx context.Context, request 
     return
 }
 
+func NewOpenAIOptimizerRequest() (request *OpenAIOptimizerRequest) {
+    request = &OpenAIOptimizerRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "OpenAIOptimizer")
+    
+    
+    return
+}
+
+func NewOpenAIOptimizerResponse() (response *OpenAIOptimizerResponse) {
+    response = &OpenAIOptimizerResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// OpenAIOptimizer
+// 本接口(OpenAIOptimizer)用于开启实例的AI优化器开关。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INVALIDPARAMETERVALUE_INSTANCENOTFOUND = "InvalidParameterValue.InstanceNotFound"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
+//  RESOURCENOTFOUND_INSTANCENOTFOUNDERROR = "ResourceNotFound.InstanceNotFoundError"
+//  RESOURCENOTFOUND_RESOURCEERROR = "ResourceNotFound.ResourceError"
+//  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) OpenAIOptimizer(request *OpenAIOptimizerRequest) (response *OpenAIOptimizerResponse, err error) {
+    return c.OpenAIOptimizerWithContext(context.Background(), request)
+}
+
+// OpenAIOptimizer
+// 本接口(OpenAIOptimizer)用于开启实例的AI优化器开关。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INVALIDPARAMETERVALUE_INSTANCENOTFOUND = "InvalidParameterValue.InstanceNotFound"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
+//  RESOURCENOTFOUND_INSTANCENOTFOUNDERROR = "ResourceNotFound.InstanceNotFoundError"
+//  RESOURCENOTFOUND_RESOURCEERROR = "ResourceNotFound.ResourceError"
+//  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) OpenAIOptimizerWithContext(ctx context.Context, request *OpenAIOptimizerRequest) (response *OpenAIOptimizerResponse, err error) {
+    if request == nil {
+        request = NewOpenAIOptimizerRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "OpenAIOptimizer")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("OpenAIOptimizer require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewOpenAIOptimizerResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewOpenAuditServiceRequest() (request *OpenAuditServiceRequest) {
     request = &OpenAuditServiceRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -13138,6 +13694,7 @@ func NewOpenAuditServiceResponse() (response *OpenAuditServiceResponse) {
 // 本接口（OpenAuditService）用于为实例开通数据库审计服务。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CREATEAUDITFAILERROR = "FailedOperation.CreateAuditFailError"
 //  FAILEDOPERATION_INSTANCEQUERYERROR = "FailedOperation.InstanceQueryError"
 //  INTERNALERROR_LISTINSTANCESERROR = "InternalError.ListInstancesError"
 //  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
@@ -13151,6 +13708,7 @@ func (c *Client) OpenAuditService(request *OpenAuditServiceRequest) (response *O
 // 本接口（OpenAuditService）用于为实例开通数据库审计服务。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CREATEAUDITFAILERROR = "FailedOperation.CreateAuditFailError"
 //  FAILEDOPERATION_INSTANCEQUERYERROR = "FailedOperation.InstanceQueryError"
 //  INTERNALERROR_LISTINSTANCESERROR = "InternalError.ListInstancesError"
 //  INTERNALERROR_UNKNOWNERROR = "InternalError.UnknownError"
@@ -13324,13 +13882,8 @@ func NewOpenClusterTransparentEncryptResponse() (response *OpenClusterTransparen
 // 开通集群透明加密
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
-//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
-//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
-//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
-//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
-//  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
-//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  INTERNALERROR_GETROLEERROR = "InternalError.GetRoleError"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) OpenClusterTransparentEncrypt(request *OpenClusterTransparentEncryptRequest) (response *OpenClusterTransparentEncryptResponse, err error) {
     return c.OpenClusterTransparentEncryptWithContext(context.Background(), request)
 }
@@ -13339,13 +13892,8 @@ func (c *Client) OpenClusterTransparentEncrypt(request *OpenClusterTransparentEn
 // 开通集群透明加密
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
-//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
-//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
-//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
-//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
-//  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
-//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  INTERNALERROR_GETROLEERROR = "InternalError.GetRoleError"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) OpenClusterTransparentEncryptWithContext(ctx context.Context, request *OpenClusterTransparentEncryptRequest) (response *OpenClusterTransparentEncryptResponse, err error) {
     if request == nil {
         request = NewOpenClusterTransparentEncryptRequest()
@@ -15065,6 +15613,7 @@ func NewStartCLSDeliveryResponse() (response *StartCLSDeliveryResponse) {
 //
 // 可能返回的错误码:
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) StartCLSDelivery(request *StartCLSDeliveryRequest) (response *StartCLSDeliveryResponse, err error) {
     return c.StartCLSDeliveryWithContext(context.Background(), request)
 }
@@ -15074,6 +15623,7 @@ func (c *Client) StartCLSDelivery(request *StartCLSDeliveryRequest) (response *S
 //
 // 可能返回的错误码:
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+//  UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 func (c *Client) StartCLSDeliveryWithContext(ctx context.Context, request *StartCLSDeliveryRequest) (response *StartCLSDeliveryResponse, err error) {
     if request == nil {
         request = NewStartCLSDeliveryRequest()
@@ -15327,6 +15877,70 @@ func (c *Client) SwitchProxyVpcWithContext(ctx context.Context, request *SwitchP
     return
 }
 
+func NewTransferClusterPrepayToPostpayRequest() (request *TransferClusterPrepayToPostpayRequest) {
+    request = &TransferClusterPrepayToPostpayRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "TransferClusterPrepayToPostpay")
+    
+    
+    return
+}
+
+func NewTransferClusterPrepayToPostpayResponse() (response *TransferClusterPrepayToPostpayResponse) {
+    response = &TransferClusterPrepayToPostpayResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// TransferClusterPrepayToPostpay
+// 本接口（TransferClusterPrepayToPostpay）用于将预付费集群转为后付费集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) TransferClusterPrepayToPostpay(request *TransferClusterPrepayToPostpayRequest) (response *TransferClusterPrepayToPostpayResponse, err error) {
+    return c.TransferClusterPrepayToPostpayWithContext(context.Background(), request)
+}
+
+// TransferClusterPrepayToPostpay
+// 本接口（TransferClusterPrepayToPostpay）用于将预付费集群转为后付费集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
+//  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
+//  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+//  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+func (c *Client) TransferClusterPrepayToPostpayWithContext(ctx context.Context, request *TransferClusterPrepayToPostpayRequest) (response *TransferClusterPrepayToPostpayResponse, err error) {
+    if request == nil {
+        request = NewTransferClusterPrepayToPostpayRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "TransferClusterPrepayToPostpay")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("TransferClusterPrepayToPostpay require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewTransferClusterPrepayToPostpayResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewTransferClusterZoneRequest() (request *TransferClusterZoneRequest) {
     request = &TransferClusterZoneRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -15387,6 +16001,62 @@ func (c *Client) TransferClusterZoneWithContext(ctx context.Context, request *Tr
     request.SetContext(ctx)
     
     response = NewTransferClusterZoneResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewTransferStoragePrepayToPostpayRequest() (request *TransferStoragePrepayToPostpayRequest) {
+    request = &TransferStoragePrepayToPostpayRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cynosdb", APIVersion, "TransferStoragePrepayToPostpay")
+    
+    
+    return
+}
+
+func NewTransferStoragePrepayToPostpayResponse() (response *TransferStoragePrepayToPostpayResponse) {
+    response = &TransferStoragePrepayToPostpayResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// TransferStoragePrepayToPostpay
+// 本接口（TransferStoragePrepayToPostpay）用于将预付费存储转为后付费存储
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INVALIDPARAMETERVALUE_INVALIDREGIONIDERROR = "InvalidParameterValue.InvalidRegionIdError"
+//  OPERATIONDENIED_CLUSTERSTATUSDENIEDERROR = "OperationDenied.ClusterStatusDeniedError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+func (c *Client) TransferStoragePrepayToPostpay(request *TransferStoragePrepayToPostpayRequest) (response *TransferStoragePrepayToPostpayResponse, err error) {
+    return c.TransferStoragePrepayToPostpayWithContext(context.Background(), request)
+}
+
+// TransferStoragePrepayToPostpay
+// 本接口（TransferStoragePrepayToPostpay）用于将预付费存储转为后付费存储
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  INVALIDPARAMETERVALUE_INVALIDREGIONIDERROR = "InvalidParameterValue.InvalidRegionIdError"
+//  OPERATIONDENIED_CLUSTERSTATUSDENIEDERROR = "OperationDenied.ClusterStatusDeniedError"
+//  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
+func (c *Client) TransferStoragePrepayToPostpayWithContext(ctx context.Context, request *TransferStoragePrepayToPostpayRequest) (response *TransferStoragePrepayToPostpayResponse, err error) {
+    if request == nil {
+        request = NewTransferStoragePrepayToPostpayRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cynosdb", APIVersion, "TransferStoragePrepayToPostpay")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("TransferStoragePrepayToPostpay require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewTransferStoragePrepayToPostpayResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/errors.go
@@ -35,6 +35,9 @@ const (
 	// 鉴权失败，请稍后重试。如果持续不成功，请联系客服进行处理。
 	FAILEDOPERATION_CAMSIGANDAUTHERROR = "FailedOperation.CamSigAndAuthError"
 
+	// 创建审计失败
+	FAILEDOPERATION_CREATEAUDITFAILERROR = "FailedOperation.CreateAuditFailError"
+
 	// 创建并支付订单失败。
 	FAILEDOPERATION_CREATEORDER = "FailedOperation.CreateOrder"
 
@@ -439,4 +442,7 @@ const (
 
 	// CAM鉴权不通过。
 	UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
+
+	// 授权失败或已取消授权
+	UNAUTHORIZEDOPERATION_ROLEUNAUTHORIZED = "UnauthorizedOperation.RoleUnauthorized"
 )

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/models.go
@@ -37,63 +37,63 @@ type AIOptimizerTaskData struct {
 }
 
 type Ability struct {
-	// 是否支持从可用区
+	// <p>是否支持从可用区</p>
 	IsSupportSlaveZone *string `json:"IsSupportSlaveZone,omitnil,omitempty" name:"IsSupportSlaveZone"`
 
-	// 不支持从可用区的原因
+	// <p>不支持从可用区的原因</p>
 	NonsupportSlaveZoneReason *string `json:"NonsupportSlaveZoneReason,omitnil,omitempty" name:"NonsupportSlaveZoneReason"`
 
-	// 是否支持RO实例
+	// <p>是否支持RO实例</p>
 	IsSupportRo *string `json:"IsSupportRo,omitnil,omitempty" name:"IsSupportRo"`
 
-	// 不支持RO实例的原因
+	// <p>不支持RO实例的原因</p>
 	NonsupportRoReason *string `json:"NonsupportRoReason,omitnil,omitempty" name:"NonsupportRoReason"`
 
-	// 是否支持手动发起快照备份
+	// <p>是否支持手动发起快照备份</p>
 	IsSupportManualSnapshot *string `json:"IsSupportManualSnapshot,omitnil,omitempty" name:"IsSupportManualSnapshot"`
 
-	// 是否支持透明数据加密
+	// <p>是否支持透明数据加密</p>
 	IsSupportTransparentDataEncryption *string `json:"IsSupportTransparentDataEncryption,omitnil,omitempty" name:"IsSupportTransparentDataEncryption"`
 
-	// 不支持透明数据加密原因
+	// <p>不支持透明数据加密原因</p>
 	NoSupportTransparentDataEncryptionReason *string `json:"NoSupportTransparentDataEncryptionReason,omitnil,omitempty" name:"NoSupportTransparentDataEncryptionReason"`
 
-	// 是否支持手动发起逻辑备份
+	// <p>是否支持手动发起逻辑备份</p>
 	IsSupportManualLogic *string `json:"IsSupportManualLogic,omitnil,omitempty" name:"IsSupportManualLogic"`
 
-	// 是否支持开启全局加密
+	// <p>是否支持开启全局加密</p>
 	IsSupportGlobalEncryption *string `json:"IsSupportGlobalEncryption,omitnil,omitempty" name:"IsSupportGlobalEncryption"`
 
-	// 不支持全局加密的原因
+	// <p>不支持全局加密的原因</p>
 	NoSupportGlobalEncryptionReason *string `json:"NoSupportGlobalEncryptionReason,omitnil,omitempty" name:"NoSupportGlobalEncryptionReason"`
 
-	// 不支持透明加密原因状态码
+	// <p>不支持透明加密原因状态码</p>
 	NoSupportTransparentDataEncryptionReasonCode *string `json:"NoSupportTransparentDataEncryptionReasonCode,omitnil,omitempty" name:"NoSupportTransparentDataEncryptionReasonCode"`
 
-	// 不支持全局加密原因状态码
+	// <p>不支持全局加密原因状态码</p>
 	NoSupportGlobalEncryptionReasonCode *string `json:"NoSupportGlobalEncryptionReasonCode,omitnil,omitempty" name:"NoSupportGlobalEncryptionReasonCode"`
 }
 
 type Account struct {
-	// 数据库账号名
+	// <p>数据库账号名</p>
 	AccountName *string `json:"AccountName,omitnil,omitempty" name:"AccountName"`
 
-	// 主机
+	// <p>主机</p>
 	Host *string `json:"Host,omitnil,omitempty" name:"Host"`
 
-	// 数据库账号描述
+	// <p>数据库账号描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
-	// 创建时间
+	// <p>创建时间</p>
 	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
-	// 更新时间
+	// <p>更新时间</p>
 	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 
-	// 用户最大连接数
+	// <p>用户最大连接数</p>
 	MaxUserConnections *int64 `json:"MaxUserConnections,omitnil,omitempty" name:"MaxUserConnections"`
 
-	// 是否开启密码轮转(0:关闭;1:开启)
+	// <p>是否开启密码轮转(0:关闭;1:开启)</p>
 	PasswordRotation *int64 `json:"PasswordRotation,omitnil,omitempty" name:"PasswordRotation"`
 }
 
@@ -954,6 +954,8 @@ type AssociateSecurityGroupsRequestParams struct {
 	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
 
 	// 可用区
+	//
+	// Deprecated: Zone is deprecated.
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 }
 
@@ -1240,38 +1242,39 @@ type AutoMapRule struct {
 }
 
 type BackupConfigInfo struct {
-	// 系统自动时间
+	// <p>系统自动时间</p>
 	BackupCustomAutoTime *bool `json:"BackupCustomAutoTime,omitnil,omitempty" name:"BackupCustomAutoTime"`
 
-	// 表示全备开始时间，[0-24*3600]， 如0:00, 1:00, 2:00 分别为 0，3600， 7200
+	// <p>表示全备开始时间，[0-24*3600]， 如0:00, 1:00, 2:00 分别为 0，3600， 7200</p>
 	BackupTimeBeg *uint64 `json:"BackupTimeBeg,omitnil,omitempty" name:"BackupTimeBeg"`
 
-	// 表示全备结束时间，[0-24*3600]， 如0:00, 1:00, 2:00 分别为 0，3600， 7200
+	// <p>表示全备结束时间，[0-24*3600]， 如0:00, 1:00, 2:00 分别为 0，3600， 7200</p>
 	BackupTimeEnd *uint64 `json:"BackupTimeEnd,omitnil,omitempty" name:"BackupTimeEnd"`
 
-	// 该参数目前不支持修改，无需填写。备份频率，长度为7的数组，分别对应周日到周六的备份方式，full-全量备份，increment-增量备份
+	// <p>该参数目前不支持修改，无需填写。备份频率，长度为7的数组，分别对应周日到周六的备份方式，full-全量备份，increment-增量备份</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	BackupWeekDays []*string `json:"BackupWeekDays,omitnil,omitempty" name:"BackupWeekDays"`
 
-	// 间隔时间
+	// <p>间隔时间</p>
 	BackupIntervalTime *int64 `json:"BackupIntervalTime,omitnil,omitempty" name:"BackupIntervalTime"`
 
-	// 表示保留备份时长, 单位秒，超过该时间将被清理, 七天表示为3600247=604800，最大为158112000
+	// <p>表示保留备份时长, 单位秒，超过该时间将被清理, 七天表示为3600247=604800，最大为158112000</p>
 	ReserveDuration *uint64 `json:"ReserveDuration,omitnil,omitempty" name:"ReserveDuration"`
 
-	// 跨地域备份开启
-	// yes-开启
-	// no-关闭
+	// <p>跨地域备份开启<br>yes-开启<br>no-关闭</p>
 	CrossRegionsEnable *string `json:"CrossRegionsEnable,omitnil,omitempty" name:"CrossRegionsEnable"`
 
-	// 跨地域备份地域
+	// <p>跨地域备份地域</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	CrossRegions []*string `json:"CrossRegions,omitnil,omitempty" name:"CrossRegions"`
 
-	// 自动数据备份触发策略，periodically:自动周期备份,frequent:高频备份
+	// <p>跨地域备份保留时间</p><p>单位：天</p>
+	CrossRegionSaveDays *int64 `json:"CrossRegionSaveDays,omitnil,omitempty" name:"CrossRegionSaveDays"`
+
+	// <p>自动数据备份触发策略，periodically:自动周期备份,frequent:高频备份</p>
 	BackupTriggerStrategy *string `json:"BackupTriggerStrategy,omitnil,omitempty" name:"BackupTriggerStrategy"`
 
-	// 备份投递关系
+	// <p>备份投递关系</p>
 	AutoCopyVaults []*CreateBackupVaultItem `json:"AutoCopyVaults,omitnil,omitempty" name:"AutoCopyVaults"`
 }
 
@@ -1371,6 +1374,17 @@ type BackupRegionAndIds struct {
 	BackupId *int64 `json:"BackupId,omitnil,omitempty" name:"BackupId"`
 }
 
+type BackupVolumeInfo struct {
+	// 备份使用量
+	BackupVolume *float64 `json:"BackupVolume,omitnil,omitempty" name:"BackupVolume"`
+
+	// 备份类型
+	BackupType *string `json:"BackupType,omitnil,omitempty" name:"BackupType"`
+
+	// 备份方式
+	BackupMethod *string `json:"BackupMethod,omitnil,omitempty" name:"BackupMethod"`
+}
+
 type BillingResourceInfo struct {
 	// 集群ID
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -1458,50 +1472,64 @@ type BindInstanceInfo struct {
 }
 
 type BinlogConfigInfo struct {
-	// binlog保留时间
+	// <p>binlog保留时间</p>
 	BinlogSaveDays *int64 `json:"BinlogSaveDays,omitnil,omitempty" name:"BinlogSaveDays"`
 
-	// binlog异地地域备份是否开启
+	// <p>binlog异地地域备份是否开启</p>
 	BinlogCrossRegionsEnable *string `json:"BinlogCrossRegionsEnable,omitnil,omitempty" name:"BinlogCrossRegionsEnable"`
 
-	// binlog异地地域
+	// <p>binlog异地地域</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	BinlogCrossRegions []*string `json:"BinlogCrossRegions,omitnil,omitempty" name:"BinlogCrossRegions"`
 
-	// 保险箱信息
+	// <p>跨地域备份保留时间</p><p>单位：天</p>
+	BinlogCrossRegionSaveDays *int64 `json:"BinlogCrossRegionSaveDays,omitnil,omitempty" name:"BinlogCrossRegionSaveDays"`
+
+	// <p>保险箱信息</p>
 	AutoCopyVaults []*CreateBackupVaultItem `json:"AutoCopyVaults,omitnil,omitempty" name:"AutoCopyVaults"`
 }
 
 type BinlogItem struct {
-	// Binlog文件名称
+	// <p>Binlog文件名称</p>
 	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
 
-	// 文件大小，单位：字节
+	// <p>文件大小，单位：字节</p>
 	FileSize *int64 `json:"FileSize,omitnil,omitempty" name:"FileSize"`
 
-	// 事务最早时间
+	// <p>事务最早时间</p>
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 事务最晚时间
+	// <p>事务最晚时间</p>
 	FinishTime *string `json:"FinishTime,omitnil,omitempty" name:"FinishTime"`
 
-	// Binlog文件ID
+	// <p>Binlog文件ID</p>
 	BinlogId *int64 `json:"BinlogId,omitnil,omitempty" name:"BinlogId"`
 
-	// binlog所跨地域
+	// <p>binlog所跨地域</p>
 	CrossRegions []*string `json:"CrossRegions,omitnil,omitempty" name:"CrossRegions"`
 
-	// 备份投递状态
+	// <p>备份投递状态</p>
 	CopyStatus *string `json:"CopyStatus,omitnil,omitempty" name:"CopyStatus"`
 
-	// 保险箱信息
+	// <p>保险箱信息</p>
 	VaultInfos []*VaultInfo `json:"VaultInfos,omitnil,omitempty" name:"VaultInfos"`
 
-	// 加密秘钥key
+	// <p>加密秘钥key</p>
 	EncryptKeyId *string `json:"EncryptKeyId,omitnil,omitempty" name:"EncryptKeyId"`
 
-	// 加密秘钥地域
+	// <p>加密秘钥地域</p>
 	EncryptRegion *string `json:"EncryptRegion,omitnil,omitempty" name:"EncryptRegion"`
+
+	// <p>备份的地域分布信息</p>
+	ExistRegions []*BinlogRegionInfo `json:"ExistRegions,omitnil,omitempty" name:"ExistRegions"`
+}
+
+type BinlogRegionInfo struct {
+	// <p>备份地域</p>
+	BackupRegion *string `json:"BackupRegion,omitnil,omitempty" name:"BackupRegion"`
+
+	// <p>备份ID</p>
+	BackupId *int64 `json:"BackupId,omitnil,omitempty" name:"BackupId"`
 }
 
 type BizTaskInfo struct {
@@ -1789,6 +1817,70 @@ func (r *CalculateBackupSaveSecExpiresResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CalculateBackupSaveSecExpiresResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CancelClusterServerlessScalePlanRequestParams struct {
+	// 集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 计划ID
+	PlanId *int64 `json:"PlanId,omitnil,omitempty" name:"PlanId"`
+}
+
+type CancelClusterServerlessScalePlanRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 计划ID
+	PlanId *int64 `json:"PlanId,omitnil,omitempty" name:"PlanId"`
+}
+
+func (r *CancelClusterServerlessScalePlanRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CancelClusterServerlessScalePlanRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "PlanId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CancelClusterServerlessScalePlanRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CancelClusterServerlessScalePlanResponseParams struct {
+	// 任务id
+	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CancelClusterServerlessScalePlanResponse struct {
+	*tchttp.BaseResponse
+	Response *CancelClusterServerlessScalePlanResponseParams `json:"Response"`
+}
+
+func (r *CancelClusterServerlessScalePlanResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CancelClusterServerlessScalePlanResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2430,12 +2522,108 @@ type ClusterParamModifyLog struct {
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 }
 
+type ClusterPeriodScalePolicy struct {
+	// <p>策略ID</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
+
+	// <p>实例类型。rw-读写类型，ro-只读类型。</p>
+	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
+
+	// <p>弹性下限, 后续废弃, 请使用MinCcu</p>
+	MinCpu *float64 `json:"MinCpu,omitnil,omitempty" name:"MinCpu"`
+
+	// <p>弹性上限,后续废弃，请使用MaxCcu</p>
+	MaxCpu *float64 `json:"MaxCpu,omitnil,omitempty" name:"MaxCpu"`
+
+	// <p>弹性开始时间</p>
+	ScaleStartTime *string `json:"ScaleStartTime,omitnil,omitempty" name:"ScaleStartTime"`
+
+	// <p>弹性结束时间</p>
+	ScaleEndTime *string `json:"ScaleEndTime,omitnil,omitempty" name:"ScaleEndTime"`
+
+	// <p>策略有效起始日期时间</p>
+	PolicyStartTime *string `json:"PolicyStartTime,omitnil,omitempty" name:"PolicyStartTime"`
+
+	// <p>策略有效截止日期时间</p>
+	PolicyEndTime *string `json:"PolicyEndTime,omitnil,omitempty" name:"PolicyEndTime"`
+
+	// <p>周期类型。day-天， week-星期，month-月</p>
+	PeriodType *string `json:"PeriodType,omitnil,omitempty" name:"PeriodType"`
+
+	// <p>在周期内的时间配置。对于week，表示星期几；对于month，表示几号。对于day，此参数不生效。</p>
+	PeriodConfig []*int64 `json:"PeriodConfig,omitnil,omitempty" name:"PeriodConfig"`
+
+	// <p>创建时间</p>
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>策略状态。normal-正常，expired-过期, deleted-删除</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
 type ClusterReadOnlyValue struct {
 	// 集群ID
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
 	// 只读开关值
 	ReadOnlyValue *string `json:"ReadOnlyValue,omitnil,omitempty" name:"ReadOnlyValue"`
+}
+
+type ClusterServerlessScalePlan struct {
+	// <p>计划ID</p>
+	PlanId *int64 `json:"PlanId,omitnil,omitempty" name:"PlanId"`
+
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>实例对象。具体是实例id或者类型。比如ro-即集群下的所有只读实例。</p>
+	ObjectInstance *string `json:"ObjectInstance,omitnil,omitempty" name:"ObjectInstance"`
+
+	// <p>策略ID</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
+
+	// <p>策略类型</p>
+	PolicyType *string `json:"PolicyType,omitnil,omitempty" name:"PolicyType"`
+
+	// <p>原规格下限</p>
+	SourceMinCpu *float64 `json:"SourceMinCpu,omitnil,omitempty" name:"SourceMinCpu"`
+
+	// <p>原规格上限</p>
+	SourceMaxCpu *float64 `json:"SourceMaxCpu,omitnil,omitempty" name:"SourceMaxCpu"`
+
+	// <p>原规格下限</p>
+	TargetMinCpu *float64 `json:"TargetMinCpu,omitnil,omitempty" name:"TargetMinCpu"`
+
+	// <p>原规格上限</p>
+	TargetMaxCpu *float64 `json:"TargetMaxCpu,omitnil,omitempty" name:"TargetMaxCpu"`
+
+	// <p>计划状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>弹性任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ScaleTaskId *int64 `json:"ScaleTaskId,omitnil,omitempty" name:"ScaleTaskId"`
+
+	// <p>失败原因</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	FailReason *string `json:"FailReason,omitnil,omitempty" name:"FailReason"`
+
+	// <p>计划预期开始执行时间</p>
+	ExpectedStartTime *string `json:"ExpectedStartTime,omitnil,omitempty" name:"ExpectedStartTime"`
+
+	// <p>计划预期结束时间</p>
+	ExpectedEndTime *string `json:"ExpectedEndTime,omitnil,omitempty" name:"ExpectedEndTime"`
+
+	// <p>恢复自动弹性任务</p>
+	ResetTaskId *int64 `json:"ResetTaskId,omitnil,omitempty" name:"ResetTaskId"`
+
+	// <p>恢复自动弹性任务执行方式</p>
+	ResetType *string `json:"ResetType,omitnil,omitempty" name:"ResetType"`
+
+	// <p>恢复自动弹性任务执行时间</p>
+	ResetTime *string `json:"ResetTime,omitnil,omitempty" name:"ResetTime"`
 }
 
 type ClusterSlaveData struct {
@@ -2598,20 +2786,20 @@ func (r *CopyClusterPasswordComplexityResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateAccountsRequestParams struct {
-	// 集群id
+	// <p>集群id</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 新账户列表
+	// <p>新账户列表</p>
 	Accounts []*NewAccount `json:"Accounts,omitnil,omitempty" name:"Accounts"`
 }
 
 type CreateAccountsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 集群id
+	// <p>集群id</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 新账户列表
+	// <p>新账户列表</p>
 	Accounts []*NewAccount `json:"Accounts,omitnil,omitempty" name:"Accounts"`
 }
 
@@ -3125,6 +3313,126 @@ func (r *CreateClusterDatabaseResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CreateClusterPeriodScalePolicyRequestParams struct {
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>实例类型。rw读写，ro-只读</p>
+	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
+
+	// <p>当天开始弹性时间。格式是小时:分钟</p>
+	ScaleStartTime *string `json:"ScaleStartTime,omitnil,omitempty" name:"ScaleStartTime"`
+
+	// <p>当天结束弹性时间。格式是小时:分钟</p>
+	ScaleEndTime *string `json:"ScaleEndTime,omitnil,omitempty" name:"ScaleEndTime"`
+
+	// <p>策略生效的起始日期时间</p>
+	PolicyStartTime *string `json:"PolicyStartTime,omitnil,omitempty" name:"PolicyStartTime"`
+
+	// <p>策略生效的截止日期时间</p>
+	PolicyEndTime *string `json:"PolicyEndTime,omitnil,omitempty" name:"PolicyEndTime"`
+
+	// <p>周期类型。day-天，week-周，month-月。</p>
+	PeriodType *string `json:"PeriodType,omitnil,omitempty" name:"PeriodType"`
+
+	// <p>弹性规格下限</p>
+	MinCpu *float64 `json:"MinCpu,omitnil,omitempty" name:"MinCpu"`
+
+	// <p>弹性规格上限</p>
+	MaxCpu *float64 `json:"MaxCpu,omitnil,omitempty" name:"MaxCpu"`
+
+	// <p>周期内的时间列表。针对PeriodType=week， 表示星期几，比如[1,3]表示星期一、星期三。同理，对于PeriodType=month，[1,3,10]表示每月的1、3、10号。PeriodType=day则该字段无效。</p>
+	PeriodConfig []*int64 `json:"PeriodConfig,omitnil,omitempty" name:"PeriodConfig"`
+}
+
+type CreateClusterPeriodScalePolicyRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>实例类型。rw读写，ro-只读</p>
+	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
+
+	// <p>当天开始弹性时间。格式是小时:分钟</p>
+	ScaleStartTime *string `json:"ScaleStartTime,omitnil,omitempty" name:"ScaleStartTime"`
+
+	// <p>当天结束弹性时间。格式是小时:分钟</p>
+	ScaleEndTime *string `json:"ScaleEndTime,omitnil,omitempty" name:"ScaleEndTime"`
+
+	// <p>策略生效的起始日期时间</p>
+	PolicyStartTime *string `json:"PolicyStartTime,omitnil,omitempty" name:"PolicyStartTime"`
+
+	// <p>策略生效的截止日期时间</p>
+	PolicyEndTime *string `json:"PolicyEndTime,omitnil,omitempty" name:"PolicyEndTime"`
+
+	// <p>周期类型。day-天，week-周，month-月。</p>
+	PeriodType *string `json:"PeriodType,omitnil,omitempty" name:"PeriodType"`
+
+	// <p>弹性规格下限</p>
+	MinCpu *float64 `json:"MinCpu,omitnil,omitempty" name:"MinCpu"`
+
+	// <p>弹性规格上限</p>
+	MaxCpu *float64 `json:"MaxCpu,omitnil,omitempty" name:"MaxCpu"`
+
+	// <p>周期内的时间列表。针对PeriodType=week， 表示星期几，比如[1,3]表示星期一、星期三。同理，对于PeriodType=month，[1,3,10]表示每月的1、3、10号。PeriodType=day则该字段无效。</p>
+	PeriodConfig []*int64 `json:"PeriodConfig,omitnil,omitempty" name:"PeriodConfig"`
+}
+
+func (r *CreateClusterPeriodScalePolicyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateClusterPeriodScalePolicyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "InstanceType")
+	delete(f, "ScaleStartTime")
+	delete(f, "ScaleEndTime")
+	delete(f, "PolicyStartTime")
+	delete(f, "PolicyEndTime")
+	delete(f, "PeriodType")
+	delete(f, "MinCpu")
+	delete(f, "MaxCpu")
+	delete(f, "PeriodConfig")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateClusterPeriodScalePolicyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateClusterPeriodScalePolicyResponseParams struct {
+	// <p>策略ID</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateClusterPeriodScalePolicyResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateClusterPeriodScalePolicyResponseParams `json:"Response"`
+}
+
+func (r *CreateClusterPeriodScalePolicyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateClusterPeriodScalePolicyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type CreateClustersData struct {
 	// 实例CPU
 	Cpu *int64 `json:"Cpu,omitnil,omitempty" name:"Cpu"`
@@ -3278,6 +3586,12 @@ type CreateClustersRequestParams struct {
 
 	// <p>内核小版本号</p>
 	CynosVersion *string `json:"CynosVersion,omitnil,omitempty" name:"CynosVersion"`
+
+	// <p>同步方式。可选值：async、semisync、sync。</p>
+	SyncWay *string `json:"SyncWay,omitnil,omitempty" name:"SyncWay"`
+
+	// <p>半同步超时时间，单位ms。为保证业务稳定性，半同步复制存在退化逻辑，当主可用区集群在等待备可用区集群确认事务时若超过该超时时间，复制方式将降为异步复制。</p><p>取值范围：[1000, 4294967295]</p><p>单位：毫秒</p><p>默认值：10000</p>
+	SemiSyncTimeout *int64 `json:"SemiSyncTimeout,omitnil,omitempty" name:"SemiSyncTimeout"`
 }
 
 type CreateClustersRequest struct {
@@ -3423,6 +3737,12 @@ type CreateClustersRequest struct {
 
 	// <p>内核小版本号</p>
 	CynosVersion *string `json:"CynosVersion,omitnil,omitempty" name:"CynosVersion"`
+
+	// <p>同步方式。可选值：async、semisync、sync。</p>
+	SyncWay *string `json:"SyncWay,omitnil,omitempty" name:"SyncWay"`
+
+	// <p>半同步超时时间，单位ms。为保证业务稳定性，半同步复制存在退化逻辑，当主可用区集群在等待备可用区集群确认事务时若超过该超时时间，复制方式将降为异步复制。</p><p>取值范围：[1000, 4294967295]</p><p>单位：毫秒</p><p>默认值：10000</p>
+	SemiSyncTimeout *int64 `json:"SemiSyncTimeout,omitnil,omitempty" name:"SemiSyncTimeout"`
 }
 
 func (r *CreateClustersRequest) ToJsonString() string {
@@ -3484,6 +3804,8 @@ func (r *CreateClustersRequest) FromJsonString(s string) error {
 	delete(f, "AutoArchiveDelayHours")
 	delete(f, "ClusterLevel")
 	delete(f, "CynosVersion")
+	delete(f, "SyncWay")
+	delete(f, "SemiSyncTimeout")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateClustersRequest has unknown keys!", "")
 	}
@@ -4235,6 +4557,9 @@ type CreateProxyEndPointRequestParams struct {
 
 	// <p>实例权重。</p>
 	InstanceWeights []*ProxyInstanceWeight `json:"InstanceWeights,omitnil,omitempty" name:"InstanceWeights"`
+
+	// <p>负载均衡模式</p><p>枚举值：</p><ul><li>static： 静态负载</li><li>dynamic： 动态负载</li></ul>
+	LoadBalanceMode *string `json:"LoadBalanceMode,omitnil,omitempty" name:"LoadBalanceMode"`
 }
 
 type CreateProxyEndPointRequest struct {
@@ -4293,6 +4618,9 @@ type CreateProxyEndPointRequest struct {
 
 	// <p>实例权重。</p>
 	InstanceWeights []*ProxyInstanceWeight `json:"InstanceWeights,omitnil,omitempty" name:"InstanceWeights"`
+
+	// <p>负载均衡模式</p><p>枚举值：</p><ul><li>static： 静态负载</li><li>dynamic： 动态负载</li></ul>
+	LoadBalanceMode *string `json:"LoadBalanceMode,omitnil,omitempty" name:"LoadBalanceMode"`
 }
 
 func (r *CreateProxyEndPointRequest) ToJsonString() string {
@@ -4325,6 +4653,7 @@ func (r *CreateProxyEndPointRequest) FromJsonString(s string) error {
 	delete(f, "TransSplit")
 	delete(f, "AccessMode")
 	delete(f, "InstanceWeights")
+	delete(f, "LoadBalanceMode")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateProxyEndPointRequest has unknown keys!", "")
 	}
@@ -4864,191 +5193,178 @@ type CynosdbCluster struct {
 }
 
 type CynosdbClusterDetail struct {
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 集群名称
+	// <p>集群名称</p>
 	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
 
-	// 地域
+	// <p>地域</p>
 	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// 可用区
+	// <p>可用区</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// 物理可用区
+	// <p>物理可用区</p>
 	PhysicalZone *string `json:"PhysicalZone,omitnil,omitempty" name:"PhysicalZone"`
 
-	// 状态，支持的值如下：
-	// - creating：创建中
-	// - running：运行中
-	// - isolating：隔离中
-	// - isolated：已隔离
-	// - activating：从回收站重新恢复
-	// - offlining：下线中
-	// - offlined：已下线
-	// - deleting：删除中
-	// - deleted：已删除
+	// <p>状态，支持的值如下：</p><ul><li>creating：创建中</li><li>running：运行中</li><li>isolating：隔离中</li><li>isolated：已隔离</li><li>activating：从回收站重新恢复</li><li>offlining：下线中</li><li>offlined：已下线</li><li>deleting：删除中</li><li>deleted：已删除</li></ul>
 	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 状态描述
+	// <p>状态描述</p>
 	StatusDesc *string `json:"StatusDesc,omitnil,omitempty" name:"StatusDesc"`
 
-	// 当Db类型为SERVERLESS时，serverless集群状态，可选值:
-	// resume
-	// resuming
-	// pause
-	// pausing
+	// <p>当Db类型为SERVERLESS时，serverless集群状态，可选值:<br>resume<br>resuming<br>pause<br>pausing</p>
 	ServerlessStatus *string `json:"ServerlessStatus,omitnil,omitempty" name:"ServerlessStatus"`
 
-	// 存储Id
+	// <p>存储Id</p>
 	StorageId *string `json:"StorageId,omitnil,omitempty" name:"StorageId"`
 
-	// 存储大小，单位为G
+	// <p>存储大小，单位为G</p>
 	Storage *int64 `json:"Storage,omitnil,omitempty" name:"Storage"`
 
-	// 最大存储规格，单位为G
+	// <p>最大存储规格，单位为G</p>
 	MaxStorageSize *int64 `json:"MaxStorageSize,omitnil,omitempty" name:"MaxStorageSize"`
 
-	// 最小存储规格，单位为G
+	// <p>最小存储规格，单位为G</p>
 	MinStorageSize *int64 `json:"MinStorageSize,omitnil,omitempty" name:"MinStorageSize"`
 
-	// 存储付费类型，1为包年包月，0为按量计费
+	// <p>存储付费类型，1为包年包月，0为按量计费</p>
 	StoragePayMode *int64 `json:"StoragePayMode,omitnil,omitempty" name:"StoragePayMode"`
 
-	// VPC名称
+	// <p>VPC名称</p>
 	VpcName *string `json:"VpcName,omitnil,omitempty" name:"VpcName"`
 
-	// vpc唯一id
+	// <p>vpc唯一id</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// 子网名称
+	// <p>子网名称</p>
 	SubnetName *string `json:"SubnetName,omitnil,omitempty" name:"SubnetName"`
 
-	// 子网ID
+	// <p>子网ID</p>
 	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
-	// 字符集
+	// <p>字符集</p>
 	Charset *string `json:"Charset,omitnil,omitempty" name:"Charset"`
 
-	// 创建时间
+	// <p>创建时间</p>
 	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
-	// 数据库类型
+	// <p>数据库类型</p>
 	DbType *string `json:"DbType,omitnil,omitempty" name:"DbType"`
 
-	// Db类型：<li>NORMAL</li><li>SERVERLESS</li>
+	// <p>Db类型：<li>NORMAL</li><li>SERVERLESS</li></p>
 	DbMode *string `json:"DbMode,omitnil,omitempty" name:"DbMode"`
 
-	// 数据库版本
+	// <p>数据库版本</p>
 	DbVersion *string `json:"DbVersion,omitnil,omitempty" name:"DbVersion"`
 
-	// 存储空间上限
+	// <p>存储空间上限</p>
 	StorageLimit *int64 `json:"StorageLimit,omitnil,omitempty" name:"StorageLimit"`
 
-	// 使用容量
+	// <p>使用容量</p>
 	UsedStorage *int64 `json:"UsedStorage,omitnil,omitempty" name:"UsedStorage"`
 
-	// vip地址
+	// <p>vip地址</p>
 	Vip *string `json:"Vip,omitnil,omitempty" name:"Vip"`
 
-	// vport端口
+	// <p>vport端口</p>
 	Vport *int64 `json:"Vport,omitnil,omitempty" name:"Vport"`
 
-	// 集群只读实例的vip地址和vport端口
+	// <p>集群只读实例的vip地址和vport端口</p>
 	RoAddr []*Addr `json:"RoAddr,omitnil,omitempty" name:"RoAddr"`
 
-	// 集群支持的功能
+	// <p>集群支持的功能</p>
 	Ability *Ability `json:"Ability,omitnil,omitempty" name:"Ability"`
 
-	// cynos版本
+	// <p>cynos版本</p>
 	CynosVersion *string `json:"CynosVersion,omitnil,omitempty" name:"CynosVersion"`
 
-	// 商业类型
+	// <p>商业类型</p>
 	BusinessType *string `json:"BusinessType,omitnil,omitempty" name:"BusinessType"`
 
-	// 是否有从可用区
+	// <p>是否有从可用区</p>
 	HasSlaveZone *string `json:"HasSlaveZone,omitnil,omitempty" name:"HasSlaveZone"`
 
-	// 是否冻结
+	// <p>是否冻结</p>
 	IsFreeze *string `json:"IsFreeze,omitnil,omitempty" name:"IsFreeze"`
 
-	// 任务列表
+	// <p>任务列表</p>
 	Tasks []*ObjectTask `json:"Tasks,omitnil,omitempty" name:"Tasks"`
 
-	// 主可用区
+	// <p>主可用区</p>
 	MasterZone *string `json:"MasterZone,omitnil,omitempty" name:"MasterZone"`
 
-	// 从可用区列表
+	// <p>从可用区列表</p>
 	SlaveZones []*string `json:"SlaveZones,omitnil,omitempty" name:"SlaveZones"`
 
-	// 实例信息
+	// <p>实例信息</p>
 	InstanceSet []*ClusterInstanceDetail `json:"InstanceSet,omitnil,omitempty" name:"InstanceSet"`
 
-	// 付费模式
+	// <p>付费模式</p>
 	PayMode *int64 `json:"PayMode,omitnil,omitempty" name:"PayMode"`
 
-	// 到期时间
+	// <p>到期时间</p>
 	PeriodEndTime *string `json:"PeriodEndTime,omitnil,omitempty" name:"PeriodEndTime"`
 
-	// 项目id
+	// <p>项目id</p>
 	ProjectID *int64 `json:"ProjectID,omitnil,omitempty" name:"ProjectID"`
 
-	// 实例绑定的tag数组信息
+	// <p>实例绑定的tag数组信息</p>
 	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 
-	// Proxy状态
+	// <p>Proxy状态</p>
 	ProxyStatus *string `json:"ProxyStatus,omitnil,omitempty" name:"ProxyStatus"`
 
-	// binlog开关，可选值：ON, OFF
+	// <p>binlog开关，可选值：ON, OFF</p>
 	LogBin *string `json:"LogBin,omitnil,omitempty" name:"LogBin"`
 
-	// 是否跳过交易
+	// <p>是否跳过交易</p>
 	IsSkipTrade *string `json:"IsSkipTrade,omitnil,omitempty" name:"IsSkipTrade"`
 
-	// pitr类型，可选值：normal, redo_pitr
+	// <p>pitr类型，可选值：normal, redo_pitr</p>
 	PitrType *string `json:"PitrType,omitnil,omitempty" name:"PitrType"`
 
-	// 是否打开密码复杂度
+	// <p>是否打开密码复杂度</p>
 	IsOpenPasswordComplexity *string `json:"IsOpenPasswordComplexity,omitnil,omitempty" name:"IsOpenPasswordComplexity"`
 
-	// 网络类型
+	// <p>网络类型</p>
 	NetworkStatus *string `json:"NetworkStatus,omitnil,omitempty" name:"NetworkStatus"`
 
-	// 集群绑定的资源包信息	
+	// <p>集群绑定的资源包信息</p>
 	ResourcePackages []*ResourcePackage `json:"ResourcePackages,omitnil,omitempty" name:"ResourcePackages"`
 
-	// 自动续费标识，1为自动续费，0为到期不续
+	// <p>自动续费标识，1为自动续费，0为到期不续</p>
 	RenewFlag *int64 `json:"RenewFlag,omitnil,omitempty" name:"RenewFlag"`
 
-	// 节点网络类型
+	// <p>节点网络类型</p>
 	NetworkType *string `json:"NetworkType,omitnil,omitempty" name:"NetworkType"`
 
-	// 备可用区属性
+	// <p>备可用区属性</p>
 	SlaveZoneAttr []*SlaveZoneAttrItem `json:"SlaveZoneAttr,omitnil,omitempty" name:"SlaveZoneAttr"`
 
-	// 版本标签
+	// <p>版本标签</p>
 	CynosVersionTag *string `json:"CynosVersionTag,omitnil,omitempty" name:"CynosVersionTag"`
 
-	// 全球数据库网络唯一标识
+	// <p>全球数据库网络唯一标识</p>
 	GdnId *string `json:"GdnId,omitnil,omitempty" name:"GdnId"`
 
-	// 集群在全球数据网络中的角色。
-	// 主集群- primary
-	// 从集群 - standby
-	// 如为空，该字段无效
+	// <p>集群在全球数据网络中的角色。<br>主集群- primary<br>从集群 - standby<br>如为空，该字段无效</p>
 	GdnRole *string `json:"GdnRole,omitnil,omitempty" name:"GdnRole"`
 
-	// 二级存储使用量，单位：G
+	// <p>二级存储使用量，单位：G</p>
 	UsedArchiveStorage *int64 `json:"UsedArchiveStorage,omitnil,omitempty" name:"UsedArchiveStorage"`
 
-	// 归档状态，枚举值<li>normal:正常</li><li>archiving:归档中</li><li>resuming:恢复中</li><li>archived :已归档</li>
+	// <p>归档状态，枚举值<li>normal:正常</li><li>archiving:归档中</li><li>resuming:恢复中</li><li>archived :已归档</li></p>
 	ArchiveStatus *string `json:"ArchiveStatus,omitnil,omitempty" name:"ArchiveStatus"`
 
-	// 归档进度，百分比。
+	// <p>归档进度，百分比。</p>
 	ArchiveProgress *int64 `json:"ArchiveProgress,omitnil,omitempty" name:"ArchiveProgress"`
 
-	// 是否开启透明加密
+	// <p>集群级别。例如 P0, P1</p>
+	ClusterLevel *string `json:"ClusterLevel,omitnil,omitempty" name:"ClusterLevel"`
+
+	// <p>是否开启透明加密</p>
 	IsOpenTDE *bool `json:"IsOpenTDE,omitnil,omitempty" name:"IsOpenTDE"`
 }
 
@@ -5584,20 +5900,20 @@ type DbTable struct {
 
 // Predefined struct for user
 type DeleteAccountsRequestParams struct {
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 账号数组，包含account和host
+	// <p>账号数组，包含account和host</p>
 	Accounts []*InputAccount `json:"Accounts,omitnil,omitempty" name:"Accounts"`
 }
 
 type DeleteAccountsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 账号数组，包含account和host
+	// <p>账号数组，包含account和host</p>
 	Accounts []*InputAccount `json:"Accounts,omitnil,omitempty" name:"Accounts"`
 }
 
@@ -6026,6 +6342,67 @@ func (r *DeleteClusterDatabaseResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteClusterDatabaseResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteClusterPeriodScalePolicyRequestParams struct {
+	// 集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 策略ID
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
+}
+
+type DeleteClusterPeriodScalePolicyRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 策略ID
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
+}
+
+func (r *DeleteClusterPeriodScalePolicyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteClusterPeriodScalePolicyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "PolicyId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteClusterPeriodScalePolicyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteClusterPeriodScalePolicyResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteClusterPeriodScalePolicyResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteClusterPeriodScalePolicyResponseParams `json:"Response"`
+}
+
+func (r *DeleteClusterPeriodScalePolicyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteClusterPeriodScalePolicyResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -7659,6 +8036,96 @@ func (r *DescribeBackupListResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeBackupOverviewRequestParams struct {
+	// 集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+type DescribeBackupOverviewRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+func (r *DescribeBackupOverviewRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeBackupOverviewRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeBackupOverviewRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeBackupOverviewResponseParams struct {
+	// 备份总容量
+	BackupTotalVolume *float64 `json:"BackupTotalVolume,omitnil,omitempty" name:"BackupTotalVolume"`
+
+	// 备份快照容量
+	BackupSnapshotVolume *float64 `json:"BackupSnapshotVolume,omitnil,omitempty" name:"BackupSnapshotVolume"`
+
+	// 备份逻辑容量
+	BackupLogicVolume *float64 `json:"BackupLogicVolume,omitnil,omitempty" name:"BackupLogicVolume"`
+
+	// 日志总容量
+	LogTotalVolume *float64 `json:"LogTotalVolume,omitnil,omitempty" name:"LogTotalVolume"`
+
+	// 日志binlog容量
+	LogBinlogVolume *float64 `json:"LogBinlogVolume,omitnil,omitempty" name:"LogBinlogVolume"`
+
+	// 日志redolog容量
+	LogRedoLogVolume *float64 `json:"LogRedoLogVolume,omitnil,omitempty" name:"LogRedoLogVolume"`
+
+	// 跨地域备份总容量
+	CrossTotalVolume *float64 `json:"CrossTotalVolume,omitnil,omitempty" name:"CrossTotalVolume"`
+
+	// 跨地域备份容量
+	CrossRegionBackupVolume *float64 `json:"CrossRegionBackupVolume,omitnil,omitempty" name:"CrossRegionBackupVolume"`
+
+	// 跨地域日志容量
+	CrossRegionLogVolume *float64 `json:"CrossRegionLogVolume,omitnil,omitempty" name:"CrossRegionLogVolume"`
+
+	// 备份容量详情
+	BackupVolumeInfos []*BackupVolumeInfo `json:"BackupVolumeInfos,omitnil,omitempty" name:"BackupVolumeInfos"`
+
+	// 跨地域备份容量详情
+	CrossRegionBackupVolumeInfos []*BackupVolumeInfo `json:"CrossRegionBackupVolumeInfos,omitnil,omitempty" name:"CrossRegionBackupVolumeInfos"`
+
+	// 跨地域信息
+	CrossRegions []*string `json:"CrossRegions,omitnil,omitempty" name:"CrossRegions"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeBackupOverviewResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeBackupOverviewResponseParams `json:"Response"`
+}
+
+func (r *DescribeBackupOverviewResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeBackupOverviewResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeBinlogConfigRequestParams struct {
 	// 集群ID
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -8582,6 +9049,66 @@ func (r *DescribeClusterInstanceGrpsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeClusterLevelsRequestParams struct {
+	// <p>可用区</p>
+	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
+}
+
+type DescribeClusterLevelsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>可用区</p>
+	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
+}
+
+func (r *DescribeClusterLevelsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterLevelsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Zone")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeClusterLevelsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterLevelsResponseParams struct {
+	// <p>集群类型列表</p>
+	LevelList []*string `json:"LevelList,omitnil,omitempty" name:"LevelList"`
+
+	// <p>专区列表</p>
+	Zones []*string `json:"Zones,omitnil,omitempty" name:"Zones"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeClusterLevelsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeClusterLevelsResponseParams `json:"Response"`
+}
+
+func (r *DescribeClusterLevelsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterLevelsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeClusterParamLogsRequestParams struct {
 	// 集群ID
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -8823,6 +9350,63 @@ func (r *DescribeClusterPasswordComplexityResponse) FromJsonString(s string) err
 }
 
 // Predefined struct for user
+type DescribeClusterPeriodScalePolicyRequestParams struct {
+	// 集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+type DescribeClusterPeriodScalePolicyRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群id
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+func (r *DescribeClusterPeriodScalePolicyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterPeriodScalePolicyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeClusterPeriodScalePolicyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterPeriodScalePolicyResponseParams struct {
+	// 集群周期弹性策略列表
+	PolicyList []*ClusterPeriodScalePolicy `json:"PolicyList,omitnil,omitempty" name:"PolicyList"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeClusterPeriodScalePolicyResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeClusterPeriodScalePolicyResponseParams `json:"Response"`
+}
+
+func (r *DescribeClusterPeriodScalePolicyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterPeriodScalePolicyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeClusterReadOnlyRequestParams struct {
 	// 集群ID列表
 	ClusterIds []*string `json:"ClusterIds,omitnil,omitempty" name:"ClusterIds"`
@@ -8876,6 +9460,115 @@ func (r *DescribeClusterReadOnlyResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeClusterReadOnlyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterServerlessScalePlansRequestParams struct {
+	// 集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 实例列表
+	InstanceIds []*string `json:"InstanceIds,omitnil,omitempty" name:"InstanceIds"`
+
+	// 策略类型. PolicyTypePeriodScale - 周期弹性
+	PolicyType *string `json:"PolicyType,omitnil,omitempty" name:"PolicyType"`
+
+	// 计划ID
+	PlanId *int64 `json:"PlanId,omitnil,omitempty" name:"PlanId"`
+
+	// 分页数量限制，默认10
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 查询偏移，默认0
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 按计划预期执行时间为条件查询的开始时间点，包含当前时间
+	ExpectedStartTime *string `json:"ExpectedStartTime,omitnil,omitempty" name:"ExpectedStartTime"`
+
+	// 按计划预期执行时间为条件查询的结束时间点，包含当前时间
+	ExpectedEndTime *string `json:"ExpectedEndTime,omitnil,omitempty" name:"ExpectedEndTime"`
+}
+
+type DescribeClusterServerlessScalePlansRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群ID
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 实例列表
+	InstanceIds []*string `json:"InstanceIds,omitnil,omitempty" name:"InstanceIds"`
+
+	// 策略类型. PolicyTypePeriodScale - 周期弹性
+	PolicyType *string `json:"PolicyType,omitnil,omitempty" name:"PolicyType"`
+
+	// 计划ID
+	PlanId *int64 `json:"PlanId,omitnil,omitempty" name:"PlanId"`
+
+	// 分页数量限制，默认10
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 查询偏移，默认0
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 按计划预期执行时间为条件查询的开始时间点，包含当前时间
+	ExpectedStartTime *string `json:"ExpectedStartTime,omitnil,omitempty" name:"ExpectedStartTime"`
+
+	// 按计划预期执行时间为条件查询的结束时间点，包含当前时间
+	ExpectedEndTime *string `json:"ExpectedEndTime,omitnil,omitempty" name:"ExpectedEndTime"`
+}
+
+func (r *DescribeClusterServerlessScalePlansRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterServerlessScalePlansRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "InstanceIds")
+	delete(f, "PolicyType")
+	delete(f, "PlanId")
+	delete(f, "Limit")
+	delete(f, "Offset")
+	delete(f, "ExpectedStartTime")
+	delete(f, "ExpectedEndTime")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeClusterServerlessScalePlansRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterServerlessScalePlansResponseParams struct {
+	// 计划总数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 策略列表
+	ServerlessScalePlans []*ClusterServerlessScalePlan `json:"ServerlessScalePlans,omitnil,omitempty" name:"ServerlessScalePlans"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeClusterServerlessScalePlansResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeClusterServerlessScalePlansResponseParams `json:"Response"`
+}
+
+func (r *DescribeClusterServerlessScalePlansResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterServerlessScalePlansResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -9703,29 +10396,33 @@ func (r *DescribeInstanceSpecsByOperationTypeResponse) FromJsonString(s string) 
 
 // Predefined struct for user
 type DescribeInstanceSpecsRequestParams struct {
-	// 数据库类型，取值范围: 
-	// <li> MYSQL </li>
+	// <p>数据库类型，取值范围: </p><li> MYSQL </li>
 	DbType *string `json:"DbType,omitnil,omitempty" name:"DbType"`
 
-	// 是否需要返回可用区信息
+	// <p>是否需要返回可用区信息</p>
 	IncludeZoneStocks *bool `json:"IncludeZoneStocks,omitnil,omitempty" name:"IncludeZoneStocks"`
 
-	// 实例机器类型
+	// <p>实例机器类型</p>
 	DeviceType *string `json:"DeviceType,omitnil,omitempty" name:"DeviceType"`
+
+	// <p>集群级别，可空。例如 P0, P1</p>
+	ClusterLevel *string `json:"ClusterLevel,omitnil,omitempty" name:"ClusterLevel"`
 }
 
 type DescribeInstanceSpecsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 数据库类型，取值范围: 
-	// <li> MYSQL </li>
+	// <p>数据库类型，取值范围: </p><li> MYSQL </li>
 	DbType *string `json:"DbType,omitnil,omitempty" name:"DbType"`
 
-	// 是否需要返回可用区信息
+	// <p>是否需要返回可用区信息</p>
 	IncludeZoneStocks *bool `json:"IncludeZoneStocks,omitnil,omitempty" name:"IncludeZoneStocks"`
 
-	// 实例机器类型
+	// <p>实例机器类型</p>
 	DeviceType *string `json:"DeviceType,omitnil,omitempty" name:"DeviceType"`
+
+	// <p>集群级别，可空。例如 P0, P1</p>
+	ClusterLevel *string `json:"ClusterLevel,omitnil,omitempty" name:"ClusterLevel"`
 }
 
 func (r *DescribeInstanceSpecsRequest) ToJsonString() string {
@@ -9743,6 +10440,7 @@ func (r *DescribeInstanceSpecsRequest) FromJsonString(s string) error {
 	delete(f, "DbType")
 	delete(f, "IncludeZoneStocks")
 	delete(f, "DeviceType")
+	delete(f, "ClusterLevel")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeInstanceSpecsRequest has unknown keys!", "")
 	}
@@ -9751,7 +10449,7 @@ func (r *DescribeInstanceSpecsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeInstanceSpecsResponseParams struct {
-	// 规格信息
+	// <p>规格信息</p>
 	InstanceSpecSet []*InstanceSpec `json:"InstanceSpecSet,omitnil,omitempty" name:"InstanceSpecSet"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -12835,15 +13533,21 @@ func (r *DescribeSaveBackupClustersResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeServerlessInstanceSpecsRequestParams struct {
-	// 可用区
+	// <p>可用区</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
+
+	// <p>集群级别</p>
+	ClusterLevel *string `json:"ClusterLevel,omitnil,omitempty" name:"ClusterLevel"`
 }
 
 type DescribeServerlessInstanceSpecsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 可用区
+	// <p>可用区</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
+
+	// <p>集群级别</p>
+	ClusterLevel *string `json:"ClusterLevel,omitnil,omitempty" name:"ClusterLevel"`
 }
 
 func (r *DescribeServerlessInstanceSpecsRequest) ToJsonString() string {
@@ -12859,6 +13563,7 @@ func (r *DescribeServerlessInstanceSpecsRequest) FromJsonString(s string) error 
 		return err
 	}
 	delete(f, "Zone")
+	delete(f, "ClusterLevel")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeServerlessInstanceSpecsRequest has unknown keys!", "")
 	}
@@ -12867,7 +13572,7 @@ func (r *DescribeServerlessInstanceSpecsRequest) FromJsonString(s string) error 
 
 // Predefined struct for user
 type DescribeServerlessInstanceSpecsResponseParams struct {
-	// Serverless实例可选规格
+	// <p>Serverless实例可选规格</p>
 	Specs []*ServerlessSpec `json:"Specs,omitnil,omitempty" name:"Specs"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -13503,6 +14208,8 @@ type DisassociateSecurityGroupsRequestParams struct {
 
 	// 可用区。
 	// 说明：请正确输入集群所在的主可用区，若输入非集群所在的主可用区可能显示调用成功，但实际执行会失败。
+	//
+	// Deprecated: Zone is deprecated.
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 }
 
@@ -14297,79 +15004,87 @@ type InputAccount struct {
 
 // Predefined struct for user
 type InquirePriceCreateRequestParams struct {
-	// 可用区,每个地域提供最佳实践
+	// <p>可用区,每个地域提供最佳实践</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// 购买计算节点个数
+	// <p>购买计算节点个数</p>
 	GoodsNum *int64 `json:"GoodsNum,omitnil,omitempty" name:"GoodsNum"`
 
-	// 实例购买类型，可选值为：PREPAID, POSTPAID, SERVERLESS
+	// <p>实例购买类型，可选值为：PREPAID, POSTPAID, SERVERLESS</p>
 	InstancePayMode *string `json:"InstancePayMode,omitnil,omitempty" name:"InstancePayMode"`
 
-	// 存储购买类型，可选值为：PREPAID, POSTPAID
+	// <p>存储购买类型，可选值为：PREPAID, POSTPAID</p>
 	StoragePayMode *string `json:"StoragePayMode,omitnil,omitempty" name:"StoragePayMode"`
 
-	// 实例设备类型，支持值如下：
-	// - common：表示通用型
-	// - exclusive：表示独享型
+	// <p>实例设备类型，支持值如下：</p><ul><li>common：表示通用型</li><li>exclusive：表示独享型</li></ul>
 	DeviceType *string `json:"DeviceType,omitnil,omitempty" name:"DeviceType"`
 
-	// CPU核数，PREPAID与POSTPAID实例类型必传
+	// <p>CPU核数，PREPAID与POSTPAID实例类型必传</p>
 	Cpu *int64 `json:"Cpu,omitnil,omitempty" name:"Cpu"`
 
-	// 内存大小，单位G，PREPAID与POSTPAID实例类型必传
+	// <p>内存大小，单位G，PREPAID与POSTPAID实例类型必传</p>
 	Memory *int64 `json:"Memory,omitnil,omitempty" name:"Memory"`
 
-	// Ccu大小，serverless类型必传
+	// <p>Ccu大小，serverless类型必传</p>
 	Ccu *float64 `json:"Ccu,omitnil,omitempty" name:"Ccu"`
 
-	// 存储大小，PREPAID存储类型必传
+	// <p>存储大小，PREPAID存储类型必传</p>
 	StorageLimit *int64 `json:"StorageLimit,omitnil,omitempty" name:"StorageLimit"`
 
-	// 购买时长，PREPAID购买类型必传
+	// <p>购买时长，PREPAID购买类型必传</p>
 	TimeSpan *int64 `json:"TimeSpan,omitnil,omitempty" name:"TimeSpan"`
 
-	// 时长单位，可选值为：m,d。PREPAID购买类型必传
+	// <p>时长单位，可选值为：m,d。PREPAID购买类型必传</p>
 	TimeUnit *string `json:"TimeUnit,omitnil,omitempty" name:"TimeUnit"`
+
+	// <p>存储架构类型。 枚举值：1.0/2.0 默认值：1.0</p>
+	StorageVersion *string `json:"StorageVersion,omitnil,omitempty" name:"StorageVersion"`
+
+	// <p>存储是否跨AZ，2.0存储架构下有效</p>
+	IsMultiAz *bool `json:"IsMultiAz,omitnil,omitempty" name:"IsMultiAz"`
 }
 
 type InquirePriceCreateRequest struct {
 	*tchttp.BaseRequest
 	
-	// 可用区,每个地域提供最佳实践
+	// <p>可用区,每个地域提供最佳实践</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// 购买计算节点个数
+	// <p>购买计算节点个数</p>
 	GoodsNum *int64 `json:"GoodsNum,omitnil,omitempty" name:"GoodsNum"`
 
-	// 实例购买类型，可选值为：PREPAID, POSTPAID, SERVERLESS
+	// <p>实例购买类型，可选值为：PREPAID, POSTPAID, SERVERLESS</p>
 	InstancePayMode *string `json:"InstancePayMode,omitnil,omitempty" name:"InstancePayMode"`
 
-	// 存储购买类型，可选值为：PREPAID, POSTPAID
+	// <p>存储购买类型，可选值为：PREPAID, POSTPAID</p>
 	StoragePayMode *string `json:"StoragePayMode,omitnil,omitempty" name:"StoragePayMode"`
 
-	// 实例设备类型，支持值如下：
-	// - common：表示通用型
-	// - exclusive：表示独享型
+	// <p>实例设备类型，支持值如下：</p><ul><li>common：表示通用型</li><li>exclusive：表示独享型</li></ul>
 	DeviceType *string `json:"DeviceType,omitnil,omitempty" name:"DeviceType"`
 
-	// CPU核数，PREPAID与POSTPAID实例类型必传
+	// <p>CPU核数，PREPAID与POSTPAID实例类型必传</p>
 	Cpu *int64 `json:"Cpu,omitnil,omitempty" name:"Cpu"`
 
-	// 内存大小，单位G，PREPAID与POSTPAID实例类型必传
+	// <p>内存大小，单位G，PREPAID与POSTPAID实例类型必传</p>
 	Memory *int64 `json:"Memory,omitnil,omitempty" name:"Memory"`
 
-	// Ccu大小，serverless类型必传
+	// <p>Ccu大小，serverless类型必传</p>
 	Ccu *float64 `json:"Ccu,omitnil,omitempty" name:"Ccu"`
 
-	// 存储大小，PREPAID存储类型必传
+	// <p>存储大小，PREPAID存储类型必传</p>
 	StorageLimit *int64 `json:"StorageLimit,omitnil,omitempty" name:"StorageLimit"`
 
-	// 购买时长，PREPAID购买类型必传
+	// <p>购买时长，PREPAID购买类型必传</p>
 	TimeSpan *int64 `json:"TimeSpan,omitnil,omitempty" name:"TimeSpan"`
 
-	// 时长单位，可选值为：m,d。PREPAID购买类型必传
+	// <p>时长单位，可选值为：m,d。PREPAID购买类型必传</p>
 	TimeUnit *string `json:"TimeUnit,omitnil,omitempty" name:"TimeUnit"`
+
+	// <p>存储架构类型。 枚举值：1.0/2.0 默认值：1.0</p>
+	StorageVersion *string `json:"StorageVersion,omitnil,omitempty" name:"StorageVersion"`
+
+	// <p>存储是否跨AZ，2.0存储架构下有效</p>
+	IsMultiAz *bool `json:"IsMultiAz,omitnil,omitempty" name:"IsMultiAz"`
 }
 
 func (r *InquirePriceCreateRequest) ToJsonString() string {
@@ -14395,6 +15110,8 @@ func (r *InquirePriceCreateRequest) FromJsonString(s string) error {
 	delete(f, "StorageLimit")
 	delete(f, "TimeSpan")
 	delete(f, "TimeUnit")
+	delete(f, "StorageVersion")
+	delete(f, "IsMultiAz")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "InquirePriceCreateRequest has unknown keys!", "")
 	}
@@ -14403,10 +15120,10 @@ func (r *InquirePriceCreateRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type InquirePriceCreateResponseParams struct {
-	// 实例价格
+	// <p>实例价格</p>
 	InstancePrice *TradePrice `json:"InstancePrice,omitnil,omitempty" name:"InstancePrice"`
 
-	// 存储价格
+	// <p>存储价格</p>
 	StoragePrice *TradePrice `json:"StoragePrice,omitnil,omitempty" name:"StoragePrice"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -15815,29 +16532,30 @@ type LogRuleTemplateInfo struct {
 }
 
 type LogicBackupConfigInfo struct {
-	// 是否开启自动逻辑备份
+	// <p>是否开启自动逻辑备份</p>
 	LogicBackupEnable *string `json:"LogicBackupEnable,omitnil,omitempty" name:"LogicBackupEnable"`
 
-	// 自动逻辑备份开始时间
+	// <p>自动逻辑备份开始时间</p>
 	LogicBackupTimeBeg *uint64 `json:"LogicBackupTimeBeg,omitnil,omitempty" name:"LogicBackupTimeBeg"`
 
-	// 自动逻辑备份结束时间
+	// <p>自动逻辑备份结束时间</p>
 	LogicBackupTimeEnd *uint64 `json:"LogicBackupTimeEnd,omitnil,omitempty" name:"LogicBackupTimeEnd"`
 
-	// 自动逻辑备份保留时间
-	// 单位：秒
+	// <p>自动逻辑备份保留时间<br>单位：秒</p>
 	LogicReserveDuration *uint64 `json:"LogicReserveDuration,omitnil,omitempty" name:"LogicReserveDuration"`
 
-	// 是否开启跨地域逻辑备份
-	// 可选值：ON/OFF
+	// <p>是否开启跨地域逻辑备份<br>可选值：ON/OFF</p>
 	LogicCrossRegionsEnable *string `json:"LogicCrossRegionsEnable,omitnil,omitempty" name:"LogicCrossRegionsEnable"`
 
-	// 逻辑备份所跨地域
+	// <p>逻辑备份所跨地域</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	LogicCrossRegions []*string `json:"LogicCrossRegions,omitnil,omitempty" name:"LogicCrossRegions"`
 
-	// 备份投递关系
+	// <p>备份投递关系</p>
 	AutoCopyVaults []*CreateBackupVaultItem `json:"AutoCopyVaults,omitnil,omitempty" name:"AutoCopyVaults"`
+
+	// <p>天</p><p>单位：跨地域逻辑备份保留时间</p>
+	LogicCrossRegionSaveDays *int64 `json:"LogicCrossRegionSaveDays,omitnil,omitempty" name:"LogicCrossRegionSaveDays"`
 }
 
 type ManualBackupData struct {
@@ -16785,21 +17503,27 @@ func (r *ModifyBinlogConfigResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyBinlogSaveDaysRequestParams struct {
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// Binlog保留天数
+	// <p>Binlog保留天数</p>
 	BinlogSaveDays *int64 `json:"BinlogSaveDays,omitnil,omitempty" name:"BinlogSaveDays"`
+
+	// <p>跨地域备份保留时间</p><p>单位：天</p>
+	BinlogCrossRegionSaveDays *int64 `json:"BinlogCrossRegionSaveDays,omitnil,omitempty" name:"BinlogCrossRegionSaveDays"`
 }
 
 type ModifyBinlogSaveDaysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// Binlog保留天数
+	// <p>Binlog保留天数</p>
 	BinlogSaveDays *int64 `json:"BinlogSaveDays,omitnil,omitempty" name:"BinlogSaveDays"`
+
+	// <p>跨地域备份保留时间</p><p>单位：天</p>
+	BinlogCrossRegionSaveDays *int64 `json:"BinlogCrossRegionSaveDays,omitnil,omitempty" name:"BinlogCrossRegionSaveDays"`
 }
 
 func (r *ModifyBinlogSaveDaysRequest) ToJsonString() string {
@@ -16816,6 +17540,7 @@ func (r *ModifyBinlogSaveDaysRequest) FromJsonString(s string) error {
 	}
 	delete(f, "ClusterId")
 	delete(f, "BinlogSaveDays")
+	delete(f, "BinlogCrossRegionSaveDays")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyBinlogSaveDaysRequest has unknown keys!", "")
 	}
@@ -17282,6 +18007,123 @@ func (r *ModifyClusterPasswordComplexityResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyClusterPasswordComplexityResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyClusterPeriodScalePolicyRequestParams struct {
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>策略ID</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
+
+	// <p>当天开始弹性时间。格式是小时:分钟</p>
+	ScaleStartTime *string `json:"ScaleStartTime,omitnil,omitempty" name:"ScaleStartTime"`
+
+	// <p>当天结束弹性时间。格式是小时:分钟</p>
+	ScaleEndTime *string `json:"ScaleEndTime,omitnil,omitempty" name:"ScaleEndTime"`
+
+	// <p>策略生效的起始日期时间</p>
+	PolicyStartTime *string `json:"PolicyStartTime,omitnil,omitempty" name:"PolicyStartTime"`
+
+	// <p>策略生效的截止日期时间</p>
+	PolicyEndTime *string `json:"PolicyEndTime,omitnil,omitempty" name:"PolicyEndTime"`
+
+	// <p>周期类型。day-天，week-周，month-月。</p>
+	PeriodType *string `json:"PeriodType,omitnil,omitempty" name:"PeriodType"`
+
+	// <p>周期内的时间列表。针对PeriodType=week， 表示星期几，比如[1,3]表示星期一、星期三。同理，对于PeriodType=month，[1,3,10]表示每月的1、3、10号。PeriodType=day则该字段无效。</p>
+	PeriodConfig []*int64 `json:"PeriodConfig,omitnil,omitempty" name:"PeriodConfig"`
+
+	// <p>弹性规格下限</p>
+	MinCpu *float64 `json:"MinCpu,omitnil,omitempty" name:"MinCpu"`
+
+	// <p>弹性规格上限</p>
+	MaxCpu *float64 `json:"MaxCpu,omitnil,omitempty" name:"MaxCpu"`
+}
+
+type ModifyClusterPeriodScalePolicyRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>策略ID</p>
+	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
+
+	// <p>当天开始弹性时间。格式是小时:分钟</p>
+	ScaleStartTime *string `json:"ScaleStartTime,omitnil,omitempty" name:"ScaleStartTime"`
+
+	// <p>当天结束弹性时间。格式是小时:分钟</p>
+	ScaleEndTime *string `json:"ScaleEndTime,omitnil,omitempty" name:"ScaleEndTime"`
+
+	// <p>策略生效的起始日期时间</p>
+	PolicyStartTime *string `json:"PolicyStartTime,omitnil,omitempty" name:"PolicyStartTime"`
+
+	// <p>策略生效的截止日期时间</p>
+	PolicyEndTime *string `json:"PolicyEndTime,omitnil,omitempty" name:"PolicyEndTime"`
+
+	// <p>周期类型。day-天，week-周，month-月。</p>
+	PeriodType *string `json:"PeriodType,omitnil,omitempty" name:"PeriodType"`
+
+	// <p>周期内的时间列表。针对PeriodType=week， 表示星期几，比如[1,3]表示星期一、星期三。同理，对于PeriodType=month，[1,3,10]表示每月的1、3、10号。PeriodType=day则该字段无效。</p>
+	PeriodConfig []*int64 `json:"PeriodConfig,omitnil,omitempty" name:"PeriodConfig"`
+
+	// <p>弹性规格下限</p>
+	MinCpu *float64 `json:"MinCpu,omitnil,omitempty" name:"MinCpu"`
+
+	// <p>弹性规格上限</p>
+	MaxCpu *float64 `json:"MaxCpu,omitnil,omitempty" name:"MaxCpu"`
+}
+
+func (r *ModifyClusterPeriodScalePolicyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyClusterPeriodScalePolicyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "PolicyId")
+	delete(f, "ScaleStartTime")
+	delete(f, "ScaleEndTime")
+	delete(f, "PolicyStartTime")
+	delete(f, "PolicyEndTime")
+	delete(f, "PeriodType")
+	delete(f, "PeriodConfig")
+	delete(f, "MinCpu")
+	delete(f, "MaxCpu")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyClusterPeriodScalePolicyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyClusterPeriodScalePolicyResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyClusterPeriodScalePolicyResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyClusterPeriodScalePolicyResponseParams `json:"Response"`
+}
+
+func (r *ModifyClusterPeriodScalePolicyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyClusterPeriodScalePolicyResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -18754,6 +19596,9 @@ type ModifyProxyRwSplitRequestParams struct {
 
 	// <p>libra节点故障，是否转发给其他节点</p>
 	ApQueryToOtherNode *bool `json:"ApQueryToOtherNode,omitnil,omitempty" name:"ApQueryToOtherNode"`
+
+	// <p>负载均衡模式</p><p>枚举值：</p><ul><li>static： 静态负载</li><li>dynamic： 动态负载</li></ul>
+	LoadBalanceMode *string `json:"LoadBalanceMode,omitnil,omitempty" name:"LoadBalanceMode"`
 }
 
 type ModifyProxyRwSplitRequest struct {
@@ -18809,6 +19654,9 @@ type ModifyProxyRwSplitRequest struct {
 
 	// <p>libra节点故障，是否转发给其他节点</p>
 	ApQueryToOtherNode *bool `json:"ApQueryToOtherNode,omitnil,omitempty" name:"ApQueryToOtherNode"`
+
+	// <p>负载均衡模式</p><p>枚举值：</p><ul><li>static： 静态负载</li><li>dynamic： 动态负载</li></ul>
+	LoadBalanceMode *string `json:"LoadBalanceMode,omitnil,omitempty" name:"LoadBalanceMode"`
 }
 
 func (r *ModifyProxyRwSplitRequest) ToJsonString() string {
@@ -18840,6 +19688,7 @@ func (r *ModifyProxyRwSplitRequest) FromJsonString(s string) error {
 	delete(f, "ConnectionPoolTimeOut")
 	delete(f, "ApNodeAsRoNode")
 	delete(f, "ApQueryToOtherNode")
+	delete(f, "LoadBalanceMode")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyProxyRwSplitRequest has unknown keys!", "")
 	}
@@ -19226,27 +20075,33 @@ func (r *ModifyServerlessStrategyResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifySnapBackupCrossRegionConfigRequestParams struct {
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 是否开启跨地域快照备份ON/OFF
+	// <p>是否开启跨地域快照备份ON/OFF</p>
 	CrossRegionsEnable *string `json:"CrossRegionsEnable,omitnil,omitempty" name:"CrossRegionsEnable"`
 
-	// 快照备份所跨地域
+	// <p>快照备份所跨地域</p>
 	CrossRegions []*string `json:"CrossRegions,omitnil,omitempty" name:"CrossRegions"`
+
+	// <p>跨地域备份保留时间</p><p>单位：天</p>
+	CrossRegionSaveDays *int64 `json:"CrossRegionSaveDays,omitnil,omitempty" name:"CrossRegionSaveDays"`
 }
 
 type ModifySnapBackupCrossRegionConfigRequest struct {
 	*tchttp.BaseRequest
 	
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 是否开启跨地域快照备份ON/OFF
+	// <p>是否开启跨地域快照备份ON/OFF</p>
 	CrossRegionsEnable *string `json:"CrossRegionsEnable,omitnil,omitempty" name:"CrossRegionsEnable"`
 
-	// 快照备份所跨地域
+	// <p>快照备份所跨地域</p>
 	CrossRegions []*string `json:"CrossRegions,omitnil,omitempty" name:"CrossRegions"`
+
+	// <p>跨地域备份保留时间</p><p>单位：天</p>
+	CrossRegionSaveDays *int64 `json:"CrossRegionSaveDays,omitnil,omitempty" name:"CrossRegionSaveDays"`
 }
 
 func (r *ModifySnapBackupCrossRegionConfigRequest) ToJsonString() string {
@@ -19264,6 +20119,7 @@ func (r *ModifySnapBackupCrossRegionConfigRequest) FromJsonString(s string) erro
 	delete(f, "ClusterId")
 	delete(f, "CrossRegionsEnable")
 	delete(f, "CrossRegions")
+	delete(f, "CrossRegionSaveDays")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifySnapBackupCrossRegionConfigRequest has unknown keys!", "")
 	}
@@ -19272,7 +20128,7 @@ func (r *ModifySnapBackupCrossRegionConfigRequest) FromJsonString(s string) erro
 
 // Predefined struct for user
 type ModifySnapBackupCrossRegionConfigResponseParams struct {
-	// 任务id
+	// <p>任务id</p>
 	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -19570,22 +20426,22 @@ type NetAddr struct {
 }
 
 type NewAccount struct {
-	// 账户名，包含字母数字_,以字母开头，字母或数字结尾，长度1-30
+	// <p>账户名，包含字母数字_,以字母开头，字母或数字结尾，长度1-30</p>
 	AccountName *string `json:"AccountName,omitnil,omitempty" name:"AccountName"`
 
-	// 主机(%或ipv4地址)
+	// <p>主机(%或ipv4地址)</p>
 	Host *string `json:"Host,omitnil,omitempty" name:"Host"`
 
-	// 密码，密码长度范围为8到64个字符
+	// <p>密码，密码长度范围为8到64个字符</p>
 	AccountPassword *string `json:"AccountPassword,omitnil,omitempty" name:"AccountPassword"`
 
-	// 是否开启密码轮转(0:关闭;1:开启)
+	// <p>是否开启密码轮转(0:关闭;1:开启)</p>
 	PasswordRotation *int64 `json:"PasswordRotation,omitnil,omitempty" name:"PasswordRotation"`
 
-	// 描述
+	// <p>描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
-	// 用户最大连接数，不能大于10240
+	// <p>用户最大连接数，不能大于10240</p>
 	MaxUserConnections *int64 `json:"MaxUserConnections,omitnil,omitempty" name:"MaxUserConnections"`
 }
 
@@ -19864,6 +20720,70 @@ type OldAddrInfo struct {
 
 	// 期望执行回收时间
 	ReturnTime *string `json:"ReturnTime,omitnil,omitempty" name:"ReturnTime"`
+}
+
+// Predefined struct for user
+type OpenAIOptimizerRequestParams struct {
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>实例ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type OpenAIOptimizerRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>实例ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *OpenAIOptimizerRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *OpenAIOptimizerRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "OpenAIOptimizerRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type OpenAIOptimizerResponseParams struct {
+	// <p>任务流id</p>
+	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type OpenAIOptimizerResponse struct {
+	*tchttp.BaseResponse
+	Response *OpenAIOptimizerResponseParams `json:"Response"`
+}
+
+func (r *OpenAIOptimizerResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *OpenAIOptimizerResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
@@ -20890,32 +21810,38 @@ type ProxyEndPointConfigInfo struct {
 }
 
 type ProxyGroup struct {
-	// 数据库代理组ID
+	// <p>数据库代理组ID</p>
 	ProxyGroupId *string `json:"ProxyGroupId,omitnil,omitempty" name:"ProxyGroupId"`
 
-	// 数据库代理组节点个数
+	// <p>数据库代理组节点个数</p>
 	ProxyNodeCount *int64 `json:"ProxyNodeCount,omitnil,omitempty" name:"ProxyNodeCount"`
 
-	// 数据库代理组状态
+	// <p>数据库代理组状态</p>
 	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 地域
+	// <p>地域</p>
 	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// 可用区
+	// <p>可用区</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// 当前代理版本
+	// <p>当前代理版本</p>
 	CurrentProxyVersion *string `json:"CurrentProxyVersion,omitnil,omitempty" name:"CurrentProxyVersion"`
 
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 用户AppId
+	// <p>用户AppId</p>
 	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
 
-	// 读写节点开通数据库代理
+	// <p>读写节点开通数据库代理</p>
 	OpenRw *string `json:"OpenRw,omitnil,omitempty" name:"OpenRw"`
+
+	// <p>创建时间</p>
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 }
 
 type ProxyGroupInfo struct {
@@ -20976,6 +21902,9 @@ type ProxyGroupRwInfo struct {
 
 	// <p>libra节点故障，是否转发给其他节点</p>
 	ApQueryToOtherNode *bool `json:"ApQueryToOtherNode,omitnil,omitempty" name:"ApQueryToOtherNode"`
+
+	// <p>自动负载</p><p>枚举值：</p><ul><li>static： 静态负载</li><li>dynamic： 动态负载</li></ul>
+	LoadBalanceMode *string `json:"LoadBalanceMode,omitnil,omitempty" name:"LoadBalanceMode"`
 }
 
 type ProxyInstanceWeight struct {
@@ -20987,38 +21916,44 @@ type ProxyInstanceWeight struct {
 }
 
 type ProxyNodeInfo struct {
-	// 数据库代理节点ID
+	// <p>数据库代理节点ID</p>
 	ProxyNodeId *string `json:"ProxyNodeId,omitnil,omitempty" name:"ProxyNodeId"`
 
-	// 节点当前连接数, DescribeProxyNodes接口此字段值不返回
+	// <p>节点当前连接数, DescribeProxyNodes接口此字段值不返回</p>
 	ProxyNodeConnections *int64 `json:"ProxyNodeConnections,omitnil,omitempty" name:"ProxyNodeConnections"`
 
-	// 数据库代理节点cpu
+	// <p>数据库代理节点cpu</p>
 	Cpu *int64 `json:"Cpu,omitnil,omitempty" name:"Cpu"`
 
-	// 数据库代理节点内存
+	// <p>数据库代理节点内存</p>
 	Mem *int64 `json:"Mem,omitnil,omitempty" name:"Mem"`
 
-	// 数据库代理节点状态
+	// <p>数据库代理节点状态</p>
 	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 数据库代理组ID
+	// <p>数据库代理组ID</p>
 	ProxyGroupId *string `json:"ProxyGroupId,omitnil,omitempty" name:"ProxyGroupId"`
 
-	// 集群ID
+	// <p>集群ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 用户AppID
+	// <p>用户AppID</p>
 	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
 
-	// 地域
+	// <p>地域</p>
 	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// 可用区
+	// <p>可用区</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// 数据库代理节点名字
+	// <p>数据库代理节点名字</p>
 	OssProxyNodeName *string `json:"OssProxyNodeName,omitnil,omitempty" name:"OssProxyNodeName"`
+
+	// <p>创建时间</p>
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 }
 
 type ProxySpec struct {
@@ -21046,19 +21981,19 @@ type ProxyZone struct {
 }
 
 type QueryFilter struct {
-	// 搜索字符串
+	// 字段值列表，与 Names 一一对应。InstanceId/ClusterId 为精确匹配，InstanceName 默认模糊匹配
 	Values []*string `json:"Values,omitnil,omitempty" name:"Values"`
 
-	// 搜索字段，目前支持："InstanceId", "ProjectId", "InstanceName", "Vip"
+	// 搜索字段名称列表，仅支持以下 3 个字段（不区分大小写，多个值为 OR 关系）：ClusterId（按集群 ID 过滤，精确匹配）、InstanceId（按实例 ID 反查所属集群）、InstanceName（按实例名称反查所属集群，默认 LIKE 模糊匹配，ExactMatch=true 时精确匹配）。InstanceId 与 InstanceName 同时传入时取交集（AND 语义）。
 	Names []*string `json:"Names,omitnil,omitempty" name:"Names"`
 
-	// 是否精确匹配
+	// 是否精确匹配。仅对 InstanceName 生效：true 精确匹配，false（默认）LIKE 模糊匹配。
 	ExactMatch *bool `json:"ExactMatch,omitnil,omitempty" name:"ExactMatch"`
 
-	// 搜索字段
+	// 搜索字段名称（单个字段模式，与 Names 二选一）。支持：ClusterId、InstanceId、InstanceName
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 操作符
+	// 操作符（预留字段，当前未启用）。可选值：>、>=、!=、=、<、<=
 	//
 	// Deprecated: Operator is deprecated.
 	Operator *string `json:"Operator,omitnil,omitempty" name:"Operator"`
@@ -22451,6 +23386,15 @@ type RollbackToNewClusterRequestParams struct {
 
 	// <p>是否从保存备份中恢复</p>
 	FromSaveBackup *bool `json:"FromSaveBackup,omitnil,omitempty" name:"FromSaveBackup"`
+
+	// <p>同步方式。可选值：async、semisync、sync，默认异步。</p>
+	SyncWay *string `json:"SyncWay,omitnil,omitempty" name:"SyncWay"`
+
+	// <p>半同步超时时间，单位ms。为保证业务稳定性，半同步复制存在退化逻辑，当主可用区集群在等待备可用区集群确认事务时若超过该超时时间，复制方式将降为异步复制。</p><p>取值范围：[1000, 4294967295]</p><p>单位：毫秒</p><p>默认值：10000</p>
+	SemiSyncTimeout *int64 `json:"SemiSyncTimeout,omitnil,omitempty" name:"SemiSyncTimeout"`
+
+	// <p>备可用区</p>
+	SlaveZone *string `json:"SlaveZone,omitnil,omitempty" name:"SlaveZone"`
 }
 
 type RollbackToNewClusterRequest struct {
@@ -22542,6 +23486,15 @@ type RollbackToNewClusterRequest struct {
 
 	// <p>是否从保存备份中恢复</p>
 	FromSaveBackup *bool `json:"FromSaveBackup,omitnil,omitempty" name:"FromSaveBackup"`
+
+	// <p>同步方式。可选值：async、semisync、sync，默认异步。</p>
+	SyncWay *string `json:"SyncWay,omitnil,omitempty" name:"SyncWay"`
+
+	// <p>半同步超时时间，单位ms。为保证业务稳定性，半同步复制存在退化逻辑，当主可用区集群在等待备可用区集群确认事务时若超过该超时时间，复制方式将降为异步复制。</p><p>取值范围：[1000, 4294967295]</p><p>单位：毫秒</p><p>默认值：10000</p>
+	SemiSyncTimeout *int64 `json:"SemiSyncTimeout,omitnil,omitempty" name:"SemiSyncTimeout"`
+
+	// <p>备可用区</p>
+	SlaveZone *string `json:"SlaveZone,omitnil,omitempty" name:"SlaveZone"`
 }
 
 func (r *RollbackToNewClusterRequest) ToJsonString() string {
@@ -22585,6 +23538,9 @@ func (r *RollbackToNewClusterRequest) FromJsonString(s string) error {
 	delete(f, "ProjectId")
 	delete(f, "AutoArchive")
 	delete(f, "FromSaveBackup")
+	delete(f, "SyncWay")
+	delete(f, "SemiSyncTimeout")
+	delete(f, "SlaveZone")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RollbackToNewClusterRequest has unknown keys!", "")
 	}
@@ -23515,32 +24471,32 @@ func (r *SwitchClusterVpcResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type SwitchClusterZoneRequestParams struct {
-	// 集群Id
+	// <p>集群Id</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 当前可用区
+	// <p>当前可用区</p>
 	OldZone *string `json:"OldZone,omitnil,omitempty" name:"OldZone"`
 
-	// 要切换到的可用区
+	// <p>要切换到的可用区</p>
 	NewZone *string `json:"NewZone,omitnil,omitempty" name:"NewZone"`
 
-	// 维护期间执行-yes,立即执行-no
+	// <p>维护期间执行-yes,立即执行-no</p>
 	IsInMaintainPeriod *string `json:"IsInMaintainPeriod,omitnil,omitempty" name:"IsInMaintainPeriod"`
 }
 
 type SwitchClusterZoneRequest struct {
 	*tchttp.BaseRequest
 	
-	// 集群Id
+	// <p>集群Id</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// 当前可用区
+	// <p>当前可用区</p>
 	OldZone *string `json:"OldZone,omitnil,omitempty" name:"OldZone"`
 
-	// 要切换到的可用区
+	// <p>要切换到的可用区</p>
 	NewZone *string `json:"NewZone,omitnil,omitempty" name:"NewZone"`
 
-	// 维护期间执行-yes,立即执行-no
+	// <p>维护期间执行-yes,立即执行-no</p>
 	IsInMaintainPeriod *string `json:"IsInMaintainPeriod,omitnil,omitempty" name:"IsInMaintainPeriod"`
 }
 
@@ -23568,7 +24524,10 @@ func (r *SwitchClusterZoneRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type SwitchClusterZoneResponseParams struct {
-	// 异步FlowId
+	// <p>任务id</p>
+	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>异步FlowId</p>
 	FlowId *int64 `json:"FlowId,omitnil,omitempty" name:"FlowId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -23811,6 +24770,57 @@ type TradePrice struct {
 }
 
 // Predefined struct for user
+type TransferClusterPrepayToPostpayRequestParams struct {
+
+}
+
+type TransferClusterPrepayToPostpayRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *TransferClusterPrepayToPostpayRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *TransferClusterPrepayToPostpayRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "TransferClusterPrepayToPostpayRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type TransferClusterPrepayToPostpayResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type TransferClusterPrepayToPostpayResponse struct {
+	*tchttp.BaseResponse
+	Response *TransferClusterPrepayToPostpayResponseParams `json:"Response"`
+}
+
+func (r *TransferClusterPrepayToPostpayResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *TransferClusterPrepayToPostpayResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type TransferClusterZoneRequestParams struct {
 	// 源集群Id
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -23899,6 +24909,57 @@ func (r *TransferClusterZoneResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *TransferClusterZoneResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type TransferStoragePrepayToPostpayRequestParams struct {
+
+}
+
+type TransferStoragePrepayToPostpayRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *TransferStoragePrepayToPostpayRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *TransferStoragePrepayToPostpayRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "TransferStoragePrepayToPostpayRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type TransferStoragePrepayToPostpayResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type TransferStoragePrepayToPostpayResponse struct {
+	*tchttp.BaseResponse
+	Response *TransferStoragePrepayToPostpayResponseParams `json:"Response"`
+}
+
+func (r *TransferStoragePrepayToPostpayResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *TransferStoragePrepayToPostpayResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1285,7 +1285,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp/v20180228
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.110
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.150
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970

--- a/website/docs/r/cynosdb_cluster.html.markdown
+++ b/website/docs/r/cynosdb_cluster.html.markdown
@@ -187,6 +187,8 @@ resource "tencentcloud_cynosdb_cluster" "example" {
   max_cpu                      = 4
   param_template_id            = tencentcloud_cynosdb_param_template.example.template_id
   force_delete                 = false
+  sync_way                     = "async"
+  semi_sync_timeout            = 10000
   instance_maintain_weekdays = [
     "Fri",
     "Mon",
@@ -218,8 +220,6 @@ The following arguments are supported:
 * `password` - (Required, String) Password of `root` account.
 * `subnet_id` - (Required, String) ID of the subnet within this VPC.
 * `vpc_id` - (Required, String) ID of the VPC.
-* `SemiSyncTimeout` - (Optional, Int) Semi-sync timeout in ms. Value range: `[1000, 4294967295]`, default `10000`.
-* `SyncWay` - (Optional, String) Synchronization way. Valid values: `async`, `semisync`, `sync`.
 * `auto_pause_delay` - (Optional, Int) Specify auto-pause delay in second while `db_mode` is `SERVERLESS`. Value range: `[600, 691200]`. Default: `600`.
 * `auto_pause` - (Optional, String) Specify whether the cluster can auto-pause while `db_mode` is `SERVERLESS`. Values: `yes` (default), `no`.
 * `auto_renew_flag` - (Optional, Int) Auto renew flag. Valid values are `0`(MANUAL_RENEW), `1`(AUTO_RENEW). Default value is `0`. Only works for PREPAID cluster.
@@ -246,10 +246,12 @@ The following arguments are supported:
 * `project_id` - (Optional, Int, ForceNew) ID of the project. `0` by default.
 * `ro_group_sg` - (Optional, List: [`String`]) IDs of security group for `ro_group`.
 * `rw_group_sg` - (Optional, List: [`String`]) IDs of security group for `rw_group`.
+* `semi_sync_timeout` - (Optional, Int) Semi-sync timeout in ms. Value range: `[1000, 4294967295]`, default `10000`.
 * `serverless_status_flag` - (Optional, String) Specify whether to pause or resume serverless cluster. values: `resume`, `pause`.
 * `slave_zone` - (Optional, String) Multi zone Addresses of the CynosDB Cluster.
 * `storage_limit` - (Optional, Int) Storage limit of CynosDB cluster instance, unit in GB. The maximum storage of a non-serverless instance in GB. NOTE: If db_type is `MYSQL` and charge_type is `PREPAID`, the value cannot exceed the maximum storage corresponding to the CPU and memory specifications, and the transaction mode is `order and pay`. when charge_type is `POSTPAID_BY_HOUR`, this argument is unnecessary.
 * `storage_pay_mode` - (Optional, Int) Cluster storage billing mode, pay-as-you-go: `0`-yearly/monthly: `1`-The default is pay-as-you-go. When the DbType is MYSQL, when the cluster computing billing mode is post-paid (including DbMode is SERVERLESS), the storage billing mode can only be billing by volume; rollback and cloning do not support yearly subscriptions monthly storage.
+* `sync_way` - (Optional, String) Synchronization way. Valid values: `async`, `semisync`, `sync`.
 * `tags` - (Optional, Map) The tags of the CynosDB cluster.
 
 The `instance_init_infos` object supports the following:
@@ -275,7 +277,6 @@ The `param_items` object supports the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-* `BinlogSyncWay` - Binlog sync way of the slave zone. Valid values: `sync`, `semisync`, `async`.
 * `charset` - Charset used by CynosDB cluster.
 * `cluster_status` - Status of the Cynosdb cluster.
 * `create_time` - Creation time of the CynosDB cluster.

--- a/website/docs/r/cynosdb_cluster.html.markdown
+++ b/website/docs/r/cynosdb_cluster.html.markdown
@@ -106,6 +106,9 @@ resource "tencentcloud_cynosdb_cluster" "example" {
     device_type    = "exclusive"
   }
 
+  SyncWay         = "async"
+  SemiSyncTimeout = 10000
+
   cynos_version = "2.1.14.001"
 
   tags = {
@@ -114,7 +117,9 @@ resource "tencentcloud_cynosdb_cluster" "example" {
 }
 ```
 
-### Create a multiple availability zone SERVERLESS CynosDB cluster
+### API.
+
+Create a multiple availability zone SERVERLESS CynosDB cluster
 
 ```hcl
 variable "availability_zone" {
@@ -213,6 +218,8 @@ The following arguments are supported:
 * `password` - (Required, String) Password of `root` account.
 * `subnet_id` - (Required, String) ID of the subnet within this VPC.
 * `vpc_id` - (Required, String) ID of the VPC.
+* `SemiSyncTimeout` - (Optional, Int) Semi-sync timeout in ms. Value range: `[1000, 4294967295]`, default `10000`.
+* `SyncWay` - (Optional, String) Synchronization way. Valid values: `async`, `semisync`, `sync`.
 * `auto_pause_delay` - (Optional, Int) Specify auto-pause delay in second while `db_mode` is `SERVERLESS`. Value range: `[600, 691200]`. Default: `600`.
 * `auto_pause` - (Optional, String) Specify whether the cluster can auto-pause while `db_mode` is `SERVERLESS`. Values: `yes` (default), `no`.
 * `auto_renew_flag` - (Optional, Int) Auto renew flag. Valid values are `0`(MANUAL_RENEW), `1`(AUTO_RENEW). Default value is `0`. Only works for PREPAID cluster.
@@ -268,6 +275,7 @@ The `param_items` object supports the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
+* `BinlogSyncWay` - Binlog sync way of the slave zone. Valid values: `sync`, `semisync`, `async`.
 * `charset` - Charset used by CynosDB cluster.
 * `cluster_status` - Status of the Cynosdb cluster.
 * `create_time` - Creation time of the CynosDB cluster.

--- a/website/docs/r/cynosdb_cluster_v2.html.markdown
+++ b/website/docs/r/cynosdb_cluster_v2.html.markdown
@@ -17,6 +17,8 @@ Provide a resource to create a CynosDB cluster.
 
 ## Example Usage
 
+### Create a CynosDB cluster with available_zone
+
 ```hcl
 resource "tencentcloud_cynosdb_cluster_v2" "example" {
   available_zone               = "ap-guangzhou-6"
@@ -34,6 +36,58 @@ resource "tencentcloud_cynosdb_cluster_v2" "example" {
   instance_memory_size         = 4
   open_ro_group                = true
   force_delete                 = true
+  instance_maintain_weekdays = [
+    "Fri",
+    "Mon",
+    "Sat",
+    "Sun",
+    "Thu",
+    "Wed",
+    "Tue",
+  ]
+
+  rw_group_sg        = ["sg-7pnojfur", "sg-37tigqat"]
+  ro_group_sg        = ["sg-7pnojfur", "sg-37tigqat", "sg-08cqf7d5"]
+  single_ro_group_sg = ["sg-7pnojfur", "sg-37tigqat", "sg-08cqf7d5", "sg-l1txcqtj"]
+
+  param_items {
+    name          = "character_set_server"
+    current_value = "utf8mb4"
+  }
+
+  param_items {
+    name          = "lower_case_table_names"
+    current_value = "0"
+  }
+
+  tags = {
+    createBy = "terraform"
+  }
+}
+```
+
+### Create a CynosDB cluster with available_zone and slave_zone
+
+```hcl
+resource "tencentcloud_cynosdb_cluster_v2" "example" {
+  available_zone               = "ap-guangzhou-6"
+  slave_zone                   = "ap-guangzhou-7"
+  vpc_id                       = "vpc-i5yyodl9"
+  subnet_id                    = "subnet-hhi88a58"
+  db_mode                      = "NORMAL"
+  db_type                      = "MYSQL"
+  db_version                   = "5.7"
+  port                         = 3306
+  cluster_name                 = "tf-example"
+  password                     = "cynosDB@123"
+  instance_maintain_duration   = 7200
+  instance_maintain_start_time = 10800
+  instance_cpu_core            = 2
+  instance_memory_size         = 4
+  open_ro_group                = true
+  force_delete                 = true
+  sync_way                     = "async"
+  semi_sync_timeout            = 10000
   instance_maintain_weekdays = [
     "Fri",
     "Mon",
@@ -102,11 +156,13 @@ The following arguments are supported:
 * `project_id` - (Optional, Int, ForceNew) ID of the project. `0` by default.
 * `ro_group_sg` - (Optional, List: [`String`]) IDs of security group for `ro_group`. Only work for `open_ro_group` is true.
 * `rw_group_sg` - (Optional, List: [`String`]) IDs of security group for `rw_group`.
+* `semi_sync_timeout` - (Optional, Int) Semi-sync timeout in ms. Value range: `[1000, 4294967295]`, default `10000`.
 * `serverless_status_flag` - (Optional, String) Specify whether to pause or resume serverless cluster. values: `resume`, `pause`.
 * `single_ro_group_sg` - (Optional, List: [`String`]) IDs of security group for `single_ro_group`.
 * `slave_zone` - (Optional, String) Multi zone Addresses of the CynosDB Cluster.
 * `storage_limit` - (Optional, Int) Storage limit of CynosDB cluster instance, unit in GB. The maximum storage of a non-serverless instance in GB. NOTE: If db_type is `MYSQL` and charge_type is `PREPAID`, the value cannot exceed the maximum storage corresponding to the CPU and memory specifications, and the transaction mode is `order and pay`. when charge_type is `POSTPAID_BY_HOUR`, this argument is unnecessary.
 * `storage_pay_mode` - (Optional, Int) Cluster storage billing mode, pay-as-you-go: `0`-yearly/monthly: `1`-The default is pay-as-you-go. When the DbType is MYSQL, when the cluster computing billing mode is post-paid (including DbMode is SERVERLESS), the storage billing mode can only be billing by volume; rollback and cloning do not support yearly subscriptions monthly storage.
+* `sync_way` - (Optional, String) Synchronization way. Valid values: `async`, `semisync`, `sync`.
 * `tags` - (Optional, Map) The tags of the CynosDB cluster.
 
 The `instance_init_infos` object supports the following:


### PR DESCRIPTION
Add SyncWay, SemiSyncTimeout and BinlogSyncWay parameters to tencentcloud_cynosdb_cluster resource.

- Add `SyncWay` (Optional, immutable) parameter passed to CreateClusters API, valid values: `async`, `semisync`, `sync`.
- Add `SemiSyncTimeout` (Optional, immutable) parameter passed to CreateClusters API, range `[1000, 4294967295]` ms.
- Read `BinlogSyncWay` and `SemiSyncTimeout` from DescribeClusterDetail response (SlaveZoneAttr) in Read function.
- Add immutable-args handling in Update function.
- Update documentation and unit tests.