### PR TITLE
fix(provider): [128000258] provider support `custom_headers`

### DIFF
--- a/.changelog/4388.txt
+++ b/.changelog/4388.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: support `custom_headers`
+```

--- a/tencentcloud/connectivity/transport.go
+++ b/tencentcloud/connectivity/transport.go
@@ -25,6 +25,16 @@ func SetReqClient(name string) {
 	ReqClient = name
 }
 
+var customHeaders = map[string]string{}
+
+func SetCustomHeaders(headers map[string]string) {
+	if headers == nil {
+		return
+	}
+
+	customHeaders = headers
+}
+
 type LogRoundTripper struct {
 	InstanceId    string
 	Authorization string
@@ -68,6 +78,10 @@ func (me *LogRoundTripper) RoundTrip(request *http.Request) (response *http.Resp
 
 	if me.Authorization != "" {
 		request.Header.Set("Authorization", me.Authorization)
+	}
+
+	for k, v := range customHeaders {
+		request.Header.Set(k, v)
 	}
 
 	request.Header.Set("X-TC-RequestClient", reqClientFormat)

--- a/tencentcloud/framework/provider.go
+++ b/tencentcloud/framework/provider.go
@@ -142,6 +142,11 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 				Optional:    true,
 				Description: "The root domain of the API request, Default is `tencentcloudapi.com`.",
 			},
+			"custom_headers": schema.MapAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Custom HTTP headers to add to all API requests.",
+			},
 			"cos_domain": schema.StringAttribute{
 				Optional:    true,
 				Description: "The cos domain of the API request, Default is `https://cos.{region}.myqcloud.com`, Other Examples: `https://cluster-123456.cos-cdc.ap-guangzhou.myqcloud.com`.",

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -140,6 +140,7 @@ const (
 	PROVIDER_REGION         = "TENCENTCLOUD_REGION"
 	PROVIDER_PROTOCOL       = "TENCENTCLOUD_PROTOCOL"
 	PROVIDER_DOMAIN         = "TENCENTCLOUD_DOMAIN"
+	PROVIDER_CUSTOM_HEADERS = "TENCENTCLOUD_CUSTOM_HEADERS"
 	PROVIDER_COS_DOMAIN     = "TENCENTCLOUD_COS_DOMAIN"
 	//internal version: replace envYunti begin, please do not modify this annotation and refrain from inserting any code between the beginning and end lines of the annotation.
 	//internal version: replace envYunti end, please do not modify this annotation and refrain from inserting any code between the beginning and end lines of the annotation.
@@ -229,6 +230,13 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc(PROVIDER_DOMAIN, nil),
 				Description: "The root domain of the API request, Default is `tencentcloudapi.com`.",
+			},
+			"custom_headers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(PROVIDER_CUSTOM_HEADERS, nil),
+				Description: "Custom HTTP headers to add to all API requests.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"cos_domain": {
 				Type:        schema.TypeString,
@@ -2824,6 +2832,15 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	if v, ok := d.GetOk("domain"); ok {
 		domain = v.(string)
+	}
+
+	customHeaders := map[string]string{}
+	if v, ok := d.GetOk("custom_headers"); ok {
+		for key, val := range v.(map[string]interface{}) {
+			customHeaders[key] = val.(string)
+		}
+
+		connectivity.SetCustomHeaders(customHeaders)
 	}
 
 	if v, ok := d.GetOk("cos_domain"); ok {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -498,6 +498,8 @@ In addition to generic provider arguments (e.g. alias and version), the followin
 * `assume_role_with_web_identity` - (Optional, Available in 1.81.111+) An `assume_role_with_web_identity` block (documented below). If provided, terraform will attempt to assume this role using the supplied credentials. Only one `assume_role_with_web_identity` block may be in the configuration.
 * `protocol` - (Optional, Available in 1.37.0+) The protocol of the API request. Valid values: `HTTP` and `HTTPS`. Default is `HTTPS`.
 * `domain` - (Optional, Available in 1.37.0+) The root domain of the API request, Default is `tencentcloudapi.com`. 
+* `custom_headers` - (Optional, Available in 1.37.0+) Custom HTTP headers to add to all API requests. 
+* `cos_domain` - (Optional, Available in 1.37.0+) The cos domain of the API request, Default is `https://cos.{region}.myqcloud.com`, Other Examples: `https://cluster-123456.cos-cdc.ap-guangzhou.myqcloud.com`. 
 * `cam_role_name` - (Optional, Available in 1.81.117+) The name of the CVM instance CAM role. It can be sourced from the `TENCENTCLOUD_CAM_ROLE_NAME` environment variable. 
 * `allowed_account_ids` - (Optional) List of allowed TencentCloud account IDs to prevent you from mistakenly using the wrong one (and potentially end up destroying a live environment). Conflicts with `forbidden_account_ids`, If use `assume_role_with_saml` or `assume_role_with_web_identity`, it is not supported.
 * `forbidden_account_ids` - (Optional) List of forbidden TencentCloud account IDs to prevent you from mistakenly using the wrong one (and potentially end up destroying a live environment). Conflicts with `allowed_account_ids`, If use `assume_role_with_saml` or `assume_role_with_web_identity`, it is not supported.


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
