### PR TITLE
feat(waf): [136795895] add key parameter to tencentcloud_waf_cc_session resource

### DIFF
--- a/.changelog/4396.txt
+++ b/.changelog/4396.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_waf_cc_session: support the `key` parameter for precise-match session key
+```

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tsf v1.0.674
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod v1.3.127
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.62
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.113
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.144
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wedata v1.3.30
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wss v1.0.199
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.74

--- a/go.sum
+++ b/go.sum
@@ -1142,8 +1142,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod v1.3.127 h1:kgR/Ne2
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod v1.3.127/go.mod h1:+oOGhfokqQkNyoii/2S/DwWyAtIPLreQDYnnyOWg7oU=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.62 h1:Ti+oLfsMykxEKgFGTZKOomyvxzvld5LROsPZwuyKFkI=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.62/go.mod h1:I8H8+QiUCf4zrnqPn/h0Je7dM6EQ7VBdswWiAZLeiyY=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.113 h1:5z7f3fUVmECIPJhmWeuZripOy613vtsxtwTK/q01aHQ=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.113/go.mod h1:zRuiLw6mJcwpby08a29rt0d09lzj5eaE9vVsXkw9hrQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.144 h1:yGX3PQ7qOzU8RfduwYGRUGG324qBf1AqoSim+maum3o=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.144/go.mod h1:zfQey2gXSAV6+GJITKz+OJLLWve3Xau/ID+4ZxvXHL4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wedata v1.3.30 h1:Al75RJni0l4n+1A8k16LezyOTGRRn7q11e56aa9bpyc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wedata v1.3.30/go.mod h1:eOB+fZ85iix6rbnzIqogm7PoccaWXs283VabE4iF0TM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wss v1.0.199 h1:hMBLtiJPnZ9GvA677cTB6ELBR6B68wCR2QY1sNoGQc4=

--- a/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/design.md
+++ b/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The `tencentcloud_waf_cc_session` resource (in `tencentcloud/services/waf/resource_tc_waf_cc_session.go`) manages WAF session definitions via the TencentCloud WAF `v20180125` SDK. It currently uses the `UpsertSession` API for both create and update operations and `DescribeSession` for read operations.
+
+The `UpsertSessionRequest` struct already contains a `Key *string` field (annotated as "精准匹配时配置的key" — the key configured for precise matching). The read-side `SessionItem` struct returned by `DescribeSession` also contains the same `Key *string` field. Today the Terraform schema does not expose this parameter, so users cannot configure precise-match keys from Terraform.
+
+The resource uses a composite ID (`domain#edition#sessionID`) and an immutable-args pattern in update (`immutableArgs` slice guards `domain`, `edition`, `session_name`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose the `Key` parameter in the `tencentcloud_waf_cc_session` resource schema so users can configure precise-match session keys.
+- Wire `Key` into the create, read, and update code paths using the exact same pattern as the other string fields (`source`, `category`, `key_or_start_mat`, etc.).
+- Keep the change backward compatible (optional field, no state migration, no ForceNew).
+
+**Non-Goals:**
+- Do not modify any existing schema fields or their behavior.
+- Do not change the composite ID structure.
+- Do not introduce a `_extension.go` file.
+- Do not add retry logic beyond what the existing `resource.Retry` blocks already provide.
+
+## Decisions
+
+### 1. Parameter Naming: `key`
+
+**Decision**: Use `key` (lowercase, matching the SDK field name `Key`).
+
+**Rationale**:
+- The existing resource schema maps SDK fields with straightforward snake_case where names are single words. `key` is a single word, so no transformation is needed.
+- Matches the SDK request field `request.Key` directly, keeping the mapping obvious.
+
+**Alternatives considered**:
+- `session_key`: More explicit, but the resource is already named `waf_cc_session`, so `session_key` would be redundant. `key` is consistent with the API naming.
+
+### 2. Parameter Type: `schema.TypeString`
+
+**Decision**: `schema.TypeString`.
+
+**Rationale**: The SDK field is `Key *string`, so a string schema type is the direct match.
+
+### 3. Optional vs Required
+
+**Decision**: Optional (`Optional: true`), no default, not ForceNew.
+
+**Rationale**:
+- The parameter is not always needed — it only applies to precise-matching scenarios. Making it optional avoids breaking existing configurations and lets the API default apply when omitted.
+- Not ForceNew so updates can modify it in-place via `UpsertSession` (which is an upsert by design, using `SessionID` to identify the target).
+
+### 4. Update Path
+
+**Decision**: Treat `key` as a mutable argument in the update operation — do NOT add it to the `immutableArgs` slice.
+
+**Rationale**: The `UpsertSession` API is an upsert; it accepts `Key` on both create and update. Since the API supports updating `Key`, it should be mutable. The existing mutable fields (`source`, `category`, `key_or_start_mat`, `end_mat`, `start_offset`, `end_offset`) follow the same pattern of populating the request from `d.GetOk`.
+
+### 5. Read Path
+
+**Decision**: In `resourceTencentCloudWafCcSessionRead`, after fetching `ccSession` via `DescribeWafCcSessionById`, set `d.Set("key", ccSession.Key)` only when `ccSession.Key != nil`, following the existing nil-guard pattern used for every other field.
+
+**Rationale**: Consistent with the existing read pattern and the project rule that requires nil-checking response fields before calling `d.Set`.
+
+## Risks / Trade-offs
+
+- **[Risk] API response omits `Key` when not set** → Mitigation: nil-guard in read (`if ccSession.Key != nil`) ensures we don't overwrite state with an empty value when the API returns nil.
+- **[Risk] `Key` only meaningful for precise-match category** → Mitigation: This is an API-level concern; Terraform simply forwards the value. No schema-level validation is added to stay consistent with other similarly constrained fields (e.g., `end_mat` which is only meaningful when `category == match`).
+- **[Trade-off] No ForceNew on `key`** → Acceptable because `UpsertSession` supports in-place update; aligns with existing mutable fields.
+
+## Migration Plan
+
+No migration required. The field is purely additive and optional. Existing configurations without `key` continue to work unchanged. Rollback is as simple as removing the parameter from the configuration; the provider remains backward compatible.
+
+## Open Questions
+
+None. The SDK supports `Key` on both the request and response structs, and the API semantics are clear.

--- a/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/proposal.md
+++ b/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The `tencentcloud_waf_cc_session` resource manages WAF session definitions but does not expose the `Key` parameter, which is required by the TencentCloud WAF `UpsertSession` API for precise matching scenarios. The API already supports this field (`request.Key`, documented as "精准匹配时配置的key" / "key configured for precise matching"), and both the request struct (`UpsertSessionRequest`) and response struct (`SessionItem`) contain the `Key` field. Exposing it lets users configure precise session key matching directly from Terraform.
+
+## What Changes
+
+- Add a new optional string parameter `key` to the `tencentcloud_waf_cc_session` resource schema.
+- Populate `request.Key` from the schema in the `Create` (`resourceTencentCloudWafCcSessionCreate`) and `Update` (`resourceTencentCloudWafCcSessionUpdate`) operations when calling the `UpsertSession` API.
+- Read `Key` from the `DescribeSession` API response (`SessionItem.Key`) and set it into Terraform state via `d.Set("key", ...)` in the `Read` operation (`resourceTencentCloudWafCcSessionRead`).
+- Update the resource documentation (`resource_tc_waf_cc_session.md`) example to show usage of the new `key` parameter.
+- Add unit test coverage in `resource_tc_waf_cc_session_test.go` for the new `key` parameter.
+
+## Capabilities
+
+### New Capabilities
+- `waf-cc-session-key`: Support for configuring the precise-match session key (`Key`) parameter on the `tencentcloud_waf_cc_session` resource.
+
+### Modified Capabilities
+<!-- None. This is a pure addition of an optional parameter. -->
+
+## Impact
+
+- **Affected code**:
+  - `tencentcloud/services/waf/resource_tc_waf_cc_session.go` — schema, create, read, update
+  - `tencentcloud/services/waf/resource_tc_waf_cc_session_test.go` — test cases
+  - `tencentcloud/services/waf/resource_tc_waf_cc_session.md` — documentation example
+- **APIs**: TencentCloud WAF `v20180125` — `UpsertSession` (create/update) and `DescribeSession` (read)
+- **Dependencies**: None new; the SDK field already exists in `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf/v20180125/models.go`
+- **Backward compatibility**: Fully backward compatible — new optional parameter, no changes to existing schema fields or state.

--- a/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/specs/waf-cc-session-key/spec.md
+++ b/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/specs/waf-cc-session-key/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: WAF CC Session supports the precise-match key parameter
+
+The `tencentcloud_waf_cc_session` resource SHALL support an optional `key` string parameter that configures the precise-match session key (`request.Key`) for the TencentCloud WAF `UpsertSession` API. The parameter SHALL be sent on both create and update operations and SHALL be read from the `DescribeSession` API response (`SessionItem.Key`).
+
+**Rationale**: The TencentCloud WAF `UpsertSession` API already supports the `Key` field for precise-matching scenarios, but the Terraform resource does not expose it. Users need to configure precise-match session keys directly from Terraform.
+
+#### Scenario: Create a WAF CC session with the key parameter
+
+- **WHEN** a user creates a `tencentcloud_waf_cc_session` resource with `key` set to a non-empty string
+- **THEN** the provider SHALL include the value in `request.Key` when calling the `UpsertSession` API
+- **AND** the created session SHALL have the `key` value reflected in Terraform state after read
+
+**Example Configuration**:
+```hcl
+resource "tencentcloud_waf_cc_session" "example" {
+  domain           = "www.demo.com"
+  source           = "get"
+  category         = "match"
+  key_or_start_mat = "key_a=123"
+  end_mat          = "&"
+  start_offset     = "-1"
+  end_offset       = "-1"
+  edition          = "sparta-waf"
+  session_name     = "terraformDemo"
+  key              = "sessionId"
+}
+```
+
+**Acceptance Criteria**:
+- The `key` parameter is accepted as a string value
+- The value is sent to the TencentCloud API in `request.Key`
+- Terraform state reflects the configured value after creation
+
+#### Scenario: Read the key parameter from an existing session
+
+- **WHEN** the provider reads an existing WAF CC session via the `DescribeSession` API and the response `SessionItem.Key` is non-nil
+- **THEN** the provider SHALL set `key` in Terraform state via `d.Set("key", ...)`
+
+**Acceptance Criteria**:
+- The read operation correctly retrieves the value from `SessionItem.Key`
+- Nil values from the API response are handled gracefully (the provider SHALL NOT call `d.Set` when the API returns nil)
+
+#### Scenario: Update the key parameter in place
+
+- **WHEN** a user updates the `key` parameter on an existing `tencentcloud_waf_cc_session` resource
+- **THEN** the provider SHALL send the updated value in `request.Key` when calling the `UpsertSession` API
+- **AND** the resource SHALL be updated in-place without recreation (no ForceNew)
+
+**Acceptance Criteria**:
+- In-place update is performed (no ForceNew)
+- The `UpsertSession` API is called with the updated `Key`
+- Terraform plan shows only the changed attribute
+
+#### Scenario: Omit the key parameter
+
+- **WHEN** a user does not specify the `key` parameter in the configuration
+- **THEN** the provider SHALL NOT set `request.Key` (the API default applies)
+- **AND** no error SHALL be raised
+
+**Acceptance Criteria**:
+- The parameter is optional
+- Omitting the parameter does not cause errors
+- The API default behavior is preserved
+
+#### Scenario: Import an existing WAF CC session with key configured
+
+- **WHEN** a WAF CC session exists in TencentCloud with `Key` configured and the resource is imported or refreshed
+- **THEN** the `key` value SHALL be correctly read from the API response and stored in Terraform state
+
+**Acceptance Criteria**:
+- Read operation retrieves the value from `DescribeSession` API
+- Value is set in Terraform state via `d.Set`
+- Import functionality works correctly
+- Nil values are handled gracefully
+
+---
+
+## MODIFIED Requirements
+
+None. This change adds a new parameter without modifying existing requirements.
+
+---
+
+## REMOVED Requirements
+
+None. This is a pure addition with no deprecations or removals.

--- a/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/tasks.md
+++ b/openspec/changes/archive/2026-08-07-add-waf-cc-session-key/tasks.md
@@ -1,0 +1,33 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add the `key` field to the `tencentcloud_waf_cc_session` resource schema in `tencentcloud/services/waf/resource_tc_waf_cc_session.go`
+  - Type: `schema.TypeString`
+  - Optional: true (not Required, not Computed, not ForceNew)
+  - Description: "Precise-match session key, configured when Category is precise matching."
+
+## 2. Create Operation
+
+- [x] 2.1 In `resourceTencentCloudWafCcSessionCreate`, read `key` from schema via `d.GetOk("key")` and set `request.Key` using `helper.String(v.(string))` when present, following the same pattern as the other string fields (e.g. `source`, `category`).
+
+## 3. Read Operation
+
+- [x] 3.1 In `resourceTencentCloudWafCcSessionRead`, after fetching `ccSession`, add a nil-guarded `d.Set("key", ccSession.Key)` block (only set when `ccSession.Key != nil`), matching the existing pattern for other response fields.
+
+## 4. Update Operation
+
+- [x] 4.1 In `resourceTencentCloudWafCcSessionUpdate`, confirm `key` is NOT added to the `immutableArgs` slice (it must remain mutable).
+- [x] 4.2 In `resourceTencentCloudWafCcSessionUpdate`, read `key` from schema via `d.GetOk("key")` and set `request.Key` when present, following the same pattern used in the create operation.
+
+## 5. Documentation
+
+- [x] 5.1 Update `tencentcloud/services/waf/resource_tc_waf_cc_session.md` example to include the new `key` parameter in the Example Usage block.
+- [x] 5.2 Run `make doc` (during finalize phase) to regenerate the `website/docs/` documentation from the updated `.md` file.
+
+## 6. Testing
+
+- [x] 6.1 Update `tencentcloud/services/waf/resource_tc_waf_cc_session_test.go` to add `key` to the test HCL configs and add `resource.TestCheckResourceAttr` assertions for the `key` parameter in both the basic and update test steps.
+
+## 7. Verification (deferred to finalize phase)
+
+- [x] 7.1 Run `gofmt` on modified Go files (during finalize phase via tfpacer-finalize skill).
+- [x] 7.2 Verify the provider registration in `tencentcloud/provider.go` does not require changes (no new resource, only a new schema field on an existing resource).

--- a/openspec/specs/waf-cc-session-key/spec.md
+++ b/openspec/specs/waf-cc-session-key/spec.md
@@ -1,0 +1,79 @@
+# waf-cc-session-key Specification
+
+## Purpose
+TBD - created by archiving change add-waf-cc-session-key. Update Purpose after archive.
+## Requirements
+### Requirement: WAF CC Session supports the precise-match key parameter
+
+The `tencentcloud_waf_cc_session` resource SHALL support an optional `key` string parameter that configures the precise-match session key (`request.Key`) for the TencentCloud WAF `UpsertSession` API. The parameter SHALL be sent on both create and update operations and SHALL be read from the `DescribeSession` API response (`SessionItem.Key`).
+
+**Rationale**: The TencentCloud WAF `UpsertSession` API already supports the `Key` field for precise-matching scenarios, but the Terraform resource does not expose it. Users need to configure precise-match session keys directly from Terraform.
+
+#### Scenario: Create a WAF CC session with the key parameter
+
+- **WHEN** a user creates a `tencentcloud_waf_cc_session` resource with `key` set to a non-empty string
+- **THEN** the provider SHALL include the value in `request.Key` when calling the `UpsertSession` API
+- **AND** the created session SHALL have the `key` value reflected in Terraform state after read
+
+**Example Configuration**:
+```hcl
+resource "tencentcloud_waf_cc_session" "example" {
+  domain           = "www.demo.com"
+  source           = "get"
+  category         = "match"
+  key_or_start_mat = "key_a=123"
+  end_mat          = "&"
+  start_offset     = "-1"
+  end_offset       = "-1"
+  edition          = "sparta-waf"
+  session_name     = "terraformDemo"
+  key              = "sessionId"
+}
+```
+
+**Acceptance Criteria**:
+- The `key` parameter is accepted as a string value
+- The value is sent to the TencentCloud API in `request.Key`
+- Terraform state reflects the configured value after creation
+
+#### Scenario: Read the key parameter from an existing session
+
+- **WHEN** the provider reads an existing WAF CC session via the `DescribeSession` API and the response `SessionItem.Key` is non-nil
+- **THEN** the provider SHALL set `key` in Terraform state via `d.Set("key", ...)`
+
+**Acceptance Criteria**:
+- The read operation correctly retrieves the value from `SessionItem.Key`
+- Nil values from the API response are handled gracefully (the provider SHALL NOT call `d.Set` when the API returns nil)
+
+#### Scenario: Update the key parameter in place
+
+- **WHEN** a user updates the `key` parameter on an existing `tencentcloud_waf_cc_session` resource
+- **THEN** the provider SHALL send the updated value in `request.Key` when calling the `UpsertSession` API
+- **AND** the resource SHALL be updated in-place without recreation (no ForceNew)
+
+**Acceptance Criteria**:
+- In-place update is performed (no ForceNew)
+- The `UpsertSession` API is called with the updated `Key`
+- Terraform plan shows only the changed attribute
+
+#### Scenario: Omit the key parameter
+
+- **WHEN** a user does not specify the `key` parameter in the configuration
+- **THEN** the provider SHALL NOT set `request.Key` (the API default applies)
+- **AND** no error SHALL be raised
+
+**Acceptance Criteria**:
+- The parameter is optional
+- Omitting the parameter does not cause errors
+- The API default behavior is preserved
+
+#### Scenario: Import an existing WAF CC session with key configured
+
+- **WHEN** a WAF CC session exists in TencentCloud with `Key` configured and the resource is imported or refreshed
+- **THEN** the `key` value SHALL be correctly read from the API response and stored in Terraform state
+
+**Acceptance Criteria**:
+- Read operation retrieves the value from `DescribeSession` API
+- Value is set in Terraform state via `d.Set`
+- Import functionality works correctly
+- Nil values are handled gracefully

--- a/tencentcloud/services/waf/resource_tc_waf_cc_session.go
+++ b/tencentcloud/services/waf/resource_tc_waf_cc_session.go
@@ -74,6 +74,7 @@ func ResourceTencentCloudWafCcSession() *schema.Resource {
 			},
 			"key": {
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeString,
 				Description: "Precise-match session key, configured when Category is precise matching.",
 			},

--- a/tencentcloud/services/waf/resource_tc_waf_cc_session.go
+++ b/tencentcloud/services/waf/resource_tc_waf_cc_session.go
@@ -72,6 +72,11 @@ func ResourceTencentCloudWafCcSession() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Session Name.",
 			},
+			"key": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "Precise-match session key, configured when Category is precise matching.",
+			},
 			"session_id": {
 				Computed:    true,
 				Type:        schema.TypeInt,
@@ -130,6 +135,10 @@ func resourceTencentCloudWafCcSessionCreate(d *schema.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("session_name"); ok {
 		request.SessionName = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("key"); ok {
+		request.Key = helper.String(v.(string))
 	}
 
 	request.SessionID = helper.IntInt64(-1)
@@ -222,6 +231,10 @@ func resourceTencentCloudWafCcSessionRead(d *schema.ResourceData, meta interface
 		_ = d.Set("session_name", ccSession.SessionName)
 	}
 
+	if ccSession.Key != nil {
+		_ = d.Set("key", ccSession.Key)
+	}
+
 	if ccSession.SessionId != nil {
 		_ = d.Set("session_id", ccSession.SessionId)
 	}
@@ -285,6 +298,10 @@ func resourceTencentCloudWafCcSessionUpdate(d *schema.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("session_name"); ok {
 		request.SessionName = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("key"); ok {
+		request.Key = helper.String(v.(string))
 	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {

--- a/tencentcloud/services/waf/resource_tc_waf_cc_session.md
+++ b/tencentcloud/services/waf/resource_tc_waf_cc_session.md
@@ -13,6 +13,7 @@ resource "tencentcloud_waf_cc_session" "example" {
   end_offset       = "-1"
   edition          = "sparta-waf"
   session_name     = "terraformDemo"
+  key              = "sessionId"
 }
 ```
 

--- a/tencentcloud/services/waf/resource_tc_waf_cc_session_test.go
+++ b/tencentcloud/services/waf/resource_tc_waf_cc_session_test.go
@@ -30,6 +30,7 @@ func TestAccTencentCloudWafCcSessionResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("tencentcloud_waf_cc_session.example", "end_offset", "-1"),
 					resource.TestCheckResourceAttr("tencentcloud_waf_cc_session.example", "edition", "sparta-waf"),
 					resource.TestCheckResourceAttr("tencentcloud_waf_cc_session.example", "session_name", "terraformDemo"),
+					resource.TestCheckResourceAttr("tencentcloud_waf_cc_session.example", "key", "sessionId"),
 				),
 			},
 			{
@@ -50,6 +51,7 @@ func TestAccTencentCloudWafCcSessionResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("tencentcloud_waf_cc_session.example", "end_offset", "-1"),
 					resource.TestCheckResourceAttr("tencentcloud_waf_cc_session.example", "edition", "sparta-waf"),
 					resource.TestCheckResourceAttr("tencentcloud_waf_cc_session.example", "session_name", "terraformDemo"),
+					resource.TestCheckResourceAttr("tencentcloud_waf_cc_session.example", "key", "sessionIdUpdated"),
 				),
 			},
 		},
@@ -67,6 +69,7 @@ resource "tencentcloud_waf_cc_session" "example" {
   end_offset       = "-1"
   edition          = "sparta-waf"
   session_name     = "terraformDemo"
+  key              = "sessionId"
 }
 `
 
@@ -81,5 +84,6 @@ resource "tencentcloud_waf_cc_session" "example" {
   end_offset       = "-1"
   edition          = "sparta-waf"
   session_name     = "terraformDemo"
+  key              = "sessionIdUpdated"
 }
 `

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf/v20180125/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf/v20180125/models.go
@@ -505,99 +505,105 @@ func (r *AddAttackWhiteRuleResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AddBatchCustomRuleRequestParams struct {
-	// 规则名称
+	// <p>规则名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 如果没有设置JobDateTime字段则用此字段，0表示永久生效，其它表示定时生效的截止时间（单位为秒）
+	// <p>如果没有设置JobDateTime字段则用此字段，0表示永久生效，其它表示定时生效的截止时间（单位为秒）</p>
 	ExpireTime *int64 `json:"ExpireTime,omitnil,omitempty" name:"ExpireTime"`
 
-	// 优先级
+	// <p>优先级</p>
 	SortId *int64 `json:"SortId,omitnil,omitempty" name:"SortId"`
 
-	// 动作类型，1代表阻断，2代表人机识别，3代表观察，4代表重定向
+	// <p>动作类型，1代表阻断，2代表人机识别，3代表观察，4代表重定向</p>
 	ActionType *int64 `json:"ActionType,omitnil,omitempty" name:"ActionType"`
 
-	// 重定向地址
+	// <p>重定向地址</p>
 	Redirect *string `json:"Redirect,omitnil,omitempty" name:"Redirect"`
 
-	// 加白模块
+	// <p>加白模块</p>
 	Bypass *string `json:"Bypass,omitnil,omitempty" name:"Bypass"`
 
-	// 备注
+	// <p>备注</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 事件Id
+	// <p>事件Id</p>
 	EventId *string `json:"EventId,omitnil,omitempty" name:"EventId"`
 
-	// 域名列表
+	// <p>域名列表</p>
 	Domains []*string `json:"Domains,omitnil,omitempty" name:"Domains"`
 
-	// 策略详情列表
+	// <p>策略详情列表</p>
 	Strategies []*Strategy `json:"Strategies,omitnil,omitempty" name:"Strategies"`
 
-	// 规则执行的方式，TimedJob为定时执行，CronJob为周期执行
+	// <p>规则执行的方式，TimedJob为定时执行，CronJob为周期执行</p>
 	JobType *string `json:"JobType,omitnil,omitempty" name:"JobType"`
 
-	// 定时任务配置
+	// <p>定时任务配置</p>
 	JobDateTime *JobDateTime `json:"JobDateTime,omitnil,omitempty" name:"JobDateTime"`
 
-	// 匹配条件的逻辑关系，支持and、or，分别表示多个逻辑匹配条件是与、或的关系
+	// <p>匹配条件的逻辑关系，支持and、or，分别表示多个逻辑匹配条件是与、或的关系</p>
 	LogicalOp *string `json:"LogicalOp,omitnil,omitempty" name:"LogicalOp"`
 
-	// 页面ID
+	// <p>页面ID</p>
 	PageId *string `json:"PageId,omitnil,omitempty" name:"PageId"`
 
-	// 动作灰度比例
+	// <p>动作灰度比例</p>
 	ActionRatio *uint64 `json:"ActionRatio,omitnil,omitempty" name:"ActionRatio"`
+
+	// <p>绑定的防护组ID</p>
+	GroupIds []*uint64 `json:"GroupIds,omitnil,omitempty" name:"GroupIds"`
 }
 
 type AddBatchCustomRuleRequest struct {
 	*tchttp.BaseRequest
 	
-	// 规则名称
+	// <p>规则名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 如果没有设置JobDateTime字段则用此字段，0表示永久生效，其它表示定时生效的截止时间（单位为秒）
+	// <p>如果没有设置JobDateTime字段则用此字段，0表示永久生效，其它表示定时生效的截止时间（单位为秒）</p>
 	ExpireTime *int64 `json:"ExpireTime,omitnil,omitempty" name:"ExpireTime"`
 
-	// 优先级
+	// <p>优先级</p>
 	SortId *int64 `json:"SortId,omitnil,omitempty" name:"SortId"`
 
-	// 动作类型，1代表阻断，2代表人机识别，3代表观察，4代表重定向
+	// <p>动作类型，1代表阻断，2代表人机识别，3代表观察，4代表重定向</p>
 	ActionType *int64 `json:"ActionType,omitnil,omitempty" name:"ActionType"`
 
-	// 重定向地址
+	// <p>重定向地址</p>
 	Redirect *string `json:"Redirect,omitnil,omitempty" name:"Redirect"`
 
-	// 加白模块
+	// <p>加白模块</p>
 	Bypass *string `json:"Bypass,omitnil,omitempty" name:"Bypass"`
 
-	// 备注
+	// <p>备注</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 事件Id
+	// <p>事件Id</p>
 	EventId *string `json:"EventId,omitnil,omitempty" name:"EventId"`
 
-	// 域名列表
+	// <p>域名列表</p>
 	Domains []*string `json:"Domains,omitnil,omitempty" name:"Domains"`
 
-	// 策略详情列表
+	// <p>策略详情列表</p>
 	Strategies []*Strategy `json:"Strategies,omitnil,omitempty" name:"Strategies"`
 
-	// 规则执行的方式，TimedJob为定时执行，CronJob为周期执行
+	// <p>规则执行的方式，TimedJob为定时执行，CronJob为周期执行</p>
 	JobType *string `json:"JobType,omitnil,omitempty" name:"JobType"`
 
-	// 定时任务配置
+	// <p>定时任务配置</p>
 	JobDateTime *JobDateTime `json:"JobDateTime,omitnil,omitempty" name:"JobDateTime"`
 
-	// 匹配条件的逻辑关系，支持and、or，分别表示多个逻辑匹配条件是与、或的关系
+	// <p>匹配条件的逻辑关系，支持and、or，分别表示多个逻辑匹配条件是与、或的关系</p>
 	LogicalOp *string `json:"LogicalOp,omitnil,omitempty" name:"LogicalOp"`
 
-	// 页面ID
+	// <p>页面ID</p>
 	PageId *string `json:"PageId,omitnil,omitempty" name:"PageId"`
 
-	// 动作灰度比例
+	// <p>动作灰度比例</p>
 	ActionRatio *uint64 `json:"ActionRatio,omitnil,omitempty" name:"ActionRatio"`
+
+	// <p>绑定的防护组ID</p>
+	GroupIds []*uint64 `json:"GroupIds,omitnil,omitempty" name:"GroupIds"`
 }
 
 func (r *AddBatchCustomRuleRequest) ToJsonString() string {
@@ -627,6 +633,7 @@ func (r *AddBatchCustomRuleRequest) FromJsonString(s string) error {
 	delete(f, "LogicalOp")
 	delete(f, "PageId")
 	delete(f, "ActionRatio")
+	delete(f, "GroupIds")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "AddBatchCustomRuleRequest has unknown keys!", "")
 	}
@@ -635,7 +642,7 @@ func (r *AddBatchCustomRuleRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AddBatchCustomRuleResponseParams struct {
-	// 操作成功
+	// <p>操作成功</p>
 	Res *string `json:"Res,omitnil,omitempty" name:"Res"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -1738,6 +1745,17 @@ type ApiEvent struct {
 	Source *string `json:"Source,omitnil,omitempty" name:"Source"`
 }
 
+type ApiEventSample struct {
+	// <p>攻击样本的请求部分</p>
+	Request *string `json:"Request,omitnil,omitempty" name:"Request"`
+
+	// <p>攻击样本的响应</p>
+	Response *string `json:"Response,omitnil,omitempty" name:"Response"`
+
+	// <p>攻击样本状态码</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
 type ApiGuardContent struct {
 	// <p>prompt</p>
 	Prompt *string `json:"Prompt,omitnil,omitempty" name:"Prompt"`
@@ -1830,38 +1848,47 @@ type ApiPkg struct {
 }
 
 type ApiSecAttackSource struct {
-	// 攻击来源ip
+	// <p>攻击来源ip</p>
 	SrcIp *string `json:"SrcIp,omitnil,omitempty" name:"SrcIp"`
 
-	// 威胁等级
+	// <p>威胁等级</p>
 	EventLevel *string `json:"EventLevel,omitnil,omitempty" name:"EventLevel"`
 
-	// BOT标签
+	// <p>BOT标签</p>
 	BotLabel *string `json:"BotLabel,omitnil,omitempty" name:"BotLabel"`
 
-	// 变更时间
+	// <p>变更时间</p>
 	Timestamp *uint64 `json:"Timestamp,omitnil,omitempty" name:"Timestamp"`
 
-	// 地理位置
+	// <p>地理位置</p>
 	City *string `json:"City,omitnil,omitempty" name:"City"`
 
-	// 开始时间
+	// <p>开始时间</p>
 	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 关联事件数量
+	// <p>关联事件数量</p>
 	EventCount *int64 `json:"EventCount,omitnil,omitempty" name:"EventCount"`
 
-	// 攻击数量
+	// <p>攻击数量</p>
 	AttackCount *int64 `json:"AttackCount,omitnil,omitempty" name:"AttackCount"`
 
-	// 缺失参数名，当事件类型是缺失参数名，缺失参数名和密码时，返回此字段
+	// <p>缺失参数名，当事件类型是缺失参数名，缺失参数名和密码时，返回此字段</p>
 	MissUserName *string `json:"MissUserName,omitnil,omitempty" name:"MissUserName"`
 
-	// 当是水平越权和垂直越权时，返回此字段
+	// <p>当是水平越权和垂直越权时，返回此字段</p>
 	AttackDetail []*string `json:"AttackDetail,omitnil,omitempty" name:"AttackDetail"`
 
-	// 缺失密码参数，当事件类型是缺失参数名，缺失参数名和密码时，返回此字段
+	// <p>缺失密码参数，当事件类型是缺失参数名，缺失参数名和密码时，返回此字段</p>
 	MissPassword *string `json:"MissPassword,omitnil,omitempty" name:"MissPassword"`
+
+	// <p>事件描述</p>
+	EventDescription *string `json:"EventDescription,omitnil,omitempty" name:"EventDescription"`
+
+	// <p>事件描述(英文)</p>
+	EventDescriptionEng *string `json:"EventDescriptionEng,omitnil,omitempty" name:"EventDescriptionEng"`
+
+	// <p>攻击样本</p>
+	Sample *ApiEventSample `json:"Sample,omitnil,omitempty" name:"Sample"`
 }
 
 type ApiSecCustomEventRule struct {
@@ -2173,71 +2200,74 @@ type BatchCustomRuleListData struct {
 }
 
 type BatchCustomRuleListItem struct {
-	// 规则Id
+	// <p>规则Id</p>
 	Id *uint64 `json:"Id,omitnil,omitempty" name:"Id"`
 
-	// 动作类型，1代表阻断，2代表人机识别，3代表观察，4代表重定向，5代表JS校验
+	// <p>动作类型，1代表阻断，2代表人机识别，3代表观察，4代表重定向，5代表JS校验</p>
 	ActionType *int64 `json:"ActionType,omitnil,omitempty" name:"ActionType"`
 
-	// 加白模块
+	// <p>加白模块</p>
 	Bypass *string `json:"Bypass,omitnil,omitempty" name:"Bypass"`
 
-	// 有效期
+	// <p>有效期</p>
 	ExpireTime *uint64 `json:"ExpireTime,omitnil,omitempty" name:"ExpireTime"`
 
-	// 规则名称
+	// <p>规则名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 重定向地址
+	// <p>重定向地址</p>
 	Redirect *string `json:"Redirect,omitnil,omitempty" name:"Redirect"`
 
-	// 优先级
+	// <p>优先级</p>
 	SortId *int64 `json:"SortId,omitnil,omitempty" name:"SortId"`
 
-	// 开关状态
+	// <p>开关状态</p>
 	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 域名列表
+	// <p>域名列表</p>
 	Domains []*string `json:"Domains,omitnil,omitempty" name:"Domains"`
 
-	// 备注
+	// <p>备注</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 策略列表
+	// <p>策略列表</p>
 	Strategies []*Strategy `json:"Strategies,omitnil,omitempty" name:"Strategies"`
 
-	// 事件Id
+	// <p>事件Id</p>
 	EventId *string `json:"EventId,omitnil,omitempty" name:"EventId"`
 
-	// 生效状态
+	// <p>生效状态</p>
 	ValidStatus *uint64 `json:"ValidStatus,omitnil,omitempty" name:"ValidStatus"`
 
-	// 创建时间
+	// <p>创建时间</p>
 	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
-	// 更新时间
+	// <p>更新时间</p>
 	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 
-	// 规则执行的方式，TimedJob为定时执行，CronJob为周期执行
+	// <p>规则执行的方式，TimedJob为定时执行，CronJob为周期执行</p>
 	JobType *string `json:"JobType,omitnil,omitempty" name:"JobType"`
 
-	// 定时任务配置
+	// <p>定时任务配置</p>
 	JobDateTime *JobDateTime `json:"JobDateTime,omitnil,omitempty" name:"JobDateTime"`
 
-	// 周期任务粒度
+	// <p>周期任务粒度</p>
 	CronType *string `json:"CronType,omitnil,omitempty" name:"CronType"`
 
-	// 标签
+	// <p>标签</p>
 	Label *string `json:"Label,omitnil,omitempty" name:"Label"`
 
-	// 页面ID
+	// <p>页面ID</p>
 	PageId *string `json:"PageId,omitnil,omitempty" name:"PageId"`
 
-	// 匹配条件的逻辑关系，支持and、or，分别表示多个逻辑匹配条件是与、或的关系
+	// <p>匹配条件的逻辑关系，支持and、or，分别表示多个逻辑匹配条件是与、或的关系</p>
 	LogicalOp *string `json:"LogicalOp,omitnil,omitempty" name:"LogicalOp"`
 
-	// 动作灰度的比例
+	// <p>动作灰度的比例</p>
 	ActionRatio *uint64 `json:"ActionRatio,omitnil,omitempty" name:"ActionRatio"`
+
+	// <p>防护对象组ID</p>
+	GroupIds []*uint64 `json:"GroupIds,omitnil,omitempty" name:"GroupIds"`
 }
 
 type BatchCustomWhiteRule struct {
@@ -3281,6 +3311,9 @@ type ClbObject struct {
 
 	// <p>waf接入状态</p>
 	WafAccessStatus *int64 `json:"WafAccessStatus,omitnil,omitempty" name:"WafAccessStatus"`
+
+	// <p>备注</p>
+	Note *string `json:"Note,omitnil,omitempty" name:"Note"`
 }
 
 type ClbWafRegionItem struct {
@@ -11066,7 +11099,7 @@ func (r *DescribeIpHitItemsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeLLMContentSecCheckRequestParams struct {
-	// <p>服务id,使用哪一套防护策略，就需要传哪一套服务id，模型会检测该服务id下的所有规则</p>
+	// <p>服务id，使用哪一套防护策略，就需要传哪一套服务id，模型会检测该服务id下的所有规则</p>
 	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
 
 	// <p>流量类型，是入向流量还是出向流量，入向：1，出向：2；入向和出向必填</p>
@@ -11078,7 +11111,7 @@ type DescribeLLMContentSecCheckRequestParams struct {
 	// <p>要审核的内容</p>
 	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
 
-	// <p>对话的id</p>
+	// <p>一问一答的对话的id</p>
 	ChatId *string `json:"ChatId,omitnil,omitempty" name:"ChatId"`
 
 	// <p>标识用户的id，限速使用，不填，则限速会不生效</p>
@@ -11095,12 +11128,18 @@ type DescribeLLMContentSecCheckRequestParams struct {
 
 	// <p>tool_call 场景工具参数</p>
 	ToolArgs *string `json:"ToolArgs,omitnil,omitempty" name:"ToolArgs"`
+
+	// <p>多轮对话的id</p>
+	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+
+	// <p>意图检测请求内容</p>
+	IntentContent *IntentContent `json:"IntentContent,omitnil,omitempty" name:"IntentContent"`
 }
 
 type DescribeLLMContentSecCheckRequest struct {
 	*tchttp.BaseRequest
 	
-	// <p>服务id,使用哪一套防护策略，就需要传哪一套服务id，模型会检测该服务id下的所有规则</p>
+	// <p>服务id，使用哪一套防护策略，就需要传哪一套服务id，模型会检测该服务id下的所有规则</p>
 	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
 
 	// <p>流量类型，是入向流量还是出向流量，入向：1，出向：2；入向和出向必填</p>
@@ -11112,7 +11151,7 @@ type DescribeLLMContentSecCheckRequest struct {
 	// <p>要审核的内容</p>
 	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
 
-	// <p>对话的id</p>
+	// <p>一问一答的对话的id</p>
 	ChatId *string `json:"ChatId,omitnil,omitempty" name:"ChatId"`
 
 	// <p>标识用户的id，限速使用，不填，则限速会不生效</p>
@@ -11129,6 +11168,12 @@ type DescribeLLMContentSecCheckRequest struct {
 
 	// <p>tool_call 场景工具参数</p>
 	ToolArgs *string `json:"ToolArgs,omitnil,omitempty" name:"ToolArgs"`
+
+	// <p>多轮对话的id</p>
+	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+
+	// <p>意图检测请求内容</p>
+	IntentContent *IntentContent `json:"IntentContent,omitnil,omitempty" name:"IntentContent"`
 }
 
 func (r *DescribeLLMContentSecCheckRequest) ToJsonString() string {
@@ -11153,6 +11198,8 @@ func (r *DescribeLLMContentSecCheckRequest) FromJsonString(s string) error {
 	delete(f, "ImageEncode")
 	delete(f, "ToolName")
 	delete(f, "ToolArgs")
+	delete(f, "SessionId")
+	delete(f, "IntentContent")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeLLMContentSecCheckRequest has unknown keys!", "")
 	}
@@ -14697,17 +14744,16 @@ type ExportInfo struct {
 }
 
 type FieldWriteConfig struct {
-	// 1:开启 0:不开启
+	// <p>1:开启 0:不开启</p>
 	EnableHeaders *int64 `json:"EnableHeaders,omitnil,omitempty" name:"EnableHeaders"`
 
-	// 1:开启 0:不开启
+	// <p>1:开启 0:不开启</p>
 	EnableBody *int64 `json:"EnableBody,omitnil,omitempty" name:"EnableBody"`
 
-	// 1:开启 0:不开启
+	// <p>1:开启 0:不开启</p>
 	EnableBot *int64 `json:"EnableBot,omitnil,omitempty" name:"EnableBot"`
 
-	// 响应方向body
-	// 1:开启 0:不开启
+	// <p>响应方向body<br>1:开启 0:不开启</p>
 	EnableResponse *int64 `json:"EnableResponse,omitnil,omitempty" name:"EnableResponse"`
 }
 
@@ -16040,6 +16086,19 @@ type InstanceInfo struct {
 	TagInfos []*TagInfo `json:"TagInfos,omitnil,omitempty" name:"TagInfos"`
 }
 
+type IntentContent struct {
+	// <p>agent的轨迹内容，参考用例</p>
+	AgentTrace *string `json:"AgentTrace,omitnil,omitempty" name:"AgentTrace"`
+}
+
+type IntentDetectResult struct {
+	// <p>是否恶意意图</p><p>枚举值：</p><ul><li>1： 恶意</li><li>0： 正常</li></ul>
+	IsUnSafe *uint64 `json:"IsUnSafe,omitnil,omitempty" name:"IsUnSafe"`
+
+	// <p>检出分类</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
+}
+
 type IpAccessControlData struct {
 	// ip黑白名单
 	Res []*IpAccessControlItem `json:"Res,omitnil,omitempty" name:"Res"`
@@ -16211,6 +16270,9 @@ type LLMDetectResult struct {
 
 	// <p>toolcall的检测结果</p>
 	ToolCallResult *ToolCallResult `json:"ToolCallResult,omitnil,omitempty" name:"ToolCallResult"`
+
+	// <p>意图检测结果</p>
+	IntentDetectResult *IntentDetectResult `json:"IntentDetectResult,omitnil,omitempty" name:"IntentDetectResult"`
 }
 
 type LLMMonPkg struct {
@@ -16244,22 +16306,25 @@ type LLMMonPkg struct {
 }
 
 type LLMPkg struct {
-	// 资源id
+	// <p>资源id</p>
 	ResourceIds *string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 状态
+	// <p>状态</p>
 	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 地域
+	// <p>地域</p>
 	Region *int64 `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// 开始时间
+	// <p>开始时间</p>
 	BeginTime *string `json:"BeginTime,omitnil,omitempty" name:"BeginTime"`
 
-	// 结束时间
+	// <p>结束时间</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 计费项
+	// <p>申请数量</p>
+	InquireNum *int64 `json:"InquireNum,omitnil,omitempty" name:"InquireNum"`
+
+	// <p>计费项标签，如 sv_wsm_waf_llm_prompt_attack</p>
 	InquireKey *string `json:"InquireKey,omitnil,omitempty" name:"InquireKey"`
 }
 
@@ -23607,12 +23672,153 @@ type SpartaProtectionPort struct {
 }
 
 type Strategy struct {
-	// 匹配字段
-	// 
-	//     匹配字段不同，相应的匹配参数、逻辑符号、匹配内容有所不同
-	// 具体如下所示：
-	// <table><thead><tr><th>匹配字段</th><th>匹配参数</th><th>逻辑符号</th><th>匹配内容</th></tr></thead><tbody><tr><td>IP（来源IP）</td><td>不支持参数</td><td>ipmatch（匹配）<br/>ipnmatch（不匹配）</td><td>多个IP以英文逗号隔开,最多20个</td></tr><tr><td>IPV6（来源IPv6）</td><td>不支持参数</td><td>ipmatch（匹配）<br/>ipnmatch（不匹配）</td><td>支持单个IPV6地址</td></tr><tr><td>Referer（Referer）</td><td>不支持参数</td><td>empty（内容为空）<br/>null（不存在）<br/>eq（等于）<br/>neq（不等于）<br/>contains（包含）<br/>ncontains（不包含）<br/>len_eq（长度等于）<br/>len_gt（长度大于）<br/>len_lt（长度小于）<br/>strprefix（前缀匹配）<br/>strsuffix（后缀匹配）<br/>rematch（正则匹配）</td><td>请输入内容,512个字符以内</td></tr><tr><td>URL（请求路径）</td><td>不支持参数</td><td>eq（等于）<br/>neq（不等于）<br/>contains（包含）<br/>ncontains（不包含）<br/>len_eq（长度等于）<br/>len_gt（长度大于）<br/>len_lt（长度小于）<br/>strprefix（前缀匹配）<br/>strsuffix（后缀匹配）<br/>rematch（正则匹配）<br/></td><td>请以/开头,512个字符以内</td></tr><tr><td>UserAgent（UserAgent）</td><td>不支持参数</td><td>同匹配字段<font color="Red">Referer</font>逻辑符号</td><td>请输入内容,512个字符以内</td></tr><tr><td>HTTP_METHOD（HTTP请求方法）</td><td>不支持参数</td><td>eq（等于）<br/>neq（不等于）</td><td>请输入方法名称,建议大写</td></tr><tr><td>QUERY_STRING（请求字符串）</td><td>不支持参数</td><td>同匹配字段<font color="Red">请求路径</font>逻辑符号</td><td>请输入内容,512个字符以内</td></tr><tr><td>GET（GET参数值）</td><td>支持参数录入</td><td>contains（包含）<br/>ncontains（不包含）<br/>len_eq（长度等于）<br/>len_gt（长度大于）<br/>len_lt（长度小于）<br/>strprefix（前缀匹配）<br/>strsuffix（后缀匹配）</td><td>请输入内容,512个字符以内</td></tr><tr><td>GET_PARAMS_NAMES（GET参数名）</td><td>不支持参数</td><td>exsit（存在参数）<br/>nexsit（不存在参数）<br/>len_eq（长度等于）<br/>len_gt（长度大于）<br/>len_lt（长度小于）<br/>strprefix（前缀匹配）<br/>strsuffix（后缀匹配）</td><td>请输入内容,512个字符以内</td></tr><tr><td>POST（POST参数值）</td><td>支持参数录入</td><td>同匹配字段<font color="Red">GET参数值</font>逻辑符号</td><td>请输入内容,512个字符以内</td></tr><tr><td>GET_POST_NAMES（POST参数名）</td><td>不支持参数</td><td>同匹配字段<font color="Red">GET参数名</font>逻辑符号</td><td>请输入内容,512个字符以内</td></tr><tr><td>POST_BODY（完整BODY）</td><td>不支持参数</td><td>同匹配字段<font color="Red">请求路径</font>逻辑符号</td><td>请输入BODY内容,512个字符以内</td></tr><tr><td>COOKIE（Cookie）</td><td>不支持参数</td><td>empty（内容为空）<br/>null（不存在）<br/>rematch（正则匹配）</td><td><font color="Red">暂不支持</font></td></tr><tr><td>GET_COOKIES_NAMES（Cookie参数名）</td><td>不支持参数</td><td>同匹配字段<font color="Red">GET参数名</font>逻辑符号</td><td>请输入内容,512个字符以内</td></tr><tr><td>ARGS_COOKIE（Cookie参数值）</td><td>支持参数录入</td><td>同匹配字段<font color="Red">GET参数值</font>逻辑符号</td><td>请输入内容,512个字符以内</td></tr><tr><td>GET_HEADERS_NAMES（Header参数名）</td><td>不支持参数</td><td>exsit（存在参数）<br/>nexsit（不存在参数）<br/>len_eq（长度等于）<br/>len_gt（长度大于）<br/>len_lt（长度小于）<br/>strprefix（前缀匹配）<br/>strsuffix（后缀匹配）<br/>rematch（正则匹配）</td><td>请输入内容,建议小写,512个字符以内</td></tr><tr><td>ARGS_HEADER（Header参数值）</td><td>支持参数录入</td><td>contains（包含）<br/>ncontains（不包含）<br/>len_eq（长度等于）<br/>len_gt（长度大于）<br/>len_lt（长度小于）<br/>strprefix（前缀匹配）<br/>strsuffix（后缀匹配）<br/>rematch（正则匹配）</td><td>请输入内容,512个字符以内</td></tr><tr><td>CONTENT_LENGTH（Content-length）</td><td>支持参数录入</td><td>numgt（数值大于）<br/>numlt（数值小于）<br/>numeq（数值等于）<br/></td><td>请输入0-9999999999999之间的整数</td></tr><tr><td>IP_GEO（来源IP归属地）</td><td>支持参数录入</td><td>geo_in（属于）<br/>geo_not_in（不属于）<br/></td><td>请输入内容,10240字符以内，格式为序列化的JSON，格式为：[{"Country":"中国","Region":"广东","City":"深圳"}]</td></tr><tr><td>CAPTCHA_RISK（验证码风险）</td><td>不支持参数</td><td>eq（等于）<br/>neq（不等于）<br/>belong（属于）<br/>not_belong（不属于）<br/>null（不存在）<br/>exist（存在）</td><td>请输入风险等级值,支持数值范围0-255</td></tr><tr><td>CAPTCHA_DEVICE_RISK（验证码设备风险）</td><td>不支持参数</td><td>eq（等于）<br/>neq（不等于）<br/>belong（属于）<br/>not_belong（不属于）<br/>null（不存在）<br/>exist（存在）</td><td>请输入设备风险代码,支持取值：101、201、301、401、501、601、701</td></tr><tr><td>CAPTCHAR_SCORE（验证码风险评估分）</td><td>不支持参数</td><td>numeq（数值等于）<br/>numgt（数值大于）<br/>numlt（数值小于）<br/>numle（数值小于等于）<br/>numge（数值大于等于）<br/>null（不存在）<br/>exist（存在）</td><td>请输入评估分数,支持数值范围0-100</td></tr>
-	// </tbody></table>
+	// 匹配字段 匹配字段不同，相应的匹配参数、逻辑符号、匹配内容有所不同
+	// 具体如下所示： <table>
+	// 	<thead>
+	// 		<tr>
+	// 			<th>匹配字段</th>
+	// 			<th>匹配参数</th>
+	// 			<th>逻辑符号</th>
+	// 			<th>匹配内容</th>
+	// 		</tr>
+	// 	</thead>
+	// 	<tbody>
+	// 		<tr>
+	// 			<td>IP（来源IP）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>ipmatch（匹配）<br />ipnmatch（不匹配）</td>
+	// 			<td>多个IP以英文逗号隔开,最多20个</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>IPV6（来源IPv6）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>ipmatch（匹配）<br />ipnmatch（不匹配）</td>
+	// 			<td>支持单个IPV6地址</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>Referer（Referer）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>empty（内容为空）<br />null（不存在）<br />eq（等于）<br />neq（不等于）<br />contains（包含）<br />ncontains（不包含）<br/>belong_to（属于）<br/>not_belong_to（不属于）<br />len_eq（长度等于）<br />len_gt（长度大于）<br />len_lt（长度小于）<br />strprefix（前缀匹配）<br />strsuffix（后缀匹配）<br />rematch（正则匹配）</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>URL（请求路径）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>eq（等于）<br />neq（不等于）<br />contains（包含）<br />ncontains（不包含）<br />len_eq（长度等于）<br />belong_to（属于）<br />not_belong_to（不属于）<br />len_gt（长度大于）<br />len_lt（长度小于）<br />strprefix（前缀匹配）<br />strsuffix（后缀匹配）<br />rematch（正则匹配）<br /></td>
+	// 			<td>请以/开头,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>UserAgent（UserAgent）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>同匹配字段<font color="Red">Referer</font>逻辑符号</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>HTTP_METHOD（HTTP请求方法）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>eq（等于）<br />neq（不等于）<br/>belong_to（属于）<br/>not_belong_to（不属于）</td>
+	// 			<td>请输入方法名称,建议大写</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>QUERY_STRING（请求字符串）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>同匹配字段<font color="Red">请求路径</font>逻辑符号</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>GET（GET参数值）</td>
+	// 			<td>支持参数录入</td>
+	// 			<td>contains（包含）<br />ncontains（不包含）<br/>belong_to（属于）<br/>not_belong_to（不属于）<br />len_eq（长度等于）<br />len_gt（长度大于）<br />len_lt（长度小于）<br />strprefix（前缀匹配）<br />strsuffix（后缀匹配）</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>GET_PARAMS_NAMES（GET参数名）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>exsit（存在参数）<br />nexsit（不存在参数）<br/>belong_to（属于）<br/>not_belong_to（不属于）<br />len_eq（长度等于）<br />len_gt（长度大于）<br />len_lt（长度小于）<br />strprefix（前缀匹配）<br />strsuffix（后缀匹配）</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>POST（POST参数值）</td>
+	// 			<td>支持参数录入</td>
+	// 			<td>同匹配字段<font color="Red">GET参数值</font>逻辑符号</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>GET_POST_NAMES（POST参数名）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>同匹配字段<font color="Red">GET参数名</font>逻辑符号</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>POST_BODY（完整BODY）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>同匹配字段<font color="Red">请求路径</font>逻辑符号</td>
+	// 			<td>请输入BODY内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>COOKIE（Cookie）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>empty（内容为空）<br />null（不存在）<br />rematch（正则匹配）</td>
+	// 			<td>
+	// 				<font color="Red">暂不支持</font>
+	// 			</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>GET_COOKIES_NAMES（Cookie参数名）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>同匹配字段<font color="Red">GET参数名</font>逻辑符号</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>ARGS_COOKIE（Cookie参数值）</td>
+	// 			<td>支持参数录入</td>
+	// 			<td>同匹配字段<font color="Red">GET参数值</font>逻辑符号</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>GET_HEADERS_NAMES（Header参数名）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>exsit（存在参数）<br />nexsit（不存在参数）<br />len_eq（长度等于）<br />len_gt（长度大于）<br />len_lt（长度小于）<br />strprefix（前缀匹配）<br />strsuffix（后缀匹配）<br />rematch（正则匹配）</td>
+	// 			<td>请输入内容,建议小写,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>ARGS_HEADER（Header参数值）</td>
+	// 			<td>支持参数录入</td>
+	// 			<td>contains（包含）<br />ncontains（不包含）<br />len_eq（长度等于）<br />len_gt（长度大于）<br />len_lt（长度小于）<br />strprefix（前缀匹配）<br />strsuffix（后缀匹配）<br />rematch（正则匹配）</td>
+	// 			<td>请输入内容,512个字符以内</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>CONTENT_LENGTH（Content-length）</td>
+	// 			<td>支持参数录入</td>
+	// 			<td>numgt（数值大于）<br />numlt（数值小于）<br />numeq（数值等于）<br /></td>
+	// 			<td>请输入0-9999999999999之间的整数</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>IP_GEO（来源IP归属地）</td>
+	// 			<td>支持参数录入</td>
+	// 			<td>geo_in（属于）<br />geo_not_in（不属于）<br /></td>
+	// 			<td>请输入内容,10240字符以内，格式为序列化的JSON，格式为：[{"Country":"中国","Region":"广东","City":"深圳"}]</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>CAPTCHA_RISK（验证码风险）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>eq（等于）<br />neq（不等于）<br />belong（属于）<br />not_belong（不属于）<br />null（不存在）<br />exist（存在）</td>
+	// 			<td>请输入风险等级值,支持数值范围0-255</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>CAPTCHA_DEVICE_RISK（验证码设备风险）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>eq（等于）<br />neq（不等于）<br />belong（属于）<br />not_belong（不属于）<br />null（不存在）<br />exist（存在）</td>
+	// 			<td>请输入设备风险代码,支持取值：101、201、301、401、501、601、701</td>
+	// 		</tr>
+	// 		<tr>
+	// 			<td>CAPTCHAR_SCORE（验证码风险评估分）</td>
+	// 			<td>不支持参数</td>
+	// 			<td>numeq（数值等于）<br />numgt（数值大于）<br />numlt（数值小于）<br />numle（数值小于等于）<br />numge（数值大于等于）<br />null（不存在）<br />exist（存在）</td>
+	// 			<td>请输入评估分数,支持数值范围0-100</td>
+	// 		</tr>
+	// 	</tbody>
+	// </table>
 	Field *string `json:"Field,omitnil,omitempty" name:"Field"`
 
 	// 逻辑符号 
@@ -23637,6 +23843,8 @@ type Strategy struct {
 	//         numneq （ 数值不等于）
 	//         numle （ 数值小于等于）
 	//         numge （ 数值大于等于）
+	// 		belong_to（属于）
+	// 		not_belong_to（不属于）
 	//         geo_in （ IP地理属于）
 	//         geo_not_in （ IP地理不属于）
 	//     各匹配字段对应的逻辑符号不同，详见上述匹配字段表格

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1473,7 +1473,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod/v20180717
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.62
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.113
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.144
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf/v20180125
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wedata v1.3.30

--- a/website/docs/r/waf_cc_session.html.markdown
+++ b/website/docs/r/waf_cc_session.html.markdown
@@ -24,6 +24,7 @@ resource "tencentcloud_waf_cc_session" "example" {
   end_offset       = "-1"
   edition          = "sparta-waf"
   session_name     = "terraformDemo"
+  key              = "sessionId"
 }
 ```
 
@@ -40,6 +41,7 @@ The following arguments are supported:
 * `session_name` - (Required, String) Session Name.
 * `source` - (Required, String) Session matching position, Optional locations are get, post, header, cookie.
 * `start_offset` - (Required, String) Starting offset position, when Category is location.
+* `key` - (Optional, String) Precise-match session key, configured when Category is precise matching.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add the optional 'key' string parameter to the tencentcloud_waf_cc_session resource to support precise-match session key configuration. The parameter is sent in request.Key on both create and update (UpsertSession API) and read from the DescribeSession API response (SessionItem.Key).