### PR TITLE
feat(teo): add source_version field to teo config group version detail data source

### DIFF
--- a/.changelog/4413.txt
+++ b/.changelog/4413.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/tencentcloud_teo_config_group_version_detail: add `source_version` field to `config_group_version_info` block
+```

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/design.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The `tencentcloud_teo_config_group_version_detail` data source reads version detail for an EdgeOne (TEO) config group via the `DescribeConfigGroupVersionDetail` API. The SDK struct `ConfigGroupVersionInfo` (in `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/models.go`) already defines a `SourceVersion *string` field — the source version ID that the current version was derived from when created. However, the Terraform schema's `config_group_version_info` block omits this field, so the value is never surfaced to users.
+
+**Current state:**
+- Data source file: `tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail.go`
+- The `config_group_version_info` block schema currently defines: `version_id`, `version_number`, `group_id`, `group_type`, `description`, `status`, `create_time`.
+- The Read function maps fields from `respData.ConfigGroupVersionInfo` into a map and sets the `config_group_version_info` list, performing nil-checks before each `set`.
+
+**API behavior analysis:**
+
+| API | SourceVersion in Request | SourceVersion in Response |
+|-----|--------------------------|---------------------------|
+| `DescribeConfigGroupVersionDetail` | N/A (request takes `ZoneId`, `VersionId`) | Yes (`ConfigGroupVersionInfo.SourceVersion *string`) |
+
+`SourceVersion` is a read-only output field; no request parameter changes are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a `source_version` computed field to the `config_group_version_info` block of the `tencentcloud_teo_config_group_version_detail` data source.
+- Map `source_version` from `respData.ConfigGroupVersionInfo.SourceVersion` in the Read function, with a nil-check consistent with the existing pattern.
+- Update the data source `.md` documentation to describe the new field.
+
+**Non-Goals:**
+- Adding `SourceVersion` to any other teo resource or data source.
+- Changing the API request or adding new API calls.
+- Modifying the `config_group_version_info` block's existing fields or their behavior.
+
+## Decisions
+
+### Decision 1: Add `source_version` as a Computed field inside the `config_group_version_info` block
+
+**Rationale:** `SourceVersion` is an output-only field of the `DescribeConfigGroupVersionDetail` response, nested under `ConfigGroupVersionInfo`. The existing schema groups version info fields under a `config_group_version_info` list block; placing `source_version` there keeps the structure consistent with the API response and the existing field mapping. Marking it `Computed: true` (with `Optional: true` to match sibling fields' pattern) reflects that it is populated by the API, not user-supplied.
+
+### Decision 2: Follow the existing nil-check-then-set pattern in Read
+
+**Rationale:** The current Read function checks each field for nil before adding it to the `configGroupVersionInfoMap`. The new `source_version` mapping will follow the same pattern: `if respData.ConfigGroupVersionInfo.SourceVersion != nil { configGroupVersionInfoMap["source_version"] = respData.ConfigGroupVersionInfo.SourceVersion }`. This avoids setting nil pointers into state and matches surrounding code conventions.
+
+### Decision 3: No SDK update required
+
+**Rationale:** The vendored SDK already contains `ConfigGroupVersionInfo.SourceVersion` (models.go line 2034). No `go mod vendor` or dependency bump is needed.
+
+## Risks / Trade-offs
+
+- **[Risk] Field absent in some API responses**: `SourceVersion` may be empty/nil for the initial version of a config group (which has no source).
+  - **Mitigation:** The nil-check before set ensures the field is simply omitted from the map when nil, consistent with all other sibling fields. No error is raised.
+- **[Risk] Backward compatibility**: Adding a computed field to an existing block.
+  - **Mitigation:** Computed-only additive fields are backward compatible; existing configurations and state continue to work unchanged.

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/proposal.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `tencentcloud_teo_config_group_version_detail` data source currently reads the `ConfigGroupVersionInfo` from the `DescribeConfigGroupVersionDetail` API but does not expose the `SourceVersion` field. The SDK struct `ConfigGroupVersionInfo` already includes `SourceVersion` (the source version ID that the current version was derived from), but the Terraform schema omits it, so users cannot retrieve this information through the data source.
+
+## What Changes
+
+- Add a new computed field `source_version` to the `config_group_version_info` block of the `tencentcloud_teo_config_group_version_detail` data source schema, mapping to the cloud API response field `response.ConfigGroupVersionInfo.SourceVersion`.
+- Populate `source_version` in the Read function from the API response when the field is non-nil.
+- Update the data source documentation to describe the new field.
+
+## Capabilities
+
+### New Capabilities
+- `teo-config-group-version-source-version`: Expose the `source_version` field (the source version ID that the config group version was derived from) in the `tencentcloud_teo_config_group_version_detail` data source.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail.go` — add `source_version` schema field to the `config_group_version_info` block and map it from the API response in the Read function
+  - `tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail.md` — update documentation with the new field
+  - `website/docs/d/teo_config_group_version_detail.html.markdown` — generated via `make doc` (not manually edited)
+- **SDK dependency:** No SDK update needed — `ConfigGroupVersionInfo.SourceVersion` already exists in `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/models.go`
+- **Backward compatibility:** fully backward compatible — the new field is Computed only and additive
+- **API constraints:** `SourceVersion` is a read-only output field of `DescribeConfigGroupVersionDetail`; no API request changes required

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/specs/teo-config-group-version-source-version/spec.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/specs/teo-config-group-version-source-version/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Source version field in config group version detail data source
+The `tencentcloud_teo_config_group_version_detail` data source SHALL expose a `source_version` computed field within the `config_group_version_info` block, mapping to the cloud API response field `response.ConfigGroupVersionInfo.SourceVersion` of the `DescribeConfigGroupVersionDetail` API. The field represents the source version ID that the config group version was derived from.
+
+#### Scenario: Read config group version detail with source version populated
+- **WHEN** the provider reads a `tencentcloud_teo_config_group_version_detail` data source and the `DescribeConfigGroupVersionDetail` API returns a non-nil `ConfigGroupVersionInfo.SourceVersion`
+- **THEN** the provider SHALL populate `config_group_version_info.0.source_version` in state with the value of `ConfigGroupVersionInfo.SourceVersion`
+
+#### Scenario: Read config group version detail with source version nil
+- **WHEN** the provider reads a `tencentcloud_teo_config_group_version_detail` data source and the `DescribeConfigGroupVersionDetail` API returns a nil `ConfigGroupVersionInfo.SourceVersion` (e.g., the initial version with no source)
+- **THEN** the provider SHALL NOT set `source_version` into state (omit the field from the map), consistent with the nil-check pattern used for sibling fields
+
+#### Scenario: Schema definition of source_version
+- **WHEN** the `DataSourceTencentCloudTeoConfigGroupVersionDetail()` schema is defined
+- **THEN** the `config_group_version_info` block SHALL include a `source_version` field of type `schema.TypeString` with `Computed: true` and `Optional: true`

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/tasks.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-source-version/tasks.md
@@ -1,0 +1,16 @@
+## 1. Schema Changes
+
+- [x] 1.1 Add `source_version` field (TypeString, Computed: true, Optional: true, with description) to the `config_group_version_info` block schema in `DataSourceTencentCloudTeoConfigGroupVersionDetail()` in `tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail.go`
+
+## 2. Read Function Changes
+
+- [x] 2.1 In `dataSourceTencentCloudTeoConfigGroupVersionDetailRead`, add a nil-check for `respData.ConfigGroupVersionInfo.SourceVersion` and map it to `configGroupVersionInfoMap["source_version"]` within the existing `if respData.ConfigGroupVersionInfo != nil` block, placed alongside the sibling field mappings
+
+## 3. Documentation
+
+- [x] 3.1 Update `tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail.md` to describe the new `source_version` field within the `config_group_version_info` block
+
+## 4. Validation
+
+- [x] 4.1 Verify the code compiles successfully (gofmt in finalize phase)
+- [x] 4.2 Verify no lint errors

--- a/openspec/specs/teo-config-group-version-source-version/spec.md
+++ b/openspec/specs/teo-config-group-version-source-version/spec.md
@@ -1,0 +1,20 @@
+# teo-config-group-version-source-version Specification
+
+## Purpose
+Defines that the `tencentcloud_teo_config_group_version_detail` data source SHALL expose a `source_version` computed field within the `config_group_version_info` block, mapping to the cloud API response field `ConfigGroupVersionInfo.SourceVersion` of the `DescribeConfigGroupVersionDetail` API, to surface the source version ID that the config group version was derived from.
+
+## Requirements
+### Requirement: Source version field in config group version detail data source
+The `tencentcloud_teo_config_group_version_detail` data source SHALL expose a `source_version` computed field within the `config_group_version_info` block, mapping to the cloud API response field `response.ConfigGroupVersionInfo.SourceVersion` of the `DescribeConfigGroupVersionDetail` API. The field represents the source version ID that the config group version was derived from.
+
+#### Scenario: Read config group version detail with source version populated
+- **WHEN** the provider reads a `tencentcloud_teo_config_group_version_detail` data source and the `DescribeConfigGroupVersionDetail` API returns a non-nil `ConfigGroupVersionInfo.SourceVersion`
+- **THEN** the provider SHALL populate `config_group_version_info.0.source_version` in state with the value of `ConfigGroupVersionInfo.SourceVersion`
+
+#### Scenario: Read config group version detail with source version nil
+- **WHEN** the provider reads a `tencentcloud_teo_config_group_version_detail` data source and the `DescribeConfigGroupVersionDetail` API returns a nil `ConfigGroupVersionInfo.SourceVersion` (e.g., the initial version with no source)
+- **THEN** the provider SHALL NOT set `source_version` into state (omit the field from the map), consistent with the nil-check pattern used for sibling fields
+
+#### Scenario: Schema definition of source_version
+- **WHEN** the `DataSourceTencentCloudTeoConfigGroupVersionDetail()` schema is defined
+- **THEN** the `config_group_version_info` block SHALL include a `source_version` field of type `schema.TypeString` with `Computed: true` and `Optional: true`

--- a/tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail.go
+++ b/tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail.go
@@ -44,6 +44,12 @@ func DataSourceTencentCloudTeoConfigGroupVersionDetail() *schema.Resource {
 							Optional:    true,
 							Description: "Version No.",
 						},
+						"source_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Optional:    true,
+							Description: "The source version ID that the config group version was derived from.",
+						},
 						"group_id": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -134,6 +140,10 @@ func dataSourceTencentCloudTeoConfigGroupVersionDetailRead(d *schema.ResourceDat
 
 		if respData.ConfigGroupVersionInfo.VersionNumber != nil {
 			configGroupVersionInfoMap["version_number"] = respData.ConfigGroupVersionInfo.VersionNumber
+		}
+
+		if respData.ConfigGroupVersionInfo.SourceVersion != nil {
+			configGroupVersionInfoMap["source_version"] = respData.ConfigGroupVersionInfo.SourceVersion
 		}
 
 		if respData.ConfigGroupVersionInfo.GroupId != nil {

--- a/tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail_test.go
+++ b/tencentcloud/services/teo/data_source_tc_teo_config_group_version_detail_test.go
@@ -21,6 +21,7 @@ func TestAccTencentCloudTeoConfigGroupVersionDetailDataSource_basic(t *testing.T
 				resource.TestCheckResourceAttr("data.tencentcloud_teo_config_group_version_detail.teo_config_group_version_detail", "zone_id", "zone-2xkazzl8yf6k"),
 				resource.TestCheckResourceAttr("data.tencentcloud_teo_config_group_version_detail.teo_config_group_version_detail", "version_id", "ver-3lchxizh2mqn"),
 				resource.TestCheckResourceAttrSet("data.tencentcloud_teo_config_group_version_detail.teo_config_group_version_detail", "config_group_version_info.#"),
+				resource.TestCheckResourceAttrSet("data.tencentcloud_teo_config_group_version_detail.teo_config_group_version_detail", "config_group_version_info.0.source_version"),
 				resource.TestCheckResourceAttrSet("data.tencentcloud_teo_config_group_version_detail.teo_config_group_version_detail", "content"),
 			),
 		}},

--- a/website/docs/d/teo_config_group_version_detail.html.markdown
+++ b/website/docs/d/teo_config_group_version_detail.html.markdown
@@ -33,6 +33,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `config_group_version_info` - Version information.
+  * `source_version` - The source version ID that the config group version was derived from.
 * `content` - Version file content. It is returned in JSON format.
 
 


### PR DESCRIPTION
Add a new computed field `source_version` to the `config_group_version_info` block of the `tencentcloud_teo_config_group_version_detail` data source, mapping to the cloud API response field `ConfigGroupVersionInfo.SourceVersion` of the `DescribeConfigGroupVersionDetail` API. The field represents the source version ID that the config group version was derived from. This change is fully backward compatible (Computed-only additive field).