### PR TITLE
feat(cos): [000000000] support status and tags in bucket lifecycle rules

### DIFF
--- a/.changelog/4397.txt
+++ b/.changelog/4397.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_cos_bucket: support status and tag filters in lifecycle rules
+```

--- a/.changelog/4397.txt
+++ b/.changelog/4397.txt
@@ -1,3 +1,4 @@
 ```release-note:enhancement
 resource/tencentcloud_cos_bucket: support status and tag filters in lifecycle rules
+data-source/tencentcloud_cos_buckets: return lifecycle rule status and tag filters
 ```

--- a/tencentcloud/services/cos/data_source_tc_cos_buckets.go
+++ b/tencentcloud/services/cos/data_source_tc_cos_buckets.go
@@ -91,10 +91,21 @@ func DataSourceTencentCloudCosBuckets() *schema.Resource {
 							Description: "The lifecycle configuration of a bucket.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"status": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Whether the lifecycle rule is enabled.",
+									},
 									"filter_prefix": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Object key prefix identifying one or more objects to which the rule applies.",
+									},
+									"filter_tags": {
+										Type:        schema.TypeMap,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "Object tags identifying objects to which the rule applies.",
 									},
 									"transition": {
 										Type:        schema.TypeList,

--- a/tencentcloud/services/cos/data_source_tc_cos_buckets_test.go
+++ b/tencentcloud/services/cos/data_source_tc_cos_buckets_test.go
@@ -74,9 +74,13 @@ func TestAccTencentCloudCosBucketDataSource_full(t *testing.T) {
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list", "bucket_list.0.cors_rules.0.expose_headers.#", "1"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list", "bucket_list.0.cors_rules.0.expose_headers.0", "x-cos-test"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list", "bucket_list.0.cors_rules.0.max_age_seconds", "300"),
-					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list", "bucket_list.0.lifecycle_rules.#", "1"),
+					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list", "bucket_list.0.lifecycle_rules.#", "2"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list",
 						"bucket_list.0.lifecycle_rules.0.filter_prefix", "test/"),
+					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list",
+						"bucket_list.0.lifecycle_rules.0.status", "Disabled"),
+					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list",
+						"bucket_list.0.lifecycle_rules.0.filter_tags.env", "prod"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list",
 						"bucket_list.0.lifecycle_rules.0.expiration.#", "1"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list",
@@ -86,9 +90,9 @@ func TestAccTencentCloudCosBucketDataSource_full(t *testing.T) {
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list",
 						"bucket_list.0.lifecycle_rules.0.non_current_transition.#", "2"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list",
-						"bucket_list.0.lifecycle_rules.0.abort_incomplete_multipart_upload.#", "1"),
+						"bucket_list.0.lifecycle_rules.1.abort_incomplete_multipart_upload.#", "1"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list",
-						"bucket_list.0.lifecycle_rules.0.abort_incomplete_multipart_upload.0.days_after_initiation", "1"),
+						"bucket_list.0.lifecycle_rules.1.abort_incomplete_multipart_upload.0.days_after_initiation", "1"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list", "bucket_list.0.website.#", "1"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list", "bucket_list.0.website.0.index_document", "index.html"),
 					resource.TestCheckResourceAttr("data.tencentcloud_cos_buckets.bucket_list", "bucket_list.0.website.0.error_document", "error.html"),
@@ -133,7 +137,11 @@ resource "tencentcloud_cos_bucket" "bucket_full" {
   }
 
   lifecycle_rules {
+    status        = "Disabled"
     filter_prefix = "test/"
+    filter_tags = {
+      env = "prod"
+    }
 
     expiration {
       days = 365
@@ -149,20 +157,22 @@ resource "tencentcloud_cos_bucket" "bucket_full" {
       storage_class = "ARCHIVE"
     }
 
-	non_current_expiration {
+    non_current_expiration {
       non_current_days = 600
     }
 
-	non_current_transition {
+    non_current_transition {
       non_current_days = 90
       storage_class = "STANDARD_IA"
     }
-
     non_current_transition {
       non_current_days = 180
       storage_class = "ARCHIVE"
     }
 
+  }
+
+  lifecycle_rules {
     abort_incomplete_multipart_upload {
       days_after_initiation = 1
     }

--- a/tencentcloud/services/cos/resource_tc_cos_bucket.go
+++ b/tencentcloud/services/cos/resource_tc_cos_bucket.go
@@ -160,10 +160,11 @@ func originPullRules() *schema.Resource {
 
 func ResourceTencentCloudCosBucket() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceTencentCloudCosBucketCreate,
-		Read:   resourceTencentCloudCosBucketRead,
-		Update: resourceTencentCloudCosBucketUpdate,
-		Delete: resourceTencentCloudCosBucketDelete,
+		Create:        resourceTencentCloudCosBucketCreate,
+		Read:          resourceTencentCloudCosBucketRead,
+		Update:        resourceTencentCloudCosBucketUpdate,
+		Delete:        resourceTencentCloudCosBucketDelete,
+		CustomizeDiff: customizeDiffCosBucketLifecycleRules,
 		Importer: &schema.ResourceImporter{
 			State: helper.ImportWithDefaultValue(map[string]interface{}{
 				"force_clean": false,
@@ -482,10 +483,11 @@ func ResourceTencentCloudCosBucket() *schema.Resource {
 							Description: "Object key prefix identifying one or more objects to which the rule applies.",
 						},
 						"filter_tags": {
-							Type:        schema.TypeMap,
-							Optional:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-							Description: "Object tags identifying objects to which the rule applies. All tags and `filter_prefix`, when set, are combined with a logical AND. COS supports up to 10 tags.",
+							Type:         schema.TypeMap,
+							Optional:     true,
+							Elem:         &schema.Schema{Type: schema.TypeString},
+							ValidateFunc: validateCosBucketLifecycleFilterTags,
+							Description:  "Object tags identifying objects to which the rule applies. All tags and `filter_prefix`, when set, are combined with a logical AND. COS supports up to 10 tags.",
 						},
 						"transition": {
 							Type:        schema.TypeSet,
@@ -1867,6 +1869,9 @@ func resourceTencentCloudCosBucketLifecycleUpdate(ctx context.Context, meta inte
 
 	bucket := d.Get("bucket").(string)
 	lifecycleRules := d.Get("lifecycle_rules").([]interface{})
+	if err := validateCosBucketLifecycleRules(lifecycleRules); err != nil {
+		return err
+	}
 	cdcId := d.Get("cdc_id").(string)
 	if len(lifecycleRules) == 0 {
 		request := s3.DeleteBucketLifecycleInput{
@@ -2012,6 +2017,59 @@ func resourceTencentCloudCosBucketLifecycleUpdate(ctx context.Context, meta inte
 			logId, "put bucket lifecycle", request.String(), response.String())
 	}
 
+	return nil
+}
+
+func customizeDiffCosBucketLifecycleRules(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	rawRules, ok := d.Get("lifecycle_rules").([]interface{})
+	if !ok {
+		return nil
+	}
+	return validateCosBucketLifecycleRules(rawRules)
+}
+
+func validateCosBucketLifecycleFilterTags(value interface{}, key string) ([]string, []error) {
+	tags, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, []error{fmt.Errorf("%s must be a map of strings", key)}
+	}
+	if len(tags) > 10 {
+		return nil, []error{fmt.Errorf("%s supports at most 10 tags, got %d", key, len(tags))}
+	}
+	for tagKey, rawValue := range tags {
+		tagValue, ok := rawValue.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("%s.%s must be a string", key, tagKey)}
+		}
+		if len(tagKey) == 0 {
+			return nil, []error{fmt.Errorf("%s contains an empty tag key", key)}
+		}
+		if len(tagKey) > 128 {
+			return nil, []error{fmt.Errorf("%s.%s key must not exceed 128 bytes", key, tagKey)}
+		}
+		if len(tagValue) > 256 {
+			return nil, []error{fmt.Errorf("%s.%s value must not exceed 256 bytes", key, tagKey)}
+		}
+	}
+	return nil, nil
+}
+
+func validateCosBucketLifecycleRules(rules []interface{}) error {
+	for index, rawRule := range rules {
+		rule, ok := rawRule.(map[string]interface{})
+		if !ok || rule == nil {
+			continue
+		}
+		rawTags, hasTags := rule["filter_tags"]
+		tags, tagsOK := rawTags.(map[string]interface{})
+		if !hasTags || !tagsOK || len(tags) == 0 {
+			continue
+		}
+		abortUploads, ok := rule["abort_incomplete_multipart_upload"].(*schema.Set)
+		if ok && abortUploads.Len() > 0 {
+			return fmt.Errorf("lifecycle_rules.%d.filter_tags cannot be used with abort_incomplete_multipart_upload in the same rule", index)
+		}
+	}
 	return nil
 }
 

--- a/tencentcloud/services/cos/resource_tc_cos_bucket.go
+++ b/tencentcloud/services/cos/resource_tc_cos_bucket.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -468,10 +469,23 @@ func ResourceTencentCloudCosBucket() *schema.Resource {
 							Optional:    true,
 							Description: "A unique identifier for the rule. It can be up to 255 characters.",
 						},
+						"status": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      s3.ExpirationStatusEnabled,
+							ValidateFunc: tccommon.ValidateAllowedStringValue([]string{s3.ExpirationStatusEnabled, s3.ExpirationStatusDisabled}),
+							Description:  "Whether the lifecycle rule is enabled. Valid values are `Enabled` and `Disabled`.",
+						},
 						"filter_prefix": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Object key prefix identifying one or more objects to which the rule applies.",
+						},
+						"filter_tags": {
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "Object tags identifying objects to which the rule applies. All tags and `filter_prefix`, when set, are combined with a logical AND. COS supports up to 10 tags.",
 						},
 						"transition": {
 							Type:        schema.TypeSet,
@@ -1876,11 +1890,17 @@ func resourceTencentCloudCosBucketLifecycleUpdate(ctx context.Context, meta inte
 			if ok {
 				rule.ID = &id
 			}
-			rule.Status = helper.String(s3.ExpirationStatusEnabled)
-			prefix := r["filter_prefix"].(string)
-			rule.Filter = &s3.LifecycleRuleFilter{
-				Prefix: &prefix,
+			status := s3.ExpirationStatusEnabled
+			if value, ok := r["status"].(string); ok && value != "" {
+				status = value
 			}
+			rule.Status = helper.String(status)
+			prefix := r["filter_prefix"].(string)
+			filterTags := map[string]interface{}{}
+			if value, ok := r["filter_tags"].(map[string]interface{}); ok {
+				filterTags = value
+			}
+			rule.Filter = expandCosBucketLifecycleRuleFilter(prefix, filterTags)
 
 			// Transitions
 			transitions := d.Get(fmt.Sprintf("lifecycle_rules.%d.transition", i)).(*schema.Set).List()
@@ -1993,6 +2013,36 @@ func resourceTencentCloudCosBucketLifecycleUpdate(ctx context.Context, meta inte
 	}
 
 	return nil
+}
+
+func expandCosBucketLifecycleRuleFilter(prefix string, rawTags map[string]interface{}) *s3.LifecycleRuleFilter {
+	if len(rawTags) == 0 {
+		return &s3.LifecycleRuleFilter{Prefix: helper.String(prefix)}
+	}
+
+	keys := make([]string, 0, len(rawTags))
+	for key := range rawTags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	tags := make([]*s3.Tag, 0, len(keys))
+	for _, key := range keys {
+		tags = append(tags, &s3.Tag{
+			Key:   helper.String(key),
+			Value: helper.String(rawTags[key].(string)),
+		})
+	}
+
+	if prefix == "" && len(tags) == 1 {
+		return &s3.LifecycleRuleFilter{Tag: tags[0]}
+	}
+
+	and := &s3.LifecycleRuleAndOperator{Tags: tags}
+	if prefix != "" {
+		and.Prefix = helper.String(prefix)
+	}
+	return &s3.LifecycleRuleFilter{And: and}
 }
 
 func resourceTencentCloudCosBucketWebsiteUpdate(ctx context.Context, meta interface{}, d *schema.ResourceData) error {

--- a/tencentcloud/services/cos/resource_tc_cos_bucket.md
+++ b/tencentcloud/services/cos/resource_tc_cos_bucket.md
@@ -356,7 +356,11 @@ resource "tencentcloud_cos_bucket" "bucket_with_lifecycle" {
   acl    = "public-read-write"
 
   lifecycle_rules {
+    status        = "Enabled"
     filter_prefix = "path1/"
+    filter_tags = {
+      env = "prod"
+    }
 
     transition {
       days          = 30
@@ -394,6 +398,7 @@ resource "tencentcloud_cos_bucket" "bucket_with_lifecycle" {
   acl    = "private"
 
   lifecycle_rules {
+    status        = "Enabled"
     filter_prefix = "path1/"
 
     expiration {

--- a/tencentcloud/services/cos/resource_tc_cos_bucket_lifecycle_test.go
+++ b/tencentcloud/services/cos/resource_tc_cos_bucket_lifecycle_test.go
@@ -2,6 +2,7 @@ package cos
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,6 +21,83 @@ func TestCosBucketLifecycleRuleSchema(t *testing.T) {
 	}
 	if got := rules["filter_tags"].Type; got != schema.TypeMap {
 		t.Fatalf("filter_tags type = %v, want TypeMap", got)
+	}
+}
+
+func TestCosBucketLifecycleDataSourceRuleSchema(t *testing.T) {
+	bucketList := DataSourceTencentCloudCosBuckets().Schema["bucket_list"].Elem.(*schema.Resource).Schema
+	rules := bucketList["lifecycle_rules"].Elem.(*schema.Resource).Schema
+
+	if !rules["status"].Computed || rules["status"].Type != schema.TypeString {
+		t.Fatalf("status schema = %#v, want computed string", rules["status"])
+	}
+	if !rules["filter_tags"].Computed || rules["filter_tags"].Type != schema.TypeMap {
+		t.Fatalf("filter_tags schema = %#v, want computed map", rules["filter_tags"])
+	}
+}
+
+func TestValidateCosBucketLifecycleFilterTags(t *testing.T) {
+	tenTags := map[string]interface{}{
+		"tag0": "0", "tag1": "1", "tag2": "2", "tag3": "3", "tag4": "4",
+		"tag5": "5", "tag6": "6", "tag7": "7", "tag8": "8", "tag9": "9",
+	}
+	elevenTags := make(map[string]interface{}, len(tenTags)+1)
+	for key, value := range tenTags {
+		elevenTags[key] = value
+	}
+	elevenTags["tag10"] = "10"
+
+	tests := map[string]struct {
+		tags    map[string]interface{}
+		wantErr bool
+	}{
+		"ten tags":         {tags: tenTags},
+		"eleven tags":      {tags: elevenTags, wantErr: true},
+		"128 byte key":     {tags: map[string]interface{}{strings.Repeat("k", 128): "value"}},
+		"129 byte key":     {tags: map[string]interface{}{strings.Repeat("k", 129): "value"}, wantErr: true},
+		"256 byte value":   {tags: map[string]interface{}{"key": strings.Repeat("v", 256)}},
+		"257 byte value":   {tags: map[string]interface{}{"key": strings.Repeat("v", 257)}, wantErr: true},
+		"empty key":        {tags: map[string]interface{}{"": "value"}, wantErr: true},
+		"non-string value": {tags: map[string]interface{}{"key": 1}, wantErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, errors := validateCosBucketLifecycleFilterTags(test.tags, "filter_tags")
+			if gotErr := len(errors) > 0; gotErr != test.wantErr {
+				t.Fatalf("validateCosBucketLifecycleFilterTags() errors = %v, wantErr %t", errors, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCosBucketLifecycleRules(t *testing.T) {
+	abortUploads := schema.NewSet(schema.HashString, []interface{}{"configured"})
+	tests := map[string]struct {
+		rules   []interface{}
+		wantErr bool
+	}{
+		"tags only": {
+			rules: []interface{}{map[string]interface{}{"filter_tags": map[string]interface{}{"env": "prod"}}},
+		},
+		"abort only": {
+			rules: []interface{}{map[string]interface{}{"abort_incomplete_multipart_upload": abortUploads}},
+		},
+		"tags and abort": {
+			rules: []interface{}{map[string]interface{}{
+				"filter_tags":                       map[string]interface{}{"env": "prod"},
+				"abort_incomplete_multipart_upload": abortUploads,
+			}},
+			wantErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if gotErr := validateCosBucketLifecycleRules(test.rules) != nil; gotErr != test.wantErr {
+				t.Fatalf("validateCosBucketLifecycleRules() error = %t, wantErr %t", gotErr, test.wantErr)
+			}
+		})
 	}
 }
 

--- a/tencentcloud/services/cos/resource_tc_cos_bucket_lifecycle_test.go
+++ b/tencentcloud/services/cos/resource_tc_cos_bucket_lifecycle_test.go
@@ -1,0 +1,108 @@
+package cos
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestCosBucketLifecycleRuleSchema(t *testing.T) {
+	rules := ResourceTencentCloudCosBucket().Schema["lifecycle_rules"].Elem.(*schema.Resource).Schema
+
+	if got := rules["status"].Default; got != s3.ExpirationStatusEnabled {
+		t.Fatalf("status default = %v, want %q", got, s3.ExpirationStatusEnabled)
+	}
+	if _, errors := rules["status"].ValidateFunc("invalid", "status"); len(errors) == 0 {
+		t.Fatal("status validation accepted an invalid value")
+	}
+	if got := rules["filter_tags"].Type; got != schema.TypeMap {
+		t.Fatalf("filter_tags type = %v, want TypeMap", got)
+	}
+}
+
+func TestExpandCosBucketLifecycleRuleFilter(t *testing.T) {
+	tests := map[string]struct {
+		prefix string
+		tags   map[string]interface{}
+		want   *s3.LifecycleRuleFilter
+	}{
+		"all objects": {
+			want: &s3.LifecycleRuleFilter{Prefix: aws.String("")},
+		},
+		"prefix only": {
+			prefix: "logs/",
+			want:   &s3.LifecycleRuleFilter{Prefix: aws.String("logs/")},
+		},
+		"single tag only": {
+			tags: map[string]interface{}{"env": "prod"},
+			want: &s3.LifecycleRuleFilter{Tag: &s3.Tag{Key: aws.String("env"), Value: aws.String("prod")}},
+		},
+		"prefix and tag": {
+			prefix: "logs/",
+			tags:   map[string]interface{}{"env": "prod"},
+			want: &s3.LifecycleRuleFilter{And: &s3.LifecycleRuleAndOperator{
+				Prefix: aws.String("logs/"),
+				Tags:   []*s3.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+			}},
+		},
+		"multiple tags are stable": {
+			tags: map[string]interface{}{"team": "db", "env": "prod"},
+			want: &s3.LifecycleRuleFilter{And: &s3.LifecycleRuleAndOperator{Tags: []*s3.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+				{Key: aws.String("team"), Value: aws.String("db")},
+			}}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := expandCosBucketLifecycleRuleFilter(test.prefix, test.tags); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("expandCosBucketLifecycleRuleFilter() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFlattenCosBucketLifecycleRuleFilter(t *testing.T) {
+	tests := map[string]struct {
+		filter     *s3.LifecycleRuleFilter
+		wantPrefix string
+		wantTags   map[string]interface{}
+	}{
+		"nil": {
+			wantTags: map[string]interface{}{},
+		},
+		"prefix": {
+			filter:     &s3.LifecycleRuleFilter{Prefix: aws.String("logs/")},
+			wantPrefix: "logs/",
+			wantTags:   map[string]interface{}{},
+		},
+		"tag": {
+			filter:   &s3.LifecycleRuleFilter{Tag: &s3.Tag{Key: aws.String("env"), Value: aws.String("prod")}},
+			wantTags: map[string]interface{}{"env": "prod"},
+		},
+		"and": {
+			filter: &s3.LifecycleRuleFilter{And: &s3.LifecycleRuleAndOperator{
+				Prefix: aws.String("logs/"),
+				Tags: []*s3.Tag{
+					{Key: aws.String("env"), Value: aws.String("prod")},
+					{Key: aws.String("team"), Value: aws.String("db")},
+				},
+			}},
+			wantPrefix: "logs/",
+			wantTags:   map[string]interface{}{"env": "prod", "team": "db"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			prefix, tags := flattenCosBucketLifecycleRuleFilter(test.filter)
+			if prefix != test.wantPrefix || !reflect.DeepEqual(tags, test.wantTags) {
+				t.Fatalf("flattenCosBucketLifecycleRuleFilter() = (%q, %#v), want (%q, %#v)", prefix, tags, test.wantPrefix, test.wantTags)
+			}
+		})
+	}
+}

--- a/tencentcloud/services/cos/resource_tc_cos_bucket_test.go
+++ b/tencentcloud/services/cos/resource_tc_cos_bucket_test.go
@@ -244,7 +244,10 @@ func TestAccTencentCloudCosBucketResource_lifecycle(t *testing.T) {
 					testAccCheckCosBucketExists("tencentcloud_cos_bucket.bucket_lifecycle"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.#", "1"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.id", "rule1"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.status", "Disabled"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.filter_prefix", "test/"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.filter_tags.env", "test"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.filter_tags.team", "storage"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.expiration.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.expiration.*",
 						map[string]string{
@@ -269,7 +272,9 @@ func TestAccTencentCloudCosBucketResource_lifecycle(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCosBucketExists("tencentcloud_cos_bucket.bucket_lifecycle"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.#", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.status", "Enabled"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.filter_prefix", "test/"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.filter_tags.env", "prod"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.expiration.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.expiration.*",
 						map[string]string{
@@ -749,8 +754,13 @@ resource "tencentcloud_cos_bucket" "bucket_lifecycle" {
   acl    = "public-read"
   versioning_enable = true
   lifecycle_rules {
-    id = "rule1"
+    id            = "rule1"
+    status        = "Disabled"
     filter_prefix = "test/"
+    filter_tags = {
+      env  = "test"
+      team = "storage"
+    }
     expiration {
       days = 365
     }
@@ -776,8 +786,12 @@ resource "tencentcloud_cos_bucket" "bucket_lifecycle" {
   acl    = "public-read"
   versioning_enable = true
   lifecycle_rules {
-    id = "rule1"
+    id            = "rule1"
+    status        = "Enabled"
     filter_prefix = "test/"
+    filter_tags = {
+      env = "prod"
+    }
     expiration {
       days = 300
     }

--- a/tencentcloud/services/cos/resource_tc_cos_bucket_test.go
+++ b/tencentcloud/services/cos/resource_tc_cos_bucket_test.go
@@ -271,7 +271,7 @@ func TestAccTencentCloudCosBucketResource_lifecycle(t *testing.T) {
 				Config: testAccBucket_lifecycleUpdate(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCosBucketExists("tencentcloud_cos_bucket.bucket_lifecycle"),
-					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.#", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.#", "2"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.status", "Enabled"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.filter_prefix", "test/"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.filter_tags.env", "prod"),
@@ -293,8 +293,9 @@ func TestAccTencentCloudCosBucketResource_lifecycle(t *testing.T) {
 						}),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.non_current_expiration.#", "1"),
 					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.non_current_transition.#", "2"),
-					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.abort_incomplete_multipart_upload.#", "1"),
-					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.0.abort_incomplete_multipart_upload.0.days_after_initiation", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.1.status", "Enabled"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.1.abort_incomplete_multipart_upload.#", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_lifecycle", "lifecycle_rules.1.abort_incomplete_multipart_upload.0.days_after_initiation", "1"),
 				),
 			},
 			{
@@ -817,6 +818,12 @@ resource "tencentcloud_cos_bucket" "bucket_lifecycle" {
       non_current_days = 180
       storage_class = "ARCHIVE"
     }
+
+  }
+
+  lifecycle_rules {
+    id     = "abort-multipart"
+    status = "Enabled"
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 1

--- a/tencentcloud/services/cos/service_tencentcloud_cos.go
+++ b/tencentcloud/services/cos/service_tencentcloud_cos.go
@@ -624,15 +624,16 @@ func (me *CosService) GetBucketLifecycle(ctx context.Context, bucket string, cdc
 			if value.ID != nil {
 				rule["id"] = *value.ID
 			}
+			if value.Status != nil {
+				rule["status"] = *value.Status
+			}
 
-			// filter_prefix
-			if value.Filter != nil {
-				if value.Filter.And != nil && value.Filter.And.Prefix != nil &&
-					*value.Filter.And.Prefix != "" {
-					rule["filter_prefix"] = *value.Filter.And.Prefix
-				} else if value.Filter.Prefix != nil && *value.Filter.Prefix != "" {
-					rule["filter_prefix"] = *value.Filter.Prefix
-				}
+			prefix, tags := flattenCosBucketLifecycleRuleFilter(value.Filter)
+			if prefix != "" {
+				rule["filter_prefix"] = prefix
+			}
+			if len(tags) > 0 {
+				rule["filter_tags"] = tags
 			}
 			// transition
 			if len(value.Transitions) > 0 {
@@ -733,14 +734,15 @@ func (me *CosService) GetDataSourceBucketLifecycle(ctx context.Context, bucket s
 		for _, value := range response.Rules {
 			rule := make(map[string]interface{})
 
-			// filter_prefix
-			if value.Filter != nil {
-				if value.Filter.And != nil && value.Filter.And.Prefix != nil &&
-					*value.Filter.And.Prefix != "" {
-					rule["filter_prefix"] = *value.Filter.And.Prefix
-				} else if value.Filter.Prefix != nil && *value.Filter.Prefix != "" {
-					rule["filter_prefix"] = *value.Filter.Prefix
-				}
+			if value.Status != nil {
+				rule["status"] = *value.Status
+			}
+			prefix, tags := flattenCosBucketLifecycleRuleFilter(value.Filter)
+			if prefix != "" {
+				rule["filter_prefix"] = prefix
+			}
+			if len(tags) > 0 {
+				rule["filter_tags"] = tags
 			}
 			// transition
 			if len(value.Transitions) > 0 {
@@ -807,6 +809,31 @@ func (me *CosService) GetDataSourceBucketLifecycle(ctx context.Context, bucket s
 		}
 	}
 	return
+}
+
+func flattenCosBucketLifecycleRuleFilter(filter *s3.LifecycleRuleFilter) (string, map[string]interface{}) {
+	tags := map[string]interface{}{}
+	if filter == nil {
+		return "", tags
+	}
+
+	prefix := ""
+	if filter.And != nil {
+		if filter.And.Prefix != nil {
+			prefix = *filter.And.Prefix
+		}
+		for _, tag := range filter.And.Tags {
+			if tag != nil && tag.Key != nil && tag.Value != nil {
+				tags[*tag.Key] = *tag.Value
+			}
+		}
+	} else if filter.Prefix != nil {
+		prefix = *filter.Prefix
+	} else if filter.Tag != nil && filter.Tag.Key != nil && filter.Tag.Value != nil {
+		tags[*filter.Tag.Key] = *filter.Tag.Value
+	}
+
+	return prefix, tags
 }
 
 func (me *CosService) GetBucketWebsite(ctx context.Context, bucket string, cdcId string) (websites []map[string]interface{}, errRet error) {

--- a/website/docs/d/cos_buckets.html.markdown
+++ b/website/docs/d/cos_buckets.html.markdown
@@ -60,11 +60,13 @@ In addition to all arguments above, the following attributes are exported:
       * `date` - Specifies the date after which you want the corresponding action to take effect.
       * `days` - Specifies the number of days after object creation when the specific rule action takes effect.
     * `filter_prefix` - Object key prefix identifying one or more objects to which the rule applies.
+    * `filter_tags` - Object tags identifying objects to which the rule applies.
     * `non_current_expiration` - Specifies when non current object versions shall expire.
       * `non_current_days` - Number of days after non current object creation when the specific rule action takes effect. The maximum value is 3650.
     * `non_current_transition` - Specifies when to transition objects of non current versions and the target storage class.
       * `non_current_days` - Number of days after non current object creation when the specific rule action takes effect.
       * `storage_class` - Specifies the storage class to which you want the non current object to transition. Available values include STANDARD, STANDARD_IA and ARCHIVE.
+    * `status` - Whether the lifecycle rule is enabled.
     * `transition` - Specifies a period in the object's transitions.
       * `date` - Specifies the date after which you want the corresponding action to take effect.
       * `days` - Specifies the number of days after object creation when the specific rule action takes effect.

--- a/website/docs/r/cos_bucket.html.markdown
+++ b/website/docs/r/cos_bucket.html.markdown
@@ -366,7 +366,11 @@ resource "tencentcloud_cos_bucket" "bucket_with_lifecycle" {
   acl    = "public-read-write"
 
   lifecycle_rules {
+    status        = "Enabled"
     filter_prefix = "path1/"
+    filter_tags = {
+      env = "prod"
+    }
 
     transition {
       days          = 30
@@ -404,6 +408,7 @@ resource "tencentcloud_cos_bucket" "bucket_with_lifecycle" {
   acl    = "private"
 
   lifecycle_rules {
+    status        = "Enabled"
     filter_prefix = "path1/"
 
     expiration {
@@ -681,9 +686,11 @@ The `lifecycle_rules` object supports the following:
 * `abort_incomplete_multipart_upload` - (Optional, Set) Set the maximum time a multipart upload is allowed to remain running.
 * `expiration` - (Optional, Set) Specifies a period in the object's expire (documented below).
 * `filter_prefix` - (Optional, String) Object key prefix identifying one or more objects to which the rule applies.
+* `filter_tags` - (Optional, Map) Object tags identifying objects to which the rule applies. All tags and `filter_prefix`, when set, are combined with a logical AND. COS supports up to 10 tags.
 * `id` - (Optional, String) A unique identifier for the rule. It can be up to 255 characters.
 * `non_current_expiration` - (Optional, Set) Specifies when non current object versions shall expire.
 * `non_current_transition` - (Optional, Set) Specifies a period in the non current object's transitions.
+* `status` - (Optional, String) Whether the lifecycle rule is enabled. Valid values are `Enabled` and `Disabled`.
 * `transition` - (Optional, Set) Specifies a period in the object's transitions (documented below).
 
 The `non_current_expiration` object of `lifecycle_rules` supports the following:


### PR DESCRIPTION
## What

Add `status` and `filter_tags` support to `tencentcloud_cos_bucket.lifecycle_rules`, including read/flatten support for the bucket resource and `tencentcloud_cos_buckets` data source.

## Why

Tencent Cloud COS lifecycle rules support Enabled/Disabled status and tag filters, including prefix-plus-tags and multiple-tag AND filters. The provider previously hard-coded every rule to Enabled and exposed only `filter_prefix`, so these API capabilities could not be configured or preserved in Terraform state.

## Type of change

- [x] Modification to an existing resource / data source
- [x] Bug fix

## Validation

- [x] `env -u GOOS -u GOARCH go test ./tencentcloud/services/cos -count=1`
- [x] `env -u GOOS -u GOARCH go test -v ./tencentcloud -run TestProvider -count=1`
- [x] `env -u GOOS -u GOARCH make build`
- [x] `env -u GOOS -u GOARCH make check-mux`
- [x] Acceptance coverage updated for resource and data source
- [x] Website docs regenerated
- [x] No `go.mod` changes
- [ ] `make lint` unavailable locally because `golangci-lint` is not installed
- [ ] Full `make test` is blocked by unrelated existing failures in `gendoc`, `common`, `bh`, `cam`, and `cbs`; the changed COS package passes

## Notes for reviewers

- Backward compatible: `status` defaults to `Enabled`, matching the previous hard-coded behavior.
- A single tag without a prefix uses `Filter.Tag`; multiple tags or prefix-plus-tags use `Filter.And`. Tags are sorted for deterministic requests.
- `filter_tags` validates the COS maximum of 10 tags and key/value byte limits.
- Plan and apply reject `filter_tags` with `abort_incomplete_multipart_upload` in the same lifecycle rule, as COS does not support that combination.