### PR TITLE
feat(tag): make tag_value field updatable in tencentcloud_tag_attachment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssl v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcm v1.0.547

--- a/go.sum
+++ b/go.sum
@@ -1104,8 +1104,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691 h1:UE55Tqu
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.691/go.mod h1:IRaYO5mSpBMPX8ydImTcL3jyuEkALEu/55Myb0a+GMs=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11 h1:FWhgjLYFHWJvYIsLfk4k2XWaJcn7HMUmFLWNSL4pqto=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11/go.mod h1:et851eJUuaPGcsKDi1eUfQZoslCaDS3QKUgoqQZtF1c=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860 h1:epSPxNqUU0j2MY0qFoycwRl2he9AlxhEeyxUquBg/G8=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860/go.mod h1:6hzZuAz+UAG4nWudMqk+6hHwRWXZrFrpP8P7yEsEqY0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110 h1:Yahf4DkfDlq68dRp8EywDs1LgfaYGgrKt7WrNbsgviQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110/go.mod h1:1bbGbuvl0dhscea40iMjZFKSLX6450wJr0QF1dYViA8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634 h1:GJDzXxKloZeM8fN+qlIspPnZbUw1lOZGe7jGqfFbQMM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634/go.mod h1:yX1elLeYvjmtPvgBVCOyYxyy1u2XEKfXaEiZXIWRCKw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb v1.3.105 h1:6OndfnRdCLh3OTKvLaRA9OTOZbmsyB3uO8r4Hi8H/X4=

--- a/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/design.md
+++ b/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/design.md
@@ -1,0 +1,94 @@
+## Context
+
+当前 `tencentcloud_tag_attachment` 资源只实现了 Create/Read/Delete 三个操作，`tag_value` 字段为 `ForceNew: true`。用户修改 `tag_value` 时，Terraform 会先删除旧标签关联再创建新标签关联，导致标签短暂脱离资源，影响基于标签的权限策略、计费分账和自动化运维。
+
+腾讯云 tag 服务（v20180813）提供了 `UpdateResourceTagValue` 接口，其描述为"本接口用于修改资源已关联的标签值（标签键不变）"，入参为 `TagKey`、`TagValue`（修改后的值）、`Resource`，与当前资源 schema 的三个字段完全对应。该接口已存在于 vendor 目录中，无需升级 SDK。
+
+**关键文件：**
+- `tencentcloud/services/tag/resource_tc_tag_attachment.go` — 资源定义（Schema + CRUD）
+- `tencentcloud/services/tag/service_tencentcloud_tag.go` — 服务层，已有 `DescribeTagTagAttachmentById` 和 `DeleteTagTagAttachmentById`
+- `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/models.go:2697` — `UpdateResourceTagValueRequest` 定义
+
+**资源 ID 格式：** `tagKey + FILED_SP + tagValue + FILED_SP + resourceId`，修改 `tag_value` 后 ID 会变化，需重新 `SetId`。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 将 `tag_value` 字段从 `ForceNew: true` 改为 `ForceNew: false`，支持原地更新
+- 新增 `Update` 函数，当 `tag_value` 发生变化时调用 `UpdateResourceTagValue` API
+- 在服务层封装 `UpdateResourceTagValue` 调用
+- 保持向后兼容，不影响不修改 `tag_value` 的现有配置
+- 补充单元测试覆盖 update 逻辑
+
+**Non-Goals:**
+- 不支持修改 `tag_key`（`UpdateResourceTagValue` API 要求标签键不变，修改 `tag_key` 仍需重建）
+- 不支持修改 `resource`（资源六段式变更等价于换资源，仍为 ForceNew）
+- 不引入 Timeouts 块（`UpdateResourceTagValue` 是同步操作，无需轮询等待）
+
+## Decisions
+
+### Decision 1: Update 函数处理 tag_value 变更
+**决策：** 新增 `resourceTencentCloudTagAttachmentUpdate` 函数，在其中检测 `d.HasChange("tag_value")`，调用 `UpdateResourceTagValue` API 完成原地修改。
+
+**理由：**
+- `UpdateResourceTagValue` API 的语义是"标签键不变，仅修改标签值"，与 `tag_value` 可更新需求完全契合
+- API 入参 `TagKey`、`TagValue`、`Resource` 与资源 schema 字段一一对应，无需额外转换
+
+**替代方案：**
+- 在 Update 中删除旧标签关联再创建新关联 → 仍会导致标签短暂脱离资源，违背需求初衷，且浪费两次 API 调用
+
+### Decision 2: 更新后重新设置资源 ID
+**决策：** 调用 `UpdateResourceTagValue` 成功后，使用新的 `tag_value` 重新拼接并 `d.SetId(tagKey + FILED_SP + newTagValue + FILED_SP + resourceId)`，随后调用 `Read` 同步状态。
+
+**理由：**
+- 资源 ID 包含 `tag_value`，更新后旧 ID 不再匹配云端实际标签值
+- 重新 `SetId` 保证后续 Read/Delete 操作能基于新值定位资源
+
+**实现：**
+```go
+// retry 块外、错误处理后
+d.SetId(tagKey + tccommon.FILED_SP + newTagValue + tccommon.FILED_SP + resourceId)
+return resourceTencentCloudTagAttachmentRead(d, meta)
+```
+
+### Decision 3: tag_key 和 resource 变更仍触发重建
+**决策：** `tag_key` 和 `resource` 字段保持 `ForceNew: true` 不变。
+
+**理由：**
+- `UpdateResourceTagValue` API 明确要求标签键不变（"标签键不变"）
+- `resource` 变更意味着绑定到不同资源，语义上属于新关联，应重建
+
+### Decision 4: 服务层方法封装
+**决策：** 在 `service_tencentcloud_tag.go` 新增 `UpdateTagTagAttachment(ctx, tagKey, newTagValue, resource string)` 方法，封装 `UpdateResourceTagValue` 请求构造、调用和错误处理。
+
+**理由：**
+- 与现有 `DeleteTagTagAttachmentById` 方法风格保持一致
+- 集中管理 API 调用与日志，便于维护
+
+### Decision 5: API 调用使用 WriteRetryTimeout 重试
+**决策：** Update 中的 API 调用使用 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 包装，失败时使用 `tccommon.RetryError()` 包装错误。
+
+**理由：**
+- 符合项目规范：调用云 API 接口时以 `tccommon.WriteRetryTimeout` 作为超时时间添加 retry 处理
+- 与 Create 函数中的 retry 逻辑保持一致
+
+### Decision 6: 单元测试使用 gomonkey mock
+**决策：** 在 `resource_tc_tag_attachment_test.go` 中使用 gomonkey 对云 API 进行 mock，仅测试业务逻辑，不使用 terraform 测试套件。
+
+**理由：**
+- 本次为修改现有资源（新增 Update），但 Update 为全新函数，按规范使用 mock 方式补充单元测试
+- 避免依赖真实云资源和 `TF_ACC` 环境变量
+
+## Risks / Trade-offs
+
+### Risk 1: tag_value 更新失败导致 state 不一致
+**风险：** `UpdateResourceTagValue` API 调用失败，state 中已记录新值但云端仍为旧值。
+**缓解措施：** API 调用失败时直接返回 error，不执行 `SetId`，Terraform 会保持旧 state，用户可重试。
+
+### Risk 2: 并发修改 tag_value
+**风险：** 多个 Terraform 进程同时修改同一资源的 tag_value。
+**缓解措施：** 依赖云 API 的并发控制和错误返回，Provider 层不做额外加锁（与项目其他资源一致）。
+
+### Risk 3: 行为变更影响存量用户
+**风险：** 存量用户修改 `tag_value` 时，从"重建"变为"原地更新"。
+**缓解措施：** 该变更属于正向增强，原地更新比重建更安全，用户预期一致。

--- a/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/proposal.md
+++ b/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+当前 `tencentcloud_tag_attachment` 资源的 `tag_value` 字段设置为 `ForceNew: true`，用户修改 `tag_value` 会触发资源重建（先删除后创建）。对于已绑定到生产资源的标签，重建会导致标签短暂脱离资源，影响基于标签的权限策略、计费分账和自动化运维。
+
+腾讯云 tag 服务提供了 `UpdateResourceTagValue` 接口（本接口用于修改资源已关联的标签值，标签键不变），支持在不重建资源的情况下原地修改 `tag_value`，应当利用该能力将 `tag_value` 改为可更新字段。
+
+## What Changes
+
+- 将 `tencentcloud_tag_attachment` 资源的 `tag_value` 字段 `ForceNew` 从 `true` 改为 `false`
+- 为 `tencentcloud_tag_attachment` 资源新增 `Update` 函数，当 `tag_value` 发生变化时调用 `UpdateResourceTagValue` API 原地修改标签值
+- 在 `service_tencentcloud_tag.go` 服务层新增 `UpdateTagTagAttachment` 方法，封装 `UpdateResourceTagValue` API 调用
+- 资源 ID 格式为 `tagKey + FILED_SP + tagValue + FILED_SP + resourceId`，更新 `tag_value` 后需重新设置 `d.SetId()` 以保持 state 一致性
+- 补充单元测试用例（使用 gomonkey mock 云 API）
+- 更新 `resource_tc_tag_attachment.md` 文档
+
+## Capabilities
+
+### New Capabilities
+- `tag-attachment-tag-value-update`: 支持 `tencentcloud_tag_attachment` 资源 `tag_value` 字段的原地更新能力，通过 `UpdateResourceTagValue` API 实现
+
+### Modified Capabilities
+<!-- 无现有 spec 被修改 -->
+
+## Impact
+
+### 受影响的代码
+- `tencentcloud/services/tag/resource_tc_tag_attachment.go` — 新增 `Update` 函数，修改 `tag_value` 字段 Schema（去掉 ForceNew）
+- `tencentcloud/services/tag/service_tencentcloud_tag.go` — 新增 `UpdateTagTagAttachment` 服务方法
+- `tencentcloud/services/tag/resource_tc_tag_attachment_test.go` — 补充单元测试用例
+- `tencentcloud/services/tag/resource_tc_tag_attachment.md` — 更新文档说明
+
+### API 依赖
+- `UpdateResourceTagValue`（tag v20180813）：本接口用于修改资源已关联的标签值（标签键不变）
+  - 入参：`TagKey`（资源关联的标签键）、`TagValue`（修改后的标签值）、`Resource`（资源六段式描述）
+  - 该接口已存在于 vendor 目录中，无需升级 SDK
+
+### 向后兼容性
+- ✅ **向后兼容** — 现有不修改 `tag_value` 的配置行为不受影响
+- ⚠️ **行为变更** — 修改 `tag_value` 从"触发重建"变为"原地更新"，属于正向增强，符合用户预期

--- a/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/specs/tag-attachment-tag-value-update/spec.md
+++ b/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/specs/tag-attachment-tag-value-update/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: tag_value 字段支持原地更新
+`tencentcloud_tag_attachment` 资源的 `tag_value` 字段 SHALL 支持原地更新，不再触发资源重建。当 `tag_value` 发生变化时，Provider SHALL 调用 `UpdateResourceTagValue` API 修改资源已关联的标签值（标签键不变）。
+
+#### Scenario: 用户修改 tag_value 触发原地更新
+- **GIVEN** 一个已创建的 `tencentcloud_tag_attachment` 资源，tag_key 为 "env"，tag_value 为 "dev"，resource 为某资源六段式
+- **WHEN** 用户修改 Terraform 配置中的 `tag_value` 为 "prod"
+- **THEN** Provider 应调用 `UpdateResourceTagValue` API，传入 TagKey="env"、TagValue="prod"、Resource=原资源六段式
+- **AND** 不应调用 DeleteResourceTag 或 AddResourceTag
+- **AND** 更新成功后应重新设置资源 ID 为 `tagKey + FILED_SP + newTagValue + FILED_SP + resourceId`
+- **AND** 调用 Read 操作同步最新状态
+
+#### Scenario: tag_value 未变化时不调用更新 API
+- **GIVEN** 一个已创建的 `tencentcloud_tag_attachment` 资源
+- **WHEN** 用户执行 `terraform apply` 但未修改 `tag_value`
+- **THEN** Provider 不应调用 `UpdateResourceTagValue` API
+
+#### Scenario: tag_value 字段不包含 ForceNew
+- **GIVEN** `tencentcloud_tag_attachment` 资源的 Schema 定义
+- **WHEN** 检查 `tag_value` 字段属性
+- **THEN** 该字段应为 `Required`、`TypeString`
+- **AND** 不应包含 `ForceNew: true`
+
+### Requirement: tag_key 和 resource 字段保持 ForceNew
+`tencentcloud_tag_attachment` 资源的 `tag_key` 和 `resource` 字段 SHALL 保持 `ForceNew: true`，修改这两个字段仍触发资源重建。
+
+#### Scenario: 修改 tag_key 触发重建
+- **GIVEN** 一个已创建的 `tencentcloud_tag_attachment` 资源
+- **WHEN** 用户修改 `tag_key` 字段
+- **THEN** Provider 应触发资源重建（先删除后创建）
+
+#### Scenario: 修改 resource 触发重建
+- **GIVEN** 一个已创建的 `tencentcloud_tag_attachment` 资源
+- **WHEN** 用户修改 `resource` 字段
+- **THEN** Provider 应触发资源重建（先删除后创建）
+
+### Requirement: 服务层 UpdateTagTagAttachment 方法
+TagService SHALL 提供 `UpdateTagTagAttachment` 方法，封装 `UpdateResourceTagValue` API 调用。
+
+#### Scenario: 调用 UpdateResourceTagValue API
+- **GIVEN** tag_key、new_tag_value、resource 参数
+- **WHEN** 调用 `service.UpdateTagTagAttachment(ctx, tagKey, newTagValue, resource)`
+- **THEN** 应构造 `UpdateResourceTagValueRequest`，设置 TagKey、TagValue、Resource 字段
+- **AND** 调用 `UpdateResourceTagValue` API
+- **AND** 记录请求和响应日志
+
+#### Scenario: API 调用失败处理
+- **GIVEN** `UpdateResourceTagValue` API 返回错误
+- **WHEN** 错误为可重试类型
+- **THEN** 使用 `tccommon.RetryError()` 包装错误
+- **AND** 由外层 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 进行重试
+
+### Requirement: Update 操作的重试机制
+`resourceTencentCloudTagAttachmentUpdate` 函数 SHALL 使用 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 包装 `UpdateResourceTagValue` API 调用，retry 块内仅执行 API 调用，不执行 SetId 等成功操作。
+
+#### Scenario: 重试块内仅执行 API 调用
+- **GIVEN** Update 函数中的 retry 块
+- **WHEN** 执行 retry 闭包
+- **THEN** retry 块内应仅调用 `UpdateResourceTagValue` API
+- **AND** 不应在 retry 块内执行 `d.SetId()` 等成功后操作
+- **AND** SetId 操作应在 retry 块外、错误处理后执行

--- a/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/tasks.md
+++ b/openspec/changes/archive/2026-08-10-modify-tag-attachment-tag-value-force-new/tasks.md
@@ -1,0 +1,36 @@
+## 1. Schema 修改
+
+- [x] 1.1 在 `tencentcloud/services/tag/resource_tc_tag_attachment.go` 中将 `tag_value` 字段的 `ForceNew: true` 改为 `ForceNew: false`
+- [x] 1.2 在 `ResourceTencentCloudTagAttachment()` 的 `schema.Resource` 中注册 `Update: resourceTencentCloudTagAttachmentUpdate`
+- [x] 1.3 保持 `tag_key` 和 `resource` 字段的 `ForceNew: true` 不变
+
+## 2. 服务层实现
+
+- [x] 2.1 在 `tencentcloud/services/tag/service_tencentcloud_tag.go` 中新增 `UpdateTagTagAttachment(ctx context.Context, tagKey string, newTagValue string, resource string) (errRet error)` 方法
+- [x] 2.2 构造 `UpdateResourceTagValueRequest`，设置 TagKey、TagValue、Resource 字段
+- [x] 2.3 调用 `me.client.UseTagClient().UpdateResourceTagValue(request)`，记录请求和响应日志，处理错误
+
+## 3. Update 函数实现
+
+- [x] 3.1 在 `tencentcloud/services/tag/resource_tc_tag_attachment.go` 中新增 `resourceTencentCloudTagAttachmentUpdate` 函数，包含 `defer tccommon.LogElapsed()` 和 `defer tccommon.InconsistentCheck()`
+- [x] 3.2 从 `d.Id()` 解析出 tagKey、旧 tagValue、resourceId（使用 `tccommon.FILED_SP` 分隔）
+- [x] 3.3 检测 `d.HasChange("tag_value")`，获取旧值和新值
+- [x] 3.4 使用 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 包装 `service.UpdateTagTagAttachment` 调用，retry 块内仅执行 API 调用，失败时使用 `tccommon.RetryError()` 包装错误
+- [x] 3.5 retry 块外、错误处理后，使用新 tag_value 重新设置 ID：`d.SetId(tagKey + tccommon.FILED_SP + newTagValue + tccommon.FILED_SP + resourceId)`
+- [x] 3.6 调用 `resourceTencentCloudTagAttachmentRead(d, meta)` 同步状态并返回
+
+## 4. 单元测试
+
+- [x] 4.1 在 `tencentcloud/services/tag/resource_tc_tag_attachment_test.go` 中新增 Update 相关单元测试用例，使用 gomonkey mock 云 API（mock `UpdateResourceTagValue`、`GetResources` 等）
+- [x] 4.2 测试场景：tag_value 变更时正确调用 UpdateResourceTagValue 并更新 ID
+- [x] 4.3 测试场景：tag_value 未变更时不调用 UpdateResourceTagValue
+- [x] 4.4 测试场景：API 调用失败时返回错误且不更新 ID
+
+## 5. 文档更新
+
+- [x] 5.1 更新 `tencentcloud/services/tag/resource_tc_tag_attachment.md`，补充 tag_value 可修改的说明
+
+## 6. 验证
+
+- [x] 6.1 确认代码编译通过（由后续流程的 go build 验证）
+- [x] 6.2 确认单元测试用例可在当前环境下正确构建（由后续流程验证）

--- a/openspec/specs/tag-attachment-tag-value-update/spec.md
+++ b/openspec/specs/tag-attachment-tag-value-update/spec.md
@@ -1,0 +1,65 @@
+# tag-attachment-tag-value-update Specification
+
+## Purpose
+TBD - created by archiving change modify-tag-attachment-tag-value-force-new. Update Purpose after archive.
+## Requirements
+### Requirement: tag_value 字段支持原地更新
+`tencentcloud_tag_attachment` 资源的 `tag_value` 字段 SHALL 支持原地更新，不再触发资源重建。当 `tag_value` 发生变化时，Provider SHALL 调用 `UpdateResourceTagValue` API 修改资源已关联的标签值（标签键不变）。
+
+#### Scenario: 用户修改 tag_value 触发原地更新
+- **GIVEN** 一个已创建的 `tencentcloud_tag_attachment` 资源，tag_key 为 "env"，tag_value 为 "dev"，resource 为某资源六段式
+- **WHEN** 用户修改 Terraform 配置中的 `tag_value` 为 "prod"
+- **THEN** Provider 应调用 `UpdateResourceTagValue` API，传入 TagKey="env"、TagValue="prod"、Resource=原资源六段式
+- **AND** 不应调用 DeleteResourceTag 或 AddResourceTag
+- **AND** 更新成功后应重新设置资源 ID 为 `tagKey + FILED_SP + newTagValue + FILED_SP + resourceId`
+- **AND** 调用 Read 操作同步最新状态
+
+#### Scenario: tag_value 未变化时不调用更新 API
+- **GIVEN** 一个已创建的 `tencentcloud_tag_attachment` 资源
+- **WHEN** 用户执行 `terraform apply` 但未修改 `tag_value`
+- **THEN** Provider 不应调用 `UpdateResourceTagValue` API
+
+#### Scenario: tag_value 字段不包含 ForceNew
+- **GIVEN** `tencentcloud_tag_attachment` 资源的 Schema 定义
+- **WHEN** 检查 `tag_value` 字段属性
+- **THEN** 该字段应为 `Required`、`TypeString`
+- **AND** 不应包含 `ForceNew: true`
+
+### Requirement: tag_key 和 resource 字段保持 ForceNew
+`tencentcloud_tag_attachment` 资源的 `tag_key` 和 `resource` 字段 SHALL 保持 `ForceNew: true`，修改这两个字段仍触发资源重建。
+
+#### Scenario: 修改 tag_key 触发重建
+- **GIVEN** 一个已创建的 `tencentcloud_tag_attachment` 资源
+- **WHEN** 用户修改 `tag_key` 字段
+- **THEN** Provider 应触发资源重建（先删除后创建）
+
+#### Scenario: 修改 resource 触发重建
+- **GIVEN** 一个已创建的 `tencentcloud_tag_attachment` 资源
+- **WHEN** 用户修改 `resource` 字段
+- **THEN** Provider 应触发资源重建（先删除后创建）
+
+### Requirement: 服务层 UpdateTagTagAttachment 方法
+TagService SHALL 提供 `UpdateTagTagAttachment` 方法，封装 `UpdateResourceTagValue` API 调用。
+
+#### Scenario: 调用 UpdateResourceTagValue API
+- **GIVEN** tag_key、new_tag_value、resource 参数
+- **WHEN** 调用 `service.UpdateTagTagAttachment(ctx, tagKey, newTagValue, resource)`
+- **THEN** 应构造 `UpdateResourceTagValueRequest`，设置 TagKey、TagValue、Resource 字段
+- **AND** 调用 `UpdateResourceTagValue` API
+- **AND** 记录请求和响应日志
+
+#### Scenario: API 调用失败处理
+- **GIVEN** `UpdateResourceTagValue` API 返回错误
+- **WHEN** 错误为可重试类型
+- **THEN** 使用 `tccommon.RetryError()` 包装错误
+- **AND** 由外层 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 进行重试
+
+### Requirement: Update 操作的重试机制
+`resourceTencentCloudTagAttachmentUpdate` 函数 SHALL 使用 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 包装 `UpdateResourceTagValue` API 调用，retry 块内仅执行 API 调用，不执行 SetId 等成功操作。
+
+#### Scenario: 重试块内仅执行 API 调用
+- **GIVEN** Update 函数中的 retry 块
+- **WHEN** 执行 retry 闭包
+- **THEN** retry 块内应仅调用 `UpdateResourceTagValue` API
+- **AND** 不应在 retry 块内执行 `d.SetId()` 等成功后操作
+- **AND** SetId 操作应在 retry 块外、错误处理后执行

--- a/tencentcloud/services/tag/resource_tc_tag_attachment.go
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment.go
@@ -19,6 +19,7 @@ func ResourceTencentCloudTagAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTencentCloudTagAttachmentCreate,
 		Read:   resourceTencentCloudTagAttachmentRead,
+		Update: resourceTencentCloudTagAttachmentUpdate,
 		Delete: resourceTencentCloudTagAttachmentDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -33,7 +34,6 @@ func ResourceTencentCloudTagAttachment() *schema.Resource {
 
 			"tag_value": {
 				Required:    true,
-				ForceNew:    true,
 				Type:        schema.TypeString,
 				Description: "tag value.",
 			},
@@ -139,6 +139,46 @@ func resourceTencentCloudTagAttachmentRead(d *schema.ResourceData, meta interfac
 	}
 
 	return nil
+}
+
+func resourceTencentCloudTagAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_tag_attachment.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+	service := TagService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 3 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+	tagKey := idSplit[0]
+	resourceId := idSplit[2]
+
+	if d.HasChange("tag_value") {
+		oldValue, newValue := d.GetChange("tag_value")
+		log.Printf("[DEBUG]%s tag_attachment tag_value changed from %s to %s, id=%s", logId, oldValue, newValue, d.Id())
+
+		newTagValue := newValue.(string)
+
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			e := service.UpdateTagTagAttachment(ctx, tagKey, newTagValue, resourceId)
+			if e != nil {
+				return tccommon.RetryError(e)
+			}
+			return nil
+		})
+		if err != nil {
+			log.Printf("[CRITAL]%s update tag_attachment failed, reason:%+v", logId, err)
+			return err
+		}
+
+		d.SetId(tagKey + tccommon.FILED_SP + newTagValue + tccommon.FILED_SP + resourceId)
+	}
+
+	return resourceTencentCloudTagAttachmentRead(d, meta)
 }
 
 func resourceTencentCloudTagAttachmentDelete(d *schema.ResourceData, meta interface{}) error {

--- a/tencentcloud/services/tag/resource_tc_tag_attachment.md
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment.md
@@ -12,6 +12,8 @@ resource "tencentcloud_tag_attachment" "attachment" {
 
 ```
 
+~> **NOTE:** The `tag_value` field can be updated in-place via the `UpdateResourceTagValue` API, modifying the `tag_key` or `resource` field will trigger resource recreation.
+
 Import
 
 tag attachment can be imported using the id, e.g.

--- a/tencentcloud/services/tag/resource_tc_tag_attachment_test.go
+++ b/tencentcloud/services/tag/resource_tc_tag_attachment_test.go
@@ -5,12 +5,18 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	tag "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813"
+
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
 	svctag "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tag"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 )
 
 // go test -i; go test -test.run TestAccTencentCloudTagAttachmentResource_basic -v
@@ -99,3 +105,230 @@ resource "tencentcloud_tag_attachment" "tag_attachment" {
 }
 
 `
+
+// --- Unit tests using gomonkey (no TF_ACC needed) ---
+
+type mockMetaTagAttachment struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaTagAttachment) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaTagAttachment{}
+
+func newMockMetaTagAttachment() *mockMetaTagAttachment {
+	return &mockMetaTagAttachment{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringTagAttachment(s string) *string {
+	return &s
+}
+
+// buildGetResourcesResponse builds a GetResources response that simulates a
+// resource having a tag with the given tagKey and tagValue attached.
+func buildGetResourcesResponse(resource, tagKey, tagValue string) *tag.GetResourcesResponse {
+	resp := tag.NewGetResourcesResponse()
+	resp.Response = &tag.GetResourcesResponseParams{
+		ResourceTagMappingList: []*tag.ResourceTagMapping{
+			{
+				Resource: &resource,
+				Tags: []*tag.Tag{
+					{
+						TagKey:   helper.String(tagKey),
+						TagValue: helper.String(tagValue),
+					},
+				},
+			},
+		},
+		RequestId: ptrStringTagAttachment("fake-request-id"),
+	}
+	return resp
+}
+
+// TestTagAttachmentUpdate_TagValueChanged verifies that when tag_value changes,
+// the Update function calls UpdateResourceTagValue with the correct arguments
+// and rewrites the composite id with the new tag_value.
+func TestTagAttachmentUpdate_TagValueChanged(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tagClient := &tag.Client{}
+	patches.ApplyMethodReturn(newMockMetaTagAttachment().client, "UseTagClient", tagClient)
+
+	var capturedUpdateReq *tag.UpdateResourceTagValueRequest
+	patches.ApplyMethodFunc(tagClient, "UpdateResourceTagValue", func(request *tag.UpdateResourceTagValueRequest) (*tag.UpdateResourceTagValueResponse, error) {
+		capturedUpdateReq = request
+		resp := tag.NewUpdateResourceTagValueResponse()
+		resp.Response = &tag.UpdateResourceTagValueResponseParams{
+			RequestId: ptrStringTagAttachment("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock GetResources called by the read after update, returning the new tag value.
+	patches.ApplyMethodFunc(tagClient, "GetResources", func(request *tag.GetResourcesRequest) (*tag.GetResourcesResponse, error) {
+		return buildGetResourcesResponse("qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test", "env", "prod"), nil
+	})
+
+	meta := newMockMetaTagAttachment()
+	res := svctag.ResourceTencentCloudTagAttachment()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"tag_key":   "env",
+		"tag_value": "prod",
+		"resource":  "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test",
+	})
+	// Set old id containing the old tag_value "dev".
+	d.SetId("env" + tccommon.FILED_SP + "dev" + tccommon.FILED_SP + "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test")
+
+	// Patch HasChange to simulate tag_value has changed.
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		if key == "tag_value" {
+			return true
+		}
+		return false
+	})
+
+	// Patch GetChange to return the old and new tag_value.
+	patches.ApplyMethodFunc(d, "GetChange", func(key string) (interface{}, interface{}) {
+		if key == "tag_value" {
+			return "dev", "prod"
+		}
+		return nil, nil
+	})
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	// Verify UpdateResourceTagValue was called with correct args.
+	assert.NotNil(t, capturedUpdateReq)
+	assert.Equal(t, "env", *capturedUpdateReq.TagKey)
+	assert.Equal(t, "prod", *capturedUpdateReq.TagValue)
+	assert.Equal(t, "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test", *capturedUpdateReq.Resource)
+
+	// Verify the id was rewritten with the new tag_value.
+	expectedId := "env" + tccommon.FILED_SP + "prod" + tccommon.FILED_SP + "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test"
+	assert.Equal(t, expectedId, d.Id())
+	// Verify state reflects new tag_value after read.
+	assert.Equal(t, "prod", d.Get("tag_value").(string))
+}
+
+// TestTagAttachmentUpdate_TagValueUnchanged verifies that when tag_value does not
+// change, the Update function does not call UpdateResourceTagValue.
+func TestTagAttachmentUpdate_TagValueUnchanged(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tagClient := &tag.Client{}
+	patches.ApplyMethodReturn(newMockMetaTagAttachment().client, "UseTagClient", tagClient)
+
+	updateCalled := false
+	patches.ApplyMethodFunc(tagClient, "UpdateResourceTagValue", func(request *tag.UpdateResourceTagValueRequest) (*tag.UpdateResourceTagValueResponse, error) {
+		updateCalled = true
+		resp := tag.NewUpdateResourceTagValueResponse()
+		resp.Response = &tag.UpdateResourceTagValueResponseParams{
+			RequestId: ptrStringTagAttachment("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock GetResources called by read after update.
+	patches.ApplyMethodFunc(tagClient, "GetResources", func(request *tag.GetResourcesRequest) (*tag.GetResourcesResponse, error) {
+		return buildGetResourcesResponse("qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test", "env", "dev"), nil
+	})
+
+	meta := newMockMetaTagAttachment()
+	res := svctag.ResourceTencentCloudTagAttachment()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"tag_key":   "env",
+		"tag_value": "dev",
+		"resource":  "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test",
+	})
+	// id matches current tag_value.
+	d.SetId("env" + tccommon.FILED_SP + "dev" + tccommon.FILED_SP + "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test")
+
+	// Patch HasChange to simulate tag_value has NOT changed.
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		return false
+	})
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	// Verify UpdateResourceTagValue was NOT called.
+	assert.False(t, updateCalled, "UpdateResourceTagValue should not be called when tag_value is unchanged")
+
+	// Verify id unchanged.
+	assert.Equal(t, "env"+tccommon.FILED_SP+"dev"+tccommon.FILED_SP+"qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test", d.Id())
+}
+
+// TestTagAttachmentUpdate_APIError verifies that when UpdateResourceTagValue
+// returns an error, the Update function returns an error and does not update the id.
+func TestTagAttachmentUpdate_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tagClient := &tag.Client{}
+	patches.ApplyMethodReturn(newMockMetaTagAttachment().client, "UseTagClient", tagClient)
+
+	patches.ApplyMethodFunc(tagClient, "UpdateResourceTagValue", func(request *tag.UpdateResourceTagValueRequest) (*tag.UpdateResourceTagValueResponse, error) {
+		return nil, fmt.Errorf("internal error")
+	})
+
+	meta := newMockMetaTagAttachment()
+	res := svctag.ResourceTencentCloudTagAttachment()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"tag_key":   "env",
+		"tag_value": "prod",
+		"resource":  "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test",
+	})
+	// old id with old tag_value "dev".
+	d.SetId("env" + tccommon.FILED_SP + "dev" + tccommon.FILED_SP + "qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test")
+
+	// Patch HasChange to simulate tag_value has changed.
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		if key == "tag_value" {
+			return true
+		}
+		return false
+	})
+
+	// Patch GetChange to return the old and new tag_value.
+	patches.ApplyMethodFunc(d, "GetChange", func(key string) (interface{}, interface{}) {
+		if key == "tag_value" {
+			return "dev", "prod"
+		}
+		return nil, nil
+	})
+
+	err := res.Update(d, meta)
+	assert.Error(t, err)
+
+	// Verify id was NOT updated (still the old id with "dev").
+	assert.Equal(t, "env"+tccommon.FILED_SP+"dev"+tccommon.FILED_SP+"qcs::cvm:ap-guangzhou:uin/100020512675:instance/ins-test", d.Id())
+}
+
+// TestTagAttachmentSchema verifies the schema definition after the change:
+// tag_value should not be ForceNew, tag_key and resource should remain ForceNew.
+func TestTagAttachmentSchema(t *testing.T) {
+	res := svctag.ResourceTencentCloudTagAttachment()
+
+	tagKeyField, ok := res.Schema["tag_key"]
+	assert.True(t, ok, "tag_key should exist in schema")
+	assert.True(t, tagKeyField.Required, "tag_key should be required")
+	assert.True(t, tagKeyField.ForceNew, "tag_key should be ForceNew")
+
+	tagValueField, ok := res.Schema["tag_value"]
+	assert.True(t, ok, "tag_value should exist in schema")
+	assert.True(t, tagValueField.Required, "tag_value should be required")
+	assert.False(t, tagValueField.ForceNew, "tag_value should not be ForceNew")
+
+	resourceField, ok := res.Schema["resource"]
+	assert.True(t, ok, "resource should exist in schema")
+	assert.True(t, resourceField.Required, "resource should be required")
+	assert.True(t, resourceField.ForceNew, "resource should be ForceNew")
+
+	// Verify Update is registered.
+	assert.NotNil(t, res.Update, "Update function should be registered")
+}

--- a/tencentcloud/services/tag/service_tencentcloud_tag.go
+++ b/tencentcloud/services/tag/service_tencentcloud_tag.go
@@ -442,6 +442,32 @@ func (me *TagService) DeleteTagTagAttachmentById(ctx context.Context, tagKey str
 	return
 }
 
+func (me *TagService) UpdateTagTagAttachment(ctx context.Context, tagKey string, newTagValue string, resource string) (errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := tag.NewUpdateResourceTagValueRequest()
+	request.TagKey = helper.String(tagKey)
+	request.TagValue = helper.String(newTagValue)
+	request.Resource = helper.String(resource)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	ratelimit.Check(request.GetAction())
+
+	response, err := me.client.UseTagClient().UpdateResourceTagValue(request)
+	if err != nil {
+		errRet = err
+		return
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+	return
+}
+
 func (me *TagService) DescribeTagKeysByFilter(ctx context.Context, param map[string]interface{}) (ret []*string, errRet error) {
 	var (
 		logId   = tccommon.GetLogId(ctx)

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ func (c *Client) AddProjectWithContext(ctx context.Context, request *AddProjectR
     if request == nil {
         request = NewAddProjectRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AddProject")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AddProject require credential")
@@ -161,6 +162,7 @@ func (c *Client) AddResourceTagWithContext(ctx context.Context, request *AddReso
     if request == nil {
         request = NewAddResourceTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AddResourceTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AddResourceTag require credential")
@@ -250,6 +252,7 @@ func (c *Client) AttachResourcesTagWithContext(ctx context.Context, request *Att
     if request == nil {
         request = NewAttachResourcesTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "AttachResourcesTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("AttachResourcesTag require credential")
@@ -323,6 +326,7 @@ func (c *Client) CreateTagWithContext(ctx context.Context, request *CreateTagReq
     if request == nil {
         request = NewCreateTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "CreateTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateTag require credential")
@@ -398,6 +402,7 @@ func (c *Client) CreateTagsWithContext(ctx context.Context, request *CreateTagsR
     if request == nil {
         request = NewCreateTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "CreateTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateTags require credential")
@@ -461,6 +466,7 @@ func (c *Client) DeleteResourceTagWithContext(ctx context.Context, request *Dele
     if request == nil {
         request = NewDeleteResourceTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteResourceTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteResourceTag require credential")
@@ -528,6 +534,7 @@ func (c *Client) DeleteTagWithContext(ctx context.Context, request *DeleteTagReq
     if request == nil {
         request = NewDeleteTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteTag require credential")
@@ -599,6 +606,7 @@ func (c *Client) DeleteTagsWithContext(ctx context.Context, request *DeleteTagsR
     if request == nil {
         request = NewDeleteTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DeleteTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteTags require credential")
@@ -654,6 +662,7 @@ func (c *Client) DescribeProjectsWithContext(ctx context.Context, request *Descr
     if request == nil {
         request = NewDescribeProjectsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeProjects")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeProjects require credential")
@@ -703,6 +712,7 @@ func (c *Client) DescribeResourceTagsWithContext(ctx context.Context, request *D
     if request == nil {
         request = NewDescribeResourceTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTags require credential")
@@ -764,6 +774,7 @@ func (c *Client) DescribeResourceTagsByResourceIdsWithContext(ctx context.Contex
     if request == nil {
         request = NewDescribeResourceTagsByResourceIdsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByResourceIds")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByResourceIds require credential")
@@ -823,6 +834,7 @@ func (c *Client) DescribeResourceTagsByResourceIdsSeqWithContext(ctx context.Con
     if request == nil {
         request = NewDescribeResourceTagsByResourceIdsSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByResourceIdsSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByResourceIdsSeq require credential")
@@ -855,7 +867,7 @@ func NewDescribeResourceTagsByTagKeysResponse() (response *DescribeResourceTagsB
 }
 
 // DescribeResourceTagsByTagKeys
-// 根据标签键获取资源标签
+// 根据标签键获取指定资源上的标签值
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -871,7 +883,7 @@ func (c *Client) DescribeResourceTagsByTagKeys(request *DescribeResourceTagsByTa
 }
 
 // DescribeResourceTagsByTagKeys
-// 根据标签键获取资源标签
+// 根据标签键获取指定资源上的标签值
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -886,6 +898,7 @@ func (c *Client) DescribeResourceTagsByTagKeysWithContext(ctx context.Context, r
     if request == nil {
         request = NewDescribeResourceTagsByTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourceTagsByTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourceTagsByTagKeys require credential")
@@ -918,7 +931,9 @@ func NewDescribeResourcesByTagsResponse() (response *DescribeResourcesByTagsResp
 }
 
 // DescribeResourcesByTags
-// 通过标签查询资源列表
+// 通过标签查询资源列表，按TagKey取交集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。交集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，同时包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -931,7 +946,9 @@ func (c *Client) DescribeResourcesByTags(request *DescribeResourcesByTagsRequest
 }
 
 // DescribeResourcesByTags
-// 通过标签查询资源列表
+// 通过标签查询资源列表，按TagKey取交集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。交集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，同时包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -943,6 +960,7 @@ func (c *Client) DescribeResourcesByTagsWithContext(ctx context.Context, request
     if request == nil {
         request = NewDescribeResourcesByTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourcesByTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourcesByTags require credential")
@@ -975,7 +993,9 @@ func NewDescribeResourcesByTagsUnionResponse() (response *DescribeResourcesByTag
 }
 
 // DescribeResourcesByTagsUnion
-// 通过标签查询资源列表并集
+// 通过标签查询资源列表，按TagKey取并集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。并集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，或者包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -987,7 +1007,9 @@ func (c *Client) DescribeResourcesByTagsUnion(request *DescribeResourcesByTagsUn
 }
 
 // DescribeResourcesByTagsUnion
-// 通过标签查询资源列表并集
+// 通过标签查询资源列表，按TagKey取并集。
+//
+// 举例：TagFilters 为 [ {"TagKey": "k1", "TagValue":["v1","v2"]}, {"TagKey": "k2", "TagValue":["v3","v4"]} ]。并集查询逻辑：找出资源，其包含标签TagKey=k1且TagValue in (v1, v2)，或者包含标签TagKey=k2且TagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -998,6 +1020,7 @@ func (c *Client) DescribeResourcesByTagsUnionWithContext(ctx context.Context, re
     if request == nil {
         request = NewDescribeResourcesByTagsUnionRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeResourcesByTagsUnion")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeResourcesByTagsUnion require credential")
@@ -1049,6 +1072,7 @@ func (c *Client) DescribeTagKeysWithContext(ctx context.Context, request *Descri
     if request == nil {
         request = NewDescribeTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagKeys require credential")
@@ -1102,6 +1126,7 @@ func (c *Client) DescribeTagValuesWithContext(ctx context.Context, request *Desc
     if request == nil {
         request = NewDescribeTagValuesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagValues")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagValues require credential")
@@ -1153,6 +1178,7 @@ func (c *Client) DescribeTagValuesSeqWithContext(ctx context.Context, request *D
     if request == nil {
         request = NewDescribeTagValuesSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagValuesSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagValuesSeq require credential")
@@ -1185,7 +1211,9 @@ func NewDescribeTagsResponse() (response *DescribeTagsResponse) {
 }
 
 // DescribeTags
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1195,7 +1223,9 @@ func (c *Client) DescribeTags(request *DescribeTagsRequest) (response *DescribeT
 }
 
 // DescribeTags
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1204,6 +1234,7 @@ func (c *Client) DescribeTagsWithContext(ctx context.Context, request *DescribeT
     if request == nil {
         request = NewDescribeTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTags require credential")
@@ -1236,7 +1267,9 @@ func NewDescribeTagsSeqResponse() (response *DescribeTagsSeqResponse) {
 }
 
 // DescribeTagsSeq
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1247,7 +1280,9 @@ func (c *Client) DescribeTagsSeq(request *DescribeTagsSeqRequest) (response *Des
 }
 
 // DescribeTagsSeq
-// 用于查询已建立的标签列表。
+// 用于获取已建立的标签列表。
+//
+// 举例：TagKeys为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -1257,6 +1292,7 @@ func (c *Client) DescribeTagsSeqWithContext(ctx context.Context, request *Descri
     if request == nil {
         request = NewDescribeTagsSeqRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DescribeTagsSeq")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DescribeTagsSeq require credential")
@@ -1336,6 +1372,7 @@ func (c *Client) DetachResourcesTagWithContext(ctx context.Context, request *Det
     if request == nil {
         request = NewDetachResourcesTagRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "DetachResourcesTag")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DetachResourcesTag require credential")
@@ -1368,7 +1405,7 @@ func NewGetResourcesResponse() (response *GetResourcesResponse) {
 }
 
 // GetResources
-// 查询绑定了标签的资源列表。
+// 查询资源标签列表。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
@@ -1392,7 +1429,7 @@ func (c *Client) GetResources(request *GetResourcesRequest) (response *GetResour
 }
 
 // GetResources
-// 查询绑定了标签的资源列表。
+// 查询资源标签列表。
 //
 // 可能返回的错误码:
 //  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
@@ -1415,6 +1452,7 @@ func (c *Client) GetResourcesWithContext(ctx context.Context, request *GetResour
     if request == nil {
         request = NewGetResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetResources require credential")
@@ -1472,6 +1510,7 @@ func (c *Client) GetTagKeysWithContext(ctx context.Context, request *GetTagKeysR
     if request == nil {
         request = NewGetTagKeysRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTagKeys")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTagKeys require credential")
@@ -1531,6 +1570,7 @@ func (c *Client) GetTagValuesWithContext(ctx context.Context, request *GetTagVal
     if request == nil {
         request = NewGetTagValuesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTagValues")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTagValues require credential")
@@ -1565,6 +1605,8 @@ func NewGetTagsResponse() (response *GetTagsResponse) {
 // GetTags
 // 用于获取已建立的标签列表。
 //
+// 举例：TagKeys 为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  INVALIDPARAMETER = "InvalidParameter"
@@ -1579,6 +1621,8 @@ func (c *Client) GetTags(request *GetTagsRequest) (response *GetTagsResponse, er
 // GetTags
 // 用于获取已建立的标签列表。
 //
+// 举例：TagKeys 为["k1","k2"], TagValues为["v3","v4"], 查出标签，其标签键tagKey in (k1, k2)，同时标签值tagValue in (v3, v4)
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  INVALIDPARAMETER = "InvalidParameter"
@@ -1590,6 +1634,7 @@ func (c *Client) GetTagsWithContext(ctx context.Context, request *GetTagsRequest
     if request == nil {
         request = NewGetTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "GetTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetTags require credential")
@@ -1667,6 +1712,7 @@ func (c *Client) ModifyResourceTagsWithContext(ctx context.Context, request *Mod
     if request == nil {
         request = NewModifyResourceTagsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "ModifyResourceTags")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ModifyResourceTags require credential")
@@ -1750,6 +1796,7 @@ func (c *Client) ModifyResourcesTagValueWithContext(ctx context.Context, request
     if request == nil {
         request = NewModifyResourcesTagValueRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "ModifyResourcesTagValue")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ModifyResourcesTagValue require credential")
@@ -1835,6 +1882,7 @@ func (c *Client) TagResourcesWithContext(ctx context.Context, request *TagResour
     if request == nil {
         request = NewTagResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "TagResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("TagResources require credential")
@@ -1912,6 +1960,7 @@ func (c *Client) UnTagResourcesWithContext(ctx context.Context, request *UnTagRe
     if request == nil {
         request = NewUnTagResourcesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UnTagResources")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UnTagResources require credential")
@@ -1969,6 +2018,7 @@ func (c *Client) UpdateProjectWithContext(ctx context.Context, request *UpdatePr
     if request == nil {
         request = NewUpdateProjectRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UpdateProject")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateProject require credential")
@@ -2034,6 +2084,7 @@ func (c *Client) UpdateResourceTagValueWithContext(ctx context.Context, request 
     if request == nil {
         request = NewUpdateResourceTagValueRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "tag", APIVersion, "UpdateResourceTagValue")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateResourceTagValue require credential")

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813/models.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,20 +23,20 @@ import (
 // Predefined struct for user
 type AddProjectRequestParams struct {
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 项目描述
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 type AddProjectRequest struct {
 	*tchttp.BaseRequest
 	
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 项目描述
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 func (r *AddProjectRequest) ToJsonString() string {
@@ -62,13 +62,13 @@ func (r *AddProjectRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type AddProjectResponseParams struct {
 	// 项目Id
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
-	// 是否为新项目
-	IsNew *int64 `json:"IsNew,omitnil" name:"IsNew"`
+	// 是否为新项目，1是新项目，0不是新项目
+	IsNew *int64 `json:"IsNew,omitnil,omitempty" name:"IsNew"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AddProjectResponse struct {
@@ -90,26 +90,26 @@ func (r *AddProjectResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type AddResourceTagRequestParams struct {
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 待关联的资源，用标准的资源六段式表示。正确的资源六段式请参考：https://cloud.tencent.com/document/product/651/89122
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type AddResourceTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 待关联的资源，用标准的资源六段式表示。正确的资源六段式请参考：https://cloud.tencent.com/document/product/651/89122
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *AddResourceTagRequest) ToJsonString() string {
@@ -135,8 +135,8 @@ func (r *AddResourceTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AddResourceTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AddResourceTagResponse struct {
@@ -157,45 +157,45 @@ func (r *AddResourceTagResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachResourcesTagRequestParams struct {
-	// 业务的英文简称，即资源六段式第三段。资源六段式的描述方式参考：https://cloud.tencent.com/document/product/651/89122
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源所在地域，不区分地域的资源则不必填。区分地域的资源则必填，且必填时必须是参数ResourceIds.N资源所对应的地域，且如果ResourceIds.N为批量时，这些资源也必须是同一个地域的。例如示例值：ap-beijing，则参数ResourceIds.N中都应该填写该地域的资源。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分，例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type AttachResourcesTagRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务的英文简称，即资源六段式第三段。资源六段式的描述方式参考：https://cloud.tencent.com/document/product/651/89122
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要绑定的标签键，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要绑定的标签值，取值规范参考：https://cloud.tencent.com/document/product/651/13354
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源所在地域，不区分地域的资源则不必填。区分地域的资源则必填，且必填时必须是参数ResourceIds.N资源所对应的地域，且如果ResourceIds.N为批量时，这些资源也必须是同一个地域的。例如示例值：ap-beijing，则参数ResourceIds.N中都应该填写该地域的资源。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分，例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *AttachResourcesTagRequest) ToJsonString() string {
@@ -224,8 +224,8 @@ func (r *AttachResourcesTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type AttachResourcesTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type AttachResourcesTagResponse struct {
@@ -247,20 +247,20 @@ func (r *AttachResourcesTagResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateTagRequestParams struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type CreateTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 func (r *CreateTagRequest) ToJsonString() string {
@@ -285,8 +285,8 @@ func (r *CreateTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateTagResponse struct {
@@ -309,7 +309,7 @@ func (r *CreateTagResponse) FromJsonString(s string) error {
 type CreateTagsRequestParams struct {
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type CreateTagsRequest struct {
@@ -317,7 +317,7 @@ type CreateTagsRequest struct {
 	
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *CreateTagsRequest) ToJsonString() string {
@@ -341,8 +341,8 @@ func (r *CreateTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateTagsResponse struct {
@@ -364,20 +364,20 @@ func (r *CreateTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteResourceTagRequestParams struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	// 资源六段式。示例：qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type DeleteResourceTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	// 资源六段式。示例：qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *DeleteResourceTagRequest) ToJsonString() string {
@@ -402,8 +402,8 @@ func (r *DeleteResourceTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteResourceTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteResourceTagResponse struct {
@@ -425,20 +425,20 @@ func (r *DeleteResourceTagResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteTagRequestParams struct {
 	// 需要删除的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要删除的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type DeleteTagRequest struct {
 	*tchttp.BaseRequest
 	
 	// 需要删除的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 需要删除的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 func (r *DeleteTagRequest) ToJsonString() string {
@@ -463,8 +463,8 @@ func (r *DeleteTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteTagResponse struct {
@@ -487,7 +487,7 @@ func (r *DeleteTagResponse) FromJsonString(s string) error {
 type DeleteTagsRequestParams struct {
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type DeleteTagsRequest struct {
@@ -495,7 +495,7 @@ type DeleteTagsRequest struct {
 	
 	// 标签列表。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *DeleteTagsRequest) ToJsonString() string {
@@ -519,8 +519,8 @@ func (r *DeleteTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteTagsResponse struct {
@@ -542,38 +542,38 @@ func (r *DeleteTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeProjectsRequestParams struct {
 	// 传1拉取所有项目（包括隐藏项目），传0拉取显示项目
-	AllList *uint64 `json:"AllList,omitnil" name:"AllList"`
+	AllList *uint64 `json:"AllList,omitnil,omitempty" name:"AllList"`
 
 	// 分页条数，固定值1000。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 分页偏移量。
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 按项目ID筛选，大于0
-	ProjectId *int64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 按项目名称筛选
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 }
 
 type DescribeProjectsRequest struct {
 	*tchttp.BaseRequest
 	
 	// 传1拉取所有项目（包括隐藏项目），传0拉取显示项目
-	AllList *uint64 `json:"AllList,omitnil" name:"AllList"`
+	AllList *uint64 `json:"AllList,omitnil,omitempty" name:"AllList"`
 
 	// 分页条数，固定值1000。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 分页偏移量。
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 按项目ID筛选，大于0
-	ProjectId *int64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 按项目名称筛选
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 }
 
 func (r *DescribeProjectsRequest) ToJsonString() string {
@@ -602,13 +602,13 @@ func (r *DescribeProjectsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeProjectsResponseParams struct {
 	// 数据总条数
-	Total *uint64 `json:"Total,omitnil" name:"Total"`
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
 
 	// 项目列表
-	Projects []*Project `json:"Projects,omitnil" name:"Projects"`
+	Projects []*Project `json:"Projects,omitnil,omitempty" name:"Projects"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeProjectsResponse struct {
@@ -629,51 +629,51 @@ func (r *DescribeProjectsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀，示例 instance
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源ID数组，大小不超过50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou，不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeResourceTagsByResourceIdsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀，示例 instance
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源ID数组，大小不超过50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou，不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeResourceTagsByResourceIdsRequest) ToJsonString() string {
@@ -704,19 +704,19 @@ func (r *DescribeResourceTagsByResourceIdsRequest) FromJsonString(s string) erro
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*TagResource `json:"Tags,omitnil" name:"Tags"`
+	Tags []*TagResource `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByResourceIdsResponse struct {
@@ -737,45 +737,45 @@ func (r *DescribeResourceTagsByResourceIdsResponse) FromJsonString(s string) err
 
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsSeqRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou, 不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeResourceTagsByResourceIdsSeqRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou, 不区分地域的资源该字段传空字符串，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeResourceTagsByResourceIdsSeqRequest) ToJsonString() string {
@@ -805,19 +805,19 @@ func (r *DescribeResourceTagsByResourceIdsSeqRequest) FromJsonString(s string) e
 // Predefined struct for user
 type DescribeResourceTagsByResourceIdsSeqResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*TagResource `json:"Tags,omitnil" name:"Tags"`
+	Tags []*TagResource `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByResourceIdsSeqResponse struct {
@@ -838,51 +838,51 @@ func (r *DescribeResourceTagsByResourceIdsSeqResponse) FromJsonString(s string) 
 
 // Predefined struct for user
 type DescribeResourceTagsByTagKeysRequestParams struct {
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源唯一标识ID的列表，列表容量不超过20
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	// <p>资源唯一标识ID的列表，列表容量不超过20</p>
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源标签键列表，列表容量不超过20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>资源标签键列表，列表容量不超过20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 每页大小，默认为 400
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 400</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 type DescribeResourceTagsByTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源唯一标识ID的列表，列表容量不超过20
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	// <p>资源唯一标识ID的列表，列表容量不超过20</p>
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
-	// 资源标签键列表，列表容量不超过20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>资源标签键列表，列表容量不超过20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 每页大小，默认为 400
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 400</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 func (r *DescribeResourceTagsByTagKeysRequest) ToJsonString() string {
@@ -912,20 +912,20 @@ func (r *DescribeResourceTagsByTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsByTagKeysResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceIdTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceIdTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsByTagKeysResponse struct {
@@ -946,57 +946,57 @@ func (r *DescribeResourceTagsByTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourceTagsRequestParams struct {
-	// 创建者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// 资源创建者UIN
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 ckafka。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标识。只输入ResourceId进行查询可能会查询较慢，或者无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// 资源唯一标识（资源六段式中最后一段"/"后面的部分）。注：只输入ResourceId查询时，如资源量大可能较慢，或无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）。若传入的是cos资源的Id，则CosResourceId 字段请同时传1。
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否是cos的资源（0或者1），输入的ResourceId为cos资源时必填
-	CosResourceId *uint64 `json:"CosResourceId,omitnil" name:"CosResourceId"`
+	// 是否为cos的资源，取值 0 表示：非cos资源。取值1 表示：cos资源，且此时ResourceId也为必填。不填则默认为 0 
+	CosResourceId *uint64 `json:"CosResourceId,omitnil,omitempty" name:"CosResourceId"`
 }
 
 type DescribeResourceTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 创建者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// 资源创建者UIN
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 ckafka。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标识。只输入ResourceId进行查询可能会查询较慢，或者无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// 资源唯一标识（资源六段式中最后一段"/"后面的部分）。注：只输入ResourceId查询时，如资源量大可能较慢，或无法匹配到结果，建议在输入ResourceId的同时也输入ServiceType、ResourcePrefix和ResourceRegion（不区分地域的资源可忽略该参数）。若传入的是cos资源的Id，则CosResourceId 字段请同时传1。
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否是cos的资源（0或者1），输入的ResourceId为cos资源时必填
-	CosResourceId *uint64 `json:"CosResourceId,omitnil" name:"CosResourceId"`
+	// 是否为cos的资源，取值 0 表示：非cos资源。取值1 表示：cos资源，且此时ResourceId也为必填。不填则默认为 0 
+	CosResourceId *uint64 `json:"CosResourceId,omitnil,omitempty" name:"CosResourceId"`
 }
 
 func (r *DescribeResourceTagsRequest) ToJsonString() string {
@@ -1028,20 +1028,19 @@ func (r *DescribeResourceTagsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeResourceTagsResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 资源标签
-	Rows []*TagResource `json:"Rows,omitnil" name:"Rows"`
+	Rows []*TagResource `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourceTagsResponse struct {
@@ -1062,57 +1061,57 @@ func (r *DescribeResourceTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsRequestParams struct {
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 type DescribeResourcesByTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 func (r *DescribeResourcesByTagsRequest) ToJsonString() string {
@@ -1143,21 +1142,20 @@ func (r *DescribeResourcesByTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourcesByTagsResponse struct {
@@ -1178,57 +1176,57 @@ func (r *DescribeResourcesByTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsUnionRequestParams struct {
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 type DescribeResourcesByTagsUnionRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签过滤数组
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 创建标签者uin
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建标签者uin</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源前缀
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// <p>该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填</p>
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
-	// 资源唯一标记
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	// <p>资源唯一标记</p>
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
-	// 资源所在地域
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// <p>资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填</p>
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 业务类型
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// <p>业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka</p>
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 }
 
 func (r *DescribeResourcesByTagsUnionRequest) ToJsonString() string {
@@ -1259,20 +1257,20 @@ func (r *DescribeResourcesByTagsUnionRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeResourcesByTagsUnionResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 资源标签
-	Rows []*ResourceTag `json:"Rows,omitnil" name:"Rows"`
+	// <p>资源标签</p>
+	Rows []*ResourceTag `json:"Rows,omitnil,omitempty" name:"Rows"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeResourcesByTagsUnionResponse struct {
@@ -1293,39 +1291,39 @@ func (r *DescribeResourcesByTagsUnionResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagKeysRequestParams struct {
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15，最大1000
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否展现项目
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15，最大1000
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否展现项目
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeTagKeysRequest) ToJsonString() string {
@@ -1353,20 +1351,20 @@ func (r *DescribeTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagKeysResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*string `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagKeysResponse struct {
@@ -1387,39 +1385,39 @@ func (r *DescribeTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagValuesRequestParams struct {
-	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键列表</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type DescribeTagValuesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键列表</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *DescribeTagValuesRequest) ToJsonString() string {
@@ -1447,20 +1445,20 @@ func (r *DescribeTagValuesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagValuesResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagValuesResponse struct {
@@ -1482,32 +1480,32 @@ func (r *DescribeTagValuesResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeTagValuesSeqRequestParams struct {
 	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
 	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeTagValuesSeqRequest struct {
 	*tchttp.BaseRequest
 	
 	// 标签键列表
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
 	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
 	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 func (r *DescribeTagValuesSeqRequest) ToJsonString() string {
@@ -1535,19 +1533,19 @@ func (r *DescribeTagValuesSeqRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type DescribeTagValuesSeqResponseParams struct {
 	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagValuesSeqResponse struct {
@@ -1568,51 +1566,51 @@ func (r *DescribeTagValuesSeqResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsRequestParams struct {
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 type DescribeTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15，最大1000</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 func (r *DescribeTagsRequest) ToJsonString() string {
@@ -1642,20 +1640,20 @@ func (r *DescribeTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*TagWithDelete `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*TagWithDelete `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagsResponse struct {
@@ -1676,51 +1674,51 @@ func (r *DescribeTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsSeqRequestParams struct {
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 type DescribeTagsSeqRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	// <p>标签键,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	// <p>标签值,与标签键同时存在或同时不存在，不存在时表示查询该用户所有标签</p>
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 数据偏移量，默认为 0, 必须为Limit参数的整数倍
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据偏移量，默认为 0, 必须为Limit参数的整数倍</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小，默认为 15
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小，默认为 15</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 创建者用户 Uin，不传或为空只将 Uin 作为条件查询
-	CreateUin *uint64 `json:"CreateUin,omitnil" name:"CreateUin"`
+	// <p>创建者用户 Uin，不传或为空只将 Uin 作为条件查询</p>
+	CreateUin *uint64 `json:"CreateUin,omitnil,omitempty" name:"CreateUin"`
 
-	// 标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键数组,与标签值同时存在或同时不存在，不存在时表示查询该用户所有标签,当与TagKey同时传递时只取本值</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 是否展现项目标签
-	ShowProject *uint64 `json:"ShowProject,omitnil" name:"ShowProject"`
+	// <p>是否展现项目标签。1:展示 0:不展示。本功能仅供历史客户使用，需提交工单加白主账号后，入参方可有效。</p>
+	ShowProject *uint64 `json:"ShowProject,omitnil,omitempty" name:"ShowProject"`
 }
 
 func (r *DescribeTagsSeqRequest) ToJsonString() string {
@@ -1750,20 +1748,20 @@ func (r *DescribeTagsSeqRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTagsSeqResponseParams struct {
-	// 结果总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	// <p>结果总数</p>
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 数据位移偏量
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	// <p>数据位移偏量</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 每页大小
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	// <p>每页大小</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 标签列表
-	Tags []*TagWithDelete `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表</p>
+	Tags []*TagWithDelete `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DescribeTagsSeqResponse struct {
@@ -1784,39 +1782,39 @@ func (r *DescribeTagsSeqResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DetachResourcesTagRequestParams struct {
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要解绑的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type DetachResourcesTagRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm 。指资源所属业务类型，也是资源六段式中的第三段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中业务类型为ckafka
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 需要解绑的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 。不区分地域的资源则不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 该业务类型对应的资源前缀，示例 cvm对应instance、image、volume等。也是资源六段式中的第六段，例如qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584中资源前缀为ckafkaId。cos存储桶为非必填，其他云资源为必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *DetachResourcesTagRequest) ToJsonString() string {
@@ -1844,8 +1842,8 @@ func (r *DetachResourcesTagRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DetachResourcesTagResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DetachResourcesTagResponse struct {
@@ -1866,60 +1864,44 @@ func (r *DetachResourcesTagResponse) FromJsonString(s string) error {
 
 type FailedResource struct {
 	// 失败的资源六段式
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
 	// 错误码
-	Code *string `json:"Code,omitnil" name:"Code"`
+	Code *string `json:"Code,omitnil,omitempty" name:"Code"`
 
 	// 错误信息
-	Message *string `json:"Message,omitnil" name:"Message"`
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
 }
 
 // Predefined struct for user
 type GetResourcesRequestParams struct {
-	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。
-	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	// 如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。
-	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	// <p>资源六段式列表。腾讯云使用资源六段式描述一个资源。<br>例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。<br>如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。<br>N取值范围：0~9</p>
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
-	// 标签键和标签值。
-	// 指定多个标签，会查询同时绑定了该多个标签的资源。
-	// N取值范围：0~5。
-	// 每个TagFilters中的TagValue最多支持10个
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。会查询同时绑定了这多组标签的资源。<br>每组标签中的TagValue最多支持10个。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大200。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大200。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 }
 
 type GetResourcesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。
-	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	// 如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。
-	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	// <p>资源六段式列表。腾讯云使用资源六段式描述一个资源。<br>例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。<br>如果传入了此参数会返回所有匹配的资源列表，指定的MaxResults会失效。<br>N取值范围：0~9</p>
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
-	// 标签键和标签值。
-	// 指定多个标签，会查询同时绑定了该多个标签的资源。
-	// N取值范围：0~5。
-	// 每个TagFilters中的TagValue最多支持10个
-	TagFilters []*TagFilter `json:"TagFilters,omitnil" name:"TagFilters"`
+	// <p>标签过滤数组，最多支持6组标签。会查询同时绑定了这多组标签的资源。<br>每组标签中的TagValue最多支持10个。</p>
+	TagFilters []*TagFilter `json:"TagFilters,omitnil,omitempty" name:"TagFilters"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大200。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大200。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 }
 
 func (r *GetResourcesRequest) ToJsonString() string {
@@ -1946,14 +1928,14 @@ func (r *GetResourcesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetResourcesResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 资源及关联的标签(键和值)列表
-	ResourceTagMappingList []*ResourceTagMapping `json:"ResourceTagMappingList,omitnil" name:"ResourceTagMappingList"`
+	// <p>资源及关联的标签(键和值)列表</p>
+	ResourceTagMappingList []*ResourceTagMapping `json:"ResourceTagMappingList,omitnil,omitempty" name:"ResourceTagMappingList"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetResourcesResponse struct {
@@ -1974,31 +1956,27 @@ func (r *GetResourcesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagKeysRequestParams struct {
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagKeysRequest struct {
 	*tchttp.BaseRequest
 	
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagKeysRequest) ToJsonString() string {
@@ -2024,14 +2002,14 @@ func (r *GetTagKeysRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagKeysResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签键信息。
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键信息。</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagKeysResponse struct {
@@ -2052,41 +2030,33 @@ func (r *GetTagKeysResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagValuesRequestParams struct {
-	// 标签键。
-	// 返回所有标签键列表对应的标签值。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。返回所有标签键列表对应的标签值。最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagValuesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标签键。
-	// 返回所有标签键列表对应的标签值。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。返回所有标签键列表对应的标签值。最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagValuesRequest) ToJsonString() string {
@@ -2113,14 +2083,14 @@ func (r *GetTagValuesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagValuesResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签列表。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表。</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagValuesResponse struct {
@@ -2141,41 +2111,33 @@ func (r *GetTagValuesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagsRequestParams struct {
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签键。
-	// 返回所有标签键列表对应的标签。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。<br>返回所有标签键列表对应的标签。<br>最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type GetTagsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 从上一页的响应中获取的下一页的Token值。
-	// 如果是第一次请求，设置为空。
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>从上一页的响应中获取的下一页的Token值。<br>如果是第一次请求，设置为空。</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 每一页返回的数据最大条数，最大1000。
-	// 缺省值：50。
-	MaxResults *uint64 `json:"MaxResults,omitnil" name:"MaxResults"`
+	// <p>每一页返回的数据最大条数，最大1000。<br>缺省值：50。</p>
+	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 标签键。
-	// 返回所有标签键列表对应的标签。
-	// 最大长度：20
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	// <p>标签键。<br>返回所有标签键列表对应的标签。<br>最大长度：20</p>
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 
-	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	// <p>标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 func (r *GetTagsRequest) ToJsonString() string {
@@ -2202,14 +2164,14 @@ func (r *GetTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetTagsResponseParams struct {
-	// 获取的下一页的Token值
-	PaginationToken *string `json:"PaginationToken,omitnil" name:"PaginationToken"`
+	// <p>获取的下一页的Token值，如果当前是最后一页，返回为空</p>
+	PaginationToken *string `json:"PaginationToken,omitnil,omitempty" name:"PaginationToken"`
 
-	// 标签列表。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	// <p>标签列表。</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetTagsResponse struct {
@@ -2231,26 +2193,26 @@ func (r *GetTagsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type ModifyResourceTagsRequestParams struct {
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	ReplaceTags []*Tag `json:"ReplaceTags,omitnil" name:"ReplaceTags"`
+	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	ReplaceTags []*Tag `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
-	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil" name:"DeleteTags"`
+	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 type ModifyResourceTagsRequest struct {
 	*tchttp.BaseRequest
 	
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	ReplaceTags []*Tag `json:"ReplaceTags,omitnil" name:"ReplaceTags"`
+	// 需要增加或修改的标签集合。如果Resource描述的资源未关联输入的标签键，则增加关联；若已关联，则将该资源关联的键对应的标签值修改为输入值。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	ReplaceTags []*Tag `json:"ReplaceTags,omitnil,omitempty" name:"ReplaceTags"`
 
-	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。
-	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil" name:"DeleteTags"`
+	// 需要解关联的标签集合。本接口中ReplaceTags和DeleteTags二者必须存在其一，且二者不能包含相同的标签键。可以不传该参数，但不能是空数组。标签数量不超过10个。
+	DeleteTags []*TagKeyObject `json:"DeleteTags,omitnil,omitempty" name:"DeleteTags"`
 }
 
 func (r *ModifyResourceTagsRequest) ToJsonString() string {
@@ -2276,8 +2238,8 @@ func (r *ModifyResourceTagsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourceTagsResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ModifyResourceTagsResponse struct {
@@ -2298,45 +2260,45 @@ func (r *ModifyResourceTagsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourcesTagValueRequestParams struct {
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分），例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 type ModifyResourcesTagValueRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源所属业务名称（资源六段式中的第三段）
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	// 业务类型，示例 cvm。资源所属业务名称（资源六段式中的第三段）
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源ID数组，资源个数最多为50
-	ResourceIds []*string `json:"ResourceIds,omitnil" name:"ResourceIds"`
+	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
-	// 资源所在地域，不区分地域的资源不需要传入该字段，区分地域的资源必填
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	// 资源所在地域，示例：ap-guangzhou 不区分地域的资源不需要传入该字段，区分地域的资源必填
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
-	// 资源前缀（资源六段式中最后一段"/"前面的部分），cos存储桶不需要传入该字段，其他云资源必填
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	// 资源前缀（资源六段式中最后一段"/"前面的部分），例如“qcs::ckafka:ap-shanghai:uin/123456789:ckafkaId/ckafka-o85jq584” 中资源前缀为ckafkaId），cos存储桶不需要传入该字段，其他云资源必填
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 }
 
 func (r *ModifyResourcesTagValueRequest) ToJsonString() string {
@@ -2365,8 +2327,8 @@ func (r *ModifyResourcesTagValueRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyResourcesTagValueResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ModifyResourcesTagValueResponse struct {
@@ -2387,124 +2349,114 @@ func (r *ModifyResourcesTagValueResponse) FromJsonString(s string) error {
 
 type Project struct {
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 创建人uin
-	CreatorUin *uint64 `json:"CreatorUin,omitnil" name:"CreatorUin"`
+	CreatorUin *uint64 `json:"CreatorUin,omitnil,omitempty" name:"CreatorUin"`
 
 	// 项目描述
-	ProjectInfo *string `json:"ProjectInfo,omitnil" name:"ProjectInfo"`
+	ProjectInfo *string `json:"ProjectInfo,omitnil,omitempty" name:"ProjectInfo"`
 
 	// 创建时间
-	CreateTime *string `json:"CreateTime,omitnil" name:"CreateTime"`
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 }
 
 type ResourceIdTag struct {
 	// 资源唯一标识
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 标签键值对
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	TagKeyValues []*Tag `json:"TagKeyValues,omitnil" name:"TagKeyValues"`
+	TagKeyValues []*Tag `json:"TagKeyValues,omitnil,omitempty" name:"TagKeyValues"`
 }
 
 type ResourceTag struct {
 	// 资源所在地域
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceRegion *string `json:"ResourceRegion,omitnil" name:"ResourceRegion"`
+	ResourceRegion *string `json:"ResourceRegion,omitnil,omitempty" name:"ResourceRegion"`
 
 	// 业务类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 资源前缀
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourcePrefix *string `json:"ResourcePrefix,omitnil" name:"ResourcePrefix"`
+	ResourcePrefix *string `json:"ResourcePrefix,omitnil,omitempty" name:"ResourcePrefix"`
 
 	// 资源唯一标记
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 资源标签
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type ResourceTagMapping struct {
 	// 资源六段式。腾讯云使用资源六段式描述一个资源。
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}。
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
 	// 资源关联的标签列表
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type Tag struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 type TagFilter struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值数组 多个值的话是或的关系
-	TagValue []*string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue []*string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type TagKeyObject struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 }
 
 type TagResource struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 资源ID
-	ResourceId *string `json:"ResourceId,omitnil" name:"ResourceId"`
+	ResourceId *string `json:"ResourceId,omitnil,omitempty" name:"ResourceId"`
 
 	// 标签键MD5值
-	TagKeyMd5 *string `json:"TagKeyMd5,omitnil" name:"TagKeyMd5"`
+	TagKeyMd5 *string `json:"TagKeyMd5,omitnil,omitempty" name:"TagKeyMd5"`
 
 	// 标签值MD5值
-	TagValueMd5 *string `json:"TagValueMd5,omitnil" name:"TagValueMd5"`
+	TagValueMd5 *string `json:"TagValueMd5,omitnil,omitempty" name:"TagValueMd5"`
 
 	// 资源类型
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ServiceType *string `json:"ServiceType,omitnil" name:"ServiceType"`
+	ServiceType *string `json:"ServiceType,omitnil,omitempty" name:"ServiceType"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 // Predefined struct for user
 type TagResourcesRequestParams struct {
 	// 待绑定的云资源，用标准的资源六段式表示。正确的资源六段式请参考：[标准的资源六段式](https://cloud.tencent.com/document/product/598/10606)和[支持标签的云产品及资源描述方式](https://cloud.tencent.com/document/product/651/89122)。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键和标签值。
 	// 如果指定多个标签，则会为指定资源同时创建并绑定该多个标签。
 	// 同一个资源上的同一个标签键只能对应一个标签值。如果您尝试添加已有标签键，则对应的标签值会更新为新值。
 	// 如果标签不存在会为您自动创建标签。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type TagResourcesRequest struct {
@@ -2512,14 +2464,14 @@ type TagResourcesRequest struct {
 	
 	// 待绑定的云资源，用标准的资源六段式表示。正确的资源六段式请参考：[标准的资源六段式](https://cloud.tencent.com/document/product/598/10606)和[支持标签的云产品及资源描述方式](https://cloud.tencent.com/document/product/651/89122)。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键和标签值。
 	// 如果指定多个标签，则会为指定资源同时创建并绑定该多个标签。
 	// 同一个资源上的同一个标签键只能对应一个标签值。如果您尝试添加已有标签键，则对应的标签值会更新为新值。
 	// 如果标签不存在会为您自动创建标签。
 	// N取值范围：0~9
-	Tags []*Tag `json:"Tags,omitnil" name:"Tags"`
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *TagResourcesRequest) ToJsonString() string {
@@ -2547,10 +2499,10 @@ type TagResourcesResponseParams struct {
 	// 失败资源信息。
 	// 创建并绑定标签成功时，返回的FailedResources为空。
 	// 创建并绑定标签失败或部分失败时，返回的FailedResources会显示失败资源的详细信息。
-	FailedResources []*FailedResource `json:"FailedResources,omitnil" name:"FailedResources"`
+	FailedResources []*FailedResource `json:"FailedResources,omitnil,omitempty" name:"FailedResources"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type TagResourcesResponse struct {
@@ -2571,17 +2523,16 @@ func (r *TagResourcesResponse) FromJsonString(s string) error {
 
 type TagWithDelete struct {
 	// 标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// 是否可以删除
-	CanDelete *uint64 `json:"CanDelete,omitnil" name:"CanDelete"`
+	CanDelete *uint64 `json:"CanDelete,omitnil,omitempty" name:"CanDelete"`
 
 	// 标签类型。取值： Custom：自定义标签。 System：系统标签。 All：全部标签。 默认值：All。
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Category *string `json:"Category,omitnil" name:"Category"`
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
 }
 
 // Predefined struct for user
@@ -2589,11 +2540,11 @@ type UnTagResourcesRequestParams struct {
 	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。可参考[访问管理](https://cloud.tencent.com/document/product/598/67350)-概览-接口列表-资源六段式信息
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:uin/${Account}:${ResourcePrefix}/${ResourceId}。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键。
 	// 取值范围：0~9
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 }
 
 type UnTagResourcesRequest struct {
@@ -2602,11 +2553,11 @@ type UnTagResourcesRequest struct {
 	// 资源六段式列表。腾讯云使用资源六段式描述一个资源。可参考[访问管理](https://cloud.tencent.com/document/product/598/67350)-概览-接口列表-资源六段式信息
 	// 例如：ResourceList.1 = qcs::${ServiceType}:${Region}:uin/${Account}:${ResourcePrefix}/${ResourceId}。
 	// N取值范围：0~9
-	ResourceList []*string `json:"ResourceList,omitnil" name:"ResourceList"`
+	ResourceList []*string `json:"ResourceList,omitnil,omitempty" name:"ResourceList"`
 
 	// 标签键。
 	// 取值范围：0~9
-	TagKeys []*string `json:"TagKeys,omitnil" name:"TagKeys"`
+	TagKeys []*string `json:"TagKeys,omitnil,omitempty" name:"TagKeys"`
 }
 
 func (r *UnTagResourcesRequest) ToJsonString() string {
@@ -2634,10 +2585,10 @@ type UnTagResourcesResponseParams struct {
 	// 失败资源信息。
 	// 解绑标签成功时，返回的FailedResources为空。
 	// 解绑标签失败或部分失败时，返回的FailedResources会显示失败资源的详细信息。
-	FailedResources []*FailedResource `json:"FailedResources,omitnil" name:"FailedResources"`
+	FailedResources []*FailedResource `json:"FailedResources,omitnil,omitempty" name:"FailedResources"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UnTagResourcesResponse struct {
@@ -2659,32 +2610,32 @@ func (r *UnTagResourcesResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type UpdateProjectRequestParams struct {
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 禁用项目，1，禁用，0，启用
-	Disable *int64 `json:"Disable,omitnil" name:"Disable"`
+	Disable *int64 `json:"Disable,omitnil,omitempty" name:"Disable"`
 
 	// 备注
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 type UpdateProjectRequest struct {
 	*tchttp.BaseRequest
 	
 	// 项目ID
-	ProjectId *uint64 `json:"ProjectId,omitnil" name:"ProjectId"`
+	ProjectId *uint64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
 	// 项目名称
-	ProjectName *string `json:"ProjectName,omitnil" name:"ProjectName"`
+	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
 	// 禁用项目，1，禁用，0，启用
-	Disable *int64 `json:"Disable,omitnil" name:"Disable"`
+	Disable *int64 `json:"Disable,omitnil,omitempty" name:"Disable"`
 
 	// 备注
-	Info *string `json:"Info,omitnil" name:"Info"`
+	Info *string `json:"Info,omitnil,omitempty" name:"Info"`
 }
 
 func (r *UpdateProjectRequest) ToJsonString() string {
@@ -2711,8 +2662,8 @@ func (r *UpdateProjectRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateProjectResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateProjectResponse struct {
@@ -2734,26 +2685,26 @@ func (r *UpdateProjectResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type UpdateResourceTagValueRequestParams struct {
 	// 资源关联的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 修改后的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 type UpdateResourceTagValueRequest struct {
 	*tchttp.BaseRequest
 	
 	// 资源关联的标签键
-	TagKey *string `json:"TagKey,omitnil" name:"TagKey"`
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
 
 	// 修改后的标签值
-	TagValue *string `json:"TagValue,omitnil" name:"TagValue"`
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 
 	// [ 资源六段式描述 ](https://cloud.tencent.com/document/product/598/10606)
-	Resource *string `json:"Resource,omitnil" name:"Resource"`
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 }
 
 func (r *UpdateResourceTagValueRequest) ToJsonString() string {
@@ -2779,8 +2730,8 @@ func (r *UpdateResourceTagValueRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateResourceTagValueResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateResourceTagValueResponse struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1415,7 +1415,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm/v20190923
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts/v20180813
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.860
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.3.110
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tat v1.0.634


### PR DESCRIPTION
Set tag_value ForceNew to false in tencentcloud_tag_attachment resource and add Update logic via UpdateResourceTagValue API, enabling in-place update of tag_value without resource recreation.