### PR TITLE
feat(tag): support in-place update of tag_value via UpdateResourceTagValue API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssl v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcm v1.0.547

--- a/go.sum
+++ b/go.sum
@@ -1104,8 +1104,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691 h1:UE55Tqu
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691/go.mod h1:IRaYO5mSpBMPX8ydImTcL3jyuEkALEu/55Myb0a+GMs=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11 h1:FWhgjLYFHWJvYIsLfk4k2XWaJcn7HMUmFLWNSL4pqto=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11/go.mod h1:et851eJUuaPGcsKDi1eUfQZoslCaDS3QKUgoqQZtF1c=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860 h1:epSPxNqUU0j2MY0qFoycwRl2he9AlxhEeyxUquBg/G8=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860/go.mod h1:6hzZuAz+UAG4nWudMqk+6hHwRWXZrFrpP8P7yEsEqY0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110 h1:Yahf4DkfDlq68dRp8EywDs1LgfaYGgrKt7WrNbsgviQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110/go.mod h1:1bbGbuvl0dhscea40iMjZFKSLX6450wJr0QF1dYViA8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634 h1:GJDzXxKloZeM8fN+qlIspPnZbUw1lOZGe7jGqfFbQMM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634/go.mod h1:yX1elLeYvjmtPvgBVCOyYxyy1u2XEKfXaEiZXIWRCKw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105 h1:6OndfnRdCLh3OTKvLaRA9OTOZbmsyB3uO8r4Hi8H/X4=

--- a/openspec/changes/update-tag-attachment-tag-value/.openspec.yaml
+++ b/openspec/changes/update-tag-attachment-tag-value/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/update-tag-attachment-tag-value/design.md
+++ b/openspec/changes/update-tag-attachment-tag-value/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The `tencentcloud_tag_attachment` resource binds a single tag key/value pair to a cloud resource described by its six-segment QCS string. Today all three schema fields (`tag_key`, `tag_value`, `resource`) are `ForceNew: true`, so any change destroys and recreates the attachment.
+
+The destroy+recreate sequence is problematic for tag value changes. When a resource already binds `运营产品:A` and the user changes the value to `运营产品:B`, Terraform first deletes the `运营产品:A` binding and then attempts to add `运营产品:B`. The second request can fail (e.g. when the resource still carries a value for that key during propagation), and the two-step sequence is non-atomic.
+
+**Current state:**
+- Resource file: `tencentcloud/services/tag/resource_tc_tag_attachment.go`
+- Service layer: `tencentcloud/services/tag/service_tencentcloud_tag.go`
+- Composite id: `tagKey + FILED_SP + tagValue + FILED_SP + resource`
+- SDK: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813`
+
+**Available tag service APIs for modifying a bound tag value (verified in vendored SDK):**
+
+| API | Request fields | Notes |
+|-----|-----------------|-------|
+| `UpdateResourceTagValue` | `TagKey`, `TagValue` (new), `Resource` (six-segment) | Matches the existing schema fields exactly. |
+| `ModifyResourcesTagValue` | `ServiceType`, `ResourceIds[]`, `TagKey`, `TagValue`, `ResourceRegion`, `ResourcePrefix` | Requires decomposing the six-segment resource string into separate parts. |
+| `ModifyResourceTags` | `Resource`, `ReplaceTags[]`, `DeleteTags[]` | Generic add/replace/delete; accepts the full six-segment `Resource`. |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `tag_value` updatable in place (remove `ForceNew`) on `tencentcloud_tag_attachment`.
+- Implement an `Update` function that modifies the bound tag value in a single API call when only `tag_value` changes.
+- Keep `tag_key` and `resource` immutable (`ForceNew: true`).
+- Refresh the composite id after a successful tag value update so `d.Id()` reflects the new value segment.
+- Add a service-layer helper that wraps the chosen API with `tccommon.WriteRetryTimeout` retry and `ratelimit.Check`.
+- Add an acceptance test that covers the in-place update of `tag_value`.
+- Update the `.md` example to document the in-place update behavior.
+
+**Non-Goals:**
+- Updating `tag_key` or `resource` in place (they remain `ForceNew`).
+- Changing the composite id format.
+- Adding support for batch/multi-resource tag operations.
+- Migrating existing state (the id format is unchanged; only the value segment changes).
+
+## Decisions
+
+### Decision 1: Use `UpdateResourceTagValue` as the update API
+
+**Rationale:** The `UpdateResourceTagValue` request takes exactly `TagKey`, `TagValue` (the new value), and `Resource` (the six-segment QCS string). These map 1:1 to the existing schema fields (`tag_key`, `tag_value`, `resource`), so no decomposition of the resource six-segment is needed. `ModifyResourcesTagValue` would require splitting the QCS into `ServiceType`/`ResourcePrefix`/`ResourceRegion`/`ResourceIds`, adding fragile parsing logic. `ModifyResourceTags` is more generic (replace/delete tag sets) and is already used elsewhere for multi-key rewrites; using it for a single value change is overkill and adds unrelated complexity. `UpdateResourceTagValue` is the simplest, most direct fit.
+
+**Alternatives considered:**
+- `ModifyResourcesTagValue`: rejected because it requires decomposing the six-segment resource string into `ServiceType`, `ResourceRegion`, `ResourcePrefix`, and `ResourceIds`, which is fragile and duplicates parsing the QCS.
+- `ModifyResourceTags` with a single `ReplaceTags` entry: rejected because it is a generic add/replace/delete interface already used for multi-key rewrites; using it for a single tag value change adds unnecessary generality and would not clearly express "update this one value".
+
+### Decision 2: Remove `ForceNew` only from `tag_value`; keep `tag_key` and `resource` immutable
+
+**Rationale:** The requirement is specifically about updating the tag value. `tag_key` and `resource` identify which binding is being modified; changing them is a different attachment and must remain `ForceNew`. This keeps the change minimal and backward compatible.
+
+### Decision 3: Refresh the composite id after update
+
+**Rationale:** The composite id is `tagKey#tagValue#resource`. After a successful `UpdateResourceTagValue`, the `tagValue` segment changes, so the Update function recomputes and sets `d.SetId(tagKey + FILED_SP + newTagValue + FILED_SP + resource)` before calling Read. This keeps state consistent for subsequent plan/apply cycles.
+
+### Decision 4: Add a dedicated service-layer helper `UpdateTagTagValue`
+
+**Rationale:** Consistent with the existing service layer (`DescribeTagTagAttachmentById`, `DeleteTagTagAttachmentById`). The helper builds the `UpdateResourceTagValueRequest`, applies `ratelimit.Check`, and wraps the call in `resource.Retry(tccommon.WriteRetryTimeout, ...)` with `tccommon.RetryError(err)` on failure — matching the retry pattern used across the tag service. The resource six-segment is passed as the `resourceName` parameter (matching the `ModifyTags` naming convention) to avoid shadowing the imported `helper/resource` package within the retry closure.
+
+### Decision 5: Read tag_key and resource from the existing state id (not a separate Describe)
+
+**Rationale:** The Update function parses the current id (`tagKey#oldTagValue#resource`) to validate the id and obtain the `tag_key` (first segment) and `resource` (third segment). It reads the new tag value from `d.Get("tag_value")`. The old tag value segment is not needed because `UpdateResourceTagValue` only takes the key, the new value, and the resource. This avoids an extra read API call before updating and matches how the existing Read/Delete functions already split the id.
+
+## Risks / Trade-offs
+
+- **[Risk] Idempotency when the new tag value equals the old value**: Terraform only calls Update when the diff is non-empty, so a no-op change does not trigger an API call. No special handling needed.
+  - **Mitigation:** None required; the SDK/plan layer guards against no-op updates.
+
+- **[Risk] The `UpdateResourceTagValue` API could fail if the resource does not currently bind `tagKey`**: This is expected API behavior and surfaces as an error to the user.
+  - **Mitigation:** The retry wrapper handles transient errors; persistent failures are returned to the user with a clear log line.
+
+- **[Risk] State drift between Delete and the old ForceNew path**: Removing `ForceNew` from `tag_value` changes the plan behavior. Existing state is unaffected because the id format and schema types are unchanged.
+  - **Mitigation:** Composite id format is preserved; only the value segment is refreshed after update.

--- a/openspec/changes/update-tag-attachment-tag-value/proposal.md
+++ b/openspec/changes/update-tag-attachment-tag-value/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The `tencentcloud_tag_attachment` resource marks `tag_value` as `ForceNew: true`. When a user changes the tag value on an existing resource (e.g. from `运营产品:A` to `运营产品:B`), Terraform destroys and recreates the attachment: it first deletes the `运营产品:A` binding and then tries to add `运营产品:B`. The second request fails when the resource's tag key already binds a value, and even when it succeeds the delete+add sequence is non-atomic and error-prone. The tag service provides dedicated APIs to modify a tag value in one step, so the resource should update in place instead of being replaced.
+
+## What Changes
+
+- Remove `ForceNew: true` from the `tag_value` schema field of `tencentcloud_tag_attachment` so changes to the tag value trigger an Update instead of destroy+recreate.
+- Add an `Update` function to `tencentcloud_tag_attachment` that, when `tag_value` changes, calls the tag service `UpdateResourceTagValue` API (TagKey + new TagValue + Resource six-segment form) to modify the bound tag value in a single request.
+- Keep `tag_key` and `resource` as `ForceNew: true` (immutable); only `tag_value` becomes updatable.
+- Update the resource composite id (`tagKey#tagValue#resource`) when `tag_value` changes so the id reflects the new tag value after a successful update.
+- Add a service-layer helper `UpdateTagTagValue` that wraps the `UpdateResourceTagValue` API call with retry and ratelimit handling.
+- Add `Update` support to the `tencentcloud_tag_attachment` resource test (`resource_tc_tag_attachment_test.go`) covering the tag value in-place update flow.
+- Update the `tencentcloud_tag_attachment` `.md` example to document the in-place update behavior.
+
+## Capabilities
+
+### New Capabilities
+- `tag-attachment-tag-value-update`: Enable in-place update of the `tag_value` field on the `tencentcloud_tag_attachment` resource via the `UpdateResourceTagValue` API, eliminating the destructive delete+recreate behavior when only the tag value changes.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/tag/resource_tc_tag_attachment.go` — remove `ForceNew` from `tag_value`, add `Update: resourceTencentCloudTagAttachmentUpdate`, implement the update flow, refresh the composite id after update
+  - `tencentcloud/services/tag/service_tencentcloud_tag.go` — add `UpdateTagTagValue` service function wrapping `UpdateResourceTagValue`
+  - `tencentcloud/services/tag/resource_tc_tag_attachment_test.go` — add test case for tag value in-place update
+  - `tencentcloud/services/tag/resource_tc_tag_attachment.md` — document in-place update behavior
+- **API dependency:** Uses the existing `UpdateResourceTagValue` API from `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813` (already vendored). The API accepts `TagKey`, `TagValue` (new value), and `Resource` (six-segment form), matching the resource's existing schema fields exactly.
+- **Backward compatibility:** Backward compatible. `tag_key` and `resource` remain `ForceNew`. Existing configurations that create attachments are unaffected; only tag value changes now update in place instead of recreating.
+- **State migration:** None required. The composite id format (`tagKey#tagValue#resource`) is unchanged; only the value segment is refreshed after a successful update.

--- a/openspec/changes/update-tag-attachment-tag-value/specs/tag-attachment-tag-value-update/spec.md
+++ b/openspec/changes/update-tag-attachment-tag-value/specs/tag-attachment-tag-value-update/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: tag_value is updatable in place
+The `tencentcloud_tag_attachment` resource SHALL allow the `tag_value` field to be updated in place. The `tag_value` field SHALL NOT be marked `ForceNew`. Changes to `tag_value` SHALL trigger the resource `Update` function instead of destroying and recreating the attachment.
+
+#### Scenario: Changing tag_value triggers Update
+- **WHEN** a user changes only the `tag_value` field of an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL call the `Update` function
+- **AND** the provider SHALL NOT delete and recreate the attachment
+
+#### Scenario: tag_value is not ForceNew
+- **WHEN** the `tencentcloud_tag_attachment` schema is defined
+- **THEN** the `tag_value` field SHALL NOT have `ForceNew: true`
+
+### Requirement: tag_key and resource remain immutable
+The `tag_key` and `resource` fields of `tencentcloud_tag_attachment` SHALL remain `ForceNew: true`. Changing either field SHALL destroy and recreate the attachment as before.
+
+#### Scenario: Changing tag_key recreates the attachment
+- **WHEN** a user changes the `tag_key` field of an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL destroy and recreate the attachment
+
+#### Scenario: Changing resource recreates the attachment
+- **WHEN** a user changes the `resource` field of an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL destroy and recreate the attachment
+
+### Requirement: Update uses the UpdateResourceTagValue API in a single request
+The `tencentcloud_tag_attachment` `Update` function SHALL modify the bound tag value in a single API request using the tag service `UpdateResourceTagValue` API. The request SHALL pass `TagKey`, `TagValue` (the new value), and `Resource` (the six-segment QCS string) fields. The provider SHALL NOT implement the update as a delete-then-add sequence.
+
+#### Scenario: Update calls UpdateResourceTagValue with the new tag value
+- **WHEN** the `Update` function is invoked because `tag_value` changed
+- **THEN** the provider SHALL build an `UpdateResourceTagValueRequest` with `TagKey` set to the current `tag_key`, `TagValue` set to the new `tag_value`, and `Resource` set to the current `resource`
+- **AND** the provider SHALL send the request to the `UpdateResourceTagValue` API in a single call
+
+#### Scenario: Update does not delete then add
+- **WHEN** the `Update` function is invoked because `tag_value` changed
+- **THEN** the provider SHALL NOT call `DeleteResourceTag` followed by `AddResourceTag`
+
+### Requirement: UpdateResourceTagValue call is retried with WriteRetryTimeout
+The `Update` function SHALL wrap the `UpdateResourceTagValue` API call in `resource.Retry(tccommon.WriteRetryTimeout, ...)` and SHALL convert errors using `tccommon.RetryError(err)`. The retry block SHALL only perform the API call; setting the id and other success handling SHALL happen outside the retry block.
+
+#### Scenario: Transient API failure is retried
+- **WHEN** the `UpdateResourceTagValue` API returns a transient error
+- **THEN** the provider SHALL retry the call within `tccommon.WriteRetryTimeout`
+- **AND** the id SHALL NOT be set inside the retry block
+
+#### Scenario: Persistent API failure is returned
+- **WHEN** the `UpdateResourceTagValue` API returns a non-retryable error
+- **THEN** the provider SHALL return the wrapped error to the caller
+
+### Requirement: Composite id is refreshed after a successful update
+The `tencentcloud_tag_attachment` composite id is `tagKey + FILED_SP + tagValue + FILED_SP + resource`. After a successful `UpdateResourceTagValue` call, the `Update` function SHALL recompute and set `d.SetId()` with the new `tag_value` so the id reflects the updated binding. The id format SHALL remain unchanged.
+
+#### Scenario: Id reflects new tag value after update
+- **WHEN** the `UpdateResourceTagValue` call succeeds for a tag value change from `A` to `B`
+- **THEN** the provider SHALL set `d.SetId(tagKey + FILED_SP + "B" + FILED_SP + resource)`
+
+#### Scenario: Id format is preserved
+- **WHEN** the composite id is recomputed after update
+- **THEN** the id SHALL use the existing `FILED_SP` separator and three-segment structure
+
+### Requirement: Update reads tag_key and resource from the current id
+The `Update` function SHALL parse the current composite id (`tagKey#oldTagValue#resource`) to validate the id and obtain the existing `tag_key` and `resource`. It SHALL read the new `tag_value` from `d.Get("tag_value")`. If the id cannot be split into three segments, the `Update` function SHALL return an error.
+
+#### Scenario: tag_key and resource are obtained from the id
+- **WHEN** the `Update` function runs
+- **THEN** the provider SHALL split `d.Id()` by `FILED_SP` into three parts: `tagKey`, the old `tagValue`, and `resource`
+- **AND** the provider SHALL use `tagKey` (first segment) and `resource` (third segment) to build the `UpdateResourceTagValue` request
+
+#### Scenario: Broken id returns an error
+- **WHEN** `d.Id()` does not split into exactly three segments by `FILED_SP`
+- **THEN** the `Update` function SHALL return an error of the form `id is broken,%s`
+
+### Requirement: Service layer provides UpdateTagTagValue helper
+The tag service layer SHALL provide an `UpdateTagTagValue(ctx, tagKey, tagValue, resourceName string) error` function that builds an `UpdateResourceTagValueRequest`, applies `ratelimit.Check`, and calls `UpdateResourceTagValue` wrapped in `resource.Retry(tccommon.WriteRetryTimeout, ...)` with `tccommon.RetryError(err)` on failure.
+
+#### Scenario: Helper builds the request from schema fields
+- **WHEN** `UpdateTagTagValue` is called with `tagKey`, `tagValue`, and `resourceName`
+- **THEN** the service function SHALL set `request.TagKey`, `request.TagValue`, and `request.Resource` accordingly
+- **AND** the service function SHALL send the `UpdateResourceTagValue` request
+
+#### Scenario: Helper applies rate limiting and retry
+- **WHEN** `UpdateTagTagValue` calls the API
+- **THEN** the service function SHALL call `ratelimit.Check(request.GetAction())`
+- **AND** the service function SHALL wrap the call in `resource.Retry(tccommon.WriteRetryTimeout, ...)`
+
+### Requirement: tag_value in-place update is tested
+The resource test file `resource_tc_tag_attachment_test.go` SHALL include an acceptance test step that updates the `tag_value` of an existing `tencentcloud_tag_attachment` and verifies the updated value is reflected in state.
+
+#### Scenario: Test updates tag_value in place
+- **WHEN** the acceptance test runs an update step that changes `tag_value`
+- **THEN** the provider SHALL update the attachment in place
+- **AND** the test SHALL verify `tag_value` matches the new value in state

--- a/openspec/changes/update-tag-attachment-tag-value/tasks.md
+++ b/openspec/changes/update-tag-attachment-tag-value/tasks.md
@@ -1,0 +1,33 @@
+## 1. Service Layer
+
+- [x] 1.1 Add `UpdateTagTagValue(ctx context.Context, tagKey, tagValue, resourceName string) error` function to `tencentcloud/services/tag/service_tencentcloud_tag.go`
+- [x] 1.2 Build `tag.NewUpdateResourceTagValueRequest()`, set `TagKey`, `TagValue` (new value), and `Resource` from the function parameters
+- [x] 1.3 Wrap the `UpdateResourceTagValue` API call in `resource.Retry(tccommon.WriteRetryTimeout, ...)`, call `ratelimit.Check(request.GetAction())`, and convert errors with `tccommon.RetryError(err)`
+
+## 2. Resource Schema Changes
+
+- [x] 2.1 In `ResourceTencentCloudTagAttachment()` in `tencentcloud/services/tag/resource_tc_tag_attachment.go`, remove `ForceNew: true` from the `tag_value` field
+- [x] 2.2 Keep `tag_key` and `resource` as `ForceNew: true`
+- [x] 2.3 Register the new `Update: resourceTencentCloudTagAttachmentUpdate` function in the resource definition
+
+## 3. Update Function
+
+- [x] 3.1 Add `resourceTencentCloudTagAttachmentUpdate(d *schema.ResourceData, meta interface{}) error` with `defer tccommon.LogElapsed(...)` and `defer tccommon.InconsistentCheck(d, meta)()`
+- [x] 3.2 Split `d.Id()` by `tccommon.FILED_SP` into three segments; return `fmt.Errorf("id is broken,%s", d.Id())` if not exactly three segments
+- [x] 3.3 Read `tag_key` (first segment) and `resource` (third segment) from the id; read the new `tag_value` from `d.Get("tag_value")`
+- [x] 3.4 When `tag_value` changed, call `service.UpdateTagTagValue(ctx, tagKey, newTagValue, resource)`; the retry block must only perform the API call
+- [x] 3.5 After a successful update, recompute and set `d.SetId(tagKey + tccommon.FILED_SP + newTagValue + tccommon.FILED_SP + resource)` outside the retry block
+- [x] 3.6 Call `resourceTencentCloudTagAttachmentRead(d, meta)` to refresh state
+
+## 4. Tests
+
+- [x] 4.1 Add an acceptance test step to `TestAccTencentCloudTagAttachmentResource_basic` in `tencentcloud/services/tag/resource_tc_tag_attachment_test.go` that updates `tag_value` and verifies the new value is reflected in state
+
+## 5. Documentation
+
+- [x] 5.1 Update `tencentcloud/services/tag/resource_tc_tag_attachment.md` to document that `tag_value` is updated in place via `UpdateResourceTagValue`
+
+## 6. Validation
+
+- [x] 6.1 Verify the code compiles successfully
+- [x] 6.2 Verify no lint errors

--- a/openspec/specs/tag-attachment-tag-value-update/spec.md
+++ b/openspec/specs/tag-attachment-tag-value-update/spec.md
@@ -1,0 +1,96 @@
+# tag-attachment-tag-value-update Specification
+
+## Purpose
+TBD - created by archiving change update-tag-attachment-tag-value. Update Purpose after archive.
+## Requirements
+### Requirement: tag_value is updatable in place
+The `tencentcloud_tag_attachment` resource SHALL allow the `tag_value` field to be updated in place. The `tag_value` field SHALL NOT be marked `ForceNew`. Changes to `tag_value` SHALL trigger the resource `Update` function instead of destroying and recreating the attachment.
+
+#### Scenario: Changing tag_value triggers Update
+- **WHEN** a user changes only the `tag_value` field of an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL call the `Update` function
+- **AND** the provider SHALL NOT delete and recreate the attachment
+
+#### Scenario: tag_value is not ForceNew
+- **WHEN** the `tencentcloud_tag_attachment` schema is defined
+- **THEN** the `tag_value` field SHALL NOT have `ForceNew: true`
+
+### Requirement: tag_key and resource remain immutable
+The `tag_key` and `resource` fields of `tencentcloud_tag_attachment` SHALL remain `ForceNew: true`. Changing either field SHALL destroy and recreate the attachment as before.
+
+#### Scenario: Changing tag_key recreates the attachment
+- **WHEN** a user changes the `tag_key` field of an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL destroy and recreate the attachment
+
+#### Scenario: Changing resource recreates the attachment
+- **WHEN** a user changes the `resource` field of an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL destroy and recreate the attachment
+
+### Requirement: Update uses the UpdateResourceTagValue API in a single request
+The `tencentcloud_tag_attachment` `Update` function SHALL modify the bound tag value in a single API request using the tag service `UpdateResourceTagValue` API. The request SHALL pass `TagKey`, `TagValue` (the new value), and `Resource` (the six-segment QCS string) fields. The provider SHALL NOT implement the update as a delete-then-add sequence.
+
+#### Scenario: Update calls UpdateResourceTagValue with the new tag value
+- **WHEN** the `Update` function is invoked because `tag_value` changed
+- **THEN** the provider SHALL build an `UpdateResourceTagValueRequest` with `TagKey` set to the current `tag_key`, `TagValue` set to the new `tag_value`, and `Resource` set to the current `resource`
+- **AND** the provider SHALL send the request to the `UpdateResourceTagValue` API in a single call
+
+#### Scenario: Update does not delete then add
+- **WHEN** the `Update` function is invoked because `tag_value` changed
+- **THEN** the provider SHALL NOT call `DeleteResourceTag` followed by `AddResourceTag`
+
+### Requirement: UpdateResourceTagValue call is retried with WriteRetryTimeout
+The `Update` function SHALL wrap the `UpdateResourceTagValue` API call in `resource.Retry(tccommon.WriteRetryTimeout, ...)` and SHALL convert errors using `tccommon.RetryError(err)`. The retry block SHALL only perform the API call; setting the id and other success handling SHALL happen outside the retry block.
+
+#### Scenario: Transient API failure is retried
+- **WHEN** the `UpdateResourceTagValue` API returns a transient error
+- **THEN** the provider SHALL retry the call within `tccommon.WriteRetryTimeout`
+- **AND** the id SHALL NOT be set inside the retry block
+
+#### Scenario: Persistent API failure is returned
+- **WHEN** the `UpdateResourceTagValue` API returns a non-retryable error
+- **THEN** the provider SHALL return the wrapped error to the caller
+
+### Requirement: Composite id is refreshed after a successful update
+The `tencentcloud_tag_attachment` composite id is `tagKey + FILED_SP + tagValue + FILED_SP + resource`. After a successful `UpdateResourceTagValue` call, the `Update` function SHALL recompute and set `d.SetId()` with the new `tag_value` so the id reflects the updated binding. The id format SHALL remain unchanged.
+
+#### Scenario: Id reflects new tag value after update
+- **WHEN** the `UpdateResourceTagValue` call succeeds for a tag value change from `A` to `B`
+- **THEN** the provider SHALL set `d.SetId(tagKey + FILED_SP + "B" + FILED_SP + resource)`
+
+#### Scenario: Id format is preserved
+- **WHEN** the composite id is recomputed after update
+- **THEN** the id SHALL use the existing `FILED_SP` separator and three-segment structure
+
+### Requirement: Update reads tag_key and resource from the current id
+The `Update` function SHALL parse the current composite id (`tagKey#oldTagValue#resource`) to validate the id and obtain the existing `tag_key` and `resource`. It SHALL read the new `tag_value` from `d.Get("tag_value")`. If the id cannot be split into three segments, the `Update` function SHALL return an error.
+
+#### Scenario: tag_key and resource are obtained from the id
+- **WHEN** the `Update` function runs
+- **THEN** the provider SHALL split `d.Id()` by `FILED_SP` into three parts: `tagKey`, the old `tagValue`, and `resource`
+- **AND** the provider SHALL use `tagKey` (first segment) and `resource` (third segment) to build the `UpdateResourceTagValue` request
+
+#### Scenario: Broken id returns an error
+- **WHEN** `d.Id()` does not split into exactly three segments by `FILED_SP`
+- **THEN** the `Update` function SHALL return an error of the form `id is broken,%s`
+
+### Requirement: Service layer provides UpdateTagTagValue helper
+The tag service layer SHALL provide an `UpdateTagTagValue(ctx, tagKey, tagValue, resourceName string) error` function that builds an `UpdateResourceTagValueRequest`, applies `ratelimit.Check`, and calls `UpdateResourceTagValue` wrapped in `resource.Retry(tccommon.WriteRetryTimeout, ...)` with `tccommon.RetryError(err)` on failure.
+
+#### Scenario: Helper builds the request from schema fields
+- **WHEN** `UpdateTagTagValue` is called with `tagKey`, `tagValue`, and `resourceName`
+- **THEN** the service function SHALL set `request.TagKey`, `request.TagValue`, and `request.Resource` accordingly
+- **AND** the service function SHALL send the `UpdateResourceTagValue` request
+
+#### Scenario: Helper applies rate limiting and retry
+- **WHEN** `UpdateTagTagValue` calls the API
+- **THEN** the service function SHALL call `ratelimit.Check(request.GetAction())`
+- **AND** the service function SHALL wrap the call in `resource.Retry(tccommon.WriteRetryTimeout, ...)`
+
+### Requirement: tag_value in-place update is tested
+The resource test file `resource_tc_tag_attachment_test.go` SHALL include an acceptance test step that updates the `tag_value` of an existing `tencentcloud_tag_attachment` and verifies the updated value is reflected in state.
+
+#### Scenario: Test updates tag_value in place
+- **WHEN** the acceptance test runs an update step that changes `tag_value`
+- **THEN** the provider SHALL update the attachment in place
+- **AND** the test SHALL verify `tag_value` matches the new value in state
+

--- a/tencentcloud/services/tag/resource_tc_tag_attachment.go
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment.go
@@ -20,6 +20,7 @@ func ResourceTencentCloudTagAttachment() *schema.Resource {
 		Create: resourceTencentCloudTagAttachmentCreate,
 		Read:   resourceTencentCloudTagAttachmentRead,
 		Delete: resourceTencentCloudTagAttachmentDelete,
+		Update: resourceTencentCloudTagAttachmentUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -33,7 +34,6 @@ func ResourceTencentCloudTagAttachment() *schema.Resource {
 
 			"tag_value": {
 				Required:    true,
-				ForceNew:    true,
 				Type:        schema.TypeString,
 				Description: "tag value.",
 			},
@@ -90,6 +90,34 @@ func resourceTencentCloudTagAttachmentCreate(d *schema.ResourceData, meta interf
 	}
 
 	d.SetId(tagKey + tccommon.FILED_SP + tagValue + tccommon.FILED_SP + resourceId)
+
+	return resourceTencentCloudTagAttachmentRead(d, meta)
+}
+
+func resourceTencentCloudTagAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_tag_attachment.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+	service := TagService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+	tagKey := idSplit[0]
+	resource := idSplit[2]
+
+	if d.HasChange("tag_value") {
+		newTagValue := d.Get("tag_value").(string)
+		if err := service.UpdateTagTagValue(ctx, tagKey, newTagValue, resource); err != nil {
+			log.Printf("[CRITAL]%s update tag tagAttachment failed, reason:%+v", logId, err)
+			return err
+		}
+
+		d.SetId(tagKey + tccommon.FILED_SP + newTagValue + tccommon.FILED_SP + resource)
+	}
 
 	return resourceTencentCloudTagAttachmentRead(d, meta)
 }

--- a/tencentcloud/services/tag/resource_tc_tag_attachment.md
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment.md
@@ -12,6 +12,16 @@ resource "tencentcloud_tag_attachment" "attachment" {
 
 ```
 
+`tag_value` can be updated in place; changing it calls the `UpdateResourceTagValue` API to modify the bound tag value in a single request instead of destroying and recreating the attachment. `tag_key` and `resource` are immutable and require the resource to be recreated when changed.
+
+```hcl
+resource "tencentcloud_tag_attachment" "attachment" {
+  tag_key   = "test3"
+  tag_value = "Terraform3_update"
+  resource  = "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4"
+}
+```
+
 Import
 
 tag attachment can be imported using the id, e.g.

--- a/tencentcloud/services/tag/resource_tc_tag_attachment_test.go
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment_test.go
@@ -32,6 +32,14 @@ func TestAccTencentCloudTagAttachmentResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("tencentcloud_tag_attachment.tag_attachment", "resource")),
 			},
 			{
+				Config: testAccTagResourceTagUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTagAttachmentExists("tencentcloud_tag_attachment.tag_attachment"),
+					resource.TestCheckResourceAttr("tencentcloud_tag_attachment.tag_attachment", "tag_key", "test_terraform_tagAttachment_key"),
+					resource.TestCheckResourceAttr("tencentcloud_tag_attachment.tag_attachment", "tag_value", "Terraform_tagAttachment_value_update"),
+					resource.TestCheckResourceAttrSet("tencentcloud_tag_attachment.tag_attachment", "resource")),
+			},
+			{
 				ResourceName:      "tencentcloud_tag_attachment.tag_attachment",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -95,6 +103,21 @@ locals {
 resource "tencentcloud_tag_attachment" "tag_attachment" {
   tag_key = "test_terraform_tagAttachment_key"
   tag_value = "Terraform_tagAttachment_value"
+  resource = "qcs::cvm:ap-guangzhou:uin/${local.uin}:instance/${var.cvm_id}"
+}
+
+`
+
+const testAccTagResourceTagUpdate = tcacctest.DefaultCvmModificationVariable + `
+data "tencentcloud_user_info" "info" {}
+
+locals {
+  uin = data.tencentcloud_user_info.info.uin
+}
+
+resource "tencentcloud_tag_attachment" "tag_attachment" {
+  tag_key = "test_terraform_tagAttachment_key"
+  tag_value = "Terraform_tagAttachment_value_update"
   resource = "qcs::cvm:ap-guangzhou:uin/${local.uin}:instance/${var.cvm_id}"
 }
 

--- a/tencentcloud/services/tag/service_tencentcloud_tag.go
+++ b/tencentcloud/services/tag/service_tencentcloud_tag.go
@@ -442,6 +442,38 @@ func (me *TagService) DeleteTagTagAttachmentById(ctx context.Context, tagKey str
 	return
 }
 
+func (me *TagService) UpdateTagTagValue(ctx context.Context, tagKey string, tagValue string, resourceName string) (errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := tag.NewUpdateResourceTagValueRequest()
+	request.TagKey = &tagKey
+	request.TagValue = &tagValue
+	request.Resource = &resourceName
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, e := me.client.UseTagClient().UpdateResourceTagValue(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+		return nil
+	})
+	if err != nil {
+		errRet = err
+		return
+	}
+
+	return
+}
+
 func (me *TagService) DescribeTagKeysByFilter(ctx context.Context, param map[string]interface{}) (ret []*string, errRet error) {
 	var (
 		logId   = tccommon.GetLogId(ctx)

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ func (c *Client) AddProjectWithContext(ctx context.Context, request *AddProjectR
     if request == nil {
         request = NewAddProjectRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AddProject")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AddProject require credential")
@@ -161,6 +162,7 @@ func (c *Client) AddResourceTagWithContext(ctx context.Context, request *AddReso
     if request == nil {
         request = NewAddResourceTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AddResourceTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AddResourceTag require credential")
@@ -250,6 +252,7 @@ func (c *Client) AttachResourcesTagWithContext(ctx context.Context, request *Att
     if request == nil {
         request = NewAttachResourcesTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AttachResourcesTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AttachResourcesTag require credential")
@@ -323,6 +326,7 @@ func (c *Client) CreateTagWithContext(ctx context.Context, request *CreateTagReq
     if request == nil {
         request = NewCreateTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "CreateTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateTag require credential")
@@ -398,6 +402,7 @@ func (c *Client) CreateTagsWithContext(ctx context.Context, request *CreateTagsR
     if request == nil {
         request = NewCreateTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "CreateTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateTags require credential")
@@ -461,6 +466,7 @@ func (c *Client) DeleteResourceTagWithContext(ctx context.Context, request *Dele
     if request == nil {
         request = NewDeleteResourceTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteResourceTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteResourceTag require credential")
@@ -528,6 +534,7 @@ func (c *Client) DeleteTagWithContext(ctx context.Context, request *DeleteTagReq
     if request == nil {
         request = NewDeleteTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteTag require credential")
@@ -599,6 +606,7 @@ func (c *Client) DeleteTagsWithContext(ctx context.Context, request *DeleteTagsR
     if request == nil {
         request = NewDeleteTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteTags require credential")
@@ -654,6 +662,7 @@ func (c *Client) DescribeProjectsWithContext(ctx context.Context, request *Descr
     if request == nil {
         request = NewDescribeProjectsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeProjects")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeProjects require credential")
@@ -703,6 +712,7 @@ func (c *Client) DescribeResourceTagsWithContext(ctx context.Context, request *D
     if request == nil {
         request = NewDescribeResourceTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTags require credential")
@@ -764,6 +774,7 @@ func (c *Client) DescribeResourceTagsByResourceIdsWithContext(ctx context.Contex
     if request == nil {
         request = NewDescribeResourceTagsByResourceIdsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByResourceIds")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByResourceIds require credential")
@@ -823,6 +834,7 @@ func (c *Client) DescribeResourceTagsByResourceIdsSeqWithContext(ctx context.Con
     if request == nil {
         request = NewDescribeResourceTagsByResourceIdsSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByResourceIdsSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByResourceIdsSeq require credential")
@@ -855,7 +867,7 @@ func NewDescribeResourceTagsByTagKeysResponse() (response *DescribeResourceTagsB
 }
 
 // DescribeResourceTagsByTagKeys
-// 根据标签键获取资源标签
+// 根据标签键获取指定资源上的标签值
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -871,7 +883,7 @@ func (c *Client) DescribeResourceTagsByTagKeys(request *DescribeResourceTagsByTa
 }
 
 // DescribeResourceTagsByTagKeys
-// 根据标签键获取资源标签
+// 根据标签键获取指定资源上的标签值
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -886,6 +898,7 @@ func (c *Client) DescribeResourceTagsByTagKeysWithContext(ctx context.Context, r
     if request == nil {
         request = NewDescribeResourceTagsByTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByTagKeys require credential")
@@ -918,7 +931,9 @@ func NewDescribeResourcesByTagsResponse() (response *DescribeResourcesByTagsResp
 }
 
 // DescribeResourcesByTags
-// 通过标签查询资源列表
+// 通过标签查询资源列表，按TagKey取交集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。交集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，同时包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -931,7 +946,9 @@ func (c *Client) DescribeResourcesByTags(request *DescribeResourcesByTagsRequest
 }
 
 // DescribeResourcesByTags
-// 通过标签查询资源列表
+// 通过标签查询资源列表，按TagKey取交集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。交集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，同时包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -943,6 +960,7 @@ func (c *Client) DescribeResourcesByTagsWithContext(ctx context.Context, request
     if request == nil {
         request = NewDescribeResourcesByTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourcesByTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourcesByTags require credential")
@@ -975,7 +993,9 @@ func NewDescribeResourcesByTagsUnionResponse() (response *DescribeResourcesByTag
 }
 
 // DescribeResourcesByTagsUnion
-// 通过标签查询资源列表并集
+// 通过标签查询资源列表，按TagKey取并集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。并集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，或者包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -987,7 +1007,9 @@ func (c *Client) DescribeResourcesByTagsUnion(request *DescribeResourcesByTagsUn
 }
 
 // DescribeResourcesByTagsUnion
-// 通过标签查询资源列表并集
+// 通过标签查询资源列表，按TagKey取并集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。并集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，或者包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -998,6 +1020,7 @@ func (c *Client) DescribeResourcesByTagsUnionWithContext(ctx context.Context, re
     if request == nil {
         request = NewDescribeResourcesByTagsUnionRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourcesByTagsUnion")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourcesByTagsUnion require credential")
@@ -1049,6 +1072,7 @@ func (c *Client) DescribeTagKeysWithContext(ctx context.Context, request *Descri
     if request == nil {
         request = NewDescribeTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagKeys require credential")
@@ -1102,6 +1126,7 @@ func (c *Client) DescribeTagValuesWithContext(ctx context.Context, request *Desc
     if request == nil {
         request = NewDescribeTagValuesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagValues")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagValues require credential")
@@ -1153,6 +1178,7 @@ func (c *Client) DescribeTagValuesSeqWithContext(ctx context.Context, request *D
     if request == nil {
         request = NewDescribeTagValuesSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagValuesSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagValuesSeq require credential")
@@ -1185,7 +1211,9 @@ func NewDescribeTagsResponse() (response *DescribeTagsResponse) {
 }
 
 // DescribeTags
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1195,7 +1223,9 @@ func (c *Client) DescribeTags(request *DescribeTagsRequest) (response *DescribeT
 }
 
 // DescribeTags
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1204,6 +1234,7 @@ func (c *Client) DescribeTagsWithContext(ctx context.Context, request *DescribeT
     if request == nil {
         request = NewDescribeTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTags require credential")
@@ -1236,7 +1267,9 @@ func NewDescribeTagsSeqResponse() (response *DescribeTagsSeqResponse) {
 }
 
 // DescribeTagsSeq
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1247,7 +1280,9 @@ func (c *Client) DescribeTagsSeq(request *DescribeTagsSeqRequest) (response *Des
 }
 
 // DescribeTagsSeq
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1257,6 +1292,7 @@ func (c *Client) DescribeTagsSeqWithContext(ctx context.Context, request *Descri
     if request == nil {
         request = NewDescribeTagsSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagsSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagsSeq require credential")
@@ -1336,6 +1372,7 @@ func (c *Client) DetachResourcesTagWithContext(ctx context.Context, request *Det
     if request == nil {
         request = NewDetachResourcesTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DetachResourcesTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DetachResourcesTag require credential")
@@ -1368,7 +1405,7 @@ func NewGetResourcesResponse() (response *GetResourcesResponse) {
 }
 
 // GetResources
-// 查询绑定了标签的资源列表。
+// 查询资源标签列表。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
@@ -1392,7 +1429,7 @@ func (c *Client) GetResources(request *GetResourcesRequest) (response *GetResour
 }
 
 // GetResources
-// 查询绑定了标签的资源列表。
+// 查询资源标签列表。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
@@ -1415,6 +1452,7 @@ func (c *Client) GetResourcesWithContext(ctx context.Context, request *GetResour
     if request == nil {
         request = NewGetResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetResources require credential")
@@ -1472,6 +1510,7 @@ func (c *Client) GetTagKeysWithContext(ctx context.Context, request *GetTagKeysR
     if request == nil {
         request = NewGetTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTagKeys require credential")
@@ -1531,6 +1570,7 @@ func (c *Client) GetTagValuesWithContext(ctx context.Context, request *GetTagVal
     if request == nil {
         request = NewGetTagValuesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTagValues")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTagValues require credential")
@@ -1565,6 +1605,8 @@ func NewGetTagsResponse() (response *GetTagsResponse) {
 // GetTags
 // 用于获取已建立的标签列表。
 //
+// 举例：TagKeys 为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  INVALIDPARAMETER = "InvalidParameter"
@@ -1579,6 +1621,8 @@ func (c *Client) GetTags(request *GetTagsRequest) (response *GetTagsResponse, er
 // GetTags
 // 用于获取已建立的标签列表。
 //
+// 举例：TagKeys 为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  INVALIDPARAMETER = "InvalidParameter"
@@ -1590,6 +1634,7 @@ func (c *Client) GetTagsWithContext(ctx context.Context, request *GetTagsRequest
     if request == nil {
         request = NewGetTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTags require credential")
@@ -1667,6 +1712,7 @@ func (c *Client) ModifyResourceTagsWithContext(ctx context.Context, request *Mod
     if request == nil {
         request = NewModifyResourceTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "ModifyResourceTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ModifyResourceTags require credential")
@@ -1750,6 +1796,7 @@ func (c *Client) ModifyResourcesTagValueWithContext(ctx context.Context, request
     if request == nil {
         request = NewModifyResourcesTagValueRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "ModifyResourcesTagValue")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ModifyResourcesTagValue require credential")
@@ -1835,6 +1882,7 @@ func (c *Client) TagResourcesWithContext(ctx context.Context, request *TagResour
     if request == nil {
         request = NewTagResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "TagResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("TagResources require credential")
@@ -1912,6 +1960,7 @@ func (c *Client) UnTagResourcesWithContext(ctx context.Context, request *UnTagRe
     if request == nil {
         request = NewUnTagResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UnTagResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UnTagResources require credential")
@@ -1969,6 +2018,7 @@ func (c *Client) UpdateProjectWithContext(ctx context.Context, request *UpdatePr
     if request == nil {
         request = NewUpdateProjectRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UpdateProject")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateProject require credential")
@@ -2034,6 +2084,7 @@ func (c *Client) UpdateResourceTagValueWithContext(ctx context.Context, request 
     if request == nil {
         request = NewUpdateResourceTagValueRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UpdateResourceTagValue")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateResourceTagValue require credential")

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/models.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,20 +23,20 @@ import (
 // Predefined struct for user
 type AddProjectRequestParams struct {
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 项目描述
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 type AddProjectRequest struct {
 	*tchttp.BaseRequest
 	
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 项目描述
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 func (r *AddProjectRequest) ToJsonString() string {
@@ -62,13 +62,13 @@ func (r *AddProjectRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type AddProjectResponseParams struct {
 	// 项目Id
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
-	// 是否为新项目
-	IsNew *int64 `json:"IsNew,omitnil" name:"IsNew"`
+	// 是否为新项目，1是新项目，0不是新项目
+	IsNew *int64 `json:"IsNew,omitnil,omitempty" name:"IsNew"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AddProjectResponse struct {
@@ -90,26 +90,26 @@ func (r *AddProjectResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type AddResourceTagRequestParams struct {
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 待关联的资源，用标准的资源六段式表示。正确的资源六段式请参考：https://cloud.tencent.com/document/product/651/89122
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type AddResourceTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 待关联的资源，用标准的资源六段式表示。正确的资源六段式请参考：https://cloud.tencent.com/document/product/651/89122
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *AddResourceTagRequest) ToJsonString() string {
@@ -135,8 +135,8 @@ func (r *AddResourceTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AddResourceTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AddResourceTagResponse struct {
@@ -157,45 +157,45 @@ func (r *AddResourceTagResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachResourcesTagRequestParams struct {
-	// 业务的英文简称，即资源六段式第三段。资源六段式的描述方式参考：https://cloud.tencent.com/document/product/651/89122
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源所在地域，不区分地域的资源则不必填。区分地域的资源则必填，且必填时必须是参数ResourceIds.N资源所对应的地域，且如果ResourceIds.N为批量时，这些资源也必须是同一个地域的。例如示例值：ap-beijing，则参数ResourceIds.N中都应该填写该地域的资源。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分，例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type AttachResourcesTagRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务的英文简称，即资源六段式第三段。资源六段式的描述方式参考：https://cloud.tencent.com/document/product/651/89122
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源所在地域，不区分地域的资源则不必填。区分地域的资源则必填，且必填时必须是参数ResourceIds.N资源所对应的地域，且如果ResourceIds.N为批量时，这些资源也必须是同一个地域的。例如示例值：ap-beijing，则参数ResourceIds.N中都应该填写该地域的资源。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分，例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *AttachResourcesTagRequest) ToJsonString() string {
@@ -224,8 +224,8 @@ func (r *AttachResourcesTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachResourcesTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AttachResourcesTagResponse struct {
@@ -247,20 +247,20 @@ func (r *AttachResourcesTagResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateTagRequestParams struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type CreateTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 func (r *CreateTagRequest) ToJsonString() string {
@@ -285,8 +285,8 @@ func (r *CreateTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateTagResponse struct {
@@ -309,7 +309,7 @@ func (r *CreateTagResponse) FromJsonString(s string) error {
 type CreateTagsRequestParams struct {
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type CreateTagsRequest struct {
@@ -317,7 +317,7 @@ type CreateTagsRequest struct {
 	
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *CreateTagsRequest) ToJsonString() string {
@@ -341,8 +341,8 @@ func (r *CreateTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateTagsResponse struct {
@@ -364,20 +364,20 @@ func (r *CreateTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteResourceTagRequestParams struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	// 资源六段式。示例：qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type DeleteResourceTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	// 资源六段式。示例：qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *DeleteResourceTagRequest) ToJsonString() string {
@@ -402,8 +402,8 @@ func (r *DeleteResourceTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteResourceTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteResourceTagResponse struct {
@@ -425,20 +425,20 @@ func (r *DeleteResourceTagResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteTagRequestParams struct {
 	// 需要删除的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要删除的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type DeleteTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 需要删除的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要删除的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 func (r *DeleteTagRequest) ToJsonString() string {
@@ -463,8 +463,8 @@ func (r *DeleteTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteTagResponse struct {
@@ -487,7 +487,7 @@ func (r *DeleteTagResponse) FromJsonString(s string) error {
 type DeleteTagsRequestParams struct {
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type DeleteTagsRequest struct {
@@ -495,7 +495,7 @@ type DeleteTagsRequest struct {
 	
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *DeleteTagsRequest) ToJsonString() string {
@@ -519,8 +519,8 @@ func (r *DeleteTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteTagsResponse struct {
@@ -542,38 +542,38 @@ func (r *DeleteTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeProjectsRequestParams struct {
 	// 传1拉取所有项目（包括隐藏项目），传0拉取显示项目
-	AllList *uint64 `json:"AllList,omitnil" name:"AllList"`
+	AllList *uint64 `json:"AllList,omitnil,omitempty" name:"AllList"`
 
 	// 分页条数，固定值1000。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 分页偏移量。
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 按项目ID筛选，大于0
-	ProjectId *int64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 按项目名称筛选
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 }
 
 type DescribeProjectsRequest struct {
 	*tchttp.BaseRequest
 	
 	// 传1拉取所有项目（包括隐藏项目），传0拉取显示项目
-	AllList *uint64 `json:"AllList,omitnil" name:"AllList"`
+	AllList *uint64 `json:"AllList,omitnil,omitempty" name:"AllList"`
 
 	// 分页条数，固定值1000。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 分页偏移量。
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 按项目ID筛选，大于0
-	ProjectId *int64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 按项目名称筛选
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 }
 
 func (r *DescribeProjectsRequest) ToJsonString() string {
@@ -602,13 +602,13 @@ func (r *DescribeProjectsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeProjectsResponseParams struct {
 	// 数据总条数
-	Total *uint64 `json:"Total,omitnil" name:"Total"`
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
 
 	// 项目列表
-	Projects []*Project `json:"Projects,omitnil" name:"Projects"`
+	Projects []*Project `json:"Projects,omitnil,omitempty" name:"Projects"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeProjectsResponse struct {
@@ -629,51 +629,51 @@ func (r *DescribeProjectsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀，示例 instance
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源ID数组，大小不超过50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou，不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeResourceTagsByResourceIdsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀，示例 instance
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源ID数组，大小不超过50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou，不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeResourceTagsByResourceIdsRequest) ToJsonString() string {
@@ -704,19 +704,19 @@ func (r *DescribeResourceTagsByResourceIdsRequest) FromJsonString(s string) erro
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*TagResource `json:"Tags,omitnil" name:"Tags"`
+	Tags []*TagResource `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByResourceIdsResponse struct {
@@ -737,45 +737,45 @@ func (r *DescribeResourceTagsByResourceIdsResponse) FromJsonString(s string) err
 
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsSeqRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou, 不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeResourceTagsByResourceIdsSeqRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou, 不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeResourceTagsByResourceIdsSeqRequest) ToJsonString() string {
@@ -805,19 +805,19 @@ func (r *DescribeResourceTagsByResourceIdsSeqRequest) FromJsonString(s string) e
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsSeqResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*TagResource `json:"Tags,omitnil" name:"Tags"`
+	Tags []*TagResource `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByResourceIdsSeqResponse struct {
@@ -838,51 +838,51 @@ func (r *DescribeResourceTagsByResourceIdsSeqResponse) FromJsonString(s string) 
 
 // Predefined struct for user
 type DescribeResourceTagsByTagKeysRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源唯一标识ID的列表，列表容量不超过20
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	// <p>资源唯一标识ID的列表，列表容量不超过20</p>
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源标签键列表，列表容量不超过20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>资源标签键列表，列表容量不超过20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 每页大小，默认为 400
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 400</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 type DescribeResourceTagsByTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源唯一标识ID的列表，列表容量不超过20
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	// <p>资源唯一标识ID的列表，列表容量不超过20</p>
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源标签键列表，列表容量不超过20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>资源标签键列表，列表容量不超过20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 每页大小，默认为 400
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 400</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 func (r *DescribeResourceTagsByTagKeysRequest) ToJsonString() string {
@@ -912,20 +912,20 @@ func (r *DescribeResourceTagsByTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsByTagKeysResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceIdTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceIdTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByTagKeysResponse struct {
@@ -946,57 +946,57 @@ func (r *DescribeResourceTagsByTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsRequestParams struct {
-	// 创建者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// 资源创建者UIN
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 ckafka。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标识。只输入ResourceId进行查询可能会查询较慢，或者无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// 资源唯一标识（资源六段式中最后一段"/"后面的部分）。注：只输入ResourceId查询时，如资源量大可能较慢，或无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）。若传入的是cos资源的Id，则CosResourceId 字段请同时传1。
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否是cos的资源（0或者1），输入的ResourceId为cos资源时必填
-	CosResourceId *uint64 `json:"CosResourceId,omitnil" name:"CosResourceId"`
+	// 是否为cos的资源，取值 0 表示：非cos资源。取值1 表示：cos资源，且此时ResourceId也为必填。不填则默认为 0 
+	CosResourceId *uint64 `json:"CosResourceId,omitnil,omitempty" name:"CosResourceId"`
 }
 
 type DescribeResourceTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 创建者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// 资源创建者UIN
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 ckafka。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标识。只输入ResourceId进行查询可能会查询较慢，或者无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// 资源唯一标识（资源六段式中最后一段"/"后面的部分）。注：只输入ResourceId查询时，如资源量大可能较慢，或无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）。若传入的是cos资源的Id，则CosResourceId 字段请同时传1。
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否是cos的资源（0或者1），输入的ResourceId为cos资源时必填
-	CosResourceId *uint64 `json:"CosResourceId,omitnil" name:"CosResourceId"`
+	// 是否为cos的资源，取值 0 表示：非cos资源。取值1 表示：cos资源，且此时ResourceId也为必填。不填则默认为 0 
+	CosResourceId *uint64 `json:"CosResourceId,omitnil,omitempty" name:"CosResourceId"`
 }
 
 func (r *DescribeResourceTagsRequest) ToJsonString() string {
@@ -1028,20 +1028,19 @@ func (r *DescribeResourceTagsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeResourceTagsResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 资源标签
-	Rows []*TagResource `json:"Rows,omitnil" name:"Rows"`
+	Rows []*TagResource `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsResponse struct {
@@ -1062,57 +1061,57 @@ func (r *DescribeResourceTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsRequestParams struct {
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 type DescribeResourcesByTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 func (r *DescribeResourcesByTagsRequest) ToJsonString() string {
@@ -1143,21 +1142,20 @@ func (r *DescribeResourcesByTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourcesByTagsResponse struct {
@@ -1178,57 +1176,57 @@ func (r *DescribeResourcesByTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsUnionRequestParams struct {
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 type DescribeResourcesByTagsUnionRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 func (r *DescribeResourcesByTagsUnionRequest) ToJsonString() string {
@@ -1259,20 +1257,20 @@ func (r *DescribeResourcesByTagsUnionRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsUnionResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourcesByTagsUnionResponse struct {
@@ -1293,39 +1291,39 @@ func (r *DescribeResourcesByTagsUnionResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagKeysRequestParams struct {
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15，最大1000
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否展现项目
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15，最大1000
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否展现项目
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeTagKeysRequest) ToJsonString() string {
@@ -1353,20 +1351,20 @@ func (r *DescribeTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagKeysResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*string `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagKeysResponse struct {
@@ -1387,39 +1385,39 @@ func (r *DescribeTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagValuesRequestParams struct {
-	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键列表</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeTagValuesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键列表</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeTagValuesRequest) ToJsonString() string {
@@ -1447,20 +1445,20 @@ func (r *DescribeTagValuesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagValuesResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagValuesResponse struct {
@@ -1482,32 +1480,32 @@ func (r *DescribeTagValuesResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeTagValuesSeqRequestParams struct {
 	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
 	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeTagValuesSeqRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
 	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeTagValuesSeqRequest) ToJsonString() string {
@@ -1535,19 +1533,19 @@ func (r *DescribeTagValuesSeqRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeTagValuesSeqResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagValuesSeqResponse struct {
@@ -1568,51 +1566,51 @@ func (r *DescribeTagValuesSeqResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsRequestParams struct {
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 type DescribeTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 func (r *DescribeTagsRequest) ToJsonString() string {
@@ -1642,20 +1640,20 @@ func (r *DescribeTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*TagWithDelete `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*TagWithDelete `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagsResponse struct {
@@ -1676,51 +1674,51 @@ func (r *DescribeTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsSeqRequestParams struct {
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 type DescribeTagsSeqRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 func (r *DescribeTagsSeqRequest) ToJsonString() string {
@@ -1750,20 +1748,20 @@ func (r *DescribeTagsSeqRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsSeqResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*TagWithDelete `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*TagWithDelete `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagsSeqResponse struct {
@@ -1784,39 +1782,39 @@ func (r *DescribeTagsSeqResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DetachResourcesTagRequestParams struct {
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要解绑的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type DetachResourcesTagRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要解绑的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *DetachResourcesTagRequest) ToJsonString() string {
@@ -1844,8 +1842,8 @@ func (r *DetachResourcesTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DetachResourcesTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DetachResourcesTagResponse struct {
@@ -1866,60 +1864,44 @@ func (r *DetachResourcesTagResponse) FromJsonString(s string) error {
 
 type FailedResource struct {
 	// 失败的资源六段式
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
 	// 错误码
-	Code *string `json:"Code,omitnil" name:"Code"`
+	Code *string `json:"Code,omitnil,omitempty" name:"Code"`
 
 	// 错误信息
-	Message *string `json:"Message,omitnil" name:"Message"`
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
 }
 
 // Predefined struct for user
 type GetResourcesRequestParams struct {
-	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。
-	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	// 如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。
-	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	// <p>资源六段式列表。腾讯云使用资源六段式描述一个资源。<br>例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。<br>如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。<br>N取值范围：0~9</p>
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
-	// 标签键和标签值。
-	// 指定多个标签，会查询同时绑定了该多个标签的资源。
-	// N取值范围：0~5。
-	// 每个TagFilters中的TagValue最多支持10个
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。会查询同时绑定了这多组标签的资源。<br>每组标签中的TagValue最多支持10个。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大200。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大200。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 }
 
 type GetResourcesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。
-	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	// 如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。
-	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	// <p>资源六段式列表。腾讯云使用资源六段式描述一个资源。<br>例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。<br>如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。<br>N取值范围：0~9</p>
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
-	// 标签键和标签值。
-	// 指定多个标签，会查询同时绑定了该多个标签的资源。
-	// N取值范围：0~5。
-	// 每个TagFilters中的TagValue最多支持10个
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。会查询同时绑定了这多组标签的资源。<br>每组标签中的TagValue最多支持10个。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大200。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大200。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 }
 
 func (r *GetResourcesRequest) ToJsonString() string {
@@ -1946,14 +1928,14 @@ func (r *GetResourcesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetResourcesResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 资源及关联的标签(键和值)列表
-	ResourceTagMappingList []*ResourceTagMapping `json:"ResourceTagMappingList,omitnil" name:"ResourceTagMappingList"`
+	// <p>资源及关联的标签(键和值)列表</p>
+	ResourceTagMappingList []*ResourceTagMapping `json:"ResourceTagMappingList,omitnil,omitempty" name:"ResourceTagMappingList"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetResourcesResponse struct {
@@ -1974,31 +1956,27 @@ func (r *GetResourcesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagKeysRequestParams struct {
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagKeysRequest) ToJsonString() string {
@@ -2024,14 +2002,14 @@ func (r *GetTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagKeysResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签键信息。
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键信息。</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagKeysResponse struct {
@@ -2052,41 +2030,33 @@ func (r *GetTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagValuesRequestParams struct {
-	// 标签键。
-	// 返回所有标签键列表对应的标签值。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。返回所有标签键列表对应的标签值。最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagValuesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键。
-	// 返回所有标签键列表对应的标签值。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。返回所有标签键列表对应的标签值。最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagValuesRequest) ToJsonString() string {
@@ -2113,14 +2083,14 @@ func (r *GetTagValuesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagValuesResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签列表。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表。</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagValuesResponse struct {
@@ -2141,41 +2111,33 @@ func (r *GetTagValuesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagsRequestParams struct {
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签键。
-	// 返回所有标签键列表对应的标签。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。<br>返回所有标签键列表对应的标签。<br>最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签键。
-	// 返回所有标签键列表对应的标签。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。<br>返回所有标签键列表对应的标签。<br>最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagsRequest) ToJsonString() string {
@@ -2202,14 +2164,14 @@ func (r *GetTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagsResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签列表。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表。</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagsResponse struct {
@@ -2231,26 +2193,26 @@ func (r *GetTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type ModifyResourceTagsRequestParams struct {
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	ReplaceTags []*Tag `json:"ReplaceTags,omitnil" name:"ReplaceTags"`
+	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	ReplaceTags []*Tag `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
-	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil" name:"DeleteTags"`
+	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 type ModifyResourceTagsRequest struct {
 	*tchttp.BaseRequest
 	
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	ReplaceTags []*Tag `json:"ReplaceTags,omitnil" name:"ReplaceTags"`
+	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	ReplaceTags []*Tag `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
-	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil" name:"DeleteTags"`
+	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 func (r *ModifyResourceTagsRequest) ToJsonString() string {
@@ -2276,8 +2238,8 @@ func (r *ModifyResourceTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourceTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ModifyResourceTagsResponse struct {
@@ -2298,45 +2260,45 @@ func (r *ModifyResourceTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourcesTagValueRequestParams struct {
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分），例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type ModifyResourcesTagValueRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分），例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *ModifyResourcesTagValueRequest) ToJsonString() string {
@@ -2365,8 +2327,8 @@ func (r *ModifyResourcesTagValueRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourcesTagValueResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ModifyResourcesTagValueResponse struct {
@@ -2387,124 +2349,114 @@ func (r *ModifyResourcesTagValueResponse) FromJsonString(s string) error {
 
 type Project struct {
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 创建人uin
-	CreatorUin *uint64 `json:"CreatorUin,omitnil" name:"CreatorUin"`
+	CreatorUin *uint64 `json:"CreatorUin,omitnil,omitempty" name:"CreatorUin"`
 
 	// 项目描述
-	ProjectInfo *string `json:"ProjectInfo,omitnil" name:"ProjectInfo"`
+	ProjectInfo *string `json:"ProjectInfo,omitnil,omitempty" name:"ProjectInfo"`
 
 	// 创建时间
-	CreateTime *string `json:"CreateTime,omitnil" name:"CreateTime"`
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 }
 
 type ResourceIdTag struct {
 	// 资源唯一标识
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 标签键值对
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TagKeyValues []*Tag `json:"TagKeyValues,omitnil" name:"TagKeyValues"`
+	TagKeyValues []*Tag `json:"TagKeyValues,omitnil,omitempty" name:"TagKeyValues"`
 }
 
 type ResourceTag struct {
 	// 资源所在地域
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 业务类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源前缀
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 资源标签
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type ResourceTagMapping struct {
 	// 资源六段式。腾讯云使用资源六段式描述一个资源。
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
 	// 资源关联的标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type Tag struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type TagFilter struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值数组 多个值的话是或的关系
-	TagValue []*string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue []*string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type TagKeyObject struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 }
 
 type TagResource struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源ID
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 标签键MD5值
-	TagKeyMd5 *string `json:"TagKeyMd5,omitnil" name:"TagKeyMd5"`
+	TagKeyMd5 *string `json:"TagKeyMd5,omitnil,omitempty" name:"TagKeyMd5"`
 
 	// 标签值MD5值
-	TagValueMd5 *string `json:"TagValueMd5,omitnil" name:"TagValueMd5"`
+	TagValueMd5 *string `json:"TagValueMd5,omitnil,omitempty" name:"TagValueMd5"`
 
 	// 资源类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 // Predefined struct for user
 type TagResourcesRequestParams struct {
 	// 待绑定的云资源，用标准的资源六段式表示。正确的资源六段式请参考：[标准的资源六段式](https://cloud.tencent.com/document/product/598/10606)和[支持标签的云产品及资源描述方式](https://cloud.tencent.com/document/product/651/89122)。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键和标签值。
 	// 如果指定多个标签，则会为指定资源同时创建并绑定该多个标签。
 	// 同一个资源上的同一个标签键只能对应一个标签值。如果您尝试添加已有标签键，则对应的标签值会更新为新值。
 	// 如果标签不存在会为您自动创建标签。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type TagResourcesRequest struct {
@@ -2512,14 +2464,14 @@ type TagResourcesRequest struct {
 	
 	// 待绑定的云资源，用标准的资源六段式表示。正确的资源六段式请参考：[标准的资源六段式](https://cloud.tencent.com/document/product/598/10606)和[支持标签的云产品及资源描述方式](https://cloud.tencent.com/document/product/651/89122)。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键和标签值。
 	// 如果指定多个标签，则会为指定资源同时创建并绑定该多个标签。
 	// 同一个资源上的同一个标签键只能对应一个标签值。如果您尝试添加已有标签键，则对应的标签值会更新为新值。
 	// 如果标签不存在会为您自动创建标签。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *TagResourcesRequest) ToJsonString() string {
@@ -2547,10 +2499,10 @@ type TagResourcesResponseParams struct {
 	// 失败资源信息。
 	// 创建并绑定标签成功时，返回的FailedResources为空。
 	// 创建并绑定标签失败或部分失败时，返回的FailedResources会显示失败资源的详细信息。
-	FailedResources []*FailedResource `json:"FailedResources,omitnil" name:"FailedResources"`
+	FailedResources []*FailedResource `json:"FailedResources,omitnil,omitempty" name:"FailedResources"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type TagResourcesResponse struct {
@@ -2571,17 +2523,16 @@ func (r *TagResourcesResponse) FromJsonString(s string) error {
 
 type TagWithDelete struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 是否可以删除
-	CanDelete *uint64 `json:"CanDelete,omitnil" name:"CanDelete"`
+	CanDelete *uint64 `json:"CanDelete,omitnil,omitempty" name:"CanDelete"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 // Predefined struct for user
@@ -2589,11 +2540,11 @@ type UnTagResourcesRequestParams struct {
 	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。可参考[访问管理](https://cloud.tencent.com/document/product/598/67350)-概览-接口列表-资源六段式信息
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:uin/${Account}:${ResourcePrefix}/${ResourceId}。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键。
 	// 取值范围：0~9
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 }
 
 type UnTagResourcesRequest struct {
@@ -2602,11 +2553,11 @@ type UnTagResourcesRequest struct {
 	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。可参考[访问管理](https://cloud.tencent.com/document/product/598/67350)-概览-接口列表-资源六段式信息
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:uin/${Account}:${ResourcePrefix}/${ResourceId}。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键。
 	// 取值范围：0~9
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 }
 
 func (r *UnTagResourcesRequest) ToJsonString() string {
@@ -2634,10 +2585,10 @@ type UnTagResourcesResponseParams struct {
 	// 失败资源信息。
 	// 解绑标签成功时，返回的FailedResources为空。
 	// 解绑标签失败或部分失败时，返回的FailedResources会显示失败资源的详细信息。
-	FailedResources []*FailedResource `json:"FailedResources,omitnil" name:"FailedResources"`
+	FailedResources []*FailedResource `json:"FailedResources,omitnil,omitempty" name:"FailedResources"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UnTagResourcesResponse struct {
@@ -2659,32 +2610,32 @@ func (r *UnTagResourcesResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type UpdateProjectRequestParams struct {
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 禁用项目，1，禁用，0，启用
-	Disable *int64 `json:"Disable,omitnil" name:"Disable"`
+	Disable *int64 `json:"Disable,omitnil,omitempty" name:"Disable"`
 
 	// 备注
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 type UpdateProjectRequest struct {
 	*tchttp.BaseRequest
 	
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 禁用项目，1，禁用，0，启用
-	Disable *int64 `json:"Disable,omitnil" name:"Disable"`
+	Disable *int64 `json:"Disable,omitnil,omitempty" name:"Disable"`
 
 	// 备注
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 func (r *UpdateProjectRequest) ToJsonString() string {
@@ -2711,8 +2662,8 @@ func (r *UpdateProjectRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateProjectResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateProjectResponse struct {
@@ -2734,26 +2685,26 @@ func (r *UpdateProjectResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type UpdateResourceTagValueRequestParams struct {
 	// 资源关联的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 修改后的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type UpdateResourceTagValueRequest struct {
 	*tchttp.BaseRequest
 	
 	// 资源关联的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 修改后的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *UpdateResourceTagValueRequest) ToJsonString() string {
@@ -2779,8 +2730,8 @@ func (r *UpdateResourceTagValueRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateResourceTagValueResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateResourceTagValueResponse struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1415,7 +1415,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm/v20190923
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts/v20180813
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634


### PR DESCRIPTION
Make tag_value updatable in place on the tencentcloud_tag_attachment resource. When tag_value changes, the provider now calls the UpdateResourceTagValue API in a single request instead of the destructive delete+recreate sequence. tag_key and resource remain ForceNew. The composite id is refreshed after a successful update.