### PR TITLE
fix(teo): add Sensitive markers and nil checks for l7_acc_rule resources

### DIFF
--- a/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule.go
+++ b/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule.go
@@ -120,8 +120,8 @@ func resourceTencentCloudTeoL7AccRuleRead(d *schema.ResourceData, meta interface
 	}
 
 	if respData == nil {
-		d.SetId("")
 		log.Printf("[WARN]%s resource `teo_l7_acc_rule` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		d.SetId("")
 		return nil
 	}
 	rulesList := make([]map[string]interface{}, 0, len(respData.Rules))

--- a/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_extension.go
+++ b/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_extension.go
@@ -392,6 +392,7 @@ func TencentTeoL7RuleBranchBasicInfo(depth int) map[string]*schema.Schema {
 								"secret_key": {
 									Type:        schema.TypeString,
 									Optional:    true,
+									Sensitive:   true,
 									Description: "The primary authentication key consists of 6-40 uppercase and lowercase english letters or digits, and cannot contain \" and $.",
 								},
 								"timeout": {
@@ -402,6 +403,7 @@ func TencentTeoL7RuleBranchBasicInfo(depth int) map[string]*schema.Schema {
 								"backup_secret_key": {
 									Type:        schema.TypeString,
 									Optional:    true,
+									Sensitive:   true,
 									Description: "The backup authentication key consists of 6-40 uppercase and lowercase english letters or digits, and cannot contain \" and $.",
 								},
 								"auth_param": {
@@ -892,6 +894,7 @@ func TencentTeoL7RuleBranchBasicInfo(depth int) map[string]*schema.Schema {
 											"secret_access_key": {
 												Type:        schema.TypeString,
 												Required:    true,
+												Sensitive:   true,
 												Description: "Authentication parameter secret access key.",
 											},
 											"signature_version": {
@@ -1375,6 +1378,7 @@ func TencentTeoL7RuleBranchBasicInfo(depth int) map[string]*schema.Schema {
 														"secret_access_key": {
 															Type:        schema.TypeString,
 															Required:    true,
+															Sensitive:   true,
 															Description: "Authentication parameter secret access key.",
 														},
 														"signature_version": {

--- a/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2.go
+++ b/tencentcloud/services/teo/resource_tc_teo_l7_acc_rule_v2.go
@@ -109,15 +109,28 @@ func ResourceTencentCloudTeoL7AccRuleV2Create(d *schema.ResourceData, meta inter
 		} else {
 			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
 		}
-		if result.Response != nil && len(result.Response.RuleIds) > 0 && result.Response.RuleIds[0] != nil {
-			ruleId = *result.Response.RuleIds[0]
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create teo_l7_acc_rule failed, Response is nil."))
 		}
+
+		if len(result.Response.RuleIds) == 0 || result.Response.RuleIds[0] == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create teo_l7_acc_rule failed, RuleIds is empty."))
+		}
+
+		ruleId = *result.Response.RuleIds[0]
 		return nil
 	})
 	if err != nil {
+		log.Printf("[CRITAL]%s create teo_l7_acc_rule failed, reason:%+v", logId, err)
 		return err
 	}
 
+	if ruleId == "" {
+		return fmt.Errorf("Create teo_l7_acc_rule failed, ruleId is empty.")
+	}
+
+	log.Printf("[DEBUG]%s create teo_l7_acc_rule success, zoneId=%s, ruleId=%s", logId, zoneId, ruleId)
 	d.SetId(zoneId + tccommon.FILED_SP + ruleId)
 
 	return ResourceTencentCloudTeoL7AccRuleV2Read(d, meta)
@@ -149,8 +162,8 @@ func ResourceTencentCloudTeoL7AccRuleV2Read(d *schema.ResourceData, meta interfa
 	}
 
 	if respData == nil || len(respData.Rules) == 0 {
-		d.SetId("")
 		log.Printf("[WARN]%s resource `teo_l7_acc_rule` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		d.SetId("")
 		return nil
 	}
 	if len(respData.Rules) > 0 {
@@ -210,9 +223,15 @@ func ResourceTencentCloudTeoL7AccRuleV2Update(d *schema.ResourceData, meta inter
 			} else {
 				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
 			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify teo_l7_acc_rule failed, Response is nil."))
+			}
+
 			return nil
 		})
 		if err != nil {
+			log.Printf("[CRITAL]%s update teo_l7_acc_rule failed, reason:%+v", logId, err)
 			return err
 		}
 	}
@@ -244,9 +263,15 @@ func ResourceTencentCloudTeoL7AccRuleV2Delete(d *schema.ResourceData, meta inter
 		} else {
 			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
 		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Delete teo_l7_acc_rule failed, Response is nil."))
+		}
+
 		return nil
 	})
 	if err != nil {
+		log.Printf("[CRITAL]%s delete teo_l7_acc_rule failed, reason:%+v", logId, err)
 		return err
 	}
 

--- a/tencentcloud/services/teo/service_tencentcloud_teo.go
+++ b/tencentcloud/services/teo/service_tencentcloud_teo.go
@@ -1656,7 +1656,7 @@ func (me *TeoService) DescribeTeoL7AccRuleById(ctx context.Context, zoneId strin
 
 	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
 
-	if response == nil {
+	if response == nil || response.Response == nil {
 		return
 	}
 


### PR DESCRIPTION
This PR fixes issues found in the TEO L7 Accelerated Rules evaluation:

1. Sensitive fields: Added Sensitive:true to secret_key, backup_secret_key, and secret_access_key fields to prevent plaintext leakage in state files and logs.

2. Create method (v2): Added proper nil checks for result, result.Response, and RuleIds in the CreateL7AccRules API call; return NonRetryableError when responses are empty.

3. Read method (v1+v2): Fixed log order to preserve d.Id() before calling SetId for debugging.

4. Update method (v2): Added nil check for result and result.Response in the ModifyL7AccRule API call.

5. Delete method (v2): Added nil check for result and result.Response in the DeleteL7AccRules API call.

6. Service layer: Added nil check for response.Response in DescribeTeoL7AccRuleById.