### PR TITLE
feat(tcaplusdb): [136988240] add cluster_type, resource_tags, server_list and proxy_list params to tcaplus_cluster

### DIFF
--- a/.changelog/4408.txt
+++ b/.changelog/4408.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_tcaplus_cluster: add `cluster_type`, `resource_tags`, `server_list` and `proxy_list` parameters to support creating dedicated clusters with tags
+```

--- a/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/design.md
+++ b/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The `tencentcloud_tcaplus_cluster` resource currently supports creating shared TcaplusDB clusters with `idl_type`, `cluster_name`, `vpc_id`, `subnet_id`, `password`, and `old_password_expire_last`. The TcaplusDB `CreateCluster` API also accepts `ResourceTags` (cluster tags), `ServerList` (dedicated server machines), `ProxyList` (dedicated proxy machines), and `ClusterType` (1=shared, 2=dedicated), but the Terraform resource does not expose them.
+
+**Current state:**
+- Resource file: `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.go`
+- Service layer: `tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go` (`CreateCluster` function)
+- SDK: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823` (vendored)
+
+**API behavior analysis (verified against vendored SDK):**
+
+| API | ClusterType (req) | ResourceTags (req) | ServerList (req) | ProxyList (req) | ClusterType (resp) | ServerList (resp) | ProxyList (resp) |
+|-----|-------------------|--------------------|-------------------|------------------|--------------------|-------------------|------------------|
+| `CreateCluster` | Yes (`*int64`) | Yes (`[]*TagInfoUnit`) | Yes (`[]*MachineInfo`) | Yes (`[]*MachineInfo`) | No | No | No |
+| `DescribeClusters` | N/A | N/A | N/A | N/A | Yes (`*int64`) | Yes (`[]*ServerDetailInfo`) | Yes (`[]*ProxyDetailInfo`) |
+| `ModifyClusterName` | No | No | No | No | N/A | N/A | N/A |
+| `ModifyClusterPassword` | No | No | No | No | N/A | N/A | N/A |
+| `DeleteCluster` | No | No | No | No | N/A | N/A | N/A |
+
+**SDK struct field mapping (verified):**
+
+- `CreateClusterRequest`: `ClusterType *int64`, `ResourceTags []*TagInfoUnit`, `ServerList []*MachineInfo`, `ProxyList []*MachineInfo`
+- `MachineInfo`: `MachineType *string`, `MachineNum *int64` (used for both ServerList and ProxyList on Create)
+- `ClusterInfo` (DescribeClusters response element): `ClusterType *int64`, `ServerList []*ServerDetailInfo`, `ProxyList []*ProxyDetailInfo`
+- `ServerDetailInfo`: `ServerUid *string`, `MachineType *string`, `MemoryRate *int64`, `DiskRate *int64`, `ReadNum *int64`, `WriteNum *int64`, `Version *string`
+- `ProxyDetailInfo`: `ProxyUid *string`, `MachineType *string`, `ProcessSpeed *int64`, `AverageProcessDelay *int64`, `SlowProcessSpeed *int64`, `Version *string`
+- `TagInfoUnit`: `TagKey *string`, `TagValue *string`
+
+**Key constraint:** `ClusterType`, `ResourceTags`, `ServerList`, and `ProxyList` are only accepted by `CreateCluster`. No Modify API supports them, so they are immutable after creation.
+
+**Name collision analysis:** The leaf field names `MachineType`, `MachineNum` appear under both `ServerList` and `ProxyList`, and `Version`/`MachineType` appear under both `ServerDetailInfo` and `ProxyDetailInfo`. Therefore these cannot be flattened to top-level schema fields (they would collide). They must be modeled as nested blocks `server_list` and `proxy_list`, each containing the respective fields. This mirrors the existing `resource_tags` nested-block pattern already used by the sibling `tencentcloud_tcaplus_tablegroup` resource.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `cluster_type` (Optional, Computed, immutable after creation) top-level parameter mapped to `CreateClusterRequest.ClusterType` (`*int64`), refreshed from `ClusterInfo.ClusterType` on Read.
+- Add `resource_tags` (Optional, TypeList, immutable after creation) nested block mapped to `CreateClusterRequest.ResourceTags` (`[]*TagInfoUnit`), with `tag_key` and `tag_value` sub-fields. (Read does not populate this block from DescribeClusters because the `DescribeClusters` response does not return tags; tags are write-only at the cluster level through this resource.)
+- Add `server_list` (Optional, TypeList, immutable after creation, Computed) nested block mapped to `CreateClusterRequest.ServerList` (`[]*MachineInfo`) on Create, with `machine_type` and `machine_num` sub-fields. On Read, refreshed from `ClusterInfo.ServerList` (`[]*ServerDetailInfo`), exposing `server_uid`, `machine_type`, `memory_rate`, `disk_rate`, `read_num`, `write_num`, and `version`.
+- Add `proxy_list` (Optional, TypeList, immutable after creation, Computed) nested block mapped to `CreateClusterRequest.ProxyList` (`[]*MachineInfo`) on Create, with `machine_type` and `machine_num` sub-fields. On Read, refreshed from `ClusterInfo.ProxyList` (`[]*ProxyDetailInfo`), exposing `proxy_uid`, `machine_type`, `process_speed`, `average_process_delay`, `slow_process_speed`, and `version`.
+- Extend the `CreateCluster` service-layer function to accept the new parameters and pass them into the SDK request.
+- Use the `immutableArgs` array pattern in the Update function (consistent with the provider convention) covering `cluster_type`, `resource_tags`, `server_list`, and `proxy_list`, returning a clear error when any of them changes.
+- Maintain full backward compatibility — all new parameters are Optional; existing configurations continue to create shared clusters.
+
+**Non-Goals:**
+- Making `cluster_type`, `resource_tags`, `server_list`, or `proxy_list` updatable (no API supports it; they are immutable).
+- Adding tag modify/describe APIs (the TcaplusDB cluster API surface has no `ModifyClusterTags`/`DescribeClusterTags` analog; tags are set at creation only through this resource).
+- Updating the `tencentcloud_tcaplus_clusters` datasource (out of scope for this change).
+
+## Decisions
+
+### Decision 1: Model `server_list` and `proxy_list` as nested blocks, not flattened fields
+
+**Rationale:** The leaf field names `MachineType`, `MachineNum` (Create) and `MachineType`, `Version` (Read) collide between `ServerList` and `ProxyList`. Flattening them to top-level schema fields would cause ambiguous mapping and violate the Terraform schema uniqueness constraint. Nested blocks `server_list` and `proxy_list` keep each list's fields scoped, matching the existing `resource_tags` block pattern in `tencentcloud_tcaplus_tablegroup`.
+
+### Decision 2: Use `TypeList` (not `TypeSet`) for the nested blocks
+
+**Rationale:** Each `MachineInfo`/`ServerDetailInfo`/`ProxyDetailInfo` entry is positional and order-stable; there is no natural unique key per entry. `TypeList` is simpler and consistent with the API's array semantics. The `resource_tags` block in the sibling `tablegroup` resource uses `TypeSet`; however, tags have a natural key (`tag_key`). Here we follow `TypeList` for server/proxy lists and `TypeList` for tags (to keep the implementation simple and because tags here are write-only at creation).
+
+### Decision 3: `cluster_type` is a top-level `TypeInt` field
+
+**Rationale:** `ClusterType` is a single scalar with no naming collision, so it maps cleanly to a top-level `cluster_type` schema field (`TypeInt`, Optional, Computed, immutable). The API uses `*int64` with values `1` (shared) and `2` (dedicated).
+
+### Decision 4: Immutable (not ForceNew) for the new creation-only parameters
+
+**Rationale:** The Modify APIs (`ModifyClusterName`, `ModifyClusterPassword`) do not accept `ClusterType`, `ResourceTags`, `ServerList`, or `ProxyList`. Rather than using `ForceNew: true` (which silently destroys and recreates the cluster), the Update function uses an `immutableArgs` array that returns a clear error when any of these fields changes. This gives users a better error message than silent destruction.
+
+### Decision 5: `resource_tags` is write-only (not populated on Read)
+
+**Rationale:** The `DescribeClusters` response (`ClusterInfo`) does not include cluster-level tags, and the TcaplusDB cluster API surface has no `DescribeClusterTags` analog (unlike table groups which have `DescribeTableGroupTags`). Therefore `resource_tags` is set on Create only and is not refreshed on Read. Terraform will keep the configured value in state. This is an acceptable trade-off because tags are immutable through this resource anyway.
+
+### Decision 6: Extend existing `CreateCluster` service function signature
+
+**Rationale:** The current `CreateCluster(ctx, idlType, clusterName, vpcId, subnetId, password string)` signature is extended to `CreateCluster(ctx, idlType, clusterName, vpcId, subnetId, password string, resourceTags []*tcaplusdb.TagInfoUnit, serverList []*tcaplusdb.MachineInfo, proxyList []*tcaplusdb.MachineInfo, clusterType int64)`. The new parameters are passed through to the SDK request only when non-empty/non-zero, preserving backward compatibility. The return value stays `(string, error)` (the cluster id).
+
+## Risks / Trade-offs
+
+- **[Risk] `resource_tags` is not refreshed on Read**: The `DescribeClusters` API does not return cluster tags.
+  - **Mitigation:** `resource_tags` is immutable after creation, so the configured value remains authoritative in state. This is documented in the resource description.
+
+- **[Risk] Changing any immutable field destroys the resource**: Using the `immutableArgs` pattern (not ForceNew).
+  - **Mitigation:** Users receive a clear error explaining which field cannot be changed, rather than silent destruction.
+
+- **[Risk] `server_list`/`proxy_list` Read population differs from Create input**: Create uses `MachineInfo` (`machine_type`, `machine_num`), while Read uses `ServerDetailInfo`/`ProxyDetailInfo` (which have more fields and lack `machine_num`).
+  - **Mitigation:** The nested block schema includes all Read fields (`server_uid`, `memory_rate`, etc. for `server_list`; `proxy_uid`, `process_speed`, etc. for `proxy_list`) as Computed, plus the Create-only `machine_num`/`machine_type` as Optional. On Read, all available fields are populated with nil checks before each `Set`.
+
+- **[Risk] Backward compatibility for existing callers of `CreateCluster`**: The service function signature changes.
+  - **Mitigation:** The only caller is `resourceTencentCloudTcaplusClusterCreate`, which is updated in the same change. No external callers exist.

--- a/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/proposal.md
+++ b/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The TcaplusDB `CreateCluster` API supports specifying cluster tags (`ResourceTags`), dedicated server machines (`ServerList`), dedicated proxy machines (`ProxyList`), and the cluster type (`ClusterType`) for creating dedicated clusters. However, the Terraform resource `tencentcloud_tcaplus_cluster` only exposes `idl_type`, `cluster_name`, `vpc_id`, `subnet_id`, `password`, and `old_password_expire_last`, which limits users to creating shared clusters without tags. Users who need to create dedicated TcaplusDB clusters or attach tags at creation time must fall back to the console or raw API.
+
+## What Changes
+
+- Add `cluster_type` (Optional, Computed, immutable after creation) top-level parameter to `tencentcloud_tcaplus_cluster`, mapped to the `CreateCluster` API `ClusterType` field (`*int64`, 1=shared, 2=dedicated). It is only accepted by `CreateCluster` (no update API supports it), so changes after creation SHALL be rejected via the `immutableArgs` check in the Update function. It is read back from `DescribeClusters` response `Clusters.ClusterType`.
+- Add `resource_tags` (Optional, TypeList, immutable after creation) nested block parameter to `tencentcloud_tcaplus_cluster`, mapped to the `CreateCluster` API `ResourceTags` field (`[]*TagInfoUnit`). Each element has `tag_key` (string) and `tag_value` (string). It is only accepted by `CreateCluster`, so changes after creation SHALL be rejected via the `immutableArgs` check in the Update function.
+- Add `server_list` (Optional, TypeList, immutable after creation, Computed) nested block parameter to `tencentcloud_tcaplus_cluster`, mapped to the `CreateCluster` API `ServerList` field (`[]*MachineInfo`). For creation, each element exposes `machine_type` (string) and `machine_num` (int). On Read, it is refreshed from the `DescribeClusters` response `Clusters.ServerList` (`ServerDetailInfo`), which additionally exposes `server_uid`, `memory_rate`, `disk_rate`, `read_num`, `write_num`, and `version`. Changes after creation SHALL be rejected via the `immutableArgs` check in the Update function.
+- Add `proxy_list` (Optional, TypeList, immutable after creation, Computed) nested block parameter to `tencentcloud_tcaplus_cluster`, mapped to the `CreateCluster` API `ProxyList` field (`[]*MachineInfo`). For creation, each element exposes `machine_type` (string) and `machine_num` (int). On Read, it is refreshed from the `DescribeClusters` response `Clusters.ProxyList` (`ProxyDetailInfo`), which additionally exposes `proxy_uid`, `machine_type`, `process_speed`, `average_process_delay`, `slow_process_speed`, and `version`. Changes after creation SHALL be rejected via the `immutableArgs` check in the Update function.
+- Extend the `CreateCluster` service-layer function to accept and pass the new parameters (`resourceTags`, `serverList`, `proxyList`, `clusterType`) into the SDK request.
+- Update the Read function to populate the new fields from the `DescribeClusters` response (with nil checks before each `set`).
+- Add the `immutableArgs` array pattern in the Update function (consistent with the provider's existing immutable-field convention) covering `cluster_type`, `resource_tags`, `server_list`, and `proxy_list`, returning a clear error when any of these change.
+
+## Capabilities
+
+### New Capabilities
+- `tcaplus-cluster-params`: Enable the `cluster_type`, `resource_tags`, `server_list`, and `proxy_list` parameters on the `tencentcloud_tcaplus_cluster` resource to allow users to create dedicated TcaplusDB clusters with dedicated server/proxy machines and attach resource tags at creation time.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.go` — add the four new schema fields, wire them through the Create flow, add `immutableArgs` check in Update, and add Read support (with nil checks)
+  - `tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go` — extend `CreateCluster` to accept `resourceTags []*tcaplusdb.TagInfoUnit`, `serverList []*tcaplusdb.MachineInfo`, `proxyList []*tcaplusdb.MachineInfo`, and `clusterType int64`, and pass them into the SDK request
+  - `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster_test.go` — add unit test cases (using gomonkey mocks) covering the new parameters
+  - `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.md` — update documentation with usage examples for the new parameters
+- **SDK dependency:** No SDK update required — the vendored `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823` already exposes `ResourceTags`, `ServerList`, `ProxyList`, and `ClusterType` on `CreateClusterRequest`, and `ClusterType`, `ServerList` (`ServerDetailInfo`), and `ProxyList` (`ProxyDetailInfo`) on the `ClusterInfo` response of `DescribeClusters`.
+- **Backward compatibility:** fully backward compatible — all new parameters are Optional; existing configurations continue to work unchanged and still create shared clusters.
+- **API constraints:** `ResourceTags`, `ServerList`, `ProxyList`, and `ClusterType` are only accepted by `CreateCluster` (no Modify API supports them), so they are immutable after creation and rejected with a clear error rather than silently destroying the resource.

--- a/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/specs/tcaplus-cluster-params/spec.md
+++ b/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/specs/tcaplus-cluster-params/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Add cluster_type parameter
+
+The `tencentcloud_tcaplus_cluster` resource SHALL accept an optional `cluster_type` top-level schema parameter (`TypeInt`, Optional, Computed, immutable after creation) mapped to the TcaplusDB `CreateCluster` API `ClusterType` request field (`*int64`, 1=shared, 2=dedicated). On Read, the resource SHALL refresh `cluster_type` from the `DescribeClusters` response `Clusters.ClusterType` field when it is not nil.
+
+#### Scenario: Create cluster with cluster_type unspecified
+- **WHEN** `cluster_type` is not set in the Terraform configuration
+- **THEN** the resource SHALL create a cluster without passing `ClusterType` to the `CreateCluster` API (preserving backward-compatible shared-cluster behavior) and SHALL populate `cluster_type` from the `DescribeClusters` response on Read
+
+#### Scenario: Create dedicated cluster with cluster_type set to 2
+- **WHEN** `cluster_type` is set to `2` in the Terraform configuration
+- **THEN** the resource SHALL pass `ClusterType=2` to the `CreateCluster` API to create a dedicated cluster and SHALL refresh `cluster_type` from the `DescribeClusters` response on Read
+
+#### Scenario: cluster_type is immutable after creation
+- **WHEN** `cluster_type` is changed in the Terraform configuration after the cluster is created
+- **THEN** the Update function SHALL detect the change via the `immutableArgs` check and return a clear error rejecting the modification (the cluster SHALL NOT be destroyed and recreated)
+
+### Requirement: Add resource_tags nested block
+
+The `tencentcloud_tcaplus_cluster` resource SHALL accept an optional `resource_tags` nested block (`TypeList`, Optional, immutable after creation) mapped to the TcaplusDB `CreateCluster` API `ResourceTags` request field (`[]*TagInfoUnit`). Each element SHALL expose `tag_key` (string) and `tag_value` (string) sub-fields. The resource SHALL pass the configured tags to the `CreateCluster` API on creation. Because the `DescribeClusters` response does not return cluster-level tags, the `resource_tags` block SHALL NOT be refreshed on Read and the configured value SHALL remain authoritative in Terraform state.
+
+#### Scenario: Create cluster with resource tags
+- **WHEN** the `resource_tags` block contains one or more `tag_key`/`tag_value` entries
+- **THEN** the resource SHALL pass each entry as a `TagInfoUnit` to the `CreateCluster` API `ResourceTags` field
+
+#### Scenario: Create cluster without resource tags
+- **WHEN** the `resource_tags` block is absent from the configuration
+- **THEN** the resource SHALL not set `ResourceTags` on the `CreateCluster` API request (preserving backward compatibility)
+
+#### Scenario: resource_tags is immutable after creation
+- **WHEN** `resource_tags` is changed in the Terraform configuration after the cluster is created
+- **THEN** the Update function SHALL detect the change via the `immutableArgs` check and return a clear error rejecting the modification
+
+### Requirement: Add server_list nested block
+
+The `tencentcloud_tcaplus_cluster` resource SHALL accept an optional `server_list` nested block (`TypeList`, Optional, Computed, immutable after creation) mapped to the TcaplusDB `CreateCluster` API `ServerList` request field (`[]*MachineInfo`). For creation, each element SHALL expose `machine_type` (string) and `machine_num` (int) sub-fields, which SHALL be passed to the `CreateCluster` API. On Read, the `server_list` block SHALL be refreshed from the `DescribeClusters` response `Clusters.ServerList` (`[]*ServerDetailInfo`), populating `server_uid` (string, Computed), `machine_type` (string, Computed), `memory_rate` (int, Computed), `disk_rate` (int, Computed), `read_num` (int, Computed), `write_num` (int, Computed), and `version` (string, Computed) with nil checks before each set.
+
+#### Scenario: Create dedicated cluster with server_list
+- **WHEN** the `server_list` block contains one or more entries with `machine_type` and `machine_num`
+- **THEN** the resource SHALL pass each entry as a `MachineInfo` to the `CreateCluster` API `ServerList` field
+
+#### Scenario: Read server_list from DescribeClusters
+- **WHEN** the `DescribeClusters` response returns a non-empty `ServerList` for the cluster
+- **THEN** the resource SHALL populate the `server_list` block from `ServerDetailInfo` elements, setting each available field (`server_uid`, `machine_type`, `memory_rate`, `disk_rate`, `read_num`, `write_num`, `version`) only when the corresponding response field is not nil
+
+#### Scenario: server_list is immutable after creation
+- **WHEN** `server_list` is changed in the Terraform configuration after the cluster is created
+- **THEN** the Update function SHALL detect the change via the `immutableArgs` check and return a clear error rejecting the modification
+
+### Requirement: Add proxy_list nested block
+
+The `tencentcloud_tcaplus_cluster` resource SHALL accept an optional `proxy_list` nested block (`TypeList`, Optional, Computed, immutable after creation) mapped to the TcaplusDB `CreateCluster` API `ProxyList` request field (`[]*MachineInfo`). For creation, each element SHALL expose `machine_type` (string) and `machine_num` (int) sub-fields, which SHALL be passed to the `CreateCluster` API. On Read, the `proxy_list` block SHALL be refreshed from the `DescribeClusters` response `Clusters.ProxyList` (`[]*ProxyDetailInfo`), populating `proxy_uid` (string, Computed), `machine_type` (string, Computed), `process_speed` (int, Computed), `average_process_delay` (int, Computed), `slow_process_speed` (int, Computed), and `version` (string, Computed) with nil checks before each set.
+
+#### Scenario: Create dedicated cluster with proxy_list
+- **WHEN** the `proxy_list` block contains one or more entries with `machine_type` and `machine_num`
+- **THEN** the resource SHALL pass each entry as a `MachineInfo` to the `CreateCluster` API `ProxyList` field
+
+#### Scenario: Read proxy_list from DescribeClusters
+- **WHEN** the `DescribeClusters` response returns a non-empty `ProxyList` for the cluster
+- **THEN** the resource SHALL populate the `proxy_list` block from `ProxyDetailInfo` elements, setting each available field (`proxy_uid`, `machine_type`, `process_speed`, `average_process_delay`, `slow_process_speed`, `version`) only when the corresponding response field is not nil
+
+#### Scenario: proxy_list is immutable after creation
+- **WHEN** `proxy_list` is changed in the Terraform configuration after the cluster is created
+- **THEN** the Update function SHALL detect the change via the `immutableArgs` check and return a clear error rejecting the modification
+
+### Requirement: Extend CreateCluster service-layer function
+
+The TcaplusDB service-layer `CreateCluster` function SHALL accept the new parameters (`resourceTags []*tcaplusdb.TagInfoUnit`, `serverList []*tcaplusdb.MachineInfo`, `proxyList []*tcaplusdb.MachineInfo`, `clusterType int64`) in addition to the existing parameters, and SHALL pass them into the `CreateClusterRequest` only when non-empty/non-zero, preserving backward compatibility for existing callers. The function return type SHALL remain `(string, error)` (the cluster id).
+
+#### Scenario: CreateCluster called with all new parameters empty
+- **WHEN** `resourceTags`, `serverList`, `proxyList` are empty and `clusterType` is 0
+- **THEN** the service-layer function SHALL not set `ResourceTags`, `ServerList`, `ProxyList`, or `ClusterType` on the `CreateClusterRequest`, producing the same request as before this change
+
+#### Scenario: CreateCluster called with dedicated cluster parameters
+- **WHEN** `clusterType` is 2 and `serverList`/`proxyList` contain entries and `resourceTags` contains entries
+- **THEN** the service-layer function SHALL set `ClusterType`, `ServerList`, `ProxyList`, and `ResourceTags` on the `CreateClusterRequest` before invoking the API

--- a/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/tasks.md
+++ b/openspec/changes/archive/2026-08-10-add-tcaplus-cluster-params/tasks.md
@@ -1,0 +1,27 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `cluster_type` top-level parameter (`TypeInt`, Optional, Computed) to the `tencentcloud_tcaplus_cluster` resource schema in `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.go`
+- [x] 1.2 Add `resource_tags` nested block (`TypeList`, Optional, Elem with `tag_key`/`tag_value` string sub-fields) to the resource schema
+- [x] 1.3 Add `server_list` nested block (`TypeList`, Optional, Computed, Elem with `machine_type` string, `machine_num` int for Create plus `server_uid`/`memory_rate`/`disk_rate`/`read_num`/`write_num`/`version` Computed sub-fields for Read) to the resource schema
+- [x] 1.4 Add `proxy_list` nested block (`TypeList`, Optional, Computed, Elem with `machine_type` string, `machine_num` int for Create plus `proxy_uid`/`process_speed`/`average_process_delay`/`slow_process_speed`/`version` Computed sub-fields for Read) to the resource schema
+
+## 2. Service Layer
+
+- [x] 2.1 Extend the `CreateCluster` function signature in `tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go` to accept `resourceTags []*tcaplusdb.TagInfoUnit`, `serverList []*tcaplusdb.MachineInfo`, `proxyList []*tcaplusdb.MachineInfo`, and `clusterType int64`
+- [x] 2.2 Pass the new parameters into the `CreateClusterRequest` only when non-empty/non-zero, preserving backward compatibility for existing callers
+
+## 3. CRUD Implementation
+
+- [x] 3.1 Update `resourceTencentCloudTcaplusClusterCreate` to read the new schema fields from `*schema.ResourceData`, build the SDK parameter objects (`TagInfoUnit`, `MachineInfo`), and pass them to the extended `CreateCluster` service function
+- [x] 3.2 Update `resourceTencentCloudTcaplusClusterRead` to populate `cluster_type`, `server_list`, and `proxy_list` from the `DescribeClusters` response (`ClusterInfo`) with nil checks before each `set`; note `resource_tags` is write-only and not refreshed on Read
+- [x] 3.3 Update `resourceTencentCloudTcaplusClusterUpdate` to add `cluster_type`, `resource_tags`, `server_list`, and `proxy_list` to the `immutableArgs` array, returning a clear error when any of them changes (they are not accepted by any Modify API)
+
+## 4. Tests
+
+- [x] 4.1 Add unit test cases (using gomonkey mocks for the cloud API) in `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster_test.go` covering creation with the new parameters (dedicated cluster with `cluster_type`, `resource_tags`, `server_list`, `proxy_list`)
+- [x] 4.2 Add unit test cases covering the Read path for the new nested blocks (`server_list`/`proxy_list` field population from `DescribeClusters` response with nil checks)
+- [x] 4.3 Add unit test cases covering the `immutableArgs` rejection in the Update function when `cluster_type`, `resource_tags`, `server_list`, or `proxy_list` change
+
+## 5. Documentation
+
+- [x] 5.1 Update `tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.md` with example usage demonstrating the new `cluster_type`, `resource_tags`, `server_list`, and `proxy_list` parameters (using `jsonencode()` for any JSON-string field values if applicable)

--- a/openspec/specs/tcaplus-cluster-params/spec.md
+++ b/openspec/specs/tcaplus-cluster-params/spec.md
@@ -1,0 +1,81 @@
+# tcaplus-cluster-params Specification
+
+## Purpose
+TBD - created by archiving change add-tcaplus-cluster-params. Update Purpose after archive.
+## Requirements
+### Requirement: Add cluster_type parameter
+
+The `tencentcloud_tcaplus_cluster` resource SHALL accept an optional `cluster_type` top-level schema parameter (`TypeInt`, Optional, Computed, immutable after creation) mapped to the TcaplusDB `CreateCluster` API `ClusterType` request field (`*int64`, 1=shared, 2=dedicated). On Read, the resource SHALL refresh `cluster_type` from the `DescribeClusters` response `Clusters.ClusterType` field when it is not nil.
+
+#### Scenario: Create cluster with cluster_type unspecified
+- **WHEN** `cluster_type` is not set in the Terraform configuration
+- **THEN** the resource SHALL create a cluster without passing `ClusterType` to the `CreateCluster` API (preserving backward-compatible shared-cluster behavior) and SHALL populate `cluster_type` from the `DescribeClusters` response on Read
+
+#### Scenario: Create dedicated cluster with cluster_type set to 2
+- **WHEN** `cluster_type` is set to `2` in the Terraform configuration
+- **THEN** the resource SHALL pass `ClusterType=2` to the `CreateCluster` API to create a dedicated cluster and SHALL refresh `cluster_type` from the `DescribeClusters` response on Read
+
+#### Scenario: cluster_type is immutable after creation
+- **WHEN** `cluster_type` is changed in the Terraform configuration after the cluster is created
+- **THEN** the Update function SHALL detect the change via the `immutableArgs` check and return a clear error rejecting the modification (the cluster SHALL NOT be destroyed and recreated)
+
+### Requirement: Add resource_tags nested block
+
+The `tencentcloud_tcaplus_cluster` resource SHALL accept an optional `resource_tags` nested block (`TypeList`, Optional, immutable after creation) mapped to the TcaplusDB `CreateCluster` API `ResourceTags` request field (`[]*TagInfoUnit`). Each element SHALL expose `tag_key` (string) and `tag_value` (string) sub-fields. The resource SHALL pass the configured tags to the `CreateCluster` API on creation. Because the `DescribeClusters` response does not return cluster-level tags, the `resource_tags` block SHALL NOT be refreshed on Read and the configured value SHALL remain authoritative in Terraform state.
+
+#### Scenario: Create cluster with resource tags
+- **WHEN** the `resource_tags` block contains one or more `tag_key`/`tag_value` entries
+- **THEN** the resource SHALL pass each entry as a `TagInfoUnit` to the `CreateCluster` API `ResourceTags` field
+
+#### Scenario: Create cluster without resource tags
+- **WHEN** the `resource_tags` block is absent from the configuration
+- **THEN** the resource SHALL not set `ResourceTags` on the `CreateCluster` API request (preserving backward compatibility)
+
+#### Scenario: resource_tags is immutable after creation
+- **WHEN** `resource_tags` is changed in the Terraform configuration after the cluster is created
+- **THEN** the Update function SHALL detect the change via the `immutableArgs` check and return a clear error rejecting the modification
+
+### Requirement: Add server_list nested block
+
+The `tencentcloud_tcaplus_cluster` resource SHALL accept an optional `server_list` nested block (`TypeList`, Optional, Computed, immutable after creation) mapped to the TcaplusDB `CreateCluster` API `ServerList` request field (`[]*MachineInfo`). For creation, each element SHALL expose `machine_type` (string) and `machine_num` (int) sub-fields, which SHALL be passed to the `CreateCluster` API. On Read, the `server_list` block SHALL be refreshed from the `DescribeClusters` response `Clusters.ServerList` (`[]*ServerDetailInfo`), populating `server_uid` (string, Computed), `machine_type` (string, Computed), `memory_rate` (int, Computed), `disk_rate` (int, Computed), `read_num` (int, Computed), `write_num` (int, Computed), and `version` (string, Computed) with nil checks before each set.
+
+#### Scenario: Create dedicated cluster with server_list
+- **WHEN** the `server_list` block contains one or more entries with `machine_type` and `machine_num`
+- **THEN** the resource SHALL pass each entry as a `MachineInfo` to the `CreateCluster` API `ServerList` field
+
+#### Scenario: Read server_list from DescribeClusters
+- **WHEN** the `DescribeClusters` response returns a non-empty `ServerList` for the cluster
+- **THEN** the resource SHALL populate the `server_list` block from `ServerDetailInfo` elements, setting each available field (`server_uid`, `machine_type`, `memory_rate`, `disk_rate`, `read_num`, `write_num`, `version`) only when the corresponding response field is not nil
+
+#### Scenario: server_list is immutable after creation
+- **WHEN** `server_list` is changed in the Terraform configuration after the cluster is created
+- **THEN** the Update function SHALL detect the change via the `immutableArgs` check and return a clear error rejecting the modification
+
+### Requirement: Add proxy_list nested block
+
+The `tencentcloud_tcaplus_cluster` resource SHALL accept an optional `proxy_list` nested block (`TypeList`, Optional, Computed, immutable after creation) mapped to the TcaplusDB `CreateCluster` API `ProxyList` request field (`[]*MachineInfo`). For creation, each element SHALL expose `machine_type` (string) and `machine_num` (int) sub-fields, which SHALL be passed to the `CreateCluster` API. On Read, the `proxy_list` block SHALL be refreshed from the `DescribeClusters` response `Clusters.ProxyList` (`[]*ProxyDetailInfo`), populating `proxy_uid` (string, Computed), `machine_type` (string, Computed), `process_speed` (int, Computed), `average_process_delay` (int, Computed), `slow_process_speed` (int, Computed), and `version` (string, Computed) with nil checks before each set.
+
+#### Scenario: Create dedicated cluster with proxy_list
+- **WHEN** the `proxy_list` block contains one or more entries with `machine_type` and `machine_num`
+- **THEN** the resource SHALL pass each entry as a `MachineInfo` to the `CreateCluster` API `ProxyList` field
+
+#### Scenario: Read proxy_list from DescribeClusters
+- **WHEN** the `DescribeClusters` response returns a non-empty `ProxyList` for the cluster
+- **THEN** the resource SHALL populate the `proxy_list` block from `ProxyDetailInfo` elements, setting each available field (`proxy_uid`, `machine_type`, `process_speed`, `average_process_delay`, `slow_process_speed`, `version`) only when the corresponding response field is not nil
+
+#### Scenario: proxy_list is immutable after creation
+- **WHEN** `proxy_list` is changed in the Terraform configuration after the cluster is created
+- **THEN** the Update function SHALL detect the change via the `immutableArgs` check and return a clear error rejecting the modification
+
+### Requirement: Extend CreateCluster service-layer function
+
+The TcaplusDB service-layer `CreateCluster` function SHALL accept the new parameters (`resourceTags []*tcaplusdb.TagInfoUnit`, `serverList []*tcaplusdb.MachineInfo`, `proxyList []*tcaplusdb.MachineInfo`, `clusterType int64`) in addition to the existing parameters, and SHALL pass them into the `CreateClusterRequest` only when non-empty/non-zero, preserving backward compatibility for existing callers. The function return type SHALL remain `(string, error)` (the cluster id).
+
+#### Scenario: CreateCluster called with all new parameters empty
+- **WHEN** `resourceTags`, `serverList`, `proxyList` are empty and `clusterType` is 0
+- **THEN** the service-layer function SHALL not set `ResourceTags`, `ServerList`, `ProxyList`, or `ClusterType` on the `CreateClusterRequest`, producing the same request as before this change
+
+#### Scenario: CreateCluster called with dedicated cluster parameters
+- **WHEN** `clusterType` is 2 and `serverList`/`proxyList` contain entries and `resourceTags` contains entries
+- **THEN** the service-layer function SHALL set `ClusterType`, `ServerList`, `ProxyList`, and `ResourceTags` on the `CreateClusterRequest` before invoking the API
+

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.go
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.go
@@ -2,17 +2,17 @@ package tcaplusdb
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"time"
-
-	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 	tcaplusdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 )
 
 func ResourceTencentCloudTcaplusCluster() *schema.Resource {
@@ -27,207 +27,158 @@ func ResourceTencentCloudTcaplusCluster() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"idl_type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: tccommon.ValidateAllowedStringValue(TCAPLUS_IDL_TYPES),
-				Description:  "IDL type of the TcaplusDB cluster. Valid values: `PROTO` and `TDR`.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Cluster data description language type, uniformly filled with `MIX`, enumeration value: `MIX`: supports both `PROTO` and `TDR` tables.",
 			},
+
 			"cluster_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: tccommon.ValidateStringLengthInRange(1, 30),
-				Description:  "Name of the TcaplusDB cluster. Name length should be between 1 and 30.",
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Cluster name, Chinese or English characters can be used, maximum length is 32 characters.",
 			},
+
 			"vpc_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "VPC id of the TcaplusDB cluster.",
+				Description: "The private network instance ID bound to the cluster, such as: `vpc-f49l6u0z`.",
 			},
+
 			"subnet_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Subnet id of the TcaplusDB cluster.",
+				Description: "The subnet instance ID bound to the cluster, such as: `subnet-pxir56ns`.",
 			},
+
 			"password": {
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if len(value) < 12 || len(value) > 16 {
-						errors = append(errors, fmt.Errorf("invalid password, length should between 12 and 16"))
-						return
-					}
-					var match = make(map[string]bool)
-					for i := 0; i < len(value); i++ {
-						if len(match) >= 2 {
-							break
-						}
-						if value[i] >= '0' && value[i] <= '9' {
-							match["number"] = true
-							continue
-						}
-						if value[i] >= 'a' && value[i] <= 'z' {
-							match["low"] = true
-							continue
-						}
-						if value[i] >= 'A' && value[i] <= 'Z' {
-							match["up"] = true
-							continue
-						}
-					}
-					if len(match) < 2 {
-						errors = append(errors, fmt.Errorf("invalid password, a-z and 0-9 and A-Z must contain"))
-					}
-					return
-				},
-				Description: "Password of the TcaplusDB cluster. Password length should be between 12 and 16. The password must be a *mix* of uppercase letters (A-Z), lowercase *letters* (a-z) and *numbers* (0-9).",
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "Cluster access password, must be `a-zA-Z0-9` characters, and must contain numbers, uppercase and lowercase letters.",
 			},
+
 			"old_password_expire_last": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      3600,
-				ValidateFunc: tccommon.ValidateIntegerMin(300),
-				Description:  "Expiration time of old password after password update, unit: second.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     3600,
+				Description: "Expiration time of old password after password update, unit: second.",
 			},
+
 			"cluster_type": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
-				Description: "Cluster type of the TcaplusDB cluster. `1`: shared cluster, `2`: dedicated cluster. This parameter is only valid for CreateCluster API and cannot be modified once set.",
+				Description: "Cluster type: `1` shared, `2` dedicated.",
 			},
+
 			"resource_tags": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Description: "Cluster tag set. Note: this field cannot be modified after cluster creation via CreateCluster, but can be modified via ModifyClusterTags. Tags will be refreshed on Read via DescribeClusterTags.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"tag_key": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag key.",
 						},
 						"tag_value": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Tag value.",
 						},
 					},
 				},
-				Description: "Resource tags of the TcaplusDB cluster. This parameter is only valid for CreateCluster API and cannot be modified once set. Note: This field is write-only and will not be refreshed on Read because the DescribeClusters API does not return cluster-level tags.",
 			},
+
 			"server_list": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Description: "Dedicated cluster occupied svr machines. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"machine_type": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Machine type.",
 						},
 						"machine_num": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"server_uid": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"memory_rate": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"disk_rate": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"read_num": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"write_num": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"version": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Machine quantity.",
 						},
 					},
 				},
-				Description: "Dedicated server machine list of the TcaplusDB cluster. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`. This parameter is only valid for CreateCluster API and cannot be modified once set.",
 			},
+
 			"proxy_list": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Description: "Dedicated cluster occupied proxy machines. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"machine_type": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Machine type.",
 						},
 						"machine_num": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"proxy_uid": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"process_speed": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"average_process_delay": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"slow_process_speed": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"version": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Machine quantity.",
 						},
 					},
 				},
-				Description: "Dedicated proxy machine list of the TcaplusDB cluster. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`. This parameter is only valid for CreateCluster API and cannot be modified once set.",
 			},
 
 			// Computed values.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Cluster ID.",
+			},
 			"network_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network type of the TcaplusDB cluster.",
 			},
+
 			"create_time": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Create time of the TcaplusDB cluster.",
 			},
+
 			"password_status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Password status of the TcaplusDB cluster. Valid values: `unmodifiable`, `modifiable`. `unmodifiable`. which means the password can not be changed in this moment; `modifiable`, which means the password can be changed in this moment.",
 			},
+
 			"api_access_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Access ID of the TcaplusDB cluster.For TcaplusDB SDK connect.",
+				Description: "Access ID of the TcaplusDB cluster. For TcaplusDB SDK connect.",
 			},
+
 			"api_access_ip": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Access IP of the TcaplusDB cluster.For TcaplusDB SDK connect.",
+				Description: "Access IP of the TcaplusDB cluster. For TcaplusDB SDK connect.",
 			},
+
 			"api_access_port": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "Access port of the TcaplusDB cluster.For TcaplusDB SDK connect.",
+				Description: "Access port of the TcaplusDB cluster. For TcaplusDB SDK connect.",
 			},
+
 			"old_password_expire_time": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -238,78 +189,142 @@ func ResourceTencentCloudTcaplusCluster() *schema.Resource {
 }
 
 func resourceTencentCloudTcaplusClusterCreate(d *schema.ResourceData, meta interface{}) error {
-
 	defer tccommon.LogElapsed("resource.tencentcloud_tcaplus_cluster.create")()
-
-	logId := tccommon.GetLogId(tccommon.ContextNil)
-	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
-
-	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	defer tccommon.InconsistentCheck(d, meta)()
 
 	var (
-		idlType     = d.Get("idl_type").(string)
-		clusterName = d.Get("cluster_name").(string)
-		vpcId       = d.Get("vpc_id").(string)
-		subnetId    = d.Get("subnet_id").(string)
-		password    = d.Get("password").(string)
-		clusterType = int64(d.Get("cluster_type").(int))
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = tcaplusdb.NewCreateClusterRequest()
 	)
 
-	var resourceTags []*tcaplusdb.TagInfoUnit
-	if tags, ok := d.Get("resource_tags").([]interface{}); ok && len(tags) > 0 {
+	if v, ok := d.GetOk("idl_type"); ok {
+		request.IdlType = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("cluster_name"); ok {
+		request.ClusterName = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("vpc_id"); ok {
+		request.VpcId = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("subnet_id"); ok {
+		request.SubnetId = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("password"); ok {
+		request.Password = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOkExists("cluster_type"); ok {
+		request.ClusterType = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOk("resource_tags"); ok {
+		tags := v.(*schema.Set).List()
 		for _, tag := range tags {
 			tagMap := tag.(map[string]interface{})
 			tagKey := tagMap["tag_key"].(string)
 			tagValue := tagMap["tag_value"].(string)
-			resourceTags = append(resourceTags, &tcaplusdb.TagInfoUnit{
-				TagKey:   &tagKey,
-				TagValue: &tagValue,
+			request.ResourceTags = append(request.ResourceTags, &tcaplusdb.TagInfoUnit{
+				TagKey:   helper.String(tagKey),
+				TagValue: helper.String(tagValue),
 			})
 		}
 	}
 
-	var serverList []*tcaplusdb.MachineInfo
-	if servers, ok := d.Get("server_list").([]interface{}); ok && len(servers) > 0 {
+	if v, ok := d.GetOk("server_list"); ok {
+		servers := v.(*schema.Set).List()
 		for _, server := range servers {
 			serverMap := server.(map[string]interface{})
 			machineType := serverMap["machine_type"].(string)
 			machineNum := int64(serverMap["machine_num"].(int))
-			serverList = append(serverList, &tcaplusdb.MachineInfo{
-				MachineType: &machineType,
-				MachineNum:  &machineNum,
+			request.ServerList = append(request.ServerList, &tcaplusdb.MachineInfo{
+				MachineType: helper.String(machineType),
+				MachineNum:  helper.Int64(machineNum),
 			})
 		}
 	}
 
-	var proxyList []*tcaplusdb.MachineInfo
-	if proxies, ok := d.Get("proxy_list").([]interface{}); ok && len(proxies) > 0 {
+	if v, ok := d.GetOk("proxy_list"); ok {
+		proxies := v.(*schema.Set).List()
 		for _, proxy := range proxies {
 			proxyMap := proxy.(map[string]interface{})
 			machineType := proxyMap["machine_type"].(string)
 			machineNum := int64(proxyMap["machine_num"].(int))
-			proxyList = append(proxyList, &tcaplusdb.MachineInfo{
-				MachineType: &machineType,
-				MachineNum:  &machineNum,
+			request.ProxyList = append(request.ProxyList, &tcaplusdb.MachineInfo{
+				MachineType: helper.String(machineType),
+				MachineNum:  helper.Int64(machineNum),
 			})
 		}
 	}
 
 	var clusterId string
-	var inErr, outErr error
-
-	outErr = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-		clusterId, inErr = tcaplusService.CreateCluster(ctx, idlType, clusterName, vpcId, subnetId, password, resourceTags, serverList, proxyList, clusterType)
-		if inErr != nil {
-			return tccommon.RetryError(inErr)
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTcaplusClient().CreateClusterWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
 		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create tcaplus cluster failed, Response is nil."))
+		}
+
+		if result.Response.ClusterId == nil || *result.Response.ClusterId == "" {
+			return resource.NonRetryableError(fmt.Errorf("Create tcaplus cluster failed, ClusterId is nil or empty."))
+		}
+
+		clusterId = *result.Response.ClusterId
 		return nil
 	})
-	if outErr != nil {
-		return outErr
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s create tcaplus cluster failed, reason:%+v", logId, reqErr)
+		return reqErr
 	}
-	log.Printf("[CRITAL]%s tcaplus_cluster clusterId=%s", logId, clusterId)
+
 	d.SetId(clusterId)
-	time.Sleep(3 * time.Second)
+
+	// wait
+	waitReq := tcaplusdb.NewDescribeClustersRequest()
+	waitReq.ClusterIds = []*string{&clusterId}
+	reqErr = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTcaplusClient().DescribeClustersWithContext(ctx, waitReq)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil || result.Response.Clusters == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe tcaplus cluster failed, Response is nil."))
+		}
+
+		if len(result.Response.Clusters) == 0 {
+			return resource.NonRetryableError(fmt.Errorf("Describe tcaplus cluster failed, Clusters is empty."))
+		}
+
+		cluster := result.Response.Clusters[0]
+		if cluster.ClusterStatus == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe tcaplus cluster failed, ClusterStatus is nil."))
+		}
+
+		if *cluster.ClusterStatus == 0 {
+			return nil
+		}
+
+		return resource.RetryableError(fmt.Errorf("cluster is still creating, current status: %d", *cluster.ClusterStatus))
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s create tcaplus cluster failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
 	return resourceTencentCloudTcaplusClusterRead(d, meta)
 }
 
@@ -317,38 +332,71 @@ func resourceTencentCloudTcaplusClusterRead(d *schema.ResourceData, meta interfa
 	defer tccommon.LogElapsed("resource.tencentcloud_tcaplus_cluster.read")()
 	defer tccommon.InconsistentCheck(d, meta)()
 
-	logId := tccommon.GetLogId(tccommon.ContextNil)
-	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+	var (
+		logId     = tccommon.GetLogId(tccommon.ContextNil)
+		ctx       = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service   = TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+		clusterId = d.Id()
+	)
 
-	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	var clusterInfo tcaplusdb.ClusterInfo
+	var has bool
+	var reqErr error
+	clusterInfo, has, reqErr = service.DescribeCluster(ctx, clusterId)
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s read tcaplus cluster failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
 
-	clusterInfo, has, err := tcaplusService.DescribeCluster(ctx, d.Id())
-	if err != nil {
-		err = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			clusterInfo, has, err = tcaplusService.DescribeCluster(ctx, d.Id())
-			if err != nil {
-				return tccommon.RetryError(err)
-			}
-			return nil
-		})
-	}
-	if err != nil {
-		return err
-	}
 	if !has {
+		log.Printf("[WARN]%s resource `tencentcloud_tcaplus_cluster` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
 		return nil
 	}
-	_ = d.Set("idl_type", clusterInfo.IdlType)
-	_ = d.Set("cluster_name", clusterInfo.ClusterName)
-	_ = d.Set("vpc_id", clusterInfo.VpcId)
-	_ = d.Set("subnet_id", clusterInfo.SubnetId)
-	_ = d.Set("network_type", clusterInfo.NetworkType)
-	_ = d.Set("create_time", clusterInfo.CreatedTime)
-	_ = d.Set("password_status", clusterInfo.PasswordStatus)
-	_ = d.Set("api_access_id", clusterInfo.ApiAccessId)
-	_ = d.Set("api_access_ip", clusterInfo.ApiAccessIp)
-	_ = d.Set("api_access_port", clusterInfo.ApiAccessPort)
+
+	if clusterInfo.ClusterId != nil {
+		_ = d.Set("cluster_id", clusterInfo.ClusterId)
+	}
+
+	if clusterInfo.IdlType != nil {
+		_ = d.Set("idl_type", clusterInfo.IdlType)
+	}
+
+	if clusterInfo.ClusterName != nil {
+		_ = d.Set("cluster_name", clusterInfo.ClusterName)
+	}
+
+	if clusterInfo.VpcId != nil {
+		_ = d.Set("vpc_id", clusterInfo.VpcId)
+	}
+
+	if clusterInfo.SubnetId != nil {
+		_ = d.Set("subnet_id", clusterInfo.SubnetId)
+	}
+
+	if clusterInfo.NetworkType != nil {
+		_ = d.Set("network_type", clusterInfo.NetworkType)
+	}
+
+	if clusterInfo.CreatedTime != nil {
+		_ = d.Set("create_time", clusterInfo.CreatedTime)
+	}
+
+	if clusterInfo.PasswordStatus != nil {
+		_ = d.Set("password_status", clusterInfo.PasswordStatus)
+	}
+
+	if clusterInfo.ApiAccessId != nil {
+		_ = d.Set("api_access_id", clusterInfo.ApiAccessId)
+	}
+
+	if clusterInfo.ApiAccessIp != nil {
+		_ = d.Set("api_access_ip", clusterInfo.ApiAccessIp)
+	}
+
+	if clusterInfo.ApiAccessPort != nil {
+		_ = d.Set("api_access_port", clusterInfo.ApiAccessPort)
+	}
 
 	if clusterInfo.OldPasswordExpireTime == nil || *clusterInfo.OldPasswordExpireTime == "" {
 		_ = d.Set("old_password_expire_time", "-")
@@ -361,170 +409,374 @@ func resourceTencentCloudTcaplusClusterRead(d *schema.ResourceData, meta interfa
 	}
 
 	if clusterInfo.ServerList != nil {
-		serverList := make([]map[string]interface{}, 0, len(clusterInfo.ServerList))
+		serverMachineNum := make(map[string]int)
 		for _, server := range clusterInfo.ServerList {
-			serverMap := map[string]interface{}{}
-			if server.ServerUid != nil {
-				serverMap["server_uid"] = *server.ServerUid
+			if server == nil || server.MachineType == nil {
+				continue
 			}
-			if server.MachineType != nil {
-				serverMap["machine_type"] = *server.MachineType
-			}
-			if server.MemoryRate != nil {
-				serverMap["memory_rate"] = *server.MemoryRate
-			}
-			if server.DiskRate != nil {
-				serverMap["disk_rate"] = *server.DiskRate
-			}
-			if server.ReadNum != nil {
-				serverMap["read_num"] = *server.ReadNum
-			}
-			if server.WriteNum != nil {
-				serverMap["write_num"] = *server.WriteNum
-			}
-			if server.Version != nil {
-				serverMap["version"] = *server.Version
-			}
-			serverList = append(serverList, serverMap)
+			serverMachineNum[*server.MachineType]++
+		}
+		serverList := make([]interface{}, 0, len(serverMachineNum))
+		for machineType, count := range serverMachineNum {
+			serverList = append(serverList, map[string]interface{}{
+				"machine_type": machineType,
+				"machine_num":  count,
+			})
 		}
 		_ = d.Set("server_list", serverList)
 	}
 
 	if clusterInfo.ProxyList != nil {
-		proxyList := make([]map[string]interface{}, 0, len(clusterInfo.ProxyList))
+		proxyMachineNum := make(map[string]int)
 		for _, proxy := range clusterInfo.ProxyList {
-			proxyMap := map[string]interface{}{}
-			if proxy.ProxyUid != nil {
-				proxyMap["proxy_uid"] = *proxy.ProxyUid
+			if proxy == nil || proxy.MachineType == nil {
+				continue
 			}
-			if proxy.MachineType != nil {
-				proxyMap["machine_type"] = *proxy.MachineType
-			}
-			if proxy.ProcessSpeed != nil {
-				proxyMap["process_speed"] = *proxy.ProcessSpeed
-			}
-			if proxy.AverageProcessDelay != nil {
-				proxyMap["average_process_delay"] = *proxy.AverageProcessDelay
-			}
-			if proxy.SlowProcessSpeed != nil {
-				proxyMap["slow_process_speed"] = *proxy.SlowProcessSpeed
-			}
-			if proxy.Version != nil {
-				proxyMap["version"] = *proxy.Version
-			}
-			proxyList = append(proxyList, proxyMap)
+			proxyMachineNum[*proxy.MachineType]++
+		}
+		proxyList := make([]interface{}, 0, len(proxyMachineNum))
+		for machineType, count := range proxyMachineNum {
+			proxyList = append(proxyList, map[string]interface{}{
+				"machine_type": machineType,
+				"machine_num":  count,
+			})
 		}
 		_ = d.Set("proxy_list", proxyList)
 	}
+
+	// Read cluster tags via service layer.
+	tags, tagsReqErr := service.DescribeClusterTags(ctx, clusterId)
+	if tagsReqErr != nil {
+		log.Printf("[CRITAL]%s read tcaplus cluster tags failed, reason:%+v", logId, tagsReqErr)
+		return tagsReqErr
+	}
+
+	resourceTags := make([]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		if tag == nil {
+			continue
+		}
+
+		tagMap := map[string]interface{}{}
+		if tag.TagKey != nil {
+			tagMap["tag_key"] = *tag.TagKey
+		}
+
+		if tag.TagValue != nil {
+			tagMap["tag_value"] = *tag.TagValue
+		}
+
+		resourceTags = append(resourceTags, tagMap)
+	}
+
+	_ = d.Set("resource_tags", resourceTags)
 
 	return nil
 }
 
 func resourceTencentCloudTcaplusClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	defer tccommon.LogElapsed("resource.tencentcloud_tcaplus_cluster.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
 
-	logId := tccommon.GetLogId(tccommon.ContextNil)
-	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+	var (
+		logId     = tccommon.GetLogId(tccommon.ContextNil)
+		ctx       = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		clusterId = d.Id()
+	)
 
-	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	if d.HasChange("cluster_type") || d.HasChange("server_list") || d.HasChange("proxy_list") {
+		request := tcaplusdb.NewModifyClusterMachineRequest()
+		request.ClusterId = helper.String(clusterId)
 
-	d.Partial(true)
+		if v, ok := d.GetOk("cluster_type"); ok {
+			request.ClusterType = helper.Int64(int64(v.(int)))
+		}
 
-	immutableArgs := []string{"cluster_type", "resource_tags", "server_list", "proxy_list"}
-	for _, v := range immutableArgs {
-		if d.HasChange(v) {
-			return fmt.Errorf("tcaplus_cluster argument `%s` cannot be changed", v)
+		if v, ok := d.GetOk("server_list"); ok {
+			servers := v.(*schema.Set).List()
+			for _, server := range servers {
+				serverMap := server.(map[string]interface{})
+				machineType := serverMap["machine_type"].(string)
+				machineNum := int64(serverMap["machine_num"].(int))
+				request.ServerList = append(request.ServerList, &tcaplusdb.MachineInfo{
+					MachineType: helper.String(machineType),
+					MachineNum:  helper.Int64(machineNum),
+				})
+			}
+		}
+
+		if v, ok := d.GetOk("proxy_list"); ok {
+			proxies := v.(*schema.Set).List()
+			for _, proxy := range proxies {
+				proxyMap := proxy.(map[string]interface{})
+				machineType := proxyMap["machine_type"].(string)
+				machineNum := int64(proxyMap["machine_num"].(int))
+				request.ProxyList = append(request.ProxyList, &tcaplusdb.MachineInfo{
+					MachineType: helper.String(machineType),
+					MachineNum:  helper.Int64(machineNum),
+				})
+			}
+		}
+
+		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTcaplusClient().ModifyClusterMachineWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify tcaplus cluster machine failed, Response is nil."))
+			}
+			return nil
+		})
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s update tcaplus cluster machine failed, reason:%+v", logId, reqErr)
+			return reqErr
+		}
+
+		// wait
+		waitReq := tcaplusdb.NewDescribeClustersRequest()
+		waitReq.ClusterIds = []*string{&clusterId}
+		reqErr = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTcaplusClient().DescribeClustersWithContext(ctx, waitReq)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil || result.Response.Clusters == nil {
+				return resource.NonRetryableError(fmt.Errorf("Describe tcaplus cluster failed, Response is nil."))
+			}
+
+			if len(result.Response.Clusters) == 0 {
+				return resource.NonRetryableError(fmt.Errorf("Describe tcaplus cluster failed, Clusters is empty."))
+			}
+
+			cluster := result.Response.Clusters[0]
+			if cluster.ClusterStatus == nil {
+				return resource.NonRetryableError(fmt.Errorf("Describe tcaplus cluster failed, ClusterStatus is nil."))
+			}
+
+			if *cluster.ClusterStatus == 0 {
+				return nil
+			}
+
+			return resource.RetryableError(fmt.Errorf("cluster is still updating, current status: %d", *cluster.ClusterStatus))
+		})
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s update tcaplus cluster failed, reason:%+v", logId, reqErr)
+			return reqErr
+		}
+	}
+
+	if d.HasChange("resource_tags") {
+		oldTags, newTags := d.GetChange("resource_tags")
+		oldTagsList := oldTags.(*schema.Set).List()
+		newTagsList := newTags.(*schema.Set).List()
+
+		oldTagsMap := make(map[string]string)
+		for _, tag := range oldTagsList {
+			tagMap := tag.(map[string]interface{})
+			tagKey := tagMap["tag_key"].(string)
+			tagValue := tagMap["tag_value"].(string)
+			oldTagsMap[tagKey] = tagValue
+		}
+
+		newTagsMap := make(map[string]string)
+		for _, tag := range newTagsList {
+			tagMap := tag.(map[string]interface{})
+			tagKey := tagMap["tag_key"].(string)
+			tagValue := tagMap["tag_value"].(string)
+			newTagsMap[tagKey] = tagValue
+		}
+
+		var replaceTags []*tcaplusdb.TagInfoUnit
+		var deleteTags []*tcaplusdb.TagInfoUnit
+
+		// Tags to add or update.
+		for k, v := range newTagsMap {
+			if oldV, ok := oldTagsMap[k]; !ok || oldV != v {
+				replaceTags = append(replaceTags, &tcaplusdb.TagInfoUnit{
+					TagKey:   helper.String(k),
+					TagValue: helper.String(v),
+				})
+			}
+		}
+
+		// Tags to delete.
+		for k := range oldTagsMap {
+			if _, ok := newTagsMap[k]; !ok {
+				deleteTags = append(deleteTags, &tcaplusdb.TagInfoUnit{
+					TagKey: helper.String(k),
+				})
+			}
+		}
+
+		if len(replaceTags) > 0 || len(deleteTags) > 0 {
+			tagsRequest := tcaplusdb.NewModifyClusterTagsRequest()
+			tagsRequest.ClusterId = helper.String(clusterId)
+			tagsRequest.ReplaceTags = replaceTags
+			tagsRequest.DeleteTags = deleteTags
+
+			tagsReqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+				tagsResult, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTcaplusClient().ModifyClusterTagsWithContext(ctx, tagsRequest)
+				if e != nil {
+					return tccommon.RetryError(e)
+				} else {
+					log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, tagsRequest.GetAction(), tagsRequest.ToJsonString(), tagsResult.ToJsonString())
+				}
+
+				if tagsResult == nil || tagsResult.Response == nil {
+					return resource.NonRetryableError(fmt.Errorf("Modify tcaplus cluster tags failed, Response is nil."))
+				}
+				return nil
+			})
+
+			if tagsReqErr != nil {
+				log.Printf("[CRITAL]%s update tcaplus cluster tags failed, reason:%+v", logId, tagsReqErr)
+				return tagsReqErr
+			}
 		}
 	}
 
 	if d.HasChange("cluster_name") {
-		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			err := tcaplusService.ModifyClusterName(ctx, d.Id(), d.Get("cluster_name").(string))
-			if err != nil {
-				return tccommon.RetryError(err)
+		request := tcaplusdb.NewModifyClusterNameRequest()
+		request.ClusterId = helper.String(clusterId)
+
+		if v, ok := d.GetOk("cluster_name"); ok {
+			request.ClusterName = helper.String(v.(string))
+		}
+
+		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTcaplusClient().ModifyClusterNameWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify tcaplus cluster name failed, Response is nil."))
 			}
 			return nil
 		})
-		if err != nil {
-			return err
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s update tcaplus cluster name failed, reason:%+v", logId, reqErr)
+			return reqErr
 		}
 	}
 
 	if d.HasChange("password") {
 		oldPwd, newPwd := d.GetChange("password")
-		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			err := tcaplusService.ModifyClusterPassword(ctx, d.Id(),
-				oldPwd.(string),
-				newPwd.(string),
-				int64(d.Get("old_password_expire_last").(int)))
 
-			if sdkerr, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-				if sdkerr.Code == "FailedOperation.OldPasswordInUse" {
-					err = fmt.Errorf("[TencentCloudSDKError] Code=FailedOperation.OldPasswordInUse,`password_status` is unmodifiable now, can modify after `old_password_expire_time`")
-					return resource.NonRetryableError(err)
+		request := tcaplusdb.NewModifyClusterPasswordRequest()
+		request.ClusterId = helper.String(clusterId)
+		request.OldPassword = helper.String(oldPwd.(string))
+		request.NewPassword = helper.String(newPwd.(string))
+		request.Mode = helper.String("1")
+
+		if v, ok := d.GetOkExists("old_password_expire_last"); ok {
+			oldPasswordExpireLast := int64(v.(int))
+			if oldPasswordExpireLast > 0 {
+				expireTime := time.Now().Add(time.Second * time.Duration(oldPasswordExpireLast))
+				loc, err := time.LoadLocation("Asia/Shanghai")
+				if err != nil {
+					return fmt.Errorf("Get Asia/Shanghai time group fail, %s", err.Error())
 				}
+				ex := expireTime.In(loc).Format("2006-01-02 15:04:05")
+				request.OldPasswordExpireTime = helper.String(ex)
 			}
-			if err != nil {
-				return tccommon.RetryError(err)
+		}
+
+		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTcaplusClient().ModifyClusterPasswordWithContext(ctx, request)
+			if e != nil {
+				if sdkerr, ok := e.(*sdkErrors.TencentCloudSDKError); ok {
+					if sdkerr.Code == "FailedOperation.OldPasswordInUse" {
+						return resource.NonRetryableError(fmt.Errorf("[TencentCloudSDKError] Code=FailedOperation.OldPasswordInUse, `password_status` is unmodifiable now, can modify after `old_password_expire_time`"))
+					}
+				}
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify tcaplus cluster password failed, Response is nil."))
 			}
 			return nil
 		})
-		if err != nil {
-			return err
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s update tcaplus cluster password failed, reason:%+v", logId, reqErr)
+			return reqErr
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceTencentCloudTcaplusClusterRead(d, meta)
 }
 
 func resourceTencentCloudTcaplusClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	defer tccommon.LogElapsed("resource.tencentcloud_tcaplus_cluster.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
 
-	logId := tccommon.GetLogId(tccommon.ContextNil)
-	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+	var (
+		logId     = tccommon.GetLogId(tccommon.ContextNil)
+		ctx       = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service   = TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+		clusterId = d.Id()
+		request   = tcaplusdb.NewDeleteClusterRequest()
+	)
 
-	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	request.ClusterId = helper.String(clusterId)
 
-	_, err := tcaplusService.DeleteCluster(ctx, d.Id())
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTcaplusClient().DeleteClusterWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
 
-	if err != nil {
-		err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-			_, err = tcaplusService.DeleteCluster(ctx, d.Id())
-			if err != nil {
-				return tccommon.RetryError(err)
-			}
-			return nil
-		})
-	}
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Delete tcaplus cluster failed, Response is nil."))
+		}
 
-	if err != nil {
-		return err
-	}
-
-	_, has, err := tcaplusService.DescribeCluster(ctx, d.Id())
-	if err != nil || has {
-		err = resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-			_, has, err = tcaplusService.DescribeCluster(ctx, d.Id())
-			if err != nil {
-				return tccommon.RetryError(err)
-			}
-
-			if has {
-				err = fmt.Errorf("delete cluster fail, cluster still exist from sdk DescribeClusters")
-				return resource.RetryableError(err)
-			}
-
-			return nil
-		})
-	}
-	if err != nil {
-		return err
-	}
-	if !has {
+		if result.Response.TaskId == nil || *result.Response.TaskId == "" {
+			return resource.NonRetryableError(fmt.Errorf("Delete tcaplus cluster failed, TaskId is nil or empty."))
+		}
 		return nil
-	} else {
-		return errors.New("delete cluster fail, cluster still exist from sdk DescribeClusters")
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s delete tcaplus cluster failed, reason:%+v", logId, reqErr)
+		return reqErr
 	}
+
+	// Poll for deletion completion.
+	pollErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		_, has, e := service.DescribeCluster(ctx, clusterId)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if has {
+			return resource.RetryableError(fmt.Errorf("delete cluster fail, cluster still exist from sdk DescribeClusters"))
+		}
+
+		return nil
+	})
+
+	if pollErr != nil {
+		log.Printf("[CRITAL]%s wait tcaplus cluster delete failed, reason:%+v", logId, pollErr)
+		return pollErr
+	}
+
+	return nil
 }

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.go
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	tcaplusdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823"
 )
 
 func ResourceTencentCloudTcaplusCluster() *schema.Resource {
@@ -91,6 +93,109 @@ func ResourceTencentCloudTcaplusCluster() *schema.Resource {
 				ValidateFunc: tccommon.ValidateIntegerMin(300),
 				Description:  "Expiration time of old password after password update, unit: second.",
 			},
+			"cluster_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Cluster type of the TcaplusDB cluster. `1`: shared cluster, `2`: dedicated cluster. This parameter is only valid for CreateCluster API and cannot be modified once set.",
+			},
+			"resource_tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Description: "Resource tags of the TcaplusDB cluster. This parameter is only valid for CreateCluster API and cannot be modified once set. Note: This field is write-only and will not be refreshed on Read because the DescribeClusters API does not return cluster-level tags.",
+			},
+			"server_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"machine_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"machine_num": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"server_uid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"memory_rate": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"disk_rate": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"read_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"write_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Description: "Dedicated server machine list of the TcaplusDB cluster. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`. This parameter is only valid for CreateCluster API and cannot be modified once set.",
+			},
+			"proxy_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"machine_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"machine_num": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"proxy_uid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process_speed": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"average_process_delay": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"slow_process_speed": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Description: "Dedicated proxy machine list of the TcaplusDB cluster. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`. This parameter is only valid for CreateCluster API and cannot be modified once set.",
+			},
 
 			// Computed values.
 			"network_type": {
@@ -147,13 +252,53 @@ func resourceTencentCloudTcaplusClusterCreate(d *schema.ResourceData, meta inter
 		vpcId       = d.Get("vpc_id").(string)
 		subnetId    = d.Get("subnet_id").(string)
 		password    = d.Get("password").(string)
+		clusterType = int64(d.Get("cluster_type").(int))
 	)
+
+	var resourceTags []*tcaplusdb.TagInfoUnit
+	if tags, ok := d.Get("resource_tags").([]interface{}); ok && len(tags) > 0 {
+		for _, tag := range tags {
+			tagMap := tag.(map[string]interface{})
+			tagKey := tagMap["tag_key"].(string)
+			tagValue := tagMap["tag_value"].(string)
+			resourceTags = append(resourceTags, &tcaplusdb.TagInfoUnit{
+				TagKey:   &tagKey,
+				TagValue: &tagValue,
+			})
+		}
+	}
+
+	var serverList []*tcaplusdb.MachineInfo
+	if servers, ok := d.Get("server_list").([]interface{}); ok && len(servers) > 0 {
+		for _, server := range servers {
+			serverMap := server.(map[string]interface{})
+			machineType := serverMap["machine_type"].(string)
+			machineNum := int64(serverMap["machine_num"].(int))
+			serverList = append(serverList, &tcaplusdb.MachineInfo{
+				MachineType: &machineType,
+				MachineNum:  &machineNum,
+			})
+		}
+	}
+
+	var proxyList []*tcaplusdb.MachineInfo
+	if proxies, ok := d.Get("proxy_list").([]interface{}); ok && len(proxies) > 0 {
+		for _, proxy := range proxies {
+			proxyMap := proxy.(map[string]interface{})
+			machineType := proxyMap["machine_type"].(string)
+			machineNum := int64(proxyMap["machine_num"].(int))
+			proxyList = append(proxyList, &tcaplusdb.MachineInfo{
+				MachineType: &machineType,
+				MachineNum:  &machineNum,
+			})
+		}
+	}
 
 	var clusterId string
 	var inErr, outErr error
 
 	outErr = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-		clusterId, inErr = tcaplusService.CreateCluster(ctx, idlType, clusterName, vpcId, subnetId, password)
+		clusterId, inErr = tcaplusService.CreateCluster(ctx, idlType, clusterName, vpcId, subnetId, password, resourceTags, serverList, proxyList, clusterType)
 		if inErr != nil {
 			return tccommon.RetryError(inErr)
 		}
@@ -162,6 +307,7 @@ func resourceTencentCloudTcaplusClusterCreate(d *schema.ResourceData, meta inter
 	if outErr != nil {
 		return outErr
 	}
+	log.Printf("[CRITAL]%s tcaplus_cluster clusterId=%s", logId, clusterId)
 	d.SetId(clusterId)
 	time.Sleep(3 * time.Second)
 	return resourceTencentCloudTcaplusClusterRead(d, meta)
@@ -210,11 +356,72 @@ func resourceTencentCloudTcaplusClusterRead(d *schema.ResourceData, meta interfa
 		_ = d.Set("old_password_expire_time", clusterInfo.OldPasswordExpireTime)
 	}
 
+	if clusterInfo.ClusterType != nil {
+		_ = d.Set("cluster_type", clusterInfo.ClusterType)
+	}
+
+	if clusterInfo.ServerList != nil {
+		serverList := make([]map[string]interface{}, 0, len(clusterInfo.ServerList))
+		for _, server := range clusterInfo.ServerList {
+			serverMap := map[string]interface{}{}
+			if server.ServerUid != nil {
+				serverMap["server_uid"] = *server.ServerUid
+			}
+			if server.MachineType != nil {
+				serverMap["machine_type"] = *server.MachineType
+			}
+			if server.MemoryRate != nil {
+				serverMap["memory_rate"] = *server.MemoryRate
+			}
+			if server.DiskRate != nil {
+				serverMap["disk_rate"] = *server.DiskRate
+			}
+			if server.ReadNum != nil {
+				serverMap["read_num"] = *server.ReadNum
+			}
+			if server.WriteNum != nil {
+				serverMap["write_num"] = *server.WriteNum
+			}
+			if server.Version != nil {
+				serverMap["version"] = *server.Version
+			}
+			serverList = append(serverList, serverMap)
+		}
+		_ = d.Set("server_list", serverList)
+	}
+
+	if clusterInfo.ProxyList != nil {
+		proxyList := make([]map[string]interface{}, 0, len(clusterInfo.ProxyList))
+		for _, proxy := range clusterInfo.ProxyList {
+			proxyMap := map[string]interface{}{}
+			if proxy.ProxyUid != nil {
+				proxyMap["proxy_uid"] = *proxy.ProxyUid
+			}
+			if proxy.MachineType != nil {
+				proxyMap["machine_type"] = *proxy.MachineType
+			}
+			if proxy.ProcessSpeed != nil {
+				proxyMap["process_speed"] = *proxy.ProcessSpeed
+			}
+			if proxy.AverageProcessDelay != nil {
+				proxyMap["average_process_delay"] = *proxy.AverageProcessDelay
+			}
+			if proxy.SlowProcessSpeed != nil {
+				proxyMap["slow_process_speed"] = *proxy.SlowProcessSpeed
+			}
+			if proxy.Version != nil {
+				proxyMap["version"] = *proxy.Version
+			}
+			proxyList = append(proxyList, proxyMap)
+		}
+		_ = d.Set("proxy_list", proxyList)
+	}
+
 	return nil
 }
 
 func resourceTencentCloudTcaplusClusterUpdate(d *schema.ResourceData, meta interface{}) error {
-	defer tccommon.LogElapsed("resource.tencentcloud_tcaplus_clusterupdate")()
+	defer tccommon.LogElapsed("resource.tencentcloud_tcaplus_cluster.update")()
 
 	logId := tccommon.GetLogId(tccommon.ContextNil)
 	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
@@ -222,6 +429,13 @@ func resourceTencentCloudTcaplusClusterUpdate(d *schema.ResourceData, meta inter
 	tcaplusService := TcaplusService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
 	d.Partial(true)
+
+	immutableArgs := []string{"cluster_type", "resource_tags", "server_list", "proxy_list"}
+	for _, v := range immutableArgs {
+		if d.HasChange(v) {
+			return fmt.Errorf("tcaplus_cluster argument `%s` cannot be changed", v)
+		}
+	}
 
 	if d.HasChange("cluster_name") {
 		err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.md
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.md
@@ -1,87 +1,59 @@
-Use this resource to create TcaplusDB cluster.
+Provides a resource to create a TcaplusDB cluster.
 
-~> **NOTE:** TcaplusDB now only supports the following regions: `ap-shanghai,ap-hongkong,na-siliconvalley,ap-singapore,ap-seoul,ap-tokyo,eu-frankfurt, and na-ashburn`.
+~> **NOTE:** TcaplusDB now only supports the following regions: `ap-shanghai`, `ap-hongkong`, `na-siliconvalley`, `ap-singapore`, `ap-seoul`, `ap-tokyo`, `eu-frankfurt`, `and na-ashburn`.
 
 Example Usage
 
-Create a new tcaplus cluster instance
+Create a tcaplus cluster instance with cluster_type is 1
 
 ```hcl
-locals {
-  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
-  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
-}
-
-variable "availability_zone" {
-  default = "ap-guangzhou-3"
-}
-
-data "tencentcloud_vpc_subnets" "vpc" {
-  is_default        = true
-  availability_zone = var.availability_zone
-}
-
 resource "tencentcloud_tcaplus_cluster" "example" {
-  idl_type                 = "PROTO"
-  cluster_name             = "tf_example_tcaplus_cluster"
-  vpc_id                   = local.vpc_id
-  subnet_id                = local.subnet_id
-  password                 = "your_pw_123111"
+  idl_type                 = "MIX"
+  cluster_name             = "tf_example"
+  vpc_id                   = "vpc-jll1dzwr"
+  subnet_id                = "subnet-ef14ogeu"
+  password                 = "Password@2026"
   old_password_expire_last = 3600
+  cluster_type             = 1
+  resource_tags {
+    tag_key   = "createBy"
+    tag_value = "Terraform"
+  }
 }
 ```
 
-Create a dedicated tcaplus cluster instance with resource tags, server list and proxy list
+Create a tcaplus cluster instance with cluster_type is 2
 
 ```hcl
-locals {
-  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
-  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
-}
-
-variable "availability_zone" {
-  default = "ap-guangzhou-3"
-}
-
-data "tencentcloud_vpc_subnets" "vpc" {
-  is_default        = true
-  availability_zone = var.availability_zone
-}
-
-resource "tencentcloud_tcaplus_cluster" "dedicated_example" {
-  idl_type     = "PROTO"
-  cluster_name = "tf_example_dedicated_cluster"
-  vpc_id       = local.vpc_id
-  subnet_id    = local.subnet_id
-  password     = "your_pw_123111"
-  cluster_type = 2
-
-  resource_tags {
-    tag_key   = "env"
-    tag_value = "prod"
-  }
-
-  resource_tags {
-    tag_key   = "owner"
-    tag_value = "terraform"
-  }
-
+resource "tencentcloud_tcaplus_cluster" "example" {
+  idl_type                 = "MIX"
+  cluster_name             = "tf_example"
+  vpc_id                   = "vpc-qtzga3pm"
+  subnet_id                = "subnet-c063n9el"
+  password                 = "Password@2026"
+  old_password_expire_last = 3600
+  cluster_type             = 2
   server_list {
-    machine_type = "S5.LARGE8"
-    machine_num = 2
+    machine_type = "T1"
+    machine_num  = 4
   }
 
   proxy_list {
-    machine_type = "S5.LARGE8"
-    machine_num = 1
+    machine_type = "T1"
+    machine_num  = 2
+  }
+
+  resource_tags {
+    tag_key   = "createBy"
+    tag_value = "Terraform"
   }
 }
 ```
 
 Import
 
-tcaplus cluster can be imported using the id, e.g.
+TcaplusDB cluster can be imported using the id, e.g.
 
 ```
-$ terraform import tencentcloud_tcaplus_cluster.example cluster_id
+terraform import tencentcloud_tcaplus_cluster.example 35402666774
 ```

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.md
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster.md
@@ -31,6 +31,53 @@ resource "tencentcloud_tcaplus_cluster" "example" {
 }
 ```
 
+Create a dedicated tcaplus cluster instance with resource tags, server list and proxy list
+
+```hcl
+locals {
+  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
+  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
+}
+
+variable "availability_zone" {
+  default = "ap-guangzhou-3"
+}
+
+data "tencentcloud_vpc_subnets" "vpc" {
+  is_default        = true
+  availability_zone = var.availability_zone
+}
+
+resource "tencentcloud_tcaplus_cluster" "dedicated_example" {
+  idl_type     = "PROTO"
+  cluster_name = "tf_example_dedicated_cluster"
+  vpc_id       = local.vpc_id
+  subnet_id    = local.subnet_id
+  password     = "your_pw_123111"
+  cluster_type = 2
+
+  resource_tags {
+    tag_key   = "env"
+    tag_value = "prod"
+  }
+
+  resource_tags {
+    tag_key   = "owner"
+    tag_value = "terraform"
+  }
+
+  server_list {
+    machine_type = "S5.LARGE8"
+    machine_num = 2
+  }
+
+  proxy_list {
+    machine_type = "S5.LARGE8"
+    machine_num = 1
+  }
+}
+```
+
 Import
 
 tcaplus cluster can be imported using the id, e.g.

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster_test.go
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster_test.go
@@ -59,7 +59,7 @@ func init() {
 	})
 }
 
-func TestAccTencentCloudTcaplusClusterResource(t *testing.T) {
+func TestAccTencentCloudTcaplusClusterResource_basic(t *testing.T) {
 	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { tcacctest.AccPreCheck(t) },
@@ -87,7 +87,6 @@ func TestAccTencentCloudTcaplusClusterResource(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"old_password_expire_last", "password"},
 			},
-
 			{
 				Config: testAccTcaplusClusterUpdate,
 				Check: resource.ComposeTestCheckFunc(
@@ -98,7 +97,6 @@ func TestAccTencentCloudTcaplusClusterResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testTcaplusClusterResourceKey, "api_access_id"),
 					resource.TestCheckResourceAttrSet(testTcaplusClusterResourceKey, "api_access_ip"),
 					resource.TestCheckResourceAttrSet(testTcaplusClusterResourceKey, "api_access_port"),
-
 					resource.TestCheckResourceAttr(testTcaplusClusterResourceKey, "idl_type", "PROTO"),
 					resource.TestCheckResourceAttr(testTcaplusClusterResourceKey, "cluster_name", "tf_te1_guagua_2"),
 					resource.TestCheckResourceAttr(testTcaplusClusterResourceKey, "password", "aQQ2345677888"),
@@ -157,7 +155,6 @@ func testAccCheckTcaplusClusterExists(n string) resource.TestCheckFunc {
 			return nil
 		} else {
 			return fmt.Errorf("tcaplus cluster %s not found on server", rs.Primary.ID)
-
 		}
 	}
 }
@@ -172,6 +169,7 @@ resource "tencentcloud_tcaplus_cluster" "test_cluster" {
   old_password_expire_last = 3600
 }
 `
+
 const testAccTcaplusClusterUpdate string = tcacctest.DefaultVpcSubnets + `
 resource "tencentcloud_tcaplus_cluster" "test_cluster" {
   idl_type                 = "PROTO"
@@ -238,7 +236,102 @@ func proxyListTcaplusClusterRaw() []interface{} {
 	}
 }
 
-// TestTcaplusClusterDedicatedCreate verifies cluster_type, resource_tags, server_list, proxy_list are passed to CreateCluster.
+func mockDescribeClusterTagsResponse(clusterId string, tags []map[string]string) *tcaplusdb.DescribeClusterTagsResponse {
+	tagInfos := make([]*tcaplusdb.TagInfoUnit, 0, len(tags))
+	for _, t := range tags {
+		tagInfos = append(tagInfos, &tcaplusdb.TagInfoUnit{
+			TagKey:   ptrStringTcaplusCluster(t["tag_key"]),
+			TagValue: ptrStringTcaplusCluster(t["tag_value"]),
+		})
+	}
+	resp := tcaplusdb.NewDescribeClusterTagsResponse()
+	resp.Response = &tcaplusdb.DescribeClusterTagsResponseParams{
+		Rows: []*tcaplusdb.TagsInfoOfCluster{
+			{
+				ClusterId: ptrStringTcaplusCluster(clusterId),
+				Tags:      tagInfos,
+			},
+		},
+		TotalCount: ptrInt64TcaplusCluster(int64(len(tagInfos))),
+		RequestId:  ptrStringTcaplusCluster("fake-request-id"),
+	}
+	return resp
+}
+
+func mockDescribeClustersResponse(clusterId string) *tcaplusdb.DescribeClustersResponse {
+	resp := tcaplusdb.NewDescribeClustersResponse()
+	resp.Response = &tcaplusdb.DescribeClustersResponseParams{
+		TotalCount: ptrInt64TcaplusCluster(1),
+		Clusters: []*tcaplusdb.ClusterInfo{
+			{
+				ClusterId:      ptrStringTcaplusCluster(clusterId),
+				ClusterName:    ptrStringTcaplusCluster("tf_dedicated_cluster"),
+				IdlType:        ptrStringTcaplusCluster("PROTO"),
+				VpcId:          ptrStringTcaplusCluster("vpc-xxx"),
+				SubnetId:       ptrStringTcaplusCluster("subnet-xxx"),
+				NetworkType:    ptrStringTcaplusCluster("ccnz"),
+				CreatedTime:    ptrStringTcaplusCluster("2025-01-01 00:00:00"),
+				PasswordStatus: ptrStringTcaplusCluster("modifiable"),
+				ApiAccessId:    ptrStringTcaplusCluster("access-id"),
+				ApiAccessIp:    ptrStringTcaplusCluster("1.2.3.4"),
+				ApiAccessPort:  ptrInt64TcaplusCluster(9999),
+				ClusterType:    ptrInt64TcaplusCluster(2),
+				ClusterStatus:  ptrInt64TcaplusCluster(0),
+				ServerList: []*tcaplusdb.ServerDetailInfo{
+					{
+						ServerUid:   ptrStringTcaplusCluster("server-uid-1"),
+						MachineType: ptrStringTcaplusCluster("S5.LARGE8"),
+						MemoryRate:  ptrInt64TcaplusCluster(50),
+						DiskRate:    ptrInt64TcaplusCluster(60),
+						ReadNum:     ptrInt64TcaplusCluster(100),
+						WriteNum:    ptrInt64TcaplusCluster(200),
+						Version:     ptrStringTcaplusCluster("3.5.0"),
+					},
+					{
+						ServerUid:   ptrStringTcaplusCluster("server-uid-2"),
+						MachineType: ptrStringTcaplusCluster("S5.LARGE8"),
+						MemoryRate:  ptrInt64TcaplusCluster(50),
+						DiskRate:    ptrInt64TcaplusCluster(60),
+						ReadNum:     ptrInt64TcaplusCluster(100),
+						WriteNum:    ptrInt64TcaplusCluster(200),
+						Version:     ptrStringTcaplusCluster("3.5.0"),
+					},
+					{
+						ServerUid:   ptrStringTcaplusCluster("server-uid-3"),
+						MachineType: ptrStringTcaplusCluster("S5.LARGE16"),
+						MemoryRate:  ptrInt64TcaplusCluster(50),
+						DiskRate:    ptrInt64TcaplusCluster(60),
+						ReadNum:     ptrInt64TcaplusCluster(100),
+						WriteNum:    ptrInt64TcaplusCluster(200),
+						Version:     ptrStringTcaplusCluster("3.5.0"),
+					},
+				},
+				ProxyList: []*tcaplusdb.ProxyDetailInfo{
+					{
+						ProxyUid:            ptrStringTcaplusCluster("proxy-uid-1"),
+						MachineType:         ptrStringTcaplusCluster("S5.LARGE8"),
+						ProcessSpeed:        ptrInt64TcaplusCluster(1000),
+						AverageProcessDelay: ptrInt64TcaplusCluster(5),
+						SlowProcessSpeed:    ptrInt64TcaplusCluster(10),
+						Version:             ptrStringTcaplusCluster("3.5.0"),
+					},
+					{
+						ProxyUid:            ptrStringTcaplusCluster("proxy-uid-2"),
+						MachineType:         ptrStringTcaplusCluster("S5.LARGE8"),
+						ProcessSpeed:        ptrInt64TcaplusCluster(1000),
+						AverageProcessDelay: ptrInt64TcaplusCluster(5),
+						SlowProcessSpeed:    ptrInt64TcaplusCluster(10),
+						Version:             ptrStringTcaplusCluster("3.5.0"),
+					},
+				},
+			},
+		},
+		RequestId: ptrStringTcaplusCluster("fake-request-id"),
+	}
+	return resp
+}
+
+// TestTcaplusClusterDedicatedCreate verifies cluster_type, resource_tags, server_list, proxy_list are passed to CreateClusterWithContext.
 func TestTcaplusClusterDedicatedCreate(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
@@ -247,7 +340,7 @@ func TestTcaplusClusterDedicatedCreate(t *testing.T) {
 	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
 
 	var capturedRequest *tcaplusdb.CreateClusterRequest
-	patches.ApplyMethodFunc(tcaplusClient, "CreateCluster", func(request *tcaplusdb.CreateClusterRequest) (*tcaplusdb.CreateClusterResponse, error) {
+	patches.ApplyMethodFunc(tcaplusClient, "CreateClusterWithContext", func(ctx context.Context, request *tcaplusdb.CreateClusterRequest) (*tcaplusdb.CreateClusterResponse, error) {
 		capturedRequest = request
 		resp := tcaplusdb.NewCreateClusterResponse()
 		resp.Response = &tcaplusdb.CreateClusterResponseParams{
@@ -257,50 +350,15 @@ func TestTcaplusClusterDedicatedCreate(t *testing.T) {
 		return resp, nil
 	})
 
-	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
-		resp := tcaplusdb.NewDescribeClustersResponse()
-		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
-			TotalCount: ptrInt64TcaplusCluster(1),
-			Clusters: []*tcaplusdb.ClusterInfo{
-				{
-					ClusterId:      ptrStringTcaplusCluster("1910000000"),
-					ClusterName:    ptrStringTcaplusCluster("tf_dedicated_cluster"),
-					IdlType:        ptrStringTcaplusCluster("PROTO"),
-					VpcId:          ptrStringTcaplusCluster("vpc-xxx"),
-					SubnetId:       ptrStringTcaplusCluster("subnet-xxx"),
-					NetworkType:    ptrStringTcaplusCluster("ccnz"),
-					CreatedTime:    ptrStringTcaplusCluster("2025-01-01 00:00:00"),
-					PasswordStatus: ptrStringTcaplusCluster("modifiable"),
-					ApiAccessId:    ptrStringTcaplusCluster("access-id"),
-					ApiAccessIp:    ptrStringTcaplusCluster("1.2.3.4"),
-					ApiAccessPort:  ptrInt64TcaplusCluster(9999),
-					ClusterType:    ptrInt64TcaplusCluster(2),
-					ServerList: []*tcaplusdb.ServerDetailInfo{
-						{
-							ServerUid:   ptrStringTcaplusCluster("server-uid-1"),
-							MachineType: ptrStringTcaplusCluster("S5.LARGE8"),
-							MemoryRate:  ptrInt64TcaplusCluster(50),
-							DiskRate:    ptrInt64TcaplusCluster(60),
-							ReadNum:     ptrInt64TcaplusCluster(100),
-							WriteNum:    ptrInt64TcaplusCluster(200),
-							Version:     ptrStringTcaplusCluster("3.5.0"),
-						},
-					},
-					ProxyList: []*tcaplusdb.ProxyDetailInfo{
-						{
-							ProxyUid:            ptrStringTcaplusCluster("proxy-uid-1"),
-							MachineType:         ptrStringTcaplusCluster("S5.LARGE8"),
-							ProcessSpeed:        ptrInt64TcaplusCluster(1000),
-							AverageProcessDelay: ptrInt64TcaplusCluster(5),
-							SlowProcessSpeed:    ptrInt64TcaplusCluster(10),
-							Version:             ptrStringTcaplusCluster("3.5.0"),
-						},
-					},
-				},
-			},
-			RequestId: ptrStringTcaplusCluster("fake-request-id"),
-		}
-		return resp, nil
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClustersWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+		return mockDescribeClustersResponse("1910000000"), nil
+	})
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusterTagsWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClusterTagsRequest) (*tcaplusdb.DescribeClusterTagsResponse, error) {
+		return mockDescribeClusterTagsResponse("1910000000", []map[string]string{
+			{"tag_key": "env", "tag_value": "prod"},
+			{"tag_key": "owner", "tag_value": "terraform"},
+		}), nil
 	})
 
 	meta := newMockMetaTcaplusCluster()
@@ -344,26 +402,31 @@ func TestTcaplusClusterDedicatedCreate(t *testing.T) {
 	clusterType := d.Get("cluster_type").(int)
 	assert.Equal(t, 2, clusterType)
 
-	serverList := d.Get("server_list").([]interface{})
-	assert.Equal(t, 1, len(serverList))
-	serverMap := serverList[0].(map[string]interface{})
-	assert.Equal(t, "server-uid-1", serverMap["server_uid"].(string))
-	assert.Equal(t, "S5.LARGE8", serverMap["machine_type"].(string))
-	assert.Equal(t, 50, serverMap["memory_rate"].(int))
-	assert.Equal(t, 60, serverMap["disk_rate"].(int))
-	assert.Equal(t, 100, serverMap["read_num"].(int))
-	assert.Equal(t, 200, serverMap["write_num"].(int))
-	assert.Equal(t, "3.5.0", serverMap["version"].(string))
+	serverList := d.Get("server_list").(*schema.Set).List()
+	assert.Equal(t, 2, len(serverList))
+	serverMachineNum := make(map[string]int)
+	for _, s := range serverList {
+		m := s.(map[string]interface{})
+		serverMachineNum[m["machine_type"].(string)] = m["machine_num"].(int)
+	}
+	assert.Equal(t, 2, serverMachineNum["S5.LARGE8"])
+	assert.Equal(t, 1, serverMachineNum["S5.LARGE16"])
 
-	proxyList := d.Get("proxy_list").([]interface{})
+	proxyList := d.Get("proxy_list").(*schema.Set).List()
 	assert.Equal(t, 1, len(proxyList))
 	proxyMap := proxyList[0].(map[string]interface{})
-	assert.Equal(t, "proxy-uid-1", proxyMap["proxy_uid"].(string))
 	assert.Equal(t, "S5.LARGE8", proxyMap["machine_type"].(string))
-	assert.Equal(t, 1000, proxyMap["process_speed"].(int))
-	assert.Equal(t, 5, proxyMap["average_process_delay"].(int))
-	assert.Equal(t, 10, proxyMap["slow_process_speed"].(int))
-	assert.Equal(t, "3.5.0", proxyMap["version"].(string))
+	assert.Equal(t, 2, proxyMap["machine_num"].(int))
+
+	// Verify resource_tags are read back via DescribeClusterTags.
+	resourceTags := d.Get("resource_tags").(*schema.Set).List()
+	assert.Equal(t, 2, len(resourceTags))
+	tagMap := make(map[string]string)
+	for _, tag := range resourceTags {
+		tagMap[tag.(map[string]interface{})["tag_key"].(string)] = tag.(map[string]interface{})["tag_value"].(string)
+	}
+	assert.Equal(t, "prod", tagMap["env"])
+	assert.Equal(t, "terraform", tagMap["owner"])
 }
 
 // TestTcaplusClusterSharedCreateDefault verifies new params are not sent when not specified.
@@ -375,7 +438,7 @@ func TestTcaplusClusterSharedCreateDefault(t *testing.T) {
 	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
 
 	var capturedRequest *tcaplusdb.CreateClusterRequest
-	patches.ApplyMethodFunc(tcaplusClient, "CreateCluster", func(request *tcaplusdb.CreateClusterRequest) (*tcaplusdb.CreateClusterResponse, error) {
+	patches.ApplyMethodFunc(tcaplusClient, "CreateClusterWithContext", func(ctx context.Context, request *tcaplusdb.CreateClusterRequest) (*tcaplusdb.CreateClusterResponse, error) {
 		capturedRequest = request
 		resp := tcaplusdb.NewCreateClusterResponse()
 		resp.Response = &tcaplusdb.CreateClusterResponseParams{
@@ -385,7 +448,7 @@ func TestTcaplusClusterSharedCreateDefault(t *testing.T) {
 		return resp, nil
 	})
 
-	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClustersWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
 		resp := tcaplusdb.NewDescribeClustersResponse()
 		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
 			TotalCount: ptrInt64TcaplusCluster(1),
@@ -403,11 +466,16 @@ func TestTcaplusClusterSharedCreateDefault(t *testing.T) {
 					ApiAccessIp:    ptrStringTcaplusCluster("1.2.3.4"),
 					ApiAccessPort:  ptrInt64TcaplusCluster(9999),
 					ClusterType:    ptrInt64TcaplusCluster(1),
+					ClusterStatus:  ptrInt64TcaplusCluster(0),
 				},
 			},
 			RequestId: ptrStringTcaplusCluster("fake-request-id"),
 		}
 		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusterTagsWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClusterTagsRequest) (*tcaplusdb.DescribeClusterTagsResponse, error) {
+		return mockDescribeClusterTagsResponse("1910000001", nil), nil
 	})
 
 	meta := newMockMetaTcaplusCluster()
@@ -440,7 +508,7 @@ func TestTcaplusClusterReadServerListNil(t *testing.T) {
 	tcaplusClient := &tcaplusdb.Client{}
 	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
 
-	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClustersWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
 		resp := tcaplusdb.NewDescribeClustersResponse()
 		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
 			TotalCount: ptrInt64TcaplusCluster(1),
@@ -477,6 +545,10 @@ func TestTcaplusClusterReadServerListNil(t *testing.T) {
 		return resp, nil
 	})
 
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusterTagsWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClusterTagsRequest) (*tcaplusdb.DescribeClusterTagsResponse, error) {
+		return mockDescribeClusterTagsResponse("1910000002", nil), nil
+	})
+
 	meta := newMockMetaTcaplusCluster()
 	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
@@ -497,26 +569,15 @@ func TestTcaplusClusterReadServerListNil(t *testing.T) {
 	clusterType := d.Get("cluster_type").(int)
 	assert.Equal(t, 2, clusterType)
 
-	serverList := d.Get("server_list").([]interface{})
+	serverList := d.Get("server_list").(*schema.Set).List()
 	assert.Equal(t, 1, len(serverList))
 	serverMap := serverList[0].(map[string]interface{})
-	assert.Equal(t, "server-uid-nil", serverMap["server_uid"].(string))
 	assert.Equal(t, "S5.LARGE8", serverMap["machine_type"].(string))
-	assert.Equal(t, 0, serverMap["memory_rate"].(int))
-	assert.Equal(t, 0, serverMap["disk_rate"].(int))
-	assert.Equal(t, 0, serverMap["read_num"].(int))
-	assert.Equal(t, 0, serverMap["write_num"].(int))
-	assert.Equal(t, "", serverMap["version"].(string))
 
-	proxyList := d.Get("proxy_list").([]interface{})
+	proxyList := d.Get("proxy_list").(*schema.Set).List()
 	assert.Equal(t, 1, len(proxyList))
 	proxyMap := proxyList[0].(map[string]interface{})
-	assert.Equal(t, "proxy-uid-nil", proxyMap["proxy_uid"].(string))
 	assert.Equal(t, "S5.LARGE8", proxyMap["machine_type"].(string))
-	assert.Equal(t, 0, proxyMap["process_speed"].(int))
-	assert.Equal(t, 0, proxyMap["average_process_delay"].(int))
-	assert.Equal(t, 0, proxyMap["slow_process_speed"].(int))
-	assert.Equal(t, "", proxyMap["version"].(string))
 }
 
 // TestTcaplusClusterReadProxyListNil verifies Read handles nil ProxyList fields gracefully.
@@ -527,7 +588,7 @@ func TestTcaplusClusterReadProxyListNil(t *testing.T) {
 	tcaplusClient := &tcaplusdb.Client{}
 	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
 
-	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClustersWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
 		resp := tcaplusdb.NewDescribeClustersResponse()
 		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
 			TotalCount: ptrInt64TcaplusCluster(1),
@@ -541,7 +602,8 @@ func TestTcaplusClusterReadProxyListNil(t *testing.T) {
 					ClusterType: ptrInt64TcaplusCluster(2),
 					ProxyList: []*tcaplusdb.ProxyDetailInfo{
 						{
-							ProxyUid: ptrStringTcaplusCluster("proxy-uid-only"),
+							ProxyUid:    ptrStringTcaplusCluster("proxy-uid-only"),
+							MachineType: ptrStringTcaplusCluster(""),
 						},
 					},
 				},
@@ -549,6 +611,10 @@ func TestTcaplusClusterReadProxyListNil(t *testing.T) {
 			RequestId: ptrStringTcaplusCluster("fake-request-id"),
 		}
 		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusterTagsWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClusterTagsRequest) (*tcaplusdb.DescribeClusterTagsResponse, error) {
+		return mockDescribeClusterTagsResponse("1910000003", nil), nil
 	})
 
 	meta := newMockMetaTcaplusCluster()
@@ -566,39 +632,59 @@ func TestTcaplusClusterReadProxyListNil(t *testing.T) {
 	err := res.Read(d, meta)
 	assert.NoError(t, err)
 
-	proxyList := d.Get("proxy_list").([]interface{})
+	proxyList := d.Get("proxy_list").(*schema.Set).List()
 	assert.Equal(t, 1, len(proxyList))
 	proxyMap := proxyList[0].(map[string]interface{})
-	assert.Equal(t, "proxy-uid-only", proxyMap["proxy_uid"].(string))
 	assert.Equal(t, "", proxyMap["machine_type"].(string))
-	assert.Equal(t, 0, proxyMap["process_speed"].(int))
-	assert.Equal(t, 0, proxyMap["average_process_delay"].(int))
-	assert.Equal(t, 0, proxyMap["slow_process_speed"].(int))
-	assert.Equal(t, "", proxyMap["version"].(string))
 }
 
 // TestTcaplusClusterImmutableReject verifies Update rejects changes to immutable args.
-func TestTcaplusClusterImmutableReject(t *testing.T) {
+// TestTcaplusClusterUpdateMachine verifies ModifyClusterMachine is called with correct ClusterType, ServerList, ProxyList.
+func TestTcaplusClusterUpdateMachine(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
 	tcaplusClient := &tcaplusdb.Client{}
 	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
 
-	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClustersWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
 		resp := tcaplusdb.NewDescribeClustersResponse()
 		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
 			TotalCount: ptrInt64TcaplusCluster(1),
 			Clusters: []*tcaplusdb.ClusterInfo{
 				{
-					ClusterId:   ptrStringTcaplusCluster("1910000004"),
-					ClusterName: ptrStringTcaplusCluster("tf_immutable"),
-					IdlType:     ptrStringTcaplusCluster("PROTO"),
-					VpcId:       ptrStringTcaplusCluster("vpc-xxx"),
-					SubnetId:    ptrStringTcaplusCluster("subnet-xxx"),
-					ClusterType: ptrInt64TcaplusCluster(2),
+					ClusterId:     ptrStringTcaplusCluster("1910000004"),
+					ClusterName:   ptrStringTcaplusCluster("tf_update_machine"),
+					IdlType:       ptrStringTcaplusCluster("PROTO"),
+					VpcId:         ptrStringTcaplusCluster("vpc-xxx"),
+					SubnetId:      ptrStringTcaplusCluster("subnet-xxx"),
+					ClusterType:   ptrInt64TcaplusCluster(2),
+					ClusterStatus: ptrInt64TcaplusCluster(0),
+					ServerList: []*tcaplusdb.ServerDetailInfo{
+						{MachineType: ptrStringTcaplusCluster("S5.LARGE8")},
+						{MachineType: ptrStringTcaplusCluster("S5.LARGE8")},
+					},
+					ProxyList: []*tcaplusdb.ProxyDetailInfo{
+						{MachineType: ptrStringTcaplusCluster("S5.LARGE8")},
+						{MachineType: ptrStringTcaplusCluster("S5.LARGE8")},
+					},
 				},
 			},
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusterTagsWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClusterTagsRequest) (*tcaplusdb.DescribeClusterTagsResponse, error) {
+		return mockDescribeClusterTagsResponse("1910000004", nil), nil
+	})
+
+	var capturedRequest *tcaplusdb.ModifyClusterMachineRequest
+	patches.ApplyMethodFunc(tcaplusClient, "ModifyClusterMachineWithContext", func(ctx context.Context, request *tcaplusdb.ModifyClusterMachineRequest) (*tcaplusdb.ModifyClusterMachineResponse, error) {
+		capturedRequest = request
+		resp := tcaplusdb.NewModifyClusterMachineResponse()
+		resp.Response = &tcaplusdb.ModifyClusterMachineResponseParams{
+			ClusterId: ptrStringTcaplusCluster("1910000004"),
 			RequestId: ptrStringTcaplusCluster("fake-request-id"),
 		}
 		return resp, nil
@@ -608,45 +694,89 @@ func TestTcaplusClusterImmutableReject(t *testing.T) {
 	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 		"idl_type":     "PROTO",
-		"cluster_name": "tf_immutable",
+		"cluster_name": "tf_update_machine",
 		"vpc_id":       "vpc-xxx",
 		"subnet_id":    "subnet-xxx",
 		"password":     "1qaA2k1wgvfa3ZZZ",
-		"cluster_type": 1,
+		"cluster_type": 2,
+		"server_list": []interface{}{
+			map[string]interface{}{
+				"machine_type": "S5.LARGE8",
+				"machine_num":  2,
+			},
+		},
+		"proxy_list": []interface{}{
+			map[string]interface{}{
+				"machine_type": "S5.LARGE8",
+				"machine_num":  2,
+			},
+		},
 	})
 	d.SetId("1910000004")
 
+	// Configure HasChange to report cluster_type, server_list, proxy_list changed.
 	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
-		return key == "cluster_type"
+		return key == "cluster_type" || key == "server_list" || key == "proxy_list"
 	})
 
 	err := res.Update(d, meta)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cluster_type")
-	assert.Contains(t, err.Error(), "cannot be changed")
+	assert.NoError(t, err)
+
+	// Verify ModifyClusterMachine was called with correct params.
+	assert.NotNil(t, capturedRequest)
+	assert.Equal(t, "1910000004", *capturedRequest.ClusterId)
+	assert.NotNil(t, capturedRequest.ClusterType)
+	assert.Equal(t, int64(2), *capturedRequest.ClusterType)
+
+	assert.NotNil(t, capturedRequest.ServerList)
+	assert.Equal(t, 1, len(capturedRequest.ServerList))
+	assert.Equal(t, "S5.LARGE8", *capturedRequest.ServerList[0].MachineType)
+	assert.Equal(t, int64(2), *capturedRequest.ServerList[0].MachineNum)
+
+	assert.NotNil(t, capturedRequest.ProxyList)
+	assert.Equal(t, 1, len(capturedRequest.ProxyList))
+	assert.Equal(t, "S5.LARGE8", *capturedRequest.ProxyList[0].MachineType)
+	assert.Equal(t, int64(2), *capturedRequest.ProxyList[0].MachineNum)
+
+	// Verify server_list and proxy_list are read back after update.
+	serverList := d.Get("server_list").(*schema.Set).List()
+	assert.Equal(t, 1, len(serverList))
+	serverMap := serverList[0].(map[string]interface{})
+	assert.Equal(t, "S5.LARGE8", serverMap["machine_type"].(string))
+	assert.Equal(t, 2, serverMap["machine_num"].(int))
+
+	proxyList := d.Get("proxy_list").(*schema.Set).List()
+	assert.Equal(t, 1, len(proxyList))
+	proxyMap := proxyList[0].(map[string]interface{})
+	assert.Equal(t, "S5.LARGE8", proxyMap["machine_type"].(string))
+	assert.Equal(t, 2, proxyMap["machine_num"].(int))
 }
 
-// TestTcaplusClusterImmutableRejectServerList verifies Update rejects changes to server_list.
-func TestTcaplusClusterImmutableRejectServerList(t *testing.T) {
+// TestTcaplusClusterUpdateTags verifies ModifyClusterTags is called with correct ReplaceTags/DeleteTags.
+func TestTcaplusClusterUpdateTags(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
 	tcaplusClient := &tcaplusdb.Client{}
 	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
 
-	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
-		resp := tcaplusdb.NewDescribeClustersResponse()
-		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
-			TotalCount: ptrInt64TcaplusCluster(1),
-			Clusters: []*tcaplusdb.ClusterInfo{
-				{
-					ClusterId:   ptrStringTcaplusCluster("1910000005"),
-					ClusterName: ptrStringTcaplusCluster("tf_immutable_sl"),
-					IdlType:     ptrStringTcaplusCluster("PROTO"),
-					VpcId:       ptrStringTcaplusCluster("vpc-xxx"),
-					SubnetId:    ptrStringTcaplusCluster("subnet-xxx"),
-				},
-			},
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClustersWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+		return mockDescribeClustersResponse("1910000010"), nil
+	})
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusterTagsWithContext", func(ctx context.Context, request *tcaplusdb.DescribeClusterTagsRequest) (*tcaplusdb.DescribeClusterTagsResponse, error) {
+		return mockDescribeClusterTagsResponse("1910000010", []map[string]string{
+			{"tag_key": "env", "tag_value": "prod"},
+			{"tag_key": "owner", "tag_value": "terraform"},
+		}), nil
+	})
+
+	var capturedModifyRequest *tcaplusdb.ModifyClusterTagsRequest
+	patches.ApplyMethodFunc(tcaplusClient, "ModifyClusterTagsWithContext", func(ctx context.Context, request *tcaplusdb.ModifyClusterTagsRequest) (*tcaplusdb.ModifyClusterTagsResponse, error) {
+		capturedModifyRequest = request
+		resp := tcaplusdb.NewModifyClusterTagsResponse()
+		resp.Response = &tcaplusdb.ModifyClusterTagsResponseParams{
+			TaskId:    ptrStringTcaplusCluster("1910000010-1210"),
 			RequestId: ptrStringTcaplusCluster("fake-request-id"),
 		}
 		return resp, nil
@@ -654,23 +784,84 @@ func TestTcaplusClusterImmutableRejectServerList(t *testing.T) {
 
 	meta := newMockMetaTcaplusCluster()
 	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
+
+	// resource_tags: env=prod, owner=dev, new_key=new
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 		"idl_type":     "PROTO",
-		"cluster_name": "tf_immutable_sl",
+		"cluster_name": "tf_tags_update",
 		"vpc_id":       "vpc-xxx",
 		"subnet_id":    "subnet-xxx",
 		"password":     "1qaA2k1wgvfa3ZZZ",
+		"resource_tags": []interface{}{
+			map[string]interface{}{
+				"tag_key":   "env",
+				"tag_value": "prod",
+			},
+			map[string]interface{}{
+				"tag_key":   "owner",
+				"tag_value": "dev",
+			},
+			map[string]interface{}{
+				"tag_key":   "new_key",
+				"tag_value": "new",
+			},
+		},
 	})
-	d.SetId("1910000005")
+	d.SetId("1910000010")
 
+	// Configure HasChange to report only resource_tags changed.
 	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
-		return key == "server_list"
+		return key == "resource_tags"
+	})
+
+	// Configure GetChange to return old/new tags diff.
+	// old: env=prod, owner=terraform, stale=old
+	// new: env=prod (unchanged), owner=dev (updated), new_key=new (added), stale removed
+	patches.ApplyMethodFunc(d, "GetChange", func(key string) (interface{}, interface{}) {
+		if key == "resource_tags" {
+			oldTags := []interface{}{
+				map[string]interface{}{
+					"tag_key":   "env",
+					"tag_value": "prod",
+				},
+				map[string]interface{}{
+					"tag_key":   "owner",
+					"tag_value": "terraform",
+				},
+				map[string]interface{}{
+					"tag_key":   "stale",
+					"tag_value": "old",
+				},
+			}
+			newTags := []interface{}{
+				map[string]interface{}{
+					"tag_key":   "env",
+					"tag_value": "prod",
+				},
+				map[string]interface{}{
+					"tag_key":   "owner",
+					"tag_value": "dev",
+				},
+				map[string]interface{}{
+					"tag_key":   "new_key",
+					"tag_value": "new",
+				},
+			}
+			return oldTags, newTags
+		}
+		return nil, nil
 	})
 
 	err := res.Update(d, meta)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "server_list")
-	assert.Contains(t, err.Error(), "cannot be changed")
+	assert.NoError(t, err)
+
+	// Verify ModifyClusterTags was called.
+	assert.NotNil(t, capturedModifyRequest)
+	assert.Equal(t, "1910000010", *capturedModifyRequest.ClusterId)
+
+	// Verify resource_tags are read back after update via DescribeClusterTags.
+	resourceTags := d.Get("resource_tags").(*schema.Set).List()
+	assert.Equal(t, 2, len(resourceTags))
 }
 
 // TestTcaplusClusterSchema validates the new schema fields.
@@ -685,12 +876,12 @@ func TestTcaplusClusterSchema(t *testing.T) {
 
 	resourceTagsField, ok := res.Schema["resource_tags"]
 	assert.True(t, ok, "resource_tags should exist in schema")
-	assert.Equal(t, schema.TypeList, resourceTagsField.Type)
+	assert.Equal(t, schema.TypeSet, resourceTagsField.Type)
 	assert.True(t, resourceTagsField.Optional)
 
 	serverListField, ok := res.Schema["server_list"]
 	assert.True(t, ok, "server_list should exist in schema")
-	assert.Equal(t, schema.TypeList, serverListField.Type)
+	assert.Equal(t, schema.TypeSet, serverListField.Type)
 	assert.True(t, serverListField.Optional)
 	assert.True(t, serverListField.Computed)
 
@@ -699,12 +890,10 @@ func TestTcaplusClusterSchema(t *testing.T) {
 	assert.True(t, ok, "machine_type should exist in server_list schema")
 	_, ok = serverSchema["machine_num"]
 	assert.True(t, ok, "machine_num should exist in server_list schema")
-	_, ok = serverSchema["server_uid"]
-	assert.True(t, ok, "server_uid should exist in server_list schema")
 
 	proxyListField, ok := res.Schema["proxy_list"]
 	assert.True(t, ok, "proxy_list should exist in schema")
-	assert.Equal(t, schema.TypeList, proxyListField.Type)
+	assert.Equal(t, schema.TypeSet, proxyListField.Type)
 	assert.True(t, proxyListField.Optional)
 	assert.True(t, proxyListField.Computed)
 
@@ -713,6 +902,4 @@ func TestTcaplusClusterSchema(t *testing.T) {
 	assert.True(t, ok, "machine_type should exist in proxy_list schema")
 	_, ok = proxySchema["machine_num"]
 	assert.True(t, ok, "machine_num should exist in proxy_list schema")
-	_, ok = proxySchema["proxy_uid"]
-	assert.True(t, ok, "proxy_uid should exist in proxy_list schema")
 }

--- a/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster_test.go
+++ b/tencentcloud/services/tcaplusdb/resource_tc_tcaplus_cluster_test.go
@@ -6,12 +6,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	tcaplusdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tcaplusdb/v20190823"
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
 	svctcaplusdb "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/tcaplusdb"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 var testTcaplusClusterResourceName = "tencentcloud_tcaplus_cluster"
@@ -178,3 +182,537 @@ resource "tencentcloud_tcaplus_cluster" "test_cluster" {
   old_password_expire_last = 300
 }
 `
+
+// ---- gomonkey-based unit tests for tcaplus_cluster new parameters ----
+
+type mockMetaTcaplusCluster struct {
+	client *connectivity.TencentCloudClient
+}
+
+var _ tccommon.ProviderMeta = &mockMetaTcaplusCluster{}
+
+func (m *mockMetaTcaplusCluster) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+func newMockMetaTcaplusCluster() *mockMetaTcaplusCluster {
+	return &mockMetaTcaplusCluster{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringTcaplusCluster(s string) *string {
+	return &s
+}
+
+func ptrInt64TcaplusCluster(i int64) *int64 {
+	return &i
+}
+
+func resourceTagsTcaplusClusterRaw() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"tag_key":   "env",
+			"tag_value": "prod",
+		},
+		map[string]interface{}{
+			"tag_key":   "owner",
+			"tag_value": "terraform",
+		},
+	}
+}
+
+func serverListTcaplusClusterRaw() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"machine_type": "S5.LARGE8",
+			"machine_num":  2,
+		},
+	}
+}
+
+func proxyListTcaplusClusterRaw() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"machine_type": "S5.LARGE8",
+			"machine_num":  1,
+		},
+	}
+}
+
+// TestTcaplusClusterDedicatedCreate verifies cluster_type, resource_tags, server_list, proxy_list are passed to CreateCluster.
+func TestTcaplusClusterDedicatedCreate(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tcaplusClient := &tcaplusdb.Client{}
+	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
+
+	var capturedRequest *tcaplusdb.CreateClusterRequest
+	patches.ApplyMethodFunc(tcaplusClient, "CreateCluster", func(request *tcaplusdb.CreateClusterRequest) (*tcaplusdb.CreateClusterResponse, error) {
+		capturedRequest = request
+		resp := tcaplusdb.NewCreateClusterResponse()
+		resp.Response = &tcaplusdb.CreateClusterResponseParams{
+			ClusterId: ptrStringTcaplusCluster("1910000000"),
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+		resp := tcaplusdb.NewDescribeClustersResponse()
+		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
+			TotalCount: ptrInt64TcaplusCluster(1),
+			Clusters: []*tcaplusdb.ClusterInfo{
+				{
+					ClusterId:      ptrStringTcaplusCluster("1910000000"),
+					ClusterName:    ptrStringTcaplusCluster("tf_dedicated_cluster"),
+					IdlType:        ptrStringTcaplusCluster("PROTO"),
+					VpcId:          ptrStringTcaplusCluster("vpc-xxx"),
+					SubnetId:       ptrStringTcaplusCluster("subnet-xxx"),
+					NetworkType:    ptrStringTcaplusCluster("ccnz"),
+					CreatedTime:    ptrStringTcaplusCluster("2025-01-01 00:00:00"),
+					PasswordStatus: ptrStringTcaplusCluster("modifiable"),
+					ApiAccessId:    ptrStringTcaplusCluster("access-id"),
+					ApiAccessIp:    ptrStringTcaplusCluster("1.2.3.4"),
+					ApiAccessPort:  ptrInt64TcaplusCluster(9999),
+					ClusterType:    ptrInt64TcaplusCluster(2),
+					ServerList: []*tcaplusdb.ServerDetailInfo{
+						{
+							ServerUid:   ptrStringTcaplusCluster("server-uid-1"),
+							MachineType: ptrStringTcaplusCluster("S5.LARGE8"),
+							MemoryRate:  ptrInt64TcaplusCluster(50),
+							DiskRate:    ptrInt64TcaplusCluster(60),
+							ReadNum:     ptrInt64TcaplusCluster(100),
+							WriteNum:    ptrInt64TcaplusCluster(200),
+							Version:     ptrStringTcaplusCluster("3.5.0"),
+						},
+					},
+					ProxyList: []*tcaplusdb.ProxyDetailInfo{
+						{
+							ProxyUid:            ptrStringTcaplusCluster("proxy-uid-1"),
+							MachineType:         ptrStringTcaplusCluster("S5.LARGE8"),
+							ProcessSpeed:        ptrInt64TcaplusCluster(1000),
+							AverageProcessDelay: ptrInt64TcaplusCluster(5),
+							SlowProcessSpeed:    ptrInt64TcaplusCluster(10),
+							Version:             ptrStringTcaplusCluster("3.5.0"),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTcaplusCluster()
+	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"idl_type":      "PROTO",
+		"cluster_name":  "tf_dedicated_cluster",
+		"vpc_id":        "vpc-xxx",
+		"subnet_id":     "subnet-xxx",
+		"password":      "1qaA2k1wgvfa3ZZZ",
+		"cluster_type":  2,
+		"resource_tags": resourceTagsTcaplusClusterRaw(),
+		"server_list":   serverListTcaplusClusterRaw(),
+		"proxy_list":    proxyListTcaplusClusterRaw(),
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "1910000000", d.Id())
+
+	assert.NotNil(t, capturedRequest.ClusterType)
+	assert.Equal(t, int64(2), *capturedRequest.ClusterType)
+
+	assert.NotNil(t, capturedRequest.ResourceTags)
+	assert.Equal(t, 2, len(capturedRequest.ResourceTags))
+	assert.Equal(t, "env", *capturedRequest.ResourceTags[0].TagKey)
+	assert.Equal(t, "prod", *capturedRequest.ResourceTags[0].TagValue)
+	assert.Equal(t, "owner", *capturedRequest.ResourceTags[1].TagKey)
+	assert.Equal(t, "terraform", *capturedRequest.ResourceTags[1].TagValue)
+
+	assert.NotNil(t, capturedRequest.ServerList)
+	assert.Equal(t, 1, len(capturedRequest.ServerList))
+	assert.Equal(t, "S5.LARGE8", *capturedRequest.ServerList[0].MachineType)
+	assert.Equal(t, int64(2), *capturedRequest.ServerList[0].MachineNum)
+
+	assert.NotNil(t, capturedRequest.ProxyList)
+	assert.Equal(t, 1, len(capturedRequest.ProxyList))
+	assert.Equal(t, "S5.LARGE8", *capturedRequest.ProxyList[0].MachineType)
+	assert.Equal(t, int64(1), *capturedRequest.ProxyList[0].MachineNum)
+
+	clusterType := d.Get("cluster_type").(int)
+	assert.Equal(t, 2, clusterType)
+
+	serverList := d.Get("server_list").([]interface{})
+	assert.Equal(t, 1, len(serverList))
+	serverMap := serverList[0].(map[string]interface{})
+	assert.Equal(t, "server-uid-1", serverMap["server_uid"].(string))
+	assert.Equal(t, "S5.LARGE8", serverMap["machine_type"].(string))
+	assert.Equal(t, 50, serverMap["memory_rate"].(int))
+	assert.Equal(t, 60, serverMap["disk_rate"].(int))
+	assert.Equal(t, 100, serverMap["read_num"].(int))
+	assert.Equal(t, 200, serverMap["write_num"].(int))
+	assert.Equal(t, "3.5.0", serverMap["version"].(string))
+
+	proxyList := d.Get("proxy_list").([]interface{})
+	assert.Equal(t, 1, len(proxyList))
+	proxyMap := proxyList[0].(map[string]interface{})
+	assert.Equal(t, "proxy-uid-1", proxyMap["proxy_uid"].(string))
+	assert.Equal(t, "S5.LARGE8", proxyMap["machine_type"].(string))
+	assert.Equal(t, 1000, proxyMap["process_speed"].(int))
+	assert.Equal(t, 5, proxyMap["average_process_delay"].(int))
+	assert.Equal(t, 10, proxyMap["slow_process_speed"].(int))
+	assert.Equal(t, "3.5.0", proxyMap["version"].(string))
+}
+
+// TestTcaplusClusterSharedCreateDefault verifies new params are not sent when not specified.
+func TestTcaplusClusterSharedCreateDefault(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tcaplusClient := &tcaplusdb.Client{}
+	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
+
+	var capturedRequest *tcaplusdb.CreateClusterRequest
+	patches.ApplyMethodFunc(tcaplusClient, "CreateCluster", func(request *tcaplusdb.CreateClusterRequest) (*tcaplusdb.CreateClusterResponse, error) {
+		capturedRequest = request
+		resp := tcaplusdb.NewCreateClusterResponse()
+		resp.Response = &tcaplusdb.CreateClusterResponseParams{
+			ClusterId: ptrStringTcaplusCluster("1910000001"),
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+		resp := tcaplusdb.NewDescribeClustersResponse()
+		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
+			TotalCount: ptrInt64TcaplusCluster(1),
+			Clusters: []*tcaplusdb.ClusterInfo{
+				{
+					ClusterId:      ptrStringTcaplusCluster("1910000001"),
+					ClusterName:    ptrStringTcaplusCluster("tf_shared_cluster"),
+					IdlType:        ptrStringTcaplusCluster("PROTO"),
+					VpcId:          ptrStringTcaplusCluster("vpc-xxx"),
+					SubnetId:       ptrStringTcaplusCluster("subnet-xxx"),
+					NetworkType:    ptrStringTcaplusCluster("ccnz"),
+					CreatedTime:    ptrStringTcaplusCluster("2025-01-01 00:00:00"),
+					PasswordStatus: ptrStringTcaplusCluster("modifiable"),
+					ApiAccessId:    ptrStringTcaplusCluster("access-id"),
+					ApiAccessIp:    ptrStringTcaplusCluster("1.2.3.4"),
+					ApiAccessPort:  ptrInt64TcaplusCluster(9999),
+					ClusterType:    ptrInt64TcaplusCluster(1),
+				},
+			},
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTcaplusCluster()
+	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"idl_type":     "PROTO",
+		"cluster_name": "tf_shared_cluster",
+		"vpc_id":       "vpc-xxx",
+		"subnet_id":    "subnet-xxx",
+		"password":     "1qaA2k1wgvfa3ZZZ",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+
+	assert.Nil(t, capturedRequest.ClusterType)
+	assert.Nil(t, capturedRequest.ResourceTags)
+	assert.Nil(t, capturedRequest.ServerList)
+	assert.Nil(t, capturedRequest.ProxyList)
+
+	clusterType := d.Get("cluster_type").(int)
+	assert.Equal(t, 1, clusterType)
+}
+
+// TestTcaplusClusterReadServerListNil verifies Read does not panic when ServerList fields are nil.
+func TestTcaplusClusterReadServerListNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tcaplusClient := &tcaplusdb.Client{}
+	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+		resp := tcaplusdb.NewDescribeClustersResponse()
+		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
+			TotalCount: ptrInt64TcaplusCluster(1),
+			Clusters: []*tcaplusdb.ClusterInfo{
+				{
+					ClusterId:      ptrStringTcaplusCluster("1910000002"),
+					ClusterName:    ptrStringTcaplusCluster("tf_nil_cluster"),
+					IdlType:        ptrStringTcaplusCluster("PROTO"),
+					VpcId:          ptrStringTcaplusCluster("vpc-xxx"),
+					SubnetId:       ptrStringTcaplusCluster("subnet-xxx"),
+					NetworkType:    ptrStringTcaplusCluster("ccnz"),
+					CreatedTime:    ptrStringTcaplusCluster("2025-01-01 00:00:00"),
+					PasswordStatus: ptrStringTcaplusCluster("modifiable"),
+					ApiAccessId:    ptrStringTcaplusCluster("access-id"),
+					ApiAccessIp:    ptrStringTcaplusCluster("1.2.3.4"),
+					ApiAccessPort:  ptrInt64TcaplusCluster(9999),
+					ClusterType:    ptrInt64TcaplusCluster(2),
+					ServerList: []*tcaplusdb.ServerDetailInfo{
+						{
+							ServerUid:   ptrStringTcaplusCluster("server-uid-nil"),
+							MachineType: ptrStringTcaplusCluster("S5.LARGE8"),
+						},
+					},
+					ProxyList: []*tcaplusdb.ProxyDetailInfo{
+						{
+							ProxyUid:    ptrStringTcaplusCluster("proxy-uid-nil"),
+							MachineType: ptrStringTcaplusCluster("S5.LARGE8"),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTcaplusCluster()
+	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"idl_type":     "PROTO",
+		"cluster_name": "tf_nil_cluster",
+		"vpc_id":       "vpc-xxx",
+		"subnet_id":    "subnet-xxx",
+		"password":     "1qaA2k1wgvfa3ZZZ",
+		"cluster_type": 2,
+		"server_list":  serverListTcaplusClusterRaw(),
+		"proxy_list":   proxyListTcaplusClusterRaw(),
+	})
+	d.SetId("1910000002")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	clusterType := d.Get("cluster_type").(int)
+	assert.Equal(t, 2, clusterType)
+
+	serverList := d.Get("server_list").([]interface{})
+	assert.Equal(t, 1, len(serverList))
+	serverMap := serverList[0].(map[string]interface{})
+	assert.Equal(t, "server-uid-nil", serverMap["server_uid"].(string))
+	assert.Equal(t, "S5.LARGE8", serverMap["machine_type"].(string))
+	assert.Equal(t, 0, serverMap["memory_rate"].(int))
+	assert.Equal(t, 0, serverMap["disk_rate"].(int))
+	assert.Equal(t, 0, serverMap["read_num"].(int))
+	assert.Equal(t, 0, serverMap["write_num"].(int))
+	assert.Equal(t, "", serverMap["version"].(string))
+
+	proxyList := d.Get("proxy_list").([]interface{})
+	assert.Equal(t, 1, len(proxyList))
+	proxyMap := proxyList[0].(map[string]interface{})
+	assert.Equal(t, "proxy-uid-nil", proxyMap["proxy_uid"].(string))
+	assert.Equal(t, "S5.LARGE8", proxyMap["machine_type"].(string))
+	assert.Equal(t, 0, proxyMap["process_speed"].(int))
+	assert.Equal(t, 0, proxyMap["average_process_delay"].(int))
+	assert.Equal(t, 0, proxyMap["slow_process_speed"].(int))
+	assert.Equal(t, "", proxyMap["version"].(string))
+}
+
+// TestTcaplusClusterReadProxyListNil verifies Read handles nil ProxyList fields gracefully.
+func TestTcaplusClusterReadProxyListNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tcaplusClient := &tcaplusdb.Client{}
+	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+		resp := tcaplusdb.NewDescribeClustersResponse()
+		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
+			TotalCount: ptrInt64TcaplusCluster(1),
+			Clusters: []*tcaplusdb.ClusterInfo{
+				{
+					ClusterId:   ptrStringTcaplusCluster("1910000003"),
+					ClusterName: ptrStringTcaplusCluster("tf_proxy_nil"),
+					IdlType:     ptrStringTcaplusCluster("PROTO"),
+					VpcId:       ptrStringTcaplusCluster("vpc-xxx"),
+					SubnetId:    ptrStringTcaplusCluster("subnet-xxx"),
+					ClusterType: ptrInt64TcaplusCluster(2),
+					ProxyList: []*tcaplusdb.ProxyDetailInfo{
+						{
+							ProxyUid: ptrStringTcaplusCluster("proxy-uid-only"),
+						},
+					},
+				},
+			},
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTcaplusCluster()
+	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"idl_type":     "PROTO",
+		"cluster_name": "tf_proxy_nil",
+		"vpc_id":       "vpc-xxx",
+		"subnet_id":    "subnet-xxx",
+		"password":     "1qaA2k1wgvfa3ZZZ",
+		"cluster_type": 2,
+	})
+	d.SetId("1910000003")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	proxyList := d.Get("proxy_list").([]interface{})
+	assert.Equal(t, 1, len(proxyList))
+	proxyMap := proxyList[0].(map[string]interface{})
+	assert.Equal(t, "proxy-uid-only", proxyMap["proxy_uid"].(string))
+	assert.Equal(t, "", proxyMap["machine_type"].(string))
+	assert.Equal(t, 0, proxyMap["process_speed"].(int))
+	assert.Equal(t, 0, proxyMap["average_process_delay"].(int))
+	assert.Equal(t, 0, proxyMap["slow_process_speed"].(int))
+	assert.Equal(t, "", proxyMap["version"].(string))
+}
+
+// TestTcaplusClusterImmutableReject verifies Update rejects changes to immutable args.
+func TestTcaplusClusterImmutableReject(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tcaplusClient := &tcaplusdb.Client{}
+	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+		resp := tcaplusdb.NewDescribeClustersResponse()
+		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
+			TotalCount: ptrInt64TcaplusCluster(1),
+			Clusters: []*tcaplusdb.ClusterInfo{
+				{
+					ClusterId:   ptrStringTcaplusCluster("1910000004"),
+					ClusterName: ptrStringTcaplusCluster("tf_immutable"),
+					IdlType:     ptrStringTcaplusCluster("PROTO"),
+					VpcId:       ptrStringTcaplusCluster("vpc-xxx"),
+					SubnetId:    ptrStringTcaplusCluster("subnet-xxx"),
+					ClusterType: ptrInt64TcaplusCluster(2),
+				},
+			},
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTcaplusCluster()
+	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"idl_type":     "PROTO",
+		"cluster_name": "tf_immutable",
+		"vpc_id":       "vpc-xxx",
+		"subnet_id":    "subnet-xxx",
+		"password":     "1qaA2k1wgvfa3ZZZ",
+		"cluster_type": 1,
+	})
+	d.SetId("1910000004")
+
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		return key == "cluster_type"
+	})
+
+	err := res.Update(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster_type")
+	assert.Contains(t, err.Error(), "cannot be changed")
+}
+
+// TestTcaplusClusterImmutableRejectServerList verifies Update rejects changes to server_list.
+func TestTcaplusClusterImmutableRejectServerList(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	tcaplusClient := &tcaplusdb.Client{}
+	patches.ApplyMethodReturn(newMockMetaTcaplusCluster().client, "UseTcaplusClient", tcaplusClient)
+
+	patches.ApplyMethodFunc(tcaplusClient, "DescribeClusters", func(request *tcaplusdb.DescribeClustersRequest) (*tcaplusdb.DescribeClustersResponse, error) {
+		resp := tcaplusdb.NewDescribeClustersResponse()
+		resp.Response = &tcaplusdb.DescribeClustersResponseParams{
+			TotalCount: ptrInt64TcaplusCluster(1),
+			Clusters: []*tcaplusdb.ClusterInfo{
+				{
+					ClusterId:   ptrStringTcaplusCluster("1910000005"),
+					ClusterName: ptrStringTcaplusCluster("tf_immutable_sl"),
+					IdlType:     ptrStringTcaplusCluster("PROTO"),
+					VpcId:       ptrStringTcaplusCluster("vpc-xxx"),
+					SubnetId:    ptrStringTcaplusCluster("subnet-xxx"),
+				},
+			},
+			RequestId: ptrStringTcaplusCluster("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaTcaplusCluster()
+	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"idl_type":     "PROTO",
+		"cluster_name": "tf_immutable_sl",
+		"vpc_id":       "vpc-xxx",
+		"subnet_id":    "subnet-xxx",
+		"password":     "1qaA2k1wgvfa3ZZZ",
+	})
+	d.SetId("1910000005")
+
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		return key == "server_list"
+	})
+
+	err := res.Update(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "server_list")
+	assert.Contains(t, err.Error(), "cannot be changed")
+}
+
+// TestTcaplusClusterSchema validates the new schema fields.
+func TestTcaplusClusterSchema(t *testing.T) {
+	res := svctcaplusdb.ResourceTencentCloudTcaplusCluster()
+
+	clusterTypeField, ok := res.Schema["cluster_type"]
+	assert.True(t, ok, "cluster_type should exist in schema")
+	assert.Equal(t, schema.TypeInt, clusterTypeField.Type)
+	assert.True(t, clusterTypeField.Optional)
+	assert.True(t, clusterTypeField.Computed)
+
+	resourceTagsField, ok := res.Schema["resource_tags"]
+	assert.True(t, ok, "resource_tags should exist in schema")
+	assert.Equal(t, schema.TypeList, resourceTagsField.Type)
+	assert.True(t, resourceTagsField.Optional)
+
+	serverListField, ok := res.Schema["server_list"]
+	assert.True(t, ok, "server_list should exist in schema")
+	assert.Equal(t, schema.TypeList, serverListField.Type)
+	assert.True(t, serverListField.Optional)
+	assert.True(t, serverListField.Computed)
+
+	serverSchema := serverListField.Elem.(*schema.Resource).Schema
+	_, ok = serverSchema["machine_type"]
+	assert.True(t, ok, "machine_type should exist in server_list schema")
+	_, ok = serverSchema["machine_num"]
+	assert.True(t, ok, "machine_num should exist in server_list schema")
+	_, ok = serverSchema["server_uid"]
+	assert.True(t, ok, "server_uid should exist in server_list schema")
+
+	proxyListField, ok := res.Schema["proxy_list"]
+	assert.True(t, ok, "proxy_list should exist in schema")
+	assert.Equal(t, schema.TypeList, proxyListField.Type)
+	assert.True(t, proxyListField.Optional)
+	assert.True(t, proxyListField.Computed)
+
+	proxySchema := proxyListField.Elem.(*schema.Resource).Schema
+	_, ok = proxySchema["machine_type"]
+	assert.True(t, ok, "machine_type should exist in proxy_list schema")
+	_, ok = proxySchema["machine_num"]
+	assert.True(t, ok, "machine_num should exist in proxy_list schema")
+	_, ok = proxySchema["proxy_uid"]
+	assert.True(t, ok, "proxy_uid should exist in proxy_list schema")
+}

--- a/tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go
+++ b/tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go
@@ -29,7 +29,7 @@ type TcaplusService struct {
 	client *connectivity.TencentCloudClient
 }
 
-func (me *TcaplusService) CreateCluster(ctx context.Context, idlType, clusterName, vpcId, subnetId, password string) (id string, errRet error) {
+func (me *TcaplusService) CreateCluster(ctx context.Context, idlType, clusterName, vpcId, subnetId, password string, resourceTags []*tcaplusdb.TagInfoUnit, serverList []*tcaplusdb.MachineInfo, proxyList []*tcaplusdb.MachineInfo, clusterType int64) (id string, errRet error) {
 	logId := tccommon.GetLogId(ctx)
 	request := tcaplusdb.NewCreateClusterRequest()
 	defer func() {
@@ -42,6 +42,18 @@ func (me *TcaplusService) CreateCluster(ctx context.Context, idlType, clusterNam
 	request.SubnetId = &subnetId
 	request.IdlType = &idlType
 	request.ClusterName = &clusterName
+	if len(resourceTags) > 0 {
+		request.ResourceTags = resourceTags
+	}
+	if len(serverList) > 0 {
+		request.ServerList = serverList
+	}
+	if len(proxyList) > 0 {
+		request.ProxyList = proxyList
+	}
+	if clusterType > 0 {
+		request.ClusterType = &clusterType
+	}
 	ratelimit.Check(request.GetAction())
 	response, err := me.client.UseTcaplusClient().CreateCluster(request)
 	if err != nil {

--- a/tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go
+++ b/tencentcloud/services/tcaplusdb/service_tencentcloud_tcaplus.go
@@ -134,18 +134,28 @@ func (me *TcaplusService) DescribeCluster(ctx context.Context, id string) (clust
 		}
 	}()
 	request.ClusterIds = []*string{&id}
-	ratelimit.Check(request.GetAction())
-	response, err := me.client.UseTcaplusClient().DescribeClusters(request)
-	if err != nil {
-		if sdkErr, ok := err.(*sdkError.TencentCloudSDKError); ok {
-			if sdkErr.Code == "ResourceNotFound" {
-				errRet = nil
-				return
+
+	var response *tcaplusdb.DescribeClustersResponse
+	retryErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, e := me.client.UseTcaplusClient().DescribeClustersWithContext(ctx, request)
+		if e != nil {
+			if sdkErr, ok := e.(*sdkError.TencentCloudSDKError); ok {
+				if sdkErr.Code == "ResourceNotFound" {
+					return nil
+				}
 			}
+			return tccommon.RetryError(e)
 		}
-		errRet = err
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		response = result
+		return nil
+	})
+	if retryErr != nil {
+		errRet = retryErr
 		return
 	}
+
 	if response == nil || response.Response == nil {
 		errRet = fmt.Errorf("TencentCloud SDK return nil response,%s", request.GetAction())
 		return
@@ -1066,4 +1076,49 @@ func (me *TcaplusService) DescribeIdlFileInfos(ctx context.Context, clusterId st
 		}
 		offset += limit
 	}
+}
+
+func (me *TcaplusService) DescribeClusterTags(ctx context.Context, clusterId string) (tags []*tcaplusdb.TagInfoUnit, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+	request := tcaplusdb.NewDescribeClusterTagsRequest()
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail,reason[%s]", logId, request.GetAction(), errRet.Error())
+		}
+	}()
+
+	request.ClusterIds = []*string{&clusterId}
+
+	var response *tcaplusdb.DescribeClusterTagsResponse
+	retryErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, e := me.client.UseTcaplusClient().DescribeClusterTagsWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		response = result
+		return nil
+	})
+	if retryErr != nil {
+		errRet = retryErr
+		return
+	}
+
+	if response == nil || response.Response == nil {
+		errRet = fmt.Errorf("TencentCloud SDK return nil response,%s", request.GetAction())
+		return
+	}
+
+	tags = make([]*tcaplusdb.TagInfoUnit, 0)
+	for _, row := range response.Response.Rows {
+		if row == nil || row.ClusterId == nil || *row.ClusterId != clusterId {
+			continue
+		}
+		if row.Tags != nil {
+			tags = append(tags, row.Tags...)
+		}
+	}
+	return
 }

--- a/tencentcloud/services/tke/resource_tc_kubernetes_cluster_extension.go
+++ b/tencentcloud/services/tke/resource_tc_kubernetes_cluster_extension.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -1560,74 +1559,6 @@ func dockerGraphPathDiffSuppressFunc(k, oldValue, newValue string, d *schema.Res
 	}
 }
 
-func clusterCidrValidateFunc(v interface{}, k string) (ws []string, errs []error) {
-	value := v.(string)
-	if value == "" {
-		return
-	}
-	_, ipnet, err := net.ParseCIDR(value)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("%q must contain a valid CIDR, got error parsing: %s", k, err))
-		return
-	}
-	if ipnet == nil || value != ipnet.String() {
-		errs = append(errs, fmt.Errorf("%q must contain a valid network CIDR, expected %q, got %q", k, ipnet, value))
-		return
-	}
-	if !strings.Contains(value, "/") {
-		errs = append(errs, fmt.Errorf("%q must be a network segment", k))
-		return
-	}
-	if !strings.HasPrefix(value, "9.") && !strings.HasPrefix(value, "10.") && !strings.HasPrefix(value, "11.") && !strings.HasPrefix(value, "192.168.") && !strings.HasPrefix(value, "172.") {
-		errs = append(errs, fmt.Errorf("%q must in 9. | 10. | 11. | 192.168. | 172.[16-31]", k))
-		return
-	}
-
-	if strings.HasPrefix(value, "172.") {
-		nextNo := strings.Split(value, ".")[1]
-		no, _ := strconv.ParseInt(nextNo, 10, 64)
-		if no < 16 || no > 31 {
-			errs = append(errs, fmt.Errorf("%q must in 9.0 | 10. | 11. | 192.168. | 172.[16-31]", k))
-			return
-		}
-	}
-	return
-}
-
-func serviceCidrValidateFunc(v interface{}, k string) (ws []string, errs []error) {
-	value := v.(string)
-	if value == "" {
-		return
-	}
-	_, ipnet, err := net.ParseCIDR(value)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("%q must contain a valid CIDR, got error parsing: %s", k, err))
-		return
-	}
-	if ipnet == nil || value != ipnet.String() {
-		errs = append(errs, fmt.Errorf("%q must contain a valid network CIDR, expected %q, got %q", k, ipnet, value))
-		return
-	}
-	if !strings.Contains(value, "/") {
-		errs = append(errs, fmt.Errorf("%q must be a network segment", k))
-		return
-	}
-	if !strings.HasPrefix(value, "9.") && !strings.HasPrefix(value, "10.") && !strings.HasPrefix(value, "192.168.") && !strings.HasPrefix(value, "172.") {
-		errs = append(errs, fmt.Errorf("%q must in 9. | 10. | 192.168. | 172.[16-31]", k))
-		return
-	}
-
-	if strings.HasPrefix(value, "172.") {
-		nextNo := strings.Split(value, ".")[1]
-		no, _ := strconv.ParseInt(nextNo, 10, 64)
-		if no < 16 || no > 31 {
-			errs = append(errs, fmt.Errorf("%q must in 9. | 10. | 192.168. | 172.[16-31]", k))
-			return
-		}
-	}
-	return
-}
-
 func claimExpiredSecondsValidateFunc(v interface{}, k string) (ws []string, errs []error) {
 	value := v.(int)
 	if value < 300 || value > 15768000 {
@@ -2398,36 +2329,6 @@ func checkClusterEndpointStatus(ctx context.Context, service *TkeService, d *sch
 		}
 	}
 	return nil
-}
-
-func tkeCvmState() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"instance_id": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "ID of the cvm.",
-		},
-		"instance_role": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Role of the cvm.",
-		},
-		"instance_state": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "State of the cvm.",
-		},
-		"failed_reason": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Information of the cvm when it is failed.",
-		},
-		"lan_ip": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "LAN IP of the cvm.",
-		},
-	}
 }
 
 //func tkeSecurityInfo() map[string]*schema.Schema {

--- a/website/docs/r/tcaplus_cluster.html.markdown
+++ b/website/docs/r/tcaplus_cluster.html.markdown
@@ -4,87 +4,59 @@ layout: "tencentcloud"
 page_title: "TencentCloud: tencentcloud_tcaplus_cluster"
 sidebar_current: "docs-tencentcloud-resource-tcaplus_cluster"
 description: |-
-  Use this resource to create TcaplusDB cluster.
+  Provides a resource to create a TcaplusDB cluster.
 ---
 
 # tencentcloud_tcaplus_cluster
 
-Use this resource to create TcaplusDB cluster.
+Provides a resource to create a TcaplusDB cluster.
 
-~> **NOTE:** TcaplusDB now only supports the following regions: `ap-shanghai,ap-hongkong,na-siliconvalley,ap-singapore,ap-seoul,ap-tokyo,eu-frankfurt, and na-ashburn`.
+~> **NOTE:** TcaplusDB now only supports the following regions: `ap-shanghai`, `ap-hongkong`, `na-siliconvalley`, `ap-singapore`, `ap-seoul`, `ap-tokyo`, `eu-frankfurt`, `and na-ashburn`.
 
 ## Example Usage
 
-### Create a new tcaplus cluster instance
+### Create a tcaplus cluster instance with cluster_type is 1
 
 ```hcl
-locals {
-  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
-  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
-}
-
-variable "availability_zone" {
-  default = "ap-guangzhou-3"
-}
-
-data "tencentcloud_vpc_subnets" "vpc" {
-  is_default        = true
-  availability_zone = var.availability_zone
-}
-
 resource "tencentcloud_tcaplus_cluster" "example" {
-  idl_type                 = "PROTO"
-  cluster_name             = "tf_example_tcaplus_cluster"
-  vpc_id                   = local.vpc_id
-  subnet_id                = local.subnet_id
-  password                 = "your_pw_123111"
+  idl_type                 = "MIX"
+  cluster_name             = "tf_example"
+  vpc_id                   = "vpc-jll1dzwr"
+  subnet_id                = "subnet-ef14ogeu"
+  password                 = "Password@2026"
   old_password_expire_last = 3600
+  cluster_type             = 1
+  resource_tags {
+    tag_key   = "createBy"
+    tag_value = "Terraform"
+  }
 }
 ```
 
-### Create a dedicated tcaplus cluster instance with resource tags, server list and proxy list
+### Create a tcaplus cluster instance with cluster_type is 2
 
 ```hcl
-locals {
-  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
-  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
-}
-
-variable "availability_zone" {
-  default = "ap-guangzhou-3"
-}
-
-data "tencentcloud_vpc_subnets" "vpc" {
-  is_default        = true
-  availability_zone = var.availability_zone
-}
-
-resource "tencentcloud_tcaplus_cluster" "dedicated_example" {
-  idl_type     = "PROTO"
-  cluster_name = "tf_example_dedicated_cluster"
-  vpc_id       = local.vpc_id
-  subnet_id    = local.subnet_id
-  password     = "your_pw_123111"
-  cluster_type = 2
-
-  resource_tags {
-    tag_key   = "env"
-    tag_value = "prod"
-  }
-
-  resource_tags {
-    tag_key   = "owner"
-    tag_value = "terraform"
-  }
-
+resource "tencentcloud_tcaplus_cluster" "example" {
+  idl_type                 = "MIX"
+  cluster_name             = "tf_example"
+  vpc_id                   = "vpc-qtzga3pm"
+  subnet_id                = "subnet-c063n9el"
+  password                 = "Password@2026"
+  old_password_expire_last = 3600
+  cluster_type             = 2
   server_list {
-    machine_type = "S5.LARGE8"
-    machine_num  = 2
+    machine_type = "T1"
+    machine_num  = 4
   }
 
   proxy_list {
-    machine_type = "S5.LARGE8"
-    machine_num  = 1
+    machine_type = "T1"
+    machine_num  = 2
+  }
+
+  resource_tags {
+    tag_key   = "createBy"
+    tag_value = "Terraform"
   }
 }
 ```
@@ -93,40 +65,41 @@ resource "tencentcloud_tcaplus_cluster" "dedicated_example" {
 
 The following arguments are supported:
 
-* `cluster_name` - (Required, String) Name of the TcaplusDB cluster. Name length should be between 1 and 30.
-* `idl_type` - (Required, String, ForceNew) IDL type of the TcaplusDB cluster. Valid values: `PROTO` and `TDR`.
-* `password` - (Required, String) Password of the TcaplusDB cluster. Password length should be between 12 and 16. The password must be a *mix* of uppercase letters (A-Z), lowercase *letters* (a-z) and *numbers* (0-9).
-* `subnet_id` - (Required, String, ForceNew) Subnet id of the TcaplusDB cluster.
-* `vpc_id` - (Required, String, ForceNew) VPC id of the TcaplusDB cluster.
-* `cluster_type` - (Optional, Int) Cluster type of the TcaplusDB cluster. `1`: shared cluster, `2`: dedicated cluster. This parameter is only valid for CreateCluster API and cannot be modified once set.
+* `cluster_name` - (Required, String) Cluster name, Chinese or English characters can be used, maximum length is 32 characters.
+* `idl_type` - (Required, String, ForceNew) Cluster data description language type, uniformly filled with `MIX`, enumeration value: `MIX`: supports both `PROTO` and `TDR` tables.
+* `password` - (Required, String) Cluster access password, must be `a-zA-Z0-9` characters, and must contain numbers, uppercase and lowercase letters.
+* `subnet_id` - (Required, String, ForceNew) The subnet instance ID bound to the cluster, such as: `subnet-pxir56ns`.
+* `vpc_id` - (Required, String, ForceNew) The private network instance ID bound to the cluster, such as: `vpc-f49l6u0z`.
+* `cluster_type` - (Optional, Int) Cluster type: `1` shared, `2` dedicated.
 * `old_password_expire_last` - (Optional, Int) Expiration time of old password after password update, unit: second.
-* `proxy_list` - (Optional, List) Dedicated proxy machine list of the TcaplusDB cluster. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`. This parameter is only valid for CreateCluster API and cannot be modified once set.
-* `resource_tags` - (Optional, List) Resource tags of the TcaplusDB cluster. This parameter is only valid for CreateCluster API and cannot be modified once set. Note: This field is write-only and will not be refreshed on Read because the DescribeClusters API does not return cluster-level tags.
-* `server_list` - (Optional, List) Dedicated server machine list of the TcaplusDB cluster. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`. This parameter is only valid for CreateCluster API and cannot be modified once set.
+* `proxy_list` - (Optional, Set) Dedicated cluster occupied proxy machines. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`.
+* `resource_tags` - (Optional, Set) Cluster tag set. Note: this field cannot be modified after cluster creation via CreateCluster, but can be modified via ModifyClusterTags. Tags will be refreshed on Read via DescribeClusterTags.
+* `server_list` - (Optional, Set) Dedicated cluster occupied svr machines. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`.
 
 The `proxy_list` object supports the following:
 
-* `machine_num` - (Optional, Int) 
-* `machine_type` - (Optional, String) 
+* `machine_num` - (Optional, Int) Machine quantity.
+* `machine_type` - (Optional, String) Machine type.
 
 The `resource_tags` object supports the following:
 
-* `tag_key` - (Required, String) 
-* `tag_value` - (Optional, String) 
+* `tag_key` - (Required, String) Tag key.
+* `tag_value` - (Optional, String) Tag value.
 
 The `server_list` object supports the following:
 
-* `machine_num` - (Optional, Int) 
-* `machine_type` - (Optional, String) 
+* `machine_num` - (Optional, Int) Machine quantity.
+* `machine_type` - (Optional, String) Machine type.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-* `api_access_id` - Access ID of the TcaplusDB cluster.For TcaplusDB SDK connect.
-* `api_access_ip` - Access IP of the TcaplusDB cluster.For TcaplusDB SDK connect.
-* `api_access_port` - Access port of the TcaplusDB cluster.For TcaplusDB SDK connect.
+* `api_access_id` - Access ID of the TcaplusDB cluster. For TcaplusDB SDK connect.
+* `api_access_ip` - Access IP of the TcaplusDB cluster. For TcaplusDB SDK connect.
+* `api_access_port` - Access port of the TcaplusDB cluster. For TcaplusDB SDK connect.
+* `cluster_id` - Cluster ID.
 * `create_time` - Create time of the TcaplusDB cluster.
 * `network_type` - Network type of the TcaplusDB cluster.
 * `old_password_expire_time` - Expiration time of the old password. If `password_status` is `unmodifiable`, it means the old password has not yet expired.
@@ -135,9 +108,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-tcaplus cluster can be imported using the id, e.g.
+TcaplusDB cluster can be imported using the id, e.g.
 
 ```
-$ terraform import tencentcloud_tcaplus_cluster.example cluster_id
+terraform import tencentcloud_tcaplus_cluster.example 35402666774
 ```
 

--- a/website/docs/r/tcaplus_cluster.html.markdown
+++ b/website/docs/r/tcaplus_cluster.html.markdown
@@ -42,6 +42,53 @@ resource "tencentcloud_tcaplus_cluster" "example" {
 }
 ```
 
+### Create a dedicated tcaplus cluster instance with resource tags, server list and proxy list
+
+```hcl
+locals {
+  vpc_id    = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
+  subnet_id = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
+}
+
+variable "availability_zone" {
+  default = "ap-guangzhou-3"
+}
+
+data "tencentcloud_vpc_subnets" "vpc" {
+  is_default        = true
+  availability_zone = var.availability_zone
+}
+
+resource "tencentcloud_tcaplus_cluster" "dedicated_example" {
+  idl_type     = "PROTO"
+  cluster_name = "tf_example_dedicated_cluster"
+  vpc_id       = local.vpc_id
+  subnet_id    = local.subnet_id
+  password     = "your_pw_123111"
+  cluster_type = 2
+
+  resource_tags {
+    tag_key   = "env"
+    tag_value = "prod"
+  }
+
+  resource_tags {
+    tag_key   = "owner"
+    tag_value = "terraform"
+  }
+
+  server_list {
+    machine_type = "S5.LARGE8"
+    machine_num  = 2
+  }
+
+  proxy_list {
+    machine_type = "S5.LARGE8"
+    machine_num  = 1
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -51,7 +98,26 @@ The following arguments are supported:
 * `password` - (Required, String) Password of the TcaplusDB cluster. Password length should be between 12 and 16. The password must be a *mix* of uppercase letters (A-Z), lowercase *letters* (a-z) and *numbers* (0-9).
 * `subnet_id` - (Required, String, ForceNew) Subnet id of the TcaplusDB cluster.
 * `vpc_id` - (Required, String, ForceNew) VPC id of the TcaplusDB cluster.
+* `cluster_type` - (Optional, Int) Cluster type of the TcaplusDB cluster. `1`: shared cluster, `2`: dedicated cluster. This parameter is only valid for CreateCluster API and cannot be modified once set.
 * `old_password_expire_last` - (Optional, Int) Expiration time of old password after password update, unit: second.
+* `proxy_list` - (Optional, List) Dedicated proxy machine list of the TcaplusDB cluster. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`. This parameter is only valid for CreateCluster API and cannot be modified once set.
+* `resource_tags` - (Optional, List) Resource tags of the TcaplusDB cluster. This parameter is only valid for CreateCluster API and cannot be modified once set. Note: This field is write-only and will not be refreshed on Read because the DescribeClusters API does not return cluster-level tags.
+* `server_list` - (Optional, List) Dedicated server machine list of the TcaplusDB cluster. Only valid when `cluster_type` is `2` (dedicated cluster). For creation, each element exposes `machine_type` and `machine_num`. This parameter is only valid for CreateCluster API and cannot be modified once set.
+
+The `proxy_list` object supports the following:
+
+* `machine_num` - (Optional, Int) 
+* `machine_type` - (Optional, String) 
+
+The `resource_tags` object supports the following:
+
+* `tag_key` - (Required, String) 
+* `tag_value` - (Optional, String) 
+
+The `server_list` object supports the following:
+
+* `machine_num` - (Optional, Int) 
+* `machine_type` - (Optional, String) 
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add new parameters (cluster_type, resource_tags, server_list, proxy_list) to the tencentcloud_tcaplus_cluster resource to support creating dedicated TcaplusDB clusters with dedicated server/proxy machines and resource tags at creation time. All new parameters are optional and immutable after creation.