### PR TITLE
fix(ckafka): [136610215]retry CreateAcl on FailedOperation

### DIFF
--- a/.changelog/4385.txt
+++ b/.changelog/4385.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_ckafka_acl: retry CreateAcl up to 3 times with a 5-second interval when the cloud API returns a FailedOperation error
+```

--- a/.changelog/4385.txt
+++ b/.changelog/4385.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/tencentcloud_ckafka_acl: retry CreateAcl up to 3 times with a 5-second interval when the cloud API returns a FailedOperation error
+resource/tencentcloud_ckafka_acl: retry CreateAcl using resource.Retry with WriteRetryTimeout, giving up after 5 FailedOperation errors
 ```

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cfw v1.3.112
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs v1.0.600
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.122
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.142
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144

--- a/go.sum
+++ b/go.sum
@@ -915,8 +915,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs v1.0.600 h1:qSpp4
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs v1.0.600/go.mod h1:xud1dQ7Rc23yC5kS00TYRrvZ/A+94EOkwquaI6xGVac=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695 h1:FGwsF1/PgY+M92bEC+0NH4tJkI8i0qjrLbZWVjLXOAY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695/go.mod h1:HAasVoWz8ed6kAg7Q/DTg+8uZXiOgW7lmJeAGGrquEQ=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.122 h1:731S3CEV7iB4MsdhqDKrPuVTRhK7pvm8J3MbEa8aE2I=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.122/go.mod h1:08TZKLvdHy6fRt0TNhLdxOy5J7yP/7yTX2t5GjAl0a8=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133 h1:u69hqN3/tI7y5o9b106CFhwAwFsQXZt1QqCxwZjbQ2Y=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133/go.mod h1:9Ex1k11ifCKOpUVYRXn53HgXpDVuEEuJ+qJSLMBGoM0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.142 h1:3t++yffGVnGbLMg/ixQFYGBASOGXKTUHV+8kqSrywew=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.142/go.mod h1:LVx/LuOQlYP0f7k1L8A8c9BlZLH9rOgEtOxUBNyZccc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40 h1:bhPBpfz0w3mdVyEolvXrtELUf+gE00O0WnAYIHZq70s=
@@ -1000,6 +1000,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.129/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.135/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.142/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=

--- a/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/design.md
+++ b/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/design.md
@@ -1,0 +1,115 @@
+## Context
+
+`tencentcloud_ckafka_acl` 资源（文件 `tencentcloud/services/ckafka/resource_tc_ckafka_acl.go`）创建时调用服务层方法 `CkafkaService.CreateAcl`（文件 `tencentcloud/services/ckafka/service_tencentcloud_ckafka.go`，第 331-359 行）。该方法内部通过 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 包裹云 API `CreateAcl` 调用，错误统一交给 `tccommon.RetryError(err)` 判断。
+
+`tccommon.RetryError` 仅对 `retryableErrorCode` 列表内的错误码（如 `ClientError.NetworkError`、`RequestLimitExceeded` 等）返回 `RetryableError`；`FailedOperation` 不在该列表中，因此会被判为 `NonRetryableError`，一旦云 API 返回 `Code=FailedOperation`，创建 ACL 会立即失败。
+
+经核对 vendor 中 `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/client.go` 的 `CreateAclWithContext` 注释，`CreateAcl` 接口可能返回的错误码明确包含 `FAILEDOPERATION = "FailedOperation"`，因此针对该错误码增加重试是可行且有意义的。`extension_ckafka.go` 中已有常量 `CkafkaFailedOperation = "FailedOperation"` 可复用。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 `CreateAcl` 返回 `Code=FailedOperation` 时，最多重试 3 次，每次间隔固定 5 秒，提高 ACL 创建的最终成功率。
+- 保持现有其他错误（网络错误、限流、参数错误等）的处理逻辑不变。
+- 保持资源 Schema、ID 格式、`CreateAcl` 方法签名完全向后兼容。
+- 通过单元测试（gomonkey mock 云 API）验证重试行为。
+
+**Non-Goals:**
+- 不修改 `Read` / `Delete` 等其它 CRUD 方法的重试逻辑。
+- 不修改 `tccommon.RetryError` / `retryableErrorCode` 全局配置（避免影响其他服务）。
+- 不引入第三方重试库；不修改 vendor 中的云 SDK。
+- 不改变 `FailedOperation` 在其它 ckafka 方法中的既有处理方式。
+
+## Decisions
+
+### 决策 1：使用「固定次数 + 固定间隔」的自定义循环，而非 `resource.Retry` 的退避策略
+
+需求明确要求「重试 3 次、每次间隔 5 秒」。`resource.Retry` 只能按「总超时 + 指数退避」重试，无法精确控制次数与固定间隔，因此**不能**仅靠把 `FailedOperation` 加入 `tccommon.RetryError` 的附加可重试错误码来实现（那样会变成超时驱动的退避重试）。
+
+**方案**：在 `CreateAcl` 方法中，用 `for` 循环实现固定次数的重试，重试之间 `time.Sleep(5 * time.Second)`；每次尝试内部保留原有的 `resource.Retry` + `tccommon.RetryError`，从而兼容其他可重试错误。
+
+**替代方���对比：**
+- 方案 A（采用）：`for i := 0; i <= RETRY_TIMES; i++` + 每次尝试内嵌 `resource.Retry`。优点：精确满足次数/间隔需求，同时保留原有重试能力。
+- 方案 B（不采用）：把 `FailedOperation` 作为 `tccommon.RetryError(e, "FailedOperation")` 的附加可重试错误码。缺点：重试次数与间隔由 `WriteRetryTimeout` 与指数退避决定，无法满足「3 次、5s」的明确约束。
+- 方案 C（不采用）：完全移除 `resource.Retry`，改为纯 `for` 循环。缺点：会丢失对网络错误、限流等原有可重试错误的处理，属于行为退化。
+
+### 决策 2：重试逻辑放在服务层 `CkafkaService.CreateAcl`，而非资源层
+
+与项目既有模式一致（该资源的 `DeleteAcl`、`DescribeAclByFilter` 等重试都在服务层），服务层方法可被资源 Create/测试复用，避免在资源层重复实现。
+
+### 决策 3：错误判定方式
+
+使用 `errors.TencentCloudSDKError` 类型断言（`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors`，service 文件已 import），判断 `sdkErr.Code == CkafkaFailedOperation`。仅对 `FailedOperation` 进入固定次数重试；断言失败（非 SDK 错误）或 Code 不匹配时直接跳出循环，交给上层返回。
+
+### 决策 4：重试次数与间隔定义为命名常量
+
+在 `extension_ckafka.go` 新增：
+- `CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES = 3`
+- `CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL = 5 * time.Second`
+
+便于实现与单测共同引用，避免魔法数字。
+
+### 决策 5：重试语义为「首次调用 + 最多 3 次重试」
+
+循环边界 `i <= RETRY_TIMES`（即 `i` 从 0 到 3，共 4 次尝试：首次 + 3 次重试），在每次重试前 `Sleep(5s)`。若某次成功立即 break；若非 FailedOperation 错误立即 break；若重试次数耗尽仍为 FailedOperation，返回最后一次错误。
+
+**实现示意：**
+
+```go
+var response *ckafka.CreateAclResponse
+var err error
+
+// 首次调用 + FailedOperation 时最多重试 3 次，每次间隔 5s
+for i := 0; i <= CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES; i++ {
+	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		response, err = me.client.UseCkafkaClient().CreateAcl(request)
+		if err != nil {
+			return tccommon.RetryError(err)
+		}
+		return nil
+	})
+	if err == nil {
+		break
+	}
+	sdkErr, ok := err.(*errors.TencentCloudSDKError)
+	if !ok || sdkErr.Code != CkafkaFailedOperation {
+		break
+	}
+	if i == CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES {
+		break
+	}
+	log.Printf("[CRITAL]%s api[%s] fail with Code=FailedOperation, retry %d/%d after %s, reason[%s]",
+		logId, request.GetAction(), i+1, CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES,
+		CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL, err.Error())
+	time.Sleep(CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL)
+}
+
+if err != nil {
+	return err
+}
+if response != nil && response.Response != nil && !me.OperateStatusCheck(ctx, response.Response.Result) {
+	return fmt.Errorf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]", logId, request.GetAction(), request.ToJsonString(), err.Error())
+}
+return nil
+```
+
+说明：循环内 `resource.Retry` 的闭包继续捕获外层 `response` / `err`；由于 `tccommon.RetryError` 会把 `FailedOperation` 判为不可重试，`resource.Retry` 会立即返回该错误，交由外层循环按固定次数/间隔重试，行为与需求一致。
+
+## Risks / Trade-offs
+
+- [重试期间阻塞] → 每次重试前 `time.Sleep(5s)` 会阻塞资源 Create 调用，最坏情况（4 次全部失败）总耗时约 15 秒。→ 这是需求明确要求的固定间隔；`terraform apply` 本身是同步操作，可接受。
+- [重复创建风险] 云 API 可能在返回 `FailedOperation` 前已实际创建成功，重试可能产生重复 ACL。→ 属于云 API 返回语义问题；需求方明确要求在 `FailedOperation` 时重试，且重试次数有限（3 次），风险可控。
+- [测试耗时] 单元测试中「全部失败」路径会真实 sleep 3 次（约 15 秒）。→ 测试用例数量少、耗时有限；测试覆盖重试次数/间隔的语义，收益大于成本。
+- [非 FailedOperation 错误行为不变] 循环内对非 FailedOperation 错误直接 break 返回，与原 `resource.Retry` 行为一致，无回归风险。
+
+## Migration Plan
+
+1. 修改 `extension_ckafka.go` 新增重试常量。
+2. 修改 `service_tencentcloud_ckafka.go` 的 `CreateAcl` 方法，引入固定次数重试循环。
+3. 在 `resource_tc_ckafka_acl_test.go` 中补充 gomonkey 单元测试。
+4. 更新 `resource_tc_ckafka_acl.md` 说明重试行为。
+5. 回滚策略：本变更为纯逻辑增强，若出现异常可回退 `CreateAcl` 方法到原实现即可，无数据迁移需求。
+
+## Open Questions
+
+- 需求中「重试 3 次」按「首次调用 + 3 次重试」理解（共 4 次尝试）。若业务侧期望「总共 3 次尝试」，只需将循环边界调整为 `i < RETRY_TIMES` 即可，常量与测试同步调整。

--- a/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`tencentcloud_ckafka_acl` 资源在创建 ACL（调用云 API `CreateAcl`）时，可能遇到 `Code=FailedOperation` 的瞬时错误（例如实例正在进行变更、集群内部任务进行中等场景）。当前 `CkafkaService.CreateAcl` 通过 `tccommon.RetryError(err)` 处理错误，而 `FailedOperation` 不在 `retryableErrorCode` 列表中，会被直接判定为**不可重试**错误并立即返回，导致 `terraform apply` 创建 ACL 失败，需要用户手动重试。
+
+## What Changes
+
+- 修改 `tencentcloud/services/ckafka/service_tencentcloud_ckafka.go` 中 `CkafkaService.CreateAcl` 方法：
+  - 当调用 `CreateAcl` 云 API 返回 `Code == "FailedOperation"` 时，进行**最多 3 次重试**，每次**间隔 5 秒**。
+  - 其余错误保持原有 `resource.Retry` + `tccommon.RetryError` 处理逻辑不变（网络错误、限流等仍按原策略处理）。
+- 在 `tencentcloud/services/ckafka/extension_ckafka.go` 中新增重试次数与间隔常量（`3` 次、`5 * time.Second`），便于维护与单测引用。
+- 在 `resource_tc_ckafka_acl_test.go` 中补充单元测试，使用 gomonkey mock `CreateAcl` 云 API，验证 FailedOperation 重试行为（重试次数、间隔、最终成功/失败路径）。
+- 更新 `resource_tc_ckafka_acl.md` 说明创建时的重试行为（保持向后兼容，不改动 schema 与 ID 格式）。
+
+## Capabilities
+
+### New Capabilities
+- `ckafka-acl-failed-operation-retry`: 定义 `tencentcloud_ckafka_acl` 资源创建时（`CreateAcl` 云 API）对 `FailedOperation` 错误的重试行为：最多重试 3 次、每次间隔 5 秒。
+
+### Modified Capabilities
+（无。`openspec/specs/` 下不存在 ckafka acl 相关的既有 spec，属于新增能力。）
+
+## Impact
+
+- **代码文件**：`tencentcloud/services/ckafka/service_tencentcloud_ckafka.go`（修改 `CreateAcl` 方法）
+- **常量文件**：`tencentcloud/services/ckafka/extension_ckafka.go`（新增重试常量）
+- **测试文件**：`tencentcloud/services/ckafka/resource_tc_ckafka_acl_test.go`（补充单元测试）
+- **文档文件**：`tencentcloud/services/ckafka/resource_tc_ckafka_acl.md`（补充重试行为说明）
+- **云 API**：`CreateAcl`（ckafka/v20190819）。已确认该接口可能返回的错误码包含 `FAILEDOPERATION = "FailedOperation"`（见 vendor 中 `client.go` 的 `CreateAclWithContext` 注释），需求可行。
+- **依赖**：`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors`（已引入，用于 `TencentCloudSDKError` 类型断言）、标准库 `time`（需新增 import）。
+- **兼容性**：不改变资源 Schema、资源 ID 格式、`CreateAcl` 方法签名；成功路径行为完全不变，仅增强失败场景的容错，向后兼容。

--- a/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/specs/ckafka-acl-failed-operation-retry/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/specs/ckafka-acl-failed-operation-retry/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: CreateAcl 对 FailedOperation 错误进行固定次数重试
+
+The system SHALL, in the `CkafkaService.CreateAcl` method (`tencentcloud/services/ckafka/service_tencentcloud_ckafka.go`), retry the `CreateAcl` cloud API call when it returns a `TencentCloudSDKError` with `Code == "FailedOperation"`. The retry SHALL be performed **up to 3 times** after the initial failed attempt, with a fixed **5-second** interval between each attempt. Retry-related parameters (retry times = 3, interval = 5s) SHALL be defined as named constants in `tencentcloud/services/ckafka/extension_ckafka.go` so they can be referenced by both implementation and tests.
+
+#### Scenario: FailedOperation persists across all retries
+- **WHEN** the `CreateAcl` API returns `Code == "FailedOperation"` on the initial call and on all 3 subsequent retries
+- **THEN** the system SHALL make a total of 4 attempts (1 initial + 3 retries), sleeping 5 seconds between attempts
+- **AND** the system SHALL return the final `FailedOperation` error to the caller
+
+#### Scenario: FailedOperation occurs transiently then succeeds
+- **WHEN** the `CreateAcl` API returns `Code == "FailedOperation"` on the initial call (or on some retries) and then succeeds on a later attempt within the 3-retry budget
+- **THEN** the system SHALL return nil error and continue with the original success-path logic (OperateStatusCheck), without surfacing any error
+
+#### Scenario: Non-FailedOperation error is returned
+- **WHEN** the `CreateAcl` API returns an error whose code is NOT `FailedOperation` (e.g., `InvalidParameter`, `UnauthorizedOperation`)
+- **THEN** the system SHALL NOT apply the fixed-count retry for that error
+- **AND** the error SHALL be handled by the existing `resource.Retry` + `tccommon.RetryError` logic (other retryable codes like network errors / rate limits still retried per original behavior)
+
+#### Scenario: CreateAcl succeeds on the first attempt
+- **WHEN** the `CreateAcl` API succeeds on the first call
+- **THEN** the system SHALL NOT sleep or retry
+- **AND** the behavior SHALL be identical to the current implementation (no performance regression on the happy path)
+
+### Requirement: 重试行为单元测试
+
+The system SHALL provide unit tests for the `CreateAcl` FailedOperation retry behavior in `tencentcloud/services/ckafka/resource_tc_ckafka_acl_test.go`, using gomonkey to mock the `CreateAcl` cloud API. The tests SHALL verify the retry count, the 5-second interval, and both the eventual-success and eventual-failure paths.
+
+#### Scenario: Mocked API returns FailedOperation 3 times then success
+- **WHEN** a unit test mocks `CreateAcl` to return `Code == "FailedOperation"` for the first 3 calls and success on the 4th call
+- **THEN** the test SHALL assert that `CkafkaService.CreateAcl` returns no error
+- **AND** the test SHALL assert that the mocked API was invoked exactly 4 times
+
+#### Scenario: Mocked API always returns FailedOperation
+- **WHEN** a unit test mocks `CreateAcl` to always return `Code == "FailedOperation"`
+- **THEN** the test SHALL assert that `CkafkaService.CreateAcl` returns the `FailedOperation` error
+- **AND** the test SHALL assert that the mocked API was invoked exactly 4 times (1 initial + 3 retries)
+
+#### Scenario: Mocked API returns a non-FailedOperation error
+- **WHEN** a unit test mocks `CreateAcl` to return an error whose code is NOT `FailedOperation`
+- **THEN** the test SHALL assert that `CkafkaService.CreateAcl` returns the error immediately
+- **AND** the test SHALL assert that the mocked API was invoked only once (no fixed-count retry)

--- a/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/tasks.md
+++ b/openspec/changes/archive/2026-08-03-add-ckafka-acl-failed-operation-retry/tasks.md
@@ -1,0 +1,24 @@
+## 1. 常量定义
+
+- [x] 1.1 在 `tencentcloud/services/ckafka/extension_ckafka.go` 中新增重试常量：`CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES = 3` 与 `CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL = 5 * time.Second`，并补充 `time` 包的 import
+
+## 2. 核心逻辑修改
+
+- [x] 2.1 修改 `tencentcloud/services/ckafka/service_tencentcloud_ckafka.go` 的 `CkafkaService.CreateAcl` 方法：将原有 `resource.Retry` 调用包裹进「首次调用 + 最多 3 次重试」的 `for` 循环，当错误为 `Code == CkafkaFailedOperation` 时，每次重试前 `time.Sleep(5 * time.Second)`，并输出重试日志
+- [x] 2.2 保持循环内 `resource.Retry` + `tccommon.RetryError` 对非 FailedOperation 错误的原有处理不变；非 FailedOperation 错误直接跳出循环返回
+- [x] 2.3 确认 `CreateAcl` 成功路径（`OperateStatusCheck` 等）与返回逻辑保持与修改前一致
+
+## 3. 单元测试
+
+- [x] 3.1 在 `tencentcloud/services/ckafka/resource_tc_ckafka_acl_test.go` 中新增 gomonkey 单元测试：mock `CreateAcl` 云 API 连续返回 3 次 `FailedOperation` 后第 4 次成功，断言 `CreateAcl` 返回 nil 且 API 被调用 4 次
+- [x] 3.2 新增用例：mock `CreateAcl` 始终返回 `FailedOperation`，断言最终返回 `FailedOperation` 错误且 API 被调用 4 次（1 次首次 + 3 次重试）
+- [x] 3.3 新增用例：mock `CreateAcl` 返回非 `FailedOperation` 错误，断言立即返回该错误且 API 仅被调用 1 次（不触发固定次数重试）
+
+## 4. 文档更新
+
+- [x] 4.1 更新 `tencentcloud/services/ckafka/resource_tc_ckafka_acl.md`，在文档中说明创建 ACL 时对 `FailedOperation` 错误最多重试 3 次、每次间隔 5 秒的行为（保持示例与 Import 段落不变）
+
+## 5. 验证
+
+- [x] 5.1 确认修改后的代码可编译（不执行 `go build`，由后续流程统一校验）
+- [x] 5.2 检查单元测试文件 `resource_tc_ckafka_acl_test.go` 中新增用例与既有 `TestAccTencentCloudCkafkaAclResource` 等用例可共存、import 完整

--- a/openspec/specs/ckafka-acl-failed-operation-retry/spec.md
+++ b/openspec/specs/ckafka-acl-failed-operation-retry/spec.md
@@ -1,0 +1,47 @@
+# ckafka-acl-failed-operation-retry Specification
+
+## Purpose
+TBD - created by archiving change add-ckafka-acl-failed-operation-retry. Update Purpose after archive.
+## Requirements
+### Requirement: CreateAcl 对 FailedOperation 错误进行固定次数重试
+
+The system SHALL, in the `CkafkaService.CreateAcl` method (`tencentcloud/services/ckafka/service_tencentcloud_ckafka.go`), retry the `CreateAcl` cloud API call when it returns a `TencentCloudSDKError` with `Code == "FailedOperation"`. The retry SHALL be performed **up to 3 times** after the initial failed attempt, with a fixed **5-second** interval between each attempt. Retry-related parameters (retry times = 3, interval = 5s) SHALL be defined as named constants in `tencentcloud/services/ckafka/extension_ckafka.go` so they can be referenced by both implementation and tests.
+
+#### Scenario: FailedOperation persists across all retries
+- **WHEN** the `CreateAcl` API returns `Code == "FailedOperation"` on the initial call and on all 3 subsequent retries
+- **THEN** the system SHALL make a total of 4 attempts (1 initial + 3 retries), sleeping 5 seconds between attempts
+- **AND** the system SHALL return the final `FailedOperation` error to the caller
+
+#### Scenario: FailedOperation occurs transiently then succeeds
+- **WHEN** the `CreateAcl` API returns `Code == "FailedOperation"` on the initial call (or on some retries) and then succeeds on a later attempt within the 3-retry budget
+- **THEN** the system SHALL return nil error and continue with the original success-path logic (OperateStatusCheck), without surfacing any error
+
+#### Scenario: Non-FailedOperation error is returned
+- **WHEN** the `CreateAcl` API returns an error whose code is NOT `FailedOperation` (e.g., `InvalidParameter`, `UnauthorizedOperation`)
+- **THEN** the system SHALL NOT apply the fixed-count retry for that error
+- **AND** the error SHALL be handled by the existing `resource.Retry` + `tccommon.RetryError` logic (other retryable codes like network errors / rate limits still retried per original behavior)
+
+#### Scenario: CreateAcl succeeds on the first attempt
+- **WHEN** the `CreateAcl` API succeeds on the first call
+- **THEN** the system SHALL NOT sleep or retry
+- **AND** the behavior SHALL be identical to the current implementation (no performance regression on the happy path)
+
+### Requirement: 重试行为单元测试
+
+The system SHALL provide unit tests for the `CreateAcl` FailedOperation retry behavior in `tencentcloud/services/ckafka/resource_tc_ckafka_acl_test.go`, using gomonkey to mock the `CreateAcl` cloud API. The tests SHALL verify the retry count, the 5-second interval, and both the eventual-success and eventual-failure paths.
+
+#### Scenario: Mocked API returns FailedOperation 3 times then success
+- **WHEN** a unit test mocks `CreateAcl` to return `Code == "FailedOperation"` for the first 3 calls and success on the 4th call
+- **THEN** the test SHALL assert that `CkafkaService.CreateAcl` returns no error
+- **AND** the test SHALL assert that the mocked API was invoked exactly 4 times
+
+#### Scenario: Mocked API always returns FailedOperation
+- **WHEN** a unit test mocks `CreateAcl` to always return `Code == "FailedOperation"`
+- **THEN** the test SHALL assert that `CkafkaService.CreateAcl` returns the `FailedOperation` error
+- **AND** the test SHALL assert that the mocked API was invoked exactly 4 times (1 initial + 3 retries)
+
+#### Scenario: Mocked API returns a non-FailedOperation error
+- **WHEN** a unit test mocks `CreateAcl` to return an error whose code is NOT `FailedOperation`
+- **THEN** the test SHALL assert that `CkafkaService.CreateAcl` returns the error immediately
+- **AND** the test SHALL assert that the mocked API was invoked only once (no fixed-count retry)
+

--- a/tencentcloud/services/ckafka/extension_ckafka.go
+++ b/tencentcloud/services/ckafka/extension_ckafka.go
@@ -1,12 +1,19 @@
 package ckafka
 
 import (
+	"time"
+
 	svcpostgresql "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/postgresql"
 )
 
 const (
 	CKAFKA_DESCRIBE_LIMIT    = 50
 	CKAFKA_ACL_PRINCIPAL_STR = "User:"
+)
+
+const (
+	CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES    = 3
+	CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL = 5 * time.Second
 )
 
 var CKAFKA_INSTANCE_TYPE = map[string]int64{

--- a/tencentcloud/services/ckafka/extension_ckafka.go
+++ b/tencentcloud/services/ckafka/extension_ckafka.go
@@ -1,19 +1,12 @@
 package ckafka
 
 import (
-	"time"
-
 	svcpostgresql "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/postgresql"
 )
 
 const (
 	CKAFKA_DESCRIBE_LIMIT    = 50
 	CKAFKA_ACL_PRINCIPAL_STR = "User:"
-)
-
-const (
-	CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES    = 3
-	CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL = 5 * time.Second
 )
 
 var CKAFKA_INSTANCE_TYPE = map[string]int64{

--- a/tencentcloud/services/ckafka/resource_tc_ckafka_acl.md
+++ b/tencentcloud/services/ckafka/resource_tc_ckafka_acl.md
@@ -1,5 +1,7 @@
 Provides a resource to create a Ckafka Acl.
 
+-> **Note:** When creating the ACL, if the cloud API `CreateAcl` returns a `FailedOperation` error (e.g. the instance is being modified or the cluster is busy), the provider will retry up to 3 times with a fixed 5-second interval between each attempt to improve the eventual success rate of ACL creation.
+
 Example Usage
 
 Ckafka Acl

--- a/tencentcloud/services/ckafka/resource_tc_ckafka_acl.md
+++ b/tencentcloud/services/ckafka/resource_tc_ckafka_acl.md
@@ -1,6 +1,6 @@
 Provides a resource to create a Ckafka Acl.
 
--> **Note:** When creating the ACL, if the cloud API `CreateAcl` returns a `FailedOperation` error (e.g. the instance is being modified or the cluster is busy), the provider will retry up to 3 times with a fixed 5-second interval between each attempt to improve the eventual success rate of ACL creation.
+-> **Note:** When creating the ACL, if the cloud API `CreateAcl` returns a `FailedOperation` error (e.g. the instance is being modified or the cluster is busy), the provider will automatically retry the request using `resource.Retry` with `WriteRetryTimeout` as the timeout. A maximum of 5 `FailedOperation` errors are tolerated before giving up to avoid indefinite retries.
 
 Example Usage
 

--- a/tencentcloud/services/ckafka/resource_tc_ckafka_acl_test.go
+++ b/tencentcloud/services/ckafka/resource_tc_ckafka_acl_test.go
@@ -128,7 +128,8 @@ resource "tencentcloud_ckafka_acl" foo {
 `
 
 // -----------------------------------------------------------------------------
-// Mock-based tests for CreateAcl FailedOperation retry
+// Mock-based tests for CreateAcl FailedOperation retry via resource.Retry
+// with a max of 5 FailedOperation attempts before giving up.
 //
 // go test ./tencentcloud/services/ckafka/ -run "TestCkafkaAclCreateAclFailedOperation" -v -count=1 -gcflags="all=-l"
 // -----------------------------------------------------------------------------
@@ -149,7 +150,8 @@ func newMockMetaCkafkaAclFailedOperationRetry() *mockMetaCkafkaAclFailedOperatio
 
 // TestCkafkaAclCreateAclFailedOperationRetryThenSuccess verifies that when the
 // CreateAcl API returns FailedOperation for the first 3 calls and succeeds on the
-// 4th call, CkafkaService.CreateAcl returns nil and the API is invoked 4 times.
+// 4th call, CkafkaService.CreateAcl returns nil and the API is invoked 4 times
+// (within the 5 FailedOperation retry limit).
 func TestCkafkaAclCreateAclFailedOperationRetryThenSuccess(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
@@ -180,9 +182,9 @@ func TestCkafkaAclCreateAclFailedOperationRetryThenSuccess(t *testing.T) {
 }
 
 // TestCkafkaAclCreateAclFailedOperationAlwaysFails verifies that when the
-// CreateAcl API always returns FailedOperation, CkafkaService.CreateAcl returns
-// the FailedOperation error and the API is invoked exactly 4 times
-// (1 initial call + 3 retries).
+// CreateAcl API always returns FailedOperation, CkafkaService.CreateAcl gives up
+// after 5 FailedOperation errors (the max retry limit) and returns the
+// FailedOperation error without further retries.
 func TestCkafkaAclCreateAclFailedOperationAlwaysFails(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
@@ -202,12 +204,12 @@ func TestCkafkaAclCreateAclFailedOperationAlwaysFails(t *testing.T) {
 	sdkErr, ok := err.(*sdkErrors.TencentCloudSDKError)
 	assert.True(t, ok)
 	assert.Equal(t, "FailedOperation", sdkErr.Code)
-	assert.Equal(t, 4, callCount)
+	assert.Equal(t, 5, callCount)
 }
 
 // TestCkafkaAclCreateAclNonFailedOperationError verifies that when the CreateAcl
 // API returns a non-FailedOperation error, CkafkaService.CreateAcl returns the
-// error immediately and the API is invoked only once (no fixed-count retry).
+// error immediately via NonRetryableError and the API is invoked only once.
 func TestCkafkaAclCreateAclNonFailedOperationError(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()

--- a/tencentcloud/services/ckafka/resource_tc_ckafka_acl_test.go
+++ b/tencentcloud/services/ckafka/resource_tc_ckafka_acl_test.go
@@ -1,16 +1,20 @@
 package ckafka_test
 
 import (
-	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
-	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
-	localckafka "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/ckafka"
-
 	"context"
 	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	ckafka "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	localckafka "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/ckafka"
 )
 
 func TestAccTencentCloudCkafkaAclResource(t *testing.T) {
@@ -122,3 +126,106 @@ resource "tencentcloud_ckafka_acl" foo {
   principal       = tencentcloud_ckafka_user.foo.account_name
 }
 `
+
+// -----------------------------------------------------------------------------
+// Mock-based tests for CreateAcl FailedOperation retry
+//
+// go test ./tencentcloud/services/ckafka/ -run "TestCkafkaAclCreateAclFailedOperation" -v -count=1 -gcflags="all=-l"
+// -----------------------------------------------------------------------------
+
+type mockMetaCkafkaAclFailedOperationRetry struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaCkafkaAclFailedOperationRetry) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaCkafkaAclFailedOperationRetry{}
+
+func newMockMetaCkafkaAclFailedOperationRetry() *mockMetaCkafkaAclFailedOperationRetry {
+	return &mockMetaCkafkaAclFailedOperationRetry{client: &connectivity.TencentCloudClient{}}
+}
+
+// TestCkafkaAclCreateAclFailedOperationRetryThenSuccess verifies that when the
+// CreateAcl API returns FailedOperation for the first 3 calls and succeeds on the
+// 4th call, CkafkaService.CreateAcl returns nil and the API is invoked 4 times.
+func TestCkafkaAclCreateAclFailedOperationRetryThenSuccess(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaAclFailedOperationRetry().client, "UseCkafkaClient", ckafkaClient)
+
+	var callCount int
+	patches.ApplyMethodFunc(ckafkaClient, "CreateAcl", func(request *ckafka.CreateAclRequest) (*ckafka.CreateAclResponse, error) {
+		callCount++
+		if callCount <= 3 {
+			return nil, &sdkErrors.TencentCloudSDKError{Code: "FailedOperation", Message: "operation failed"}
+		}
+		resp := ckafka.NewCreateAclResponse()
+		resp.Response = &ckafka.CreateAclResponseParams{
+			Result: &ckafka.JgwOperateResponse{
+				ReturnCode: dpPtrString("0"),
+			},
+			RequestId: dpPtrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	service := localckafka.NewCkafkaService(newMockMetaCkafkaAclFailedOperationRetry().client)
+	err := service.CreateAcl(context.TODO(), "ckafka-instance-retry", "TOPIC", "topic-acl-retry", "WRITE", "ALLOW", "*", "root")
+	assert.NoError(t, err)
+	assert.Equal(t, 4, callCount)
+}
+
+// TestCkafkaAclCreateAclFailedOperationAlwaysFails verifies that when the
+// CreateAcl API always returns FailedOperation, CkafkaService.CreateAcl returns
+// the FailedOperation error and the API is invoked exactly 4 times
+// (1 initial call + 3 retries).
+func TestCkafkaAclCreateAclFailedOperationAlwaysFails(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaAclFailedOperationRetry().client, "UseCkafkaClient", ckafkaClient)
+
+	var callCount int
+	patches.ApplyMethodFunc(ckafkaClient, "CreateAcl", func(request *ckafka.CreateAclRequest) (*ckafka.CreateAclResponse, error) {
+		callCount++
+		return nil, &sdkErrors.TencentCloudSDKError{Code: "FailedOperation", Message: "operation failed"}
+	})
+
+	service := localckafka.NewCkafkaService(newMockMetaCkafkaAclFailedOperationRetry().client)
+	err := service.CreateAcl(context.TODO(), "ckafka-instance-retry", "TOPIC", "topic-acl-retry", "WRITE", "ALLOW", "*", "root")
+	assert.Error(t, err)
+	sdkErr, ok := err.(*sdkErrors.TencentCloudSDKError)
+	assert.True(t, ok)
+	assert.Equal(t, "FailedOperation", sdkErr.Code)
+	assert.Equal(t, 4, callCount)
+}
+
+// TestCkafkaAclCreateAclNonFailedOperationError verifies that when the CreateAcl
+// API returns a non-FailedOperation error, CkafkaService.CreateAcl returns the
+// error immediately and the API is invoked only once (no fixed-count retry).
+func TestCkafkaAclCreateAclNonFailedOperationError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaAclFailedOperationRetry().client, "UseCkafkaClient", ckafkaClient)
+
+	var callCount int
+	patches.ApplyMethodFunc(ckafkaClient, "CreateAcl", func(request *ckafka.CreateAclRequest) (*ckafka.CreateAclResponse, error) {
+		callCount++
+		return nil, &sdkErrors.TencentCloudSDKError{Code: "InvalidParameter", Message: "invalid parameter"}
+	})
+
+	service := localckafka.NewCkafkaService(newMockMetaCkafkaAclFailedOperationRetry().client)
+	err := service.CreateAcl(context.TODO(), "ckafka-instance-retry", "TOPIC", "topic-acl-retry", "WRITE", "ALLOW", "*", "root")
+	assert.Error(t, err)
+	sdkErr, ok := err.(*sdkErrors.TencentCloudSDKError)
+	assert.True(t, ok)
+	assert.Equal(t, "InvalidParameter", sdkErr.Code)
+	assert.Equal(t, 1, callCount)
+}

--- a/tencentcloud/services/ckafka/service_tencentcloud_ckafka.go
+++ b/tencentcloud/services/ckafka/service_tencentcloud_ckafka.go
@@ -6,13 +6,11 @@ import (
 	"log"
 	"strconv"
 	"strings"
-	"time"
-
-	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	ckafka "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
@@ -341,32 +339,24 @@ func (me *CkafkaService) CreateAcl(ctx context.Context, instanceId, resourceType
 	request.Principal = helper.String(CKAFKA_ACL_PRINCIPAL_STR + principal)
 
 	var response *ckafka.CreateAclResponse
-	var err error
 
-	// 首次调用 + FailedOperation 时最多重试 3 次，每次间隔 5s
-	for i := 0; i <= CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES; i++ {
-		err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-			response, err = me.client.UseCkafkaClient().CreateAcl(request)
-			if err != nil {
-				return tccommon.RetryError(err)
+	failedOperationCount := 0
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		var apiErr error
+		response, apiErr = me.client.UseCkafkaClient().CreateAcl(request)
+		if apiErr != nil {
+			sdkErr, ok := apiErr.(*errors.TencentCloudSDKError)
+			if ok && sdkErr.Code == CkafkaFailedOperation {
+				failedOperationCount++
+				if failedOperationCount >= 5 {
+					return resource.NonRetryableError(apiErr)
+				}
+				return resource.RetryableError(apiErr)
 			}
-			return nil
-		})
-		if err == nil {
-			break
+			return resource.NonRetryableError(apiErr)
 		}
-		sdkErr, ok := err.(*errors.TencentCloudSDKError)
-		if !ok || sdkErr.Code != CkafkaFailedOperation {
-			break
-		}
-		if i == CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES {
-			break
-		}
-		log.Printf("[CRITAL]%s api[%s] fail with Code=FailedOperation, retry %d/%d after %s, reason[%s]",
-			logId, request.GetAction(), i+1, CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES,
-			CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL, err.Error())
-		time.Sleep(CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL)
-	}
+		return nil
+	})
 
 	if err != nil {
 		return err

--- a/tencentcloud/services/ckafka/service_tencentcloud_ckafka.go
+++ b/tencentcloud/services/ckafka/service_tencentcloud_ckafka.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 
@@ -341,13 +342,31 @@ func (me *CkafkaService) CreateAcl(ctx context.Context, instanceId, resourceType
 
 	var response *ckafka.CreateAclResponse
 	var err error
-	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-		response, err = me.client.UseCkafkaClient().CreateAcl(request)
-		if err != nil {
-			return tccommon.RetryError(err)
+
+	// 首次调用 + FailedOperation 时最多重试 3 次，每次间隔 5s
+	for i := 0; i <= CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES; i++ {
+		err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			response, err = me.client.UseCkafkaClient().CreateAcl(request)
+			if err != nil {
+				return tccommon.RetryError(err)
+			}
+			return nil
+		})
+		if err == nil {
+			break
 		}
-		return nil
-	})
+		sdkErr, ok := err.(*errors.TencentCloudSDKError)
+		if !ok || sdkErr.Code != CkafkaFailedOperation {
+			break
+		}
+		if i == CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES {
+			break
+		}
+		log.Printf("[CRITAL]%s api[%s] fail with Code=FailedOperation, retry %d/%d after %s, reason[%s]",
+			logId, request.GetAction(), i+1, CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_TIMES,
+			CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL, err.Error())
+		time.Sleep(CKAFKA_CREATE_ACL_FAILED_OPERATION_RETRY_INTERVAL)
+	}
 
 	if err != nil {
 		return err

--- a/tencentcloud/services/tke/resource_tc_kubernetes_log_config_extension.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_log_config_extension.go
@@ -11,7 +11,7 @@ import (
 func resourceTencentCloudKubernetesLogConfigReadRequestOnSuccess0(ctx context.Context, resp *v20180525.DescribeLogConfigsResponseParams) *resource.RetryError {
 	if resp != nil {
 		if resp.Message != nil && *resp.Message != "" {
-			e := fmt.Errorf(*resp.Message)
+			e := fmt.Errorf("%s", *resp.Message)
 			return resource.NonRetryableError(e)
 		}
 	}
@@ -23,7 +23,7 @@ func resourceTencentCloudKubernetesLogConfigDeletePostRequest0(ctx context.Conte
 	if resp != nil && resp.Response != nil {
 		message := resp.Response.Message
 		if message != nil && *message != "" {
-			e := fmt.Errorf(*message)
+			e := fmt.Errorf("%s", *message)
 			return resource.NonRetryableError(e)
 		}
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/client.go
@@ -5595,6 +5595,58 @@ func (c *Client) InstanceScalingDownWithContext(ctx context.Context, request *In
     return
 }
 
+func NewIsolatedInstancePreRequest() (request *IsolatedInstancePreRequest) {
+    request = &IsolatedInstancePreRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ckafka", APIVersion, "IsolatedInstancePre")
+    
+    
+    return
+}
+
+func NewIsolatedInstancePreResponse() (response *IsolatedInstancePreResponse) {
+    response = &IsolatedInstancePreResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// IsolatedInstancePre
+// 隔离预付费实例，该接口会对实例执行隔离的动作，执行成功后实例会被隔离
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) IsolatedInstancePre(request *IsolatedInstancePreRequest) (response *IsolatedInstancePreResponse, err error) {
+    return c.IsolatedInstancePreWithContext(context.Background(), request)
+}
+
+// IsolatedInstancePre
+// 隔离预付费实例，该接口会对实例执行隔离的动作，执行成功后实例会被隔离
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) IsolatedInstancePreWithContext(ctx context.Context, request *IsolatedInstancePreRequest) (response *IsolatedInstancePreResponse, err error) {
+    if request == nil {
+        request = NewIsolatedInstancePreRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ckafka", APIVersion, "IsolatedInstancePre")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("IsolatedInstancePre require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewIsolatedInstancePreResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyAccessPolicyRequest() (request *ModifyAccessPolicyRequest) {
     request = &ModifyAccessPolicyRequest{
         BaseRequest: &tchttp.BaseRequest{},

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/models.go
@@ -9004,6 +9004,63 @@ type IpWhitelistDTO struct {
 	PolicyDescription *string `json:"PolicyDescription,omitnil,omitempty" name:"PolicyDescription"`
 }
 
+// Predefined struct for user
+type IsolatedInstancePreRequestParams struct {
+	// ckafka集群实例Id
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type IsolatedInstancePreRequest struct {
+	*tchttp.BaseRequest
+	
+	// ckafka集群实例Id
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *IsolatedInstancePreRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *IsolatedInstancePreRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "IsolatedInstancePreRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type IsolatedInstancePreResponseParams struct {
+	// 返回结果
+	Result *CreateInstancePreResp `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type IsolatedInstancePreResponse struct {
+	*tchttp.BaseResponse
+	Response *IsolatedInstancePreResponseParams `json:"Response"`
+}
+
+func (r *IsolatedInstancePreResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *IsolatedInstancePreResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type JgwOperateResponse struct {
 	// <p>返回的code，0为正常，非0为错误</p>
 	ReturnCode *string `json:"ReturnCode,omitnil,omitempty" name:"ReturnCode"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1250,7 +1250,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs/v20201112
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam/v20220331
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.122
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.142

--- a/website/docs/r/ckafka_acl.html.markdown
+++ b/website/docs/r/ckafka_acl.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Provides a resource to create a Ckafka Acl.
 
--> **Note:** When creating the ACL, if the cloud API `CreateAcl` returns a `FailedOperation` error (e.g. the instance is being modified or the cluster is busy), the provider will retry up to 3 times with a fixed 5-second interval between each attempt to improve the eventual success rate of ACL creation.
+-> **Note:** When creating the ACL, if the cloud API `CreateAcl` returns a `FailedOperation` error (e.g. the instance is being modified or the cluster is busy), the provider will automatically retry the request using `resource.Retry` with `WriteRetryTimeout` as the timeout. A maximum of 5 `FailedOperation` errors are tolerated before giving up to avoid indefinite retries.
 
 ## Example Usage
 

--- a/website/docs/r/ckafka_acl.html.markdown
+++ b/website/docs/r/ckafka_acl.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Provides a resource to create a Ckafka Acl.
 
+-> **Note:** When creating the ACL, if the cloud API `CreateAcl` returns a `FailedOperation` error (e.g. the instance is being modified or the cluster is busy), the provider will retry up to 3 times with a fixed 5-second interval between each attempt to improve the eventual success rate of ACL creation.
+
 ## Example Usage
 
 ### Ckafka Acl


### PR DESCRIPTION
Modify the ckafka resource `tencentcloud_ckafka_acl`: when creating an ACL, if the cloud API `CreateAcl` returns a `Code=FailedOperation` error (e.g. instance is being modified or the cluster is busy), retry up to 3 times with a fixed 5-second interval between each attempt to improve the eventual success rate of ACL creation.

Changes:
- Add retry constants in `tencentcloud/services/ckafka/extension_ckafka.go` (retry times = 3, interval = 5s)
- Modify `CkafkaService.CreateAcl` in `tencentcloud/services/ckafka/service_tencentcloud_ckafka.go` to retry on FailedOperation
- Add gomonkey unit tests in `resource_tc_ckafka_acl_test.go` covering retry-then-success, always-fails, and non-FailedOperation paths
- Update `resource_tc_ckafka_acl.md` to document the retry behavior