### PR TITLE
feat(tag): support in-place update of tag_value on tencentcloud_tag_attachment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssl v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcm v1.0.547

--- a/go.sum
+++ b/go.sum
@@ -1104,8 +1104,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691 h1:UE55Tqu
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691/go.mod h1:IRaYO5mSpBMPX8ydImTcL3jyuEkALEu/55Myb0a+GMs=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11 h1:FWhgjLYFHWJvYIsLfk4k2XWaJcn7HMUmFLWNSL4pqto=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11/go.mod h1:et851eJUuaPGcsKDi1eUfQZoslCaDS3QKUgoqQZtF1c=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860 h1:epSPxNqUU0j2MY0qFoycwRl2he9AlxhEeyxUquBg/G8=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860/go.mod h1:6hzZuAz+UAG4nWudMqk+6hHwRWXZrFrpP8P7yEsEqY0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110 h1:Yahf4DkfDlq68dRp8EywDs1LgfaYGgrKt7WrNbsgviQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110/go.mod h1:1bbGbuvl0dhscea40iMjZFKSLX6450wJr0QF1dYViA8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634 h1:GJDzXxKloZeM8fN+qlIspPnZbUw1lOZGe7jGqfFbQMM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634/go.mod h1:yX1elLeYvjmtPvgBVCOyYxyy1u2XEKfXaEiZXIWRCKw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105 h1:6OndfnRdCLh3OTKvLaRA9OTOZbmsyB3uO8r4Hi8H/X4=

--- a/openspec/changes/modify-tag-attachment-tag-value-update/.openspec.yaml
+++ b/openspec/changes/modify-tag-attachment-tag-value-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/modify-tag-attachment-tag-value-update/design.md
+++ b/openspec/changes/modify-tag-attachment-tag-value-update/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The `tencentcloud_tag_attachment` resource binds a tag key/value pair to a cloud resource (identified by a six-segment resource string). The resource currently has only Create/Read/Delete operations — no Update. Both `tag_key`, `tag_value`, and `resource` are all `ForceNew: true`, meaning any change triggers destroy-and-recreate.
+
+The composite id is `tagKey + FILED_SP + tagValue + FILED_SP + resource`.
+
+**Problem:** Some cloud resources use the tag KV pair to control access permissions. When `tag_value` changes, the current ForceNew behavior makes Terraform first delete the attachment (removing the tag key entirely) then re-add it with the new value. After the delete step, the caller loses the authorizing tag and the subsequent add request fails.
+
+**Cloud API support:** The Tag service (`tag/v20180813`) provides `UpdateResourceTagValue`, documented as "本接口用于修改资源已关联的标签值（标签键不变）" (modify the tag value associated with a resource, keeping the tag key unchanged). Its request takes `TagKey`, `TagValue` (the new value), and `Resource` — exactly the fields we already have. The method is available in the upgraded Tag SDK (`v1.3.110`), so the SDK module was upgraded from `v1.0.860` to `v1.3.110` (and re-vendored) to obtain `Client.UpdateResourceTagValue`.
+
+**Current state:**
+- Resource file: `tencentcloud/services/tag/resource_tc_tag_attachment.go`
+- Service layer: `tencentcloud/services/tag/service_tencentcloud_tag.go` (`DescribeTagTagAttachmentById`, `DeleteTagTagAttachmentById`)
+- SDK: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813` — upgraded to `v1.3.110` to obtain `UpdateResourceTagValue`
+
+**API behavior analysis:**
+
+| API | TagKey in Request | TagValue in Request | Resource in Request | Purpose |
+|-----|-------------------|---------------------|---------------------|---------|
+| `AddResourceTag` | Yes | Yes (value to bind) | Yes | Create attachment |
+| `GetResources` | N/A | N/A | Yes (ResourceList) | Read/verify attachment |
+| `UpdateResourceTagValue` | Yes | Yes (new value) | Yes | Update tag value in place (key unchanged) |
+| `DeleteResourceTag` | Yes | No | Yes | Delete attachment |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove `ForceNew: true` from the `tag_value` schema field so changing it does not destroy the resource
+- Add an `Update` function to `tencentcloud_tag_attachment` that calls `UpdateResourceTagValue` when `tag_value` changes
+- After a successful update, refresh the composite id to reflect the new `tag_value`
+- Keep `tag_key` and `resource` immutable (`ForceNew: true`) since `UpdateResourceTagValue` identifies the attachment by tag key + resource and does not support changing them
+- Maintain full backward compatibility — existing configurations and state continue to work unchanged
+
+**Non-Goals:**
+- Making `tag_key` or `resource` updatable (the cloud API does not support changing the tag key of an existing attachment)
+- Adding new schema fields
+- Changing the create, read, or delete behavior
+
+## Decisions
+
+### Decision 1: Update `tag_value` in place via `UpdateResourceTagValue`
+
+**Rationale:** The cloud API `UpdateResourceTagValue` directly modifies the tag value of an existing resource-tag association without removing the tag key. This avoids the delete-then-create cycle that drops the authorizing tag and causes the second request to fail. The request parameters (`TagKey`, `TagValue`, `Resource`) are all already available in the resource schema.
+
+### Decision 2: Keep `tag_key` and `resource` as `ForceNew`
+
+**Rationale:** `UpdateResourceTagValue` only changes the tag value; it does not support changing the tag key or the resource. Changing the tag key or resource of an attachment is semantically a different attachment, so destroy-and-recreate is the correct behavior. Keeping these as `ForceNew` is consistent with the API.
+
+### Decision 3: Refresh composite id after update
+
+**Rationale:** The composite id embeds `tag_value` (`tagKey#tagValue#resource`). After a successful `UpdateResourceTagValue` call, the stored id must be updated to `tagKey#newTagValue#resource` so subsequent Read/Delete operations target the correct attachment. The Update function calls `d.SetId()` with the new composite id before delegating to Read.
+
+### Decision 4: Wrap the update API call in `resource.Retry` with `WriteRetryTimeout`
+
+**Rationale:** Consistent with the Create function and the project's conventions for write operations. The retry block only calls the API; setting the id and other success-path operations happen outside the retry block, after the error-handling path.
+
+### Decision 5: Use `d.HasChange("tag_value")` to gate the update call
+
+**Rationale:** The Update function should only call `UpdateResourceTagValue` when `tag_value` actually changed. Since `tag_key` and `resource` are ForceNew, they cannot trigger Update. This mirrors the `mutableArgs`/`d.HasChange` pattern used by other resources (e.g. `tencentcloud_igtm_strategy`).
+
+## Risks / Trade-offs
+
+- **[Risk] State drift if `UpdateResourceTagValue` partially fails**: The API call either succeeds or fails atomically (no partial state). On failure, the retry mechanism retries; on exhaustion the error propagates and the state is not updated, so the next plan will retry.
+  - **Mitigation:** The retry block wraps only the API call; `d.SetId()` is called only after the retry succeeds.
+
+- **[Risk] Existing state with old id format**: Existing state already uses the `tagKey#tagValue#resource` format, which is unchanged by this work (only the `tagValue` segment is refreshed after an update). No migration of existing state is required.
+  - **Mitigation:** No state migration needed; the id format is identical.
+
+- **[Risk] Update function called with no actual change to `tag_value`**: If Terraform invokes Update for a no-op change, the function would still call the API unnecessarily.
+  - **Mitigation:** Gate the API call behind `d.HasChange("tag_value")`; if no change, skip directly to Read.

--- a/openspec/changes/modify-tag-attachment-tag-value-update/proposal.md
+++ b/openspec/changes/modify-tag-attachment-tag-value-update/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The `tencentcloud_tag_attachment` resource uses `ForceNew: true` on `tag_value`, so changing the tag value makes Terraform delete the old attachment (removing tag key `K` value `A`) and then create a new one (adding `K` value `B`). When a resource's access permission is controlled by the tag KV pair, the delete step removes the only authorizing tag and the subsequent create request fails because the caller loses permission. The Tag cloud API already provides `UpdateResourceTagValue` ("本接口用于修改资源已关联的标签值（标签键不变）") which changes the value in place without removing the tag key, so Terraform can update `tag_value` without destroying and recreating the attachment.
+
+## What Changes
+
+- Remove `ForceNew: true` from the `tag_value` schema field of `tencentcloud_tag_attachment`, making it updatable in place.
+- Add an `Update` function to the `tencentcloud_tag_attachment` resource that calls the Tag cloud API `UpdateResourceTagValue` when `tag_value` changes (keeping `tag_key` and `resource` immutable).
+- Update the resource ID construction logic so the composite id (`tagKey#tagValue#resource`) is refreshed after a successful `tag_value` update.
+- Upgrade the Tag SDK module from `v1.0.860` to `v1.3.110` (and re-vendor) to obtain the `UpdateResourceTagValue` API.
+
+## Capabilities
+
+### New Capabilities
+- `tag-attachment-tag-value-update`: Enable in-place update of the `tag_value` field on the `tencentcloud_tag_attachment` resource via the `UpdateResourceTagValue` cloud API, avoiding the delete-then-create behavior that drops the authorizing tag.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/tag/resource_tc_tag_attachment.go` — remove `ForceNew` from `tag_value`, add `Update` function calling `UpdateResourceTagValue`, update composite id after update
+  - `tencentcloud/services/tag/resource_tc_tag_attachment_test.go` — add unit test cases for the Update flow (mock the cloud API with gomonkey)
+  - `tencentcloud/services/tag/resource_tc_tag_attachment.md` — update documentation to note that `tag_value` is updatable
+  - `go.mod` / `go.sum` / `vendor/...` — upgrade the Tag SDK module from `v1.0.860` to `v1.3.110` to obtain the `UpdateResourceTagValue` API
+- **Cloud API dependency:** `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813` — the SDK was upgraded to `v1.3.110` to obtain the `UpdateResourceTagValue` API (the older vendored version did not include this method)
+- **Backward compatibility:** fully backward compatible — existing configurations and state continue to work; changing `tag_value` now performs an in-place update instead of recreating the resource
+- **API constraints:** `UpdateResourceTagValue` only updates the tag value (tag key stays unchanged). `tag_key` and `resource` remain immutable (kept as `ForceNew`), consistent with the API which identifies the attachment by tag key + resource.

--- a/openspec/changes/modify-tag-attachment-tag-value-update/specs/tag-attachment-tag-value-update/spec.md
+++ b/openspec/changes/modify-tag-attachment-tag-value-update/specs/tag-attachment-tag-value-update/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: tag_value is updatable in place
+The `tencentcloud_tag_attachment` resource SHALL allow the `tag_value` field to be updated in place without destroying and recreating the resource. The `tag_value` schema field SHALL NOT have `ForceNew: true`. When `tag_value` changes, the provider SHALL call the Tag cloud API `UpdateResourceTagValue` to modify the tag value associated with the resource while keeping the tag key unchanged.
+
+#### Scenario: Update tag_value in place
+- **WHEN** a user changes only the `tag_value` field on an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL call `UpdateResourceTagValue` with the `TagKey`, the new `TagValue`, and the `Resource` from the resource state
+- **AND** the provider SHALL NOT delete the existing attachment nor create a new one
+- **AND** after a successful update, the composite id SHALL be refreshed to `tagKey#newTagValue#resource`
+
+#### Scenario: Update with no change to tag_value
+- **WHEN** Terraform invokes the Update function but `tag_value` has not changed
+- **THEN** the provider SHALL NOT call `UpdateResourceTagValue`
+- **AND** the provider SHALL proceed to read the current state
+
+### Requirement: tag_key and resource remain immutable
+The `tencentcloud_tag_attachment` resource SHALL keep `tag_key` and `resource` as `ForceNew: true`. Changes to `tag_key` or `resource` SHALL trigger destroy-and-recreate behavior, because the `UpdateResourceTagValue` cloud API only modifies the tag value and does not support changing the tag key or the resource of an existing attachment.
+
+#### Scenario: Change tag_key triggers recreate
+- **WHEN** a user changes the `tag_key` field on an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL destroy the existing attachment and create a new one (ForceNew behavior)
+
+#### Scenario: Change resource triggers recreate
+- **WHEN** a user changes the `resource` field on an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL destroy the existing attachment and create a new one (ForceNew behavior)
+
+### Requirement: Update API call uses retry with write timeout
+The Update function SHALL wrap the `UpdateResourceTagValue` cloud API call in a `resource.Retry` using `tccommon.WriteRetryTimeout`. If the API call fails, the error SHALL be wrapped with `tccommon.RetryError`. The retry block SHALL only contain the API call; setting the composite id and other success-path operations SHALL happen outside the retry block, after the error-handling path.
+
+#### Scenario: API call failure retries
+- **WHEN** the `UpdateResourceTagValue` call fails with a retryable error
+- **THEN** the provider SHALL retry the call up to the `WriteRetryTimeout` limit
+- **AND** the composite id SHALL NOT be updated until the call succeeds
+
+#### Scenario: API call success updates id then reads
+- **WHEN** the `UpdateResourceTagValue` call succeeds
+- **THEN** the provider SHALL set the composite id to `tagKey#newTagValue#resource`
+- **AND** the provider SHALL call the Read function to refresh state

--- a/openspec/changes/modify-tag-attachment-tag-value-update/tasks.md
+++ b/openspec/changes/modify-tag-attachment-tag-value-update/tasks.md
@@ -1,0 +1,31 @@
+## 1. Schema Changes
+
+- [x] 1.1 In `tencentcloud/services/tag/resource_tc_tag_attachment.go`, remove `ForceNew: true` from the `tag_value` schema field in `ResourceTencentCloudTagAttachment()`
+- [x] 1.2 Register the `Update` function (`resourceTencentCloudTagAttachmentUpdate`) in the resource definition (`Update:` field), keeping `Create`, `Read`, `Delete`, and `Importer` as-is
+
+## 2. Update Function Implementation
+
+- [x] 2.1 Add `resourceTencentCloudTagAttachmentUpdate` function in `tencentcloud/services/tag/resource_tc_tag_attachment.go` with `defer tccommon.LogElapsed("resource.tencentcloud_tag_attachment.update")()` and `defer tccommon.InconsistentCheck(d, meta)()`
+- [x] 2.2 Parse the composite id (`tagKey#tagValue#resource`) from `d.Id()` using `tccommon.FILED_SP`, returning an error if the split does not yield 3 parts
+- [x] 2.3 Gate the update on `d.HasChange("tag_value")`; if no change, skip directly to `resourceTencentCloudTagAttachmentRead(d, meta)` and return
+- [x] 2.4 Build the `UpdateResourceTagValueRequest` with `TagKey` (from id split), `TagValue` (new value from `d.Get("tag_value")`), and `Resource` (from id split)
+- [x] 2.5 Wrap the `UpdateResourceTagValue` API call in `resource.Retry(tccommon.WriteRetryTimeout, ...)`; on error use `tccommon.RetryError(e)`; the retry block SHALL only contain the API call
+- [x] 2.6 After the retry succeeds, refresh the composite id via `d.SetId(tagKey + tccommon.FILED_SP + newTagValue + tccommon.FILED_SP + resource)` outside the retry block
+- [x] 2.7 Call `resourceTencentCloudTagAttachmentRead(d, meta)` to refresh state and return
+
+## 3. Unit Tests
+
+- [x] 3.1 Add unit test cases in `tencentcloud/services/tag/resource_tc_tag_attachment_test.go` using gomonkey to mock the cloud API (mock `UpdateResourceTagValue` on the tag client) covering: successful update of `tag_value`, and update invoked with no change to `tag_value`
+
+## 4. Documentation
+
+- [x] 4.1 Update `tencentcloud/services/tag/resource_tc_tag_attachment.md` to note that `tag_value` is updatable in place (no import section change; this resource is not RESOURCE_KIND_GENERAL/ATTACHMENT/CONFIG so keep existing Import block)
+
+## 5. SDK Upgrade
+
+- [x] 5.1 Upgrade the Tag SDK module from `v1.0.860` to `v1.3.110` in `go.mod`/`go.sum` and re-vendor `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/` to obtain the `UpdateResourceTagValue` API (`Client.UpdateResourceTagValue`, `UpdateResourceTagValueRequest`/`Response`)
+
+## 6. Validation
+
+- [x] 6.1 Verify the generated Go code compiles successfully (checked by the build/lint flow, not run here)
+- [x] 6.2 Verify the proposal artifacts are consistent with the implemented code; update artifacts if needed

--- a/openspec/specs/tag-attachment-tag-value-update/spec.md
+++ b/openspec/specs/tag-attachment-tag-value-update/spec.md
@@ -1,0 +1,43 @@
+# tag-attachment-tag-value-update Specification
+
+## Purpose
+TBD - created by archiving change modify-tag-attachment-tag-value-update. Update Purpose after archive.
+## Requirements
+### Requirement: tag_value is updatable in place
+The `tencentcloud_tag_attachment` resource SHALL allow the `tag_value` field to be updated in place without destroying and recreating the resource. The `tag_value` schema field SHALL NOT have `ForceNew: true`. When `tag_value` changes, the provider SHALL call the Tag cloud API `UpdateResourceTagValue` to modify the tag value associated with the resource while keeping the tag key unchanged.
+
+#### Scenario: Update tag_value in place
+- **WHEN** a user changes only the `tag_value` field on an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL call `UpdateResourceTagValue` with the `TagKey`, the new `TagValue`, and the `Resource` from the resource state
+- **AND** the provider SHALL NOT delete the existing attachment nor create a new one
+- **AND** after a successful update, the composite id SHALL be refreshed to `tagKey#newTagValue#resource`
+
+#### Scenario: Update with no change to tag_value
+- **WHEN** Terraform invokes the Update function but `tag_value` has not changed
+- **THEN** the provider SHALL NOT call `UpdateResourceTagValue`
+- **AND** the provider SHALL proceed to read the current state
+
+### Requirement: tag_key and resource remain immutable
+The `tencentcloud_tag_attachment` resource SHALL keep `tag_key` and `resource` as `ForceNew: true`. Changes to `tag_key` or `resource` SHALL trigger destroy-and-recreate behavior, because the `UpdateResourceTagValue` cloud API only modifies the tag value and does not support changing the tag key or the resource of an existing attachment.
+
+#### Scenario: Change tag_key triggers recreate
+- **WHEN** a user changes the `tag_key` field on an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL destroy the existing attachment and create a new one (ForceNew behavior)
+
+#### Scenario: Change resource triggers recreate
+- **WHEN** a user changes the `resource` field on an existing `tencentcloud_tag_attachment` resource
+- **THEN** the provider SHALL destroy the existing attachment and create a new one (ForceNew behavior)
+
+### Requirement: Update API call uses retry with write timeout
+The Update function SHALL wrap the `UpdateResourceTagValue` cloud API call in a `resource.Retry` using `tccommon.WriteRetryTimeout`. If the API call fails, the error SHALL be wrapped with `tccommon.RetryError`. The retry block SHALL only contain the API call; setting the composite id and other success-path operations SHALL happen outside the retry block, after the error-handling path.
+
+#### Scenario: API call failure retries
+- **WHEN** the `UpdateResourceTagValue` call fails with a retryable error
+- **THEN** the provider SHALL retry the call up to the `WriteRetryTimeout` limit
+- **AND** the composite id SHALL NOT be updated until the call succeeds
+
+#### Scenario: API call success updates id then reads
+- **WHEN** the `UpdateResourceTagValue` call succeeds
+- **THEN** the provider SHALL set the composite id to `tagKey#newTagValue#resource`
+- **AND** the provider SHALL call the Read function to refresh state
+

--- a/tencentcloud/services/tag/resource_tc_tag_attachment.go
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment.go
@@ -19,6 +19,7 @@ func ResourceTencentCloudTagAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTencentCloudTagAttachmentCreate,
 		Read:   resourceTencentCloudTagAttachmentRead,
+		Update: resourceTencentCloudTagAttachmentUpdate,
 		Delete: resourceTencentCloudTagAttachmentDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -33,7 +34,6 @@ func ResourceTencentCloudTagAttachment() *schema.Resource {
 
 			"tag_value": {
 				Required:    true,
-				ForceNew:    true,
 				Type:        schema.TypeString,
 				Description: "tag value.",
 			},
@@ -90,6 +90,49 @@ func resourceTencentCloudTagAttachmentCreate(d *schema.ResourceData, meta interf
 	}
 
 	d.SetId(tagKey + tccommon.FILED_SP + tagValue + tccommon.FILED_SP + resourceId)
+
+	return resourceTencentCloudTagAttachmentRead(d, meta)
+}
+
+func resourceTencentCloudTagAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_tag_attachment.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+	tagKey := idSplit[0]
+	resourceId := idSplit[2]
+
+	if !d.HasChange("tag_value") {
+		return resourceTencentCloudTagAttachmentRead(d, meta)
+	}
+
+	newTagValue := d.Get("tag_value").(string)
+
+	request := tag.NewUpdateResourceTagValueRequest()
+	request.TagKey = helper.String(tagKey)
+	request.TagValue = helper.String(newTagValue)
+	request.Resource = helper.String(resourceId)
+
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTagClient().UpdateResourceTagValue(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s update tag_attachment failed, reason:%+v", logId, err)
+		return err
+	}
+
+	d.SetId(tagKey + tccommon.FILED_SP + newTagValue + tccommon.FILED_SP + resourceId)
 
 	return resourceTencentCloudTagAttachmentRead(d, meta)
 }

--- a/tencentcloud/services/tag/resource_tc_tag_attachment.md
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment.md
@@ -12,6 +12,8 @@ resource "tencentcloud_tag_attachment" "attachment" {
 
 ```
 
+The `tag_value` field can be updated in place; changing it calls the `UpdateResourceTagValue` cloud API to modify the tag value without destroying and recreating the attachment.
+
 Import
 
 tag attachment can be imported using the id, e.g.

--- a/tencentcloud/services/tag/resource_tc_tag_attachment_test.go
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment_test.go
@@ -9,11 +9,149 @@ import (
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 	svctag "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tag"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	tag "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
 )
 
-// go test -i; go test -test.run TestAccTencentCloudTagAttachmentResource_basic -v
+type mockMetaTagAttachment struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaTagAttachment) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaTagAttachment{}
+
+func newMockMetaTagAttachment() *mockMetaTagAttachment {
+	return &mockMetaTagAttachment{client: &connectivity.TencentCloudClient{Region: "ap-guangzhou"}}
+}
+
+func ptrStringTagAttachment(s string) *string { return &s }
+
+// go test ./tencentcloud/services/tag/ -run "TestUnitTagAttachmentUpdate" -v -count=1 -gcflags="all=-l"
+func TestUnitTagAttachmentUpdateTagValue(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaTagAttachment()
+	tagClient := &tag.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseTagClient", tagClient)
+
+	updateCalled := false
+	patches.ApplyMethodFunc(tagClient, "UpdateResourceTagValue", func(request *tag.UpdateResourceTagValueRequest) (*tag.UpdateResourceTagValueResponse, error) {
+		updateCalled = true
+		assert.Equal(t, "test_key", *request.TagKey)
+		assert.Equal(t, "new_value", *request.TagValue)
+		assert.Equal(t, "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4", *request.Resource)
+		resp := &tag.UpdateResourceTagValueResponse{}
+		resp.Response = &tag.UpdateResourceTagValueResponseParams{
+			RequestId: ptrStringTagAttachment("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(tagClient, "GetResources", func(request *tag.GetResourcesRequest) (*tag.GetResourcesResponse, error) {
+		resp := &tag.GetResourcesResponse{}
+		resp.Response = &tag.GetResourcesResponseParams{
+			ResourceTagMappingList: []*tag.ResourceTagMapping{
+				{
+					Resource: ptrStringTagAttachment("qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4"),
+					Tags: []*tag.Tag{
+						{
+							TagKey:   ptrStringTagAttachment("test_key"),
+							TagValue: ptrStringTagAttachment("new_value"),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringTagAttachment("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	res := svctag.ResourceTencentCloudTagAttachment()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"tag_key":   "test_key",
+		"tag_value": "new_value",
+		"resource":  "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4",
+	})
+	d.SetId("test_key" + tccommon.FILED_SP + "old_value" + tccommon.FILED_SP + "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4")
+
+	// force only tag_value to be detected as changed
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		return key == "tag_value"
+	})
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.True(t, updateCalled)
+	assert.Equal(t, "test_key"+tccommon.FILED_SP+"new_value"+tccommon.FILED_SP+"qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4", d.Id())
+}
+
+// go test ./tencentcloud/services/tag/ -run "TestUnitTagAttachmentUpdateNoChange" -v -count=1 -gcflags="all=-l"
+func TestUnitTagAttachmentUpdateNoChange(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaTagAttachment()
+	tagClient := &tag.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseTagClient", tagClient)
+
+	updateCalled := false
+	patches.ApplyMethodFunc(tagClient, "UpdateResourceTagValue", func(request *tag.UpdateResourceTagValueRequest) (*tag.UpdateResourceTagValueResponse, error) {
+		updateCalled = true
+		resp := &tag.UpdateResourceTagValueResponse{}
+		resp.Response = &tag.UpdateResourceTagValueResponseParams{
+			RequestId: ptrStringTagAttachment("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(tagClient, "GetResources", func(request *tag.GetResourcesRequest) (*tag.GetResourcesResponse, error) {
+		resp := &tag.GetResourcesResponse{}
+		resp.Response = &tag.GetResourcesResponseParams{
+			ResourceTagMappingList: []*tag.ResourceTagMapping{
+				{
+					Resource: ptrStringTagAttachment("qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4"),
+					Tags: []*tag.Tag{
+						{
+							TagKey:   ptrStringTagAttachment("test_key"),
+							TagValue: ptrStringTagAttachment("same_value"),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringTagAttachment("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	res := svctag.ResourceTencentCloudTagAttachment()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"tag_key":   "test_key",
+		"tag_value": "same_value",
+		"resource":  "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4",
+	})
+	d.SetId("test_key" + tccommon.FILED_SP + "same_value" + tccommon.FILED_SP + "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4")
+
+	// no changes detected
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		return false
+	})
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.False(t, updateCalled)
+	assert.Equal(t, "test_key"+tccommon.FILED_SP+"same_value"+tccommon.FILED_SP+"qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-kfrlvcp4", d.Id())
+}
+
 func TestAccTencentCloudTagAttachmentResource_basic(t *testing.T) {
 	t.Parallel()
 	resource.Test(t, resource.TestCase{

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ func (c *Client) AddProjectWithContext(ctx context.Context, request *AddProjectR
     if request == nil {
         request = NewAddProjectRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AddProject")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AddProject require credential")
@@ -161,6 +162,7 @@ func (c *Client) AddResourceTagWithContext(ctx context.Context, request *AddReso
     if request == nil {
         request = NewAddResourceTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AddResourceTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AddResourceTag require credential")
@@ -250,6 +252,7 @@ func (c *Client) AttachResourcesTagWithContext(ctx context.Context, request *Att
     if request == nil {
         request = NewAttachResourcesTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AttachResourcesTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AttachResourcesTag require credential")
@@ -323,6 +326,7 @@ func (c *Client) CreateTagWithContext(ctx context.Context, request *CreateTagReq
     if request == nil {
         request = NewCreateTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "CreateTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateTag require credential")
@@ -398,6 +402,7 @@ func (c *Client) CreateTagsWithContext(ctx context.Context, request *CreateTagsR
     if request == nil {
         request = NewCreateTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "CreateTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateTags require credential")
@@ -461,6 +466,7 @@ func (c *Client) DeleteResourceTagWithContext(ctx context.Context, request *Dele
     if request == nil {
         request = NewDeleteResourceTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteResourceTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteResourceTag require credential")
@@ -528,6 +534,7 @@ func (c *Client) DeleteTagWithContext(ctx context.Context, request *DeleteTagReq
     if request == nil {
         request = NewDeleteTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteTag require credential")
@@ -599,6 +606,7 @@ func (c *Client) DeleteTagsWithContext(ctx context.Context, request *DeleteTagsR
     if request == nil {
         request = NewDeleteTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteTags require credential")
@@ -654,6 +662,7 @@ func (c *Client) DescribeProjectsWithContext(ctx context.Context, request *Descr
     if request == nil {
         request = NewDescribeProjectsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeProjects")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeProjects require credential")
@@ -703,6 +712,7 @@ func (c *Client) DescribeResourceTagsWithContext(ctx context.Context, request *D
     if request == nil {
         request = NewDescribeResourceTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTags require credential")
@@ -764,6 +774,7 @@ func (c *Client) DescribeResourceTagsByResourceIdsWithContext(ctx context.Contex
     if request == nil {
         request = NewDescribeResourceTagsByResourceIdsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByResourceIds")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByResourceIds require credential")
@@ -823,6 +834,7 @@ func (c *Client) DescribeResourceTagsByResourceIdsSeqWithContext(ctx context.Con
     if request == nil {
         request = NewDescribeResourceTagsByResourceIdsSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByResourceIdsSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByResourceIdsSeq require credential")
@@ -855,7 +867,7 @@ func NewDescribeResourceTagsByTagKeysResponse() (response *DescribeResourceTagsB
 }
 
 // DescribeResourceTagsByTagKeys
-// 根据标签键获取资源标签
+// 根据标签键获取指定资源上的标签值
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -871,7 +883,7 @@ func (c *Client) DescribeResourceTagsByTagKeys(request *DescribeResourceTagsByTa
 }
 
 // DescribeResourceTagsByTagKeys
-// 根据标签键获取资源标签
+// 根据标签键获取指定资源上的标签值
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -886,6 +898,7 @@ func (c *Client) DescribeResourceTagsByTagKeysWithContext(ctx context.Context, r
     if request == nil {
         request = NewDescribeResourceTagsByTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByTagKeys require credential")
@@ -918,7 +931,9 @@ func NewDescribeResourcesByTagsResponse() (response *DescribeResourcesByTagsResp
 }
 
 // DescribeResourcesByTags
-// 通过标签查询资源列表
+// 通过标签查询资源列表，按TagKey取交集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。交集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，同时包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -931,7 +946,9 @@ func (c *Client) DescribeResourcesByTags(request *DescribeResourcesByTagsRequest
 }
 
 // DescribeResourcesByTags
-// 通过标签查询资源列表
+// 通过标签查询资源列表，按TagKey取交集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。交集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，同时包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -943,6 +960,7 @@ func (c *Client) DescribeResourcesByTagsWithContext(ctx context.Context, request
     if request == nil {
         request = NewDescribeResourcesByTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourcesByTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourcesByTags require credential")
@@ -975,7 +993,9 @@ func NewDescribeResourcesByTagsUnionResponse() (response *DescribeResourcesByTag
 }
 
 // DescribeResourcesByTagsUnion
-// 通过标签查询资源列表并集
+// 通过标签查询资源列表，按TagKey取并集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。并集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，或者包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -987,7 +1007,9 @@ func (c *Client) DescribeResourcesByTagsUnion(request *DescribeResourcesByTagsUn
 }
 
 // DescribeResourcesByTagsUnion
-// 通过标签查询资源列表并集
+// 通过标签查询资源列表，按TagKey取并集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。并集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，或者包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -998,6 +1020,7 @@ func (c *Client) DescribeResourcesByTagsUnionWithContext(ctx context.Context, re
     if request == nil {
         request = NewDescribeResourcesByTagsUnionRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourcesByTagsUnion")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourcesByTagsUnion require credential")
@@ -1049,6 +1072,7 @@ func (c *Client) DescribeTagKeysWithContext(ctx context.Context, request *Descri
     if request == nil {
         request = NewDescribeTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagKeys require credential")
@@ -1102,6 +1126,7 @@ func (c *Client) DescribeTagValuesWithContext(ctx context.Context, request *Desc
     if request == nil {
         request = NewDescribeTagValuesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagValues")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagValues require credential")
@@ -1153,6 +1178,7 @@ func (c *Client) DescribeTagValuesSeqWithContext(ctx context.Context, request *D
     if request == nil {
         request = NewDescribeTagValuesSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagValuesSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagValuesSeq require credential")
@@ -1185,7 +1211,9 @@ func NewDescribeTagsResponse() (response *DescribeTagsResponse) {
 }
 
 // DescribeTags
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1195,7 +1223,9 @@ func (c *Client) DescribeTags(request *DescribeTagsRequest) (response *DescribeT
 }
 
 // DescribeTags
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1204,6 +1234,7 @@ func (c *Client) DescribeTagsWithContext(ctx context.Context, request *DescribeT
     if request == nil {
         request = NewDescribeTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTags require credential")
@@ -1236,7 +1267,9 @@ func NewDescribeTagsSeqResponse() (response *DescribeTagsSeqResponse) {
 }
 
 // DescribeTagsSeq
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1247,7 +1280,9 @@ func (c *Client) DescribeTagsSeq(request *DescribeTagsSeqRequest) (response *Des
 }
 
 // DescribeTagsSeq
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1257,6 +1292,7 @@ func (c *Client) DescribeTagsSeqWithContext(ctx context.Context, request *Descri
     if request == nil {
         request = NewDescribeTagsSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagsSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagsSeq require credential")
@@ -1336,6 +1372,7 @@ func (c *Client) DetachResourcesTagWithContext(ctx context.Context, request *Det
     if request == nil {
         request = NewDetachResourcesTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DetachResourcesTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DetachResourcesTag require credential")
@@ -1368,7 +1405,7 @@ func NewGetResourcesResponse() (response *GetResourcesResponse) {
 }
 
 // GetResources
-// 查询绑定了标签的资源列表。
+// 查询资源标签列表。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
@@ -1392,7 +1429,7 @@ func (c *Client) GetResources(request *GetResourcesRequest) (response *GetResour
 }
 
 // GetResources
-// 查询绑定了标签的资源列表。
+// 查询资源标签列表。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
@@ -1415,6 +1452,7 @@ func (c *Client) GetResourcesWithContext(ctx context.Context, request *GetResour
     if request == nil {
         request = NewGetResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetResources require credential")
@@ -1472,6 +1510,7 @@ func (c *Client) GetTagKeysWithContext(ctx context.Context, request *GetTagKeysR
     if request == nil {
         request = NewGetTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTagKeys require credential")
@@ -1531,6 +1570,7 @@ func (c *Client) GetTagValuesWithContext(ctx context.Context, request *GetTagVal
     if request == nil {
         request = NewGetTagValuesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTagValues")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTagValues require credential")
@@ -1565,6 +1605,8 @@ func NewGetTagsResponse() (response *GetTagsResponse) {
 // GetTags
 // 用于获取已建立的标签列表。
 //
+// 举例：TagKeys 为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  INVALIDPARAMETER = "InvalidParameter"
@@ -1579,6 +1621,8 @@ func (c *Client) GetTags(request *GetTagsRequest) (response *GetTagsResponse, er
 // GetTags
 // 用于获取已建立的标签列表。
 //
+// 举例：TagKeys 为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  INVALIDPARAMETER = "InvalidParameter"
@@ -1590,6 +1634,7 @@ func (c *Client) GetTagsWithContext(ctx context.Context, request *GetTagsRequest
     if request == nil {
         request = NewGetTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTags require credential")
@@ -1667,6 +1712,7 @@ func (c *Client) ModifyResourceTagsWithContext(ctx context.Context, request *Mod
     if request == nil {
         request = NewModifyResourceTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "ModifyResourceTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ModifyResourceTags require credential")
@@ -1750,6 +1796,7 @@ func (c *Client) ModifyResourcesTagValueWithContext(ctx context.Context, request
     if request == nil {
         request = NewModifyResourcesTagValueRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "ModifyResourcesTagValue")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ModifyResourcesTagValue require credential")
@@ -1835,6 +1882,7 @@ func (c *Client) TagResourcesWithContext(ctx context.Context, request *TagResour
     if request == nil {
         request = NewTagResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "TagResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("TagResources require credential")
@@ -1912,6 +1960,7 @@ func (c *Client) UnTagResourcesWithContext(ctx context.Context, request *UnTagRe
     if request == nil {
         request = NewUnTagResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UnTagResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UnTagResources require credential")
@@ -1969,6 +2018,7 @@ func (c *Client) UpdateProjectWithContext(ctx context.Context, request *UpdatePr
     if request == nil {
         request = NewUpdateProjectRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UpdateProject")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateProject require credential")
@@ -2034,6 +2084,7 @@ func (c *Client) UpdateResourceTagValueWithContext(ctx context.Context, request 
     if request == nil {
         request = NewUpdateResourceTagValueRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UpdateResourceTagValue")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateResourceTagValue require credential")

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/models.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,20 +23,20 @@ import (
 // Predefined struct for user
 type AddProjectRequestParams struct {
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 项目描述
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 type AddProjectRequest struct {
 	*tchttp.BaseRequest
 	
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 项目描述
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 func (r *AddProjectRequest) ToJsonString() string {
@@ -62,13 +62,13 @@ func (r *AddProjectRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type AddProjectResponseParams struct {
 	// 项目Id
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
-	// 是否为新项目
-	IsNew *int64 `json:"IsNew,omitnil" name:"IsNew"`
+	// 是否为新项目，1是新项目，0不是新项目
+	IsNew *int64 `json:"IsNew,omitnil,omitempty" name:"IsNew"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AddProjectResponse struct {
@@ -90,26 +90,26 @@ func (r *AddProjectResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type AddResourceTagRequestParams struct {
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 待关联的资源，用标准的资源六段式表示。正确的资源六段式请参考：https://cloud.tencent.com/document/product/651/89122
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type AddResourceTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 待关联的资源，用标准的资源六段式表示。正确的资源六段式请参考：https://cloud.tencent.com/document/product/651/89122
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *AddResourceTagRequest) ToJsonString() string {
@@ -135,8 +135,8 @@ func (r *AddResourceTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AddResourceTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AddResourceTagResponse struct {
@@ -157,45 +157,45 @@ func (r *AddResourceTagResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachResourcesTagRequestParams struct {
-	// 业务的英文简称，即资源六段式第三段。资源六段式的描述方式参考：https://cloud.tencent.com/document/product/651/89122
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源所在地域，不区分地域的资源则不必填。区分地域的资源则必填，且必填时必须是参数ResourceIds.N资源所对应的地域，且如果ResourceIds.N为批量时，这些资源也必须是同一个地域的。例如示例值：ap-beijing，则参数ResourceIds.N中都应该填写该地域的资源。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分，例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type AttachResourcesTagRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务的英文简称，即资源六段式第三段。资源六段式的描述方式参考：https://cloud.tencent.com/document/product/651/89122
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源所在地域，不区分地域的资源则不必填。区分地域的资源则必填，且必填时必须是参数ResourceIds.N资源所对应的地域，且如果ResourceIds.N为批量时，这些资源也必须是同一个地域的。例如示例值：ap-beijing，则参数ResourceIds.N中都应该填写该地域的资源。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分，例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *AttachResourcesTagRequest) ToJsonString() string {
@@ -224,8 +224,8 @@ func (r *AttachResourcesTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachResourcesTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AttachResourcesTagResponse struct {
@@ -247,20 +247,20 @@ func (r *AttachResourcesTagResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateTagRequestParams struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type CreateTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 func (r *CreateTagRequest) ToJsonString() string {
@@ -285,8 +285,8 @@ func (r *CreateTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateTagResponse struct {
@@ -309,7 +309,7 @@ func (r *CreateTagResponse) FromJsonString(s string) error {
 type CreateTagsRequestParams struct {
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type CreateTagsRequest struct {
@@ -317,7 +317,7 @@ type CreateTagsRequest struct {
 	
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *CreateTagsRequest) ToJsonString() string {
@@ -341,8 +341,8 @@ func (r *CreateTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateTagsResponse struct {
@@ -364,20 +364,20 @@ func (r *CreateTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteResourceTagRequestParams struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	// 资源六段式。示例：qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type DeleteResourceTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	// 资源六段式。示例：qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *DeleteResourceTagRequest) ToJsonString() string {
@@ -402,8 +402,8 @@ func (r *DeleteResourceTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteResourceTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteResourceTagResponse struct {
@@ -425,20 +425,20 @@ func (r *DeleteResourceTagResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteTagRequestParams struct {
 	// 需要删除的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要删除的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type DeleteTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 需要删除的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要删除的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 func (r *DeleteTagRequest) ToJsonString() string {
@@ -463,8 +463,8 @@ func (r *DeleteTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteTagResponse struct {
@@ -487,7 +487,7 @@ func (r *DeleteTagResponse) FromJsonString(s string) error {
 type DeleteTagsRequestParams struct {
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type DeleteTagsRequest struct {
@@ -495,7 +495,7 @@ type DeleteTagsRequest struct {
 	
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *DeleteTagsRequest) ToJsonString() string {
@@ -519,8 +519,8 @@ func (r *DeleteTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteTagsResponse struct {
@@ -542,38 +542,38 @@ func (r *DeleteTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeProjectsRequestParams struct {
 	// 传1拉取所有项目（包括隐藏项目），传0拉取显示项目
-	AllList *uint64 `json:"AllList,omitnil" name:"AllList"`
+	AllList *uint64 `json:"AllList,omitnil,omitempty" name:"AllList"`
 
 	// 分页条数，固定值1000。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 分页偏移量。
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 按项目ID筛选，大于0
-	ProjectId *int64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 按项目名称筛选
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 }
 
 type DescribeProjectsRequest struct {
 	*tchttp.BaseRequest
 	
 	// 传1拉取所有项目（包括隐藏项目），传0拉取显示项目
-	AllList *uint64 `json:"AllList,omitnil" name:"AllList"`
+	AllList *uint64 `json:"AllList,omitnil,omitempty" name:"AllList"`
 
 	// 分页条数，固定值1000。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 分页偏移量。
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 按项目ID筛选，大于0
-	ProjectId *int64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 按项目名称筛选
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 }
 
 func (r *DescribeProjectsRequest) ToJsonString() string {
@@ -602,13 +602,13 @@ func (r *DescribeProjectsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeProjectsResponseParams struct {
 	// 数据总条数
-	Total *uint64 `json:"Total,omitnil" name:"Total"`
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
 
 	// 项目列表
-	Projects []*Project `json:"Projects,omitnil" name:"Projects"`
+	Projects []*Project `json:"Projects,omitnil,omitempty" name:"Projects"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeProjectsResponse struct {
@@ -629,51 +629,51 @@ func (r *DescribeProjectsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀，示例 instance
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源ID数组，大小不超过50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou，不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeResourceTagsByResourceIdsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀，示例 instance
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源ID数组，大小不超过50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou，不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeResourceTagsByResourceIdsRequest) ToJsonString() string {
@@ -704,19 +704,19 @@ func (r *DescribeResourceTagsByResourceIdsRequest) FromJsonString(s string) erro
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*TagResource `json:"Tags,omitnil" name:"Tags"`
+	Tags []*TagResource `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByResourceIdsResponse struct {
@@ -737,45 +737,45 @@ func (r *DescribeResourceTagsByResourceIdsResponse) FromJsonString(s string) err
 
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsSeqRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou, 不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeResourceTagsByResourceIdsSeqRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou, 不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeResourceTagsByResourceIdsSeqRequest) ToJsonString() string {
@@ -805,19 +805,19 @@ func (r *DescribeResourceTagsByResourceIdsSeqRequest) FromJsonString(s string) e
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsSeqResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*TagResource `json:"Tags,omitnil" name:"Tags"`
+	Tags []*TagResource `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByResourceIdsSeqResponse struct {
@@ -838,51 +838,51 @@ func (r *DescribeResourceTagsByResourceIdsSeqResponse) FromJsonString(s string) 
 
 // Predefined struct for user
 type DescribeResourceTagsByTagKeysRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源唯一标识ID的列表，列表容量不超过20
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	// <p>资源唯一标识ID的列表，列表容量不超过20</p>
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源标签键列表，列表容量不超过20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>资源标签键列表，列表容量不超过20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 每页大小，默认为 400
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 400</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 type DescribeResourceTagsByTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源唯一标识ID的列表，列表容量不超过20
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	// <p>资源唯一标识ID的列表，列表容量不超过20</p>
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源标签键列表，列表容量不超过20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>资源标签键列表，列表容量不超过20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 每页大小，默认为 400
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 400</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 func (r *DescribeResourceTagsByTagKeysRequest) ToJsonString() string {
@@ -912,20 +912,20 @@ func (r *DescribeResourceTagsByTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsByTagKeysResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceIdTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceIdTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByTagKeysResponse struct {
@@ -946,57 +946,57 @@ func (r *DescribeResourceTagsByTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsRequestParams struct {
-	// 创建者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// 资源创建者UIN
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 ckafka。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标识。只输入ResourceId进行查询可能会查询较慢，或者无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// 资源唯一标识（资源六段式中最后一段"/"后面的部分）。注：只输入ResourceId查询时，如资源量大可能较慢，或无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）。若传入的是cos资源的Id，则CosResourceId 字段请同时传1。
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否是cos的资源（0或者1），输入的ResourceId为cos资源时必填
-	CosResourceId *uint64 `json:"CosResourceId,omitnil" name:"CosResourceId"`
+	// 是否为cos的资源，取值 0 表示：非cos资源。取值1 表示：cos资源，且此时ResourceId也为必填。不填则默认为 0 
+	CosResourceId *uint64 `json:"CosResourceId,omitnil,omitempty" name:"CosResourceId"`
 }
 
 type DescribeResourceTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 创建者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// 资源创建者UIN
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 ckafka。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标识。只输入ResourceId进行查询可能会查询较慢，或者无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// 资源唯一标识（资源六段式中最后一段"/"后面的部分）。注：只输入ResourceId查询时，如资源量大可能较慢，或无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）。若传入的是cos资源的Id，则CosResourceId 字段请同时传1。
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否是cos的资源（0或者1），输入的ResourceId为cos资源时必填
-	CosResourceId *uint64 `json:"CosResourceId,omitnil" name:"CosResourceId"`
+	// 是否为cos的资源，取值 0 表示：非cos资源。取值1 表示：cos资源，且此时ResourceId也为必填。不填则默认为 0 
+	CosResourceId *uint64 `json:"CosResourceId,omitnil,omitempty" name:"CosResourceId"`
 }
 
 func (r *DescribeResourceTagsRequest) ToJsonString() string {
@@ -1028,20 +1028,19 @@ func (r *DescribeResourceTagsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeResourceTagsResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 资源标签
-	Rows []*TagResource `json:"Rows,omitnil" name:"Rows"`
+	Rows []*TagResource `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsResponse struct {
@@ -1062,57 +1061,57 @@ func (r *DescribeResourceTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsRequestParams struct {
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 type DescribeResourcesByTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 func (r *DescribeResourcesByTagsRequest) ToJsonString() string {
@@ -1143,21 +1142,20 @@ func (r *DescribeResourcesByTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourcesByTagsResponse struct {
@@ -1178,57 +1176,57 @@ func (r *DescribeResourcesByTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsUnionRequestParams struct {
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 type DescribeResourcesByTagsUnionRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 func (r *DescribeResourcesByTagsUnionRequest) ToJsonString() string {
@@ -1259,20 +1257,20 @@ func (r *DescribeResourcesByTagsUnionRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsUnionResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourcesByTagsUnionResponse struct {
@@ -1293,39 +1291,39 @@ func (r *DescribeResourcesByTagsUnionResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagKeysRequestParams struct {
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15，最大1000
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否展现项目
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15，最大1000
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否展现项目
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeTagKeysRequest) ToJsonString() string {
@@ -1353,20 +1351,20 @@ func (r *DescribeTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagKeysResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*string `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagKeysResponse struct {
@@ -1387,39 +1385,39 @@ func (r *DescribeTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagValuesRequestParams struct {
-	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键列表</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeTagValuesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键列表</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeTagValuesRequest) ToJsonString() string {
@@ -1447,20 +1445,20 @@ func (r *DescribeTagValuesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagValuesResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagValuesResponse struct {
@@ -1482,32 +1480,32 @@ func (r *DescribeTagValuesResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeTagValuesSeqRequestParams struct {
 	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
 	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeTagValuesSeqRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
 	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeTagValuesSeqRequest) ToJsonString() string {
@@ -1535,19 +1533,19 @@ func (r *DescribeTagValuesSeqRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeTagValuesSeqResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagValuesSeqResponse struct {
@@ -1568,51 +1566,51 @@ func (r *DescribeTagValuesSeqResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsRequestParams struct {
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 type DescribeTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 func (r *DescribeTagsRequest) ToJsonString() string {
@@ -1642,20 +1640,20 @@ func (r *DescribeTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*TagWithDelete `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*TagWithDelete `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagsResponse struct {
@@ -1676,51 +1674,51 @@ func (r *DescribeTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsSeqRequestParams struct {
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 type DescribeTagsSeqRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 func (r *DescribeTagsSeqRequest) ToJsonString() string {
@@ -1750,20 +1748,20 @@ func (r *DescribeTagsSeqRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsSeqResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*TagWithDelete `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*TagWithDelete `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagsSeqResponse struct {
@@ -1784,39 +1782,39 @@ func (r *DescribeTagsSeqResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DetachResourcesTagRequestParams struct {
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要解绑的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type DetachResourcesTagRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要解绑的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *DetachResourcesTagRequest) ToJsonString() string {
@@ -1844,8 +1842,8 @@ func (r *DetachResourcesTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DetachResourcesTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DetachResourcesTagResponse struct {
@@ -1866,60 +1864,44 @@ func (r *DetachResourcesTagResponse) FromJsonString(s string) error {
 
 type FailedResource struct {
 	// 失败的资源六段式
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
 	// 错误码
-	Code *string `json:"Code,omitnil" name:"Code"`
+	Code *string `json:"Code,omitnil,omitempty" name:"Code"`
 
 	// 错误信息
-	Message *string `json:"Message,omitnil" name:"Message"`
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
 }
 
 // Predefined struct for user
 type GetResourcesRequestParams struct {
-	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。
-	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	// 如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。
-	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	// <p>资源六段式列表。腾讯云使用资源六段式描述一个资源。<br>例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。<br>如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。<br>N取值范围：0~9</p>
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
-	// 标签键和标签值。
-	// 指定多个标签，会查询同时绑定了该多个标签的资源。
-	// N取值范围：0~5。
-	// 每个TagFilters中的TagValue最多支持10个
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。会查询同时绑定了这多组标签的资源。<br>每组标签中的TagValue最多支持10个。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大200。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大200。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 }
 
 type GetResourcesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。
-	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	// 如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。
-	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	// <p>资源六段式列表。腾讯云使用资源六段式描述一个资源。<br>例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。<br>如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。<br>N取值范围：0~9</p>
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
-	// 标签键和标签值。
-	// 指定多个标签，会查询同时绑定了该多个标签的资源。
-	// N取值范围：0~5。
-	// 每个TagFilters中的TagValue最多支持10个
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。会查询同时绑定了这多组标签的资源。<br>每组标签中的TagValue最多支持10个。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大200。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大200。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 }
 
 func (r *GetResourcesRequest) ToJsonString() string {
@@ -1946,14 +1928,14 @@ func (r *GetResourcesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetResourcesResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 资源及关联的标签(键和值)列表
-	ResourceTagMappingList []*ResourceTagMapping `json:"ResourceTagMappingList,omitnil" name:"ResourceTagMappingList"`
+	// <p>资源及关联的标签(键和值)列表</p>
+	ResourceTagMappingList []*ResourceTagMapping `json:"ResourceTagMappingList,omitnil,omitempty" name:"ResourceTagMappingList"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetResourcesResponse struct {
@@ -1974,31 +1956,27 @@ func (r *GetResourcesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagKeysRequestParams struct {
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagKeysRequest) ToJsonString() string {
@@ -2024,14 +2002,14 @@ func (r *GetTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagKeysResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签键信息。
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键信息。</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagKeysResponse struct {
@@ -2052,41 +2030,33 @@ func (r *GetTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagValuesRequestParams struct {
-	// 标签键。
-	// 返回所有标签键列表对应的标签值。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。返回所有标签键列表对应的标签值。最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagValuesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键。
-	// 返回所有标签键列表对应的标签值。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。返回所有标签键列表对应的标签值。最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagValuesRequest) ToJsonString() string {
@@ -2113,14 +2083,14 @@ func (r *GetTagValuesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagValuesResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签列表。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表。</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagValuesResponse struct {
@@ -2141,41 +2111,33 @@ func (r *GetTagValuesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagsRequestParams struct {
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签键。
-	// 返回所有标签键列表对应的标签。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。<br>返回所有标签键列表对应的标签。<br>最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签键。
-	// 返回所有标签键列表对应的标签。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。<br>返回所有标签键列表对应的标签。<br>最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagsRequest) ToJsonString() string {
@@ -2202,14 +2164,14 @@ func (r *GetTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagsResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签列表。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表。</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagsResponse struct {
@@ -2231,26 +2193,26 @@ func (r *GetTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type ModifyResourceTagsRequestParams struct {
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	ReplaceTags []*Tag `json:"ReplaceTags,omitnil" name:"ReplaceTags"`
+	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	ReplaceTags []*Tag `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
-	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil" name:"DeleteTags"`
+	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 type ModifyResourceTagsRequest struct {
 	*tchttp.BaseRequest
 	
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	ReplaceTags []*Tag `json:"ReplaceTags,omitnil" name:"ReplaceTags"`
+	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	ReplaceTags []*Tag `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
-	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil" name:"DeleteTags"`
+	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 func (r *ModifyResourceTagsRequest) ToJsonString() string {
@@ -2276,8 +2238,8 @@ func (r *ModifyResourceTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourceTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ModifyResourceTagsResponse struct {
@@ -2298,45 +2260,45 @@ func (r *ModifyResourceTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourcesTagValueRequestParams struct {
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分），例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type ModifyResourcesTagValueRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分），例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *ModifyResourcesTagValueRequest) ToJsonString() string {
@@ -2365,8 +2327,8 @@ func (r *ModifyResourcesTagValueRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourcesTagValueResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ModifyResourcesTagValueResponse struct {
@@ -2387,124 +2349,114 @@ func (r *ModifyResourcesTagValueResponse) FromJsonString(s string) error {
 
 type Project struct {
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 创建人uin
-	CreatorUin *uint64 `json:"CreatorUin,omitnil" name:"CreatorUin"`
+	CreatorUin *uint64 `json:"CreatorUin,omitnil,omitempty" name:"CreatorUin"`
 
 	// 项目描述
-	ProjectInfo *string `json:"ProjectInfo,omitnil" name:"ProjectInfo"`
+	ProjectInfo *string `json:"ProjectInfo,omitnil,omitempty" name:"ProjectInfo"`
 
 	// 创建时间
-	CreateTime *string `json:"CreateTime,omitnil" name:"CreateTime"`
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 }
 
 type ResourceIdTag struct {
 	// 资源唯一标识
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 标签键值对
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TagKeyValues []*Tag `json:"TagKeyValues,omitnil" name:"TagKeyValues"`
+	TagKeyValues []*Tag `json:"TagKeyValues,omitnil,omitempty" name:"TagKeyValues"`
 }
 
 type ResourceTag struct {
 	// 资源所在地域
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 业务类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源前缀
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 资源标签
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type ResourceTagMapping struct {
 	// 资源六段式。腾讯云使用资源六段式描述一个资源。
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
 	// 资源关联的标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type Tag struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type TagFilter struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值数组 多个值的话是或的关系
-	TagValue []*string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue []*string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type TagKeyObject struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 }
 
 type TagResource struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源ID
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 标签键MD5值
-	TagKeyMd5 *string `json:"TagKeyMd5,omitnil" name:"TagKeyMd5"`
+	TagKeyMd5 *string `json:"TagKeyMd5,omitnil,omitempty" name:"TagKeyMd5"`
 
 	// 标签值MD5值
-	TagValueMd5 *string `json:"TagValueMd5,omitnil" name:"TagValueMd5"`
+	TagValueMd5 *string `json:"TagValueMd5,omitnil,omitempty" name:"TagValueMd5"`
 
 	// 资源类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 // Predefined struct for user
 type TagResourcesRequestParams struct {
 	// 待绑定的云资源，用标准的资源六段式表示。正确的资源六段式请参考：[标准的资源六段式](https://cloud.tencent.com/document/product/598/10606)和[支持标签的云产品及资源描述方式](https://cloud.tencent.com/document/product/651/89122)。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键和标签值。
 	// 如果指定多个标签，则会为指定资源同时创建并绑定该多个标签。
 	// 同一个资源上的同一个标签键只能对应一个标签值。如果您尝试添加已有标签键，则对应的标签值会更新为新值。
 	// 如果标签不存在会为您自动创建标签。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type TagResourcesRequest struct {
@@ -2512,14 +2464,14 @@ type TagResourcesRequest struct {
 	
 	// 待绑定的云资源，用标准的资源六段式表示。正确的资源六段式请参考：[标准的资源六段式](https://cloud.tencent.com/document/product/598/10606)和[支持标签的云产品及资源描述方式](https://cloud.tencent.com/document/product/651/89122)。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键和标签值。
 	// 如果指定多个标签，则会为指定资源同时创建并绑定该多个标签。
 	// 同一个资源上的同一个标签键只能对应一个标签值。如果您尝试添加已有标签键，则对应的标签值会更新为新值。
 	// 如果标签不存在会为您自动创建标签。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *TagResourcesRequest) ToJsonString() string {
@@ -2547,10 +2499,10 @@ type TagResourcesResponseParams struct {
 	// 失败资源信息。
 	// 创建并绑定标签成功时，返回的FailedResources为空。
 	// 创建并绑定标签失败或部分失败时，返回的FailedResources会显示失败资源的详细信息。
-	FailedResources []*FailedResource `json:"FailedResources,omitnil" name:"FailedResources"`
+	FailedResources []*FailedResource `json:"FailedResources,omitnil,omitempty" name:"FailedResources"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type TagResourcesResponse struct {
@@ -2571,17 +2523,16 @@ func (r *TagResourcesResponse) FromJsonString(s string) error {
 
 type TagWithDelete struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 是否可以删除
-	CanDelete *uint64 `json:"CanDelete,omitnil" name:"CanDelete"`
+	CanDelete *uint64 `json:"CanDelete,omitnil,omitempty" name:"CanDelete"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 // Predefined struct for user
@@ -2589,11 +2540,11 @@ type UnTagResourcesRequestParams struct {
 	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。可参考[访问管理](https://cloud.tencent.com/document/product/598/67350)-概览-接口列表-资源六段式信息
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:uin/${Account}:${ResourcePrefix}/${ResourceId}。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键。
 	// 取值范围：0~9
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 }
 
 type UnTagResourcesRequest struct {
@@ -2602,11 +2553,11 @@ type UnTagResourcesRequest struct {
 	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。可参考[访问管理](https://cloud.tencent.com/document/product/598/67350)-概览-接口列表-资源六段式信息
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:uin/${Account}:${ResourcePrefix}/${ResourceId}。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键。
 	// 取值范围：0~9
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 }
 
 func (r *UnTagResourcesRequest) ToJsonString() string {
@@ -2634,10 +2585,10 @@ type UnTagResourcesResponseParams struct {
 	// 失败资源信息。
 	// 解绑标签成功时，返回的FailedResources为空。
 	// 解绑标签失败或部分失败时，返回的FailedResources会显示失败资源的详细信息。
-	FailedResources []*FailedResource `json:"FailedResources,omitnil" name:"FailedResources"`
+	FailedResources []*FailedResource `json:"FailedResources,omitnil,omitempty" name:"FailedResources"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UnTagResourcesResponse struct {
@@ -2659,32 +2610,32 @@ func (r *UnTagResourcesResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type UpdateProjectRequestParams struct {
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 禁用项目，1，禁用，0，启用
-	Disable *int64 `json:"Disable,omitnil" name:"Disable"`
+	Disable *int64 `json:"Disable,omitnil,omitempty" name:"Disable"`
 
 	// 备注
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 type UpdateProjectRequest struct {
 	*tchttp.BaseRequest
 	
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 禁用项目，1，禁用，0，启用
-	Disable *int64 `json:"Disable,omitnil" name:"Disable"`
+	Disable *int64 `json:"Disable,omitnil,omitempty" name:"Disable"`
 
 	// 备注
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 func (r *UpdateProjectRequest) ToJsonString() string {
@@ -2711,8 +2662,8 @@ func (r *UpdateProjectRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateProjectResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateProjectResponse struct {
@@ -2734,26 +2685,26 @@ func (r *UpdateProjectResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type UpdateResourceTagValueRequestParams struct {
 	// 资源关联的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 修改后的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type UpdateResourceTagValueRequest struct {
 	*tchttp.BaseRequest
 	
 	// 资源关联的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 修改后的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *UpdateResourceTagValueRequest) ToJsonString() string {
@@ -2779,8 +2730,8 @@ func (r *UpdateResourceTagValueRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateResourceTagValueResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateResourceTagValueResponse struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1415,7 +1415,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm/v20190923
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts/v20180813
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634


### PR DESCRIPTION
Remove ForceNew from the tag_value field of tencentcloud_tag_attachment so that changing the tag value performs an in-place update via the UpdateResourceTagValue cloud API instead of destroying and recreating the attachment. This avoids the delete-then-create behavior that drops the authorizing tag and causes the subsequent add request to fail when a resource's access permission is controlled by the tag KV pair. tag_key and resource remain ForceNew.