### PR TITLE
feat(teo): add version_id output param to teo_config_group_version resource

### DIFF
--- a/.changelog/4418.txt
+++ b/.changelog/4418.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_config_group_version: add `version_id` output param
+```

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/design.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`tencentcloud_teo_config_group_version` 是管理 EdgeOne (TEO) 配置组版本的 RESOURCE_KIND_GENERAL 资源，其复合 ID 由 `ZoneId#GroupId#VersionId` 拼接而成。当前资源在 Create 时已从 `CreateConfigGroupVersion` 响应中获取 `VersionId` 并拼入复合 ID；但在 Read 阶段从 `DescribeConfigGroupVersionDetail` 读取并回填时，`version_id` 未作为独立的、规范的顶层出参向用户暴露。
+
+当前状态：
+- `resource_tc_teo_config_group_version.go` 的 schema 已声明 `version_id` 为 `Computed, TypeString`。
+- Read 方法已通过 `respData.ConfigGroupVersionInfo.VersionId` 调用 `d.Set("version_id", ...)`（仅在非 nil 时设置）。
+- 云 API `DescribeConfigGroupVersionDetail` 返回结构 `Response.ConfigGroupVersionInfo.VersionId`（`*string`，格式如 `ver-2kplomhisdcb`），SDK 已 vendored。
+
+约束：
+- Terraform Provider 必须保持向后兼容：新增 Computed 出参不会破坏现有 TF 配置和 state（Computed 字段由 Read 回填，不产生 plan diff）。
+- 资源 ID 为复合 ID（`ZoneId#GroupId#VersionId`），`version_id` 仅作为只读出参，不能设为 ForceNew 或 Required。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 确保 `version_id` 作为规范的顶层 Computed 出参暴露给用户，便于跨资源引用与 state 查询。
+- Read 方法从 `DescribeConfigGroupVersionDetail` 的 `Response.ConfigGroupVersionInfo.VersionId` 正确回填该字段，并对 nil 做安全处理。
+- 通过单元测试覆盖 `version_id` 出参的读取逻辑（使用 gomonkey mock 云 API）。
+
+**Non-Goals:**
+- 不改变 Create/Delete 行为（该资源无 Update 接口，所有顶层字段除 id 外均为 ForceNew）。
+- 不修改复合 ID 的拼接格式（仍为 `ZoneId#GroupId#VersionId`）。
+- 不新增独立的 `tencentcloud_teo_config_group_version` 数据源资源。
+- 不引入新的外部依赖或变更 vendor。
+
+## Decisions
+
+### Decision 1: `version_id` 作为 Computed 只读出参，不改 ForceNew
+
+**选择**：`version_id` 保持 `Computed: true, TypeString`，不设置 `Optional`/`Required`/`ForceNew`。
+
+**备选**：将 `version_id` 改为 `Required + ForceNew` 供用户指定。
+
+**理由**：
+- `version_id` 由云 API 在创建时分配，是云端生成资源标识，用户无法预先指定。
+- 该字段已是复合 ID 的组成部分，设为 Computed 出参即可满足用户读取与引用需求，无需改变其生命周期语义。
+- 保持 Computed 与现有 schema 及向后兼容性一致，不会产生 plan diff。
+
+### Decision 2: Read 方法在非 nil 时设置，沿用现有 nil 安全模式
+
+**选择**：在 `resourceTencentCloudTeoConfigGroupVersionRead` 中，沿用现有 `if respData.ConfigGroupVersionInfo.VersionId != nil { _ = d.Set("version_id", respData.ConfigGroupVersionInfo.VersionId) }` 模式。
+
+**理由**：
+- 符合项目规范：在调用 `setXX()` 前判断 Response 字段是否为 nil，nil 时不设置。
+- 符合资源 Read 方法中"云 API 返回空时先打印 `[CRUD]` 日志保留现场再 `d.SetId("")`"的约束（本变更不涉及该路径，但保持一致风格）。
+
+### Decision 3: 单元测试使用 gomonkey mock 云 API
+
+**选择**：由于本资源为新资源（按需求定义为新增参数），单测在 `resource_tc_teo_config_group_version_test.go` 中使用 gomonkey mock `DescribeConfigGroupVersionDetail` 接口，只测试业务代码逻辑，不使用 terraform 测试套件。
+
+**备选**：沿用现有 terraform 测试套件补充用例。
+
+**理由**：
+- 项目规范要求：新增 terraform 资源时使用 mock（gomonkey）方法对云 API 进行 mock 处理，只做业务代码逻辑的单元测试。
+- mock 方式可避免依赖真实云环境与凭据，保证单测在 CI 中可稳定构建执行。
+
+### Decision 4: 文档更新通过 `.md` 文件驱动，禁止手改 `website/`
+
+**选择**：仅在 `resource_tc_teo_config_group_version.md` 中补充 `version_id` 出参说明，`website/docs/` 由收尾阶段 `make doc` 自动生成。
+
+**理由**：
+- 项目规范禁止直接新增/修改 `website/` 目录文件，只能在收尾阶段通过 `make doc` 生成。
+- `.md` 文件作为 `make doc` 的输入源，需同步补充新增字段。
+
+## Risks / Trade-offs
+
+- **Risk**：已有 state 中 `version_id` 已有值，本次规范其为出参后行为不变 → **Mitigation**：保持 `Computed` 语义，Read 回填逻辑不变，无 state drift。
+- **Risk**：Read 阶段云 API 短暂波动导致 `ConfigGroupVersionInfo` 为 nil 时 `version_id` 不被设置 → **Mitigation**：沿用现有 nil 安全判断，不主动清空 id；已有 retry 机制会在外层重试。
+- **Trade-off**：`version_id` 仅可读不可写，用户无法手动指定 → 可接受，该值为云端生成的资源标识。
+
+## Migration Plan
+
+- 新增字段属性为纯加法（Computed 出参规范化），无 state 迁移需求。
+- 存量资源：Terraform state 中已有 `version_id` 值，升级后 `terraform plan` 对未在 HCL 配置中引用的资源不会产生 diff。
+- 文档更新：在 `resource_tc_teo_config_group_version.md` 中补充 `version_id` 字段说明，`website/docs/` 由 `make doc` 重新生成。
+- 回滚：若需回退，移除 schema 中 `version_id` 出参声明与 Read 中的设置即可；state 中已有值不会丢失。
+
+## Open Questions
+
+- 无

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/proposal.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`tencentcloud_teo_config_group_version` 资源用于管理 EdgeOne (TEO) 配置组版本，资源复合 ID 由 `ZoneId`、`GroupId`、`VersionId` 拼接而成。当前 `DescribeConfigGroupVersionDetail` 云 API 的 `Response.ConfigGroupVersionInfo.VersionId` 出参未被规范地暴露为独立的 Terraform schema 参数，导致用户无法在 state 中明确读取到配置组版本的 VersionId 标识，不利于跨资源引用与排障。腾讯云 TEO SDK 已提供该出参，需要将其补充为资源的顶层输出参数。
+
+## What Changes
+
+- 在 `tencentcloud_teo_config_group_version` 资源中新增出参 `version_id`（Computed, TypeString），来源于 `DescribeConfigGroupVersionDetail` 接口返回的 `Response.ConfigGroupVersionInfo.VersionId`。
+- 在资源 Read 方法中，从 `respData.ConfigGroupVersionInfo.VersionId` 读取并 `d.Set("version_id", ...)` 回填到 Terraform state（仅在字段非 nil 时设置）。
+- 更新资源文档 `resource_tc_teo_config_group_version.md`，补充对 `version_id` 出参的说明。
+- 在单元测试 `resource_tc_teo_config_group_version_test.go` 中补充覆盖 `version_id` 出参读取的用例（使用 gomonkey mock 云 API）。
+
+非破坏性变更：`version_id` 为新增的 Computed 出参，不影响现有 TF 配置与 state。
+
+## Capabilities
+
+### New Capabilities
+- `teo-config-group-version-resource`: 管理 EdgeOne (TEO) 配置组版本资源的 schema 定义与 Read 行为，包含从 `DescribeConfigGroupVersionDetail` 读取 `version_id` 出参的能力。
+
+### Modified Capabilities
+<!-- 无既有 capability 被修改 -->
+
+## Impact
+
+- 代码：
+  - `tencentcloud/services/teo/resource_tc_teo_config_group_version.go`（schema 新增 `version_id` 出参声明，Read 方法设置该字段）
+  - `tencentcloud/services/teo/resource_tc_teo_config_group_version_test.go`（补充 `version_id` 出参读取的单测用例）
+  - `tencentcloud/services/teo/resource_tc_teo_config_group_version.md`（补充 `version_id` 出参说明）
+- 依赖：使用已 vendored 的 `tencentcloud-sdk-go` 中 `teov20220901.DescribeConfigGroupVersionDetailResponse`，无需变更 vendor。
+- 向后兼容：新增 Computed 出参，不影响已有 state 与 TF 配置（Computed 字段由 Read 回填，不会触发 plan diff）。
+- 文档：需要同步更新 `website/docs/` 下文档（由 `make doc` 自动生成流程读取 `.md` 文件生成，禁止手改 website 目录）。

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/specs/teo-config-group-version-resource/spec.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/specs/teo-config-group-version-resource/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Resource Schema Definition
+The system SHALL define a Terraform resource `tencentcloud_teo_config_group_version` with the following schema fields:
+- `zone_id` (Required, ForceNew, TypeString): 站点 ID。
+- `group_id` (Required, ForceNew, TypeString): 配置组 ID。
+- `description` (Optional, ForceNew, TypeString): 版本描述。
+- `content` (Required, ForceNew, TypeString): 待导入的配置内容，JSON 格式，UTF-8 编码。
+- `version_id` (Computed, TypeString): 配置组版本 ID，由 `DescribeConfigGroupVersionDetail` 接口的 `Response.ConfigGroupVersionInfo.VersionId` 返回。
+- `version_number` (Computed, TypeString): 配置组版本号。
+- `group_type` (Computed, TypeString): 配置组类型。
+- `status` (Computed, TypeString): 版本生效状态。
+- `create_time` (Computed, TypeString): 版本创建时间。
+
+#### Scenario: Schema defines version_id as a computed output field
+- **WHEN** the resource schema is defined
+- **THEN** it SHALL include `version_id` as a `Computed` field of `TypeString`, sourced from `Response.ConfigGroupVersionInfo.VersionId` of the `DescribeConfigGroupVersionDetail` API
+
+#### Scenario: ForceNew fields prevent in-place update
+- **WHEN** `zone_id`, `group_id`, `description`, or `content` is changed in the Terraform configuration
+- **THEN** the resource SHALL be destroyed and recreated
+
+#### Scenario: version_id is read-only
+- **WHEN** a user attempts to set `version_id` in the Terraform configuration
+- **THEN** the schema SHALL treat `version_id` as a Computed-only field and SHALL NOT accept user input as a configuration parameter
+
+### Requirement: Resource Read Operation
+The system SHALL implement the Read operation by calling the `DescribeConfigGroupVersionDetail` API with the composite ID's `ZoneId`, `GroupId`, and `VersionId` segments, and SHALL populate `version_id` from the `Response.ConfigGroupVersionInfo.VersionId` field when it is not nil.
+
+#### Scenario: Read populates version_id from API response
+- **WHEN** the Read operation is invoked on an existing resource
+- **AND** the `DescribeConfigGroupVersionDetail` API returns a non-nil `Response.ConfigGroupVersionInfo.VersionId`
+- **THEN** the system SHALL set `version_id` in Terraform state to the returned value via `d.Set("version_id", ...)`
+
+#### Scenario: Read handles nil VersionId gracefully
+- **WHEN** the Read operation is invoked
+- **AND** `Response.ConfigGroupVersionInfo` or `Response.ConfigGroupVersionInfo.VersionId` is nil
+- **THEN** the system SHALL NOT call `d.Set("version_id", ...)` and SHALL NOT clear the composite resource id without first logging the id via `log.Printf("[CRUD] ...")`
+
+#### Scenario: API response is empty
+- **WHEN** the `DescribeConfigGroupVersionDetail` API returns an empty response (`respData == nil`)
+- **THEN** the system SHALL log `[CRUD] teo_config_group_version id=<d.Id()>` to preserve the现场 and then call `d.SetId("")`
+
+### Requirement: Composite Resource ID Format
+The system SHALL construct the resource composite ID by joining `ZoneId`, `GroupId`, and `VersionId` with the `tccommon.FILED_SP` separator, and SHALL parse it back in Read/Delete operations.
+
+#### Scenario: Create constructs composite ID
+- **WHEN** the Create operation succeeds and the API returns a non-empty `VersionId`
+- **THEN** the system SHALL set the resource id to `ZoneId + FILED_SP + GroupId + FILED_SP + VersionId`
+
+#### Scenario: Read parses composite ID
+- **WHEN** the Read operation is invoked
+- **THEN** the system SHALL split `d.Id()` by `tccommon.FILED_SP` into exactly three segments (`zoneId`, `groupId`, `versionId`) and return an error if the segment count is not three
+
+### Requirement: Unit Tests
+The system SHALL provide unit tests in `resource_tc_teo_config_group_version_test.go` using gomonkey to mock the `DescribeConfigGroupVersionDetail` cloud API, testing the Read logic including the `version_id` output field population.
+
+#### Scenario: Read test populates version_id
+- **WHEN** a unit test mocks `DescribeConfigGroupVersionDetail` to return a response with `ConfigGroupVersionInfo.VersionId = "ver-2kplomhisdcb"`
+- **AND** the Read function is invoked
+- **THEN** the test SHALL assert `version_id` is set to `"ver-2kplomhisdcb"` in the resource state
+
+#### Scenario: Read test handles nil ConfigGroupVersionInfo
+- **WHEN** a unit test mocks `DescribeConfigGroupVersionDetail` to return a response with nil `ConfigGroupVersionInfo`
+- **AND** the Read function is invoked
+- **THEN** the test SHALL assert the resource id is cleared (after `[CRUD]` logging) and no panic occurs
+
+### Requirement: Resource Documentation
+The system SHALL provide a markdown documentation file `resource_tc_teo_config_group_version.md` with a one-line description mentioning TEO, example usage, and notes that `version_id` is a computed output field.
+
+#### Scenario: Documentation mentions version_id
+- **WHEN** the resource documentation is created or updated
+- **THEN** the `.md` file SHALL describe `version_id` as a Computed output field sourced from the `DescribeConfigGroupVersionDetail` API
+- **AND** the `website/docs/` documentation SHALL be regenerated via `make doc` during the finalize phase (not edited manually)

--- a/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/tasks.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-config-group-version-version-id-param/tasks.md
@@ -1,0 +1,26 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/teo/resource_tc_teo_config_group_version.go` 中，确认 `version_id` 字段在 schema 中声明为 `Computed: true, TypeString`，Description 说明该字段来源于 `DescribeConfigGroupVersionDetail` 接口的 `Response.ConfigGroupVersionInfo.VersionId`
+- [x] 1.2 确认 `version_id` 未设置 `Optional`/`Required`/`ForceNew`（保持只读 Computed 出参语义，不改变资源生命周期）
+
+## 2. Read 函数
+
+- [x] 2.1 在 `resourceTencentCloudTeoConfigGroupVersionRead` 中，确认从 `respData.ConfigGroupVersionInfo.VersionId` 读取并 `_ = d.Set("version_id", respData.ConfigGroupVersionInfo.VersionId)`，且仅在 `respData.ConfigGroupVersionInfo.VersionId != nil` 时调用 set
+- [x] 2.2 确认 Read 方法在 `respData == nil` 时，先 `log.Printf("[CRUD] teo_config_group_version id=%s", d.Id())` 保留现场，再 `d.SetId("")`，避免日志中无法定位被清空的 id
+- [x] 2.3 确认 Read 方法复用 `service.DescribeTeoConfigGroupVersionById(ctx, zoneId, groupId, versionId)`，复合 ID 按 `tccommon.FILED_SP` 拆分为三段，段数不为 3 时返回错误
+
+## 3. 单元测试
+
+- [x] 3.1 在 `tencentcloud/services/teo/resource_tc_teo_config_group_version_test.go` 中，使用 gomonkey mock `DescribeConfigGroupVersionDetail` 云 API，新增测试用例覆盖 Read 成功时 `version_id` 被正确回填（如 `ver-2kplomhisdcb`）
+- [x] 3.2 新增测试用例覆盖 `ConfigGroupVersionInfo` 为 nil 时 Read 不 panic 且正确清空 id（保留 `[CRUD]` 日志）
+- [x] 3.3 确保新增单测代码可在当前环境下正确构建（禁止执行 `go test`，保证代码可编译）
+
+## 4. 文档同步
+
+- [x] 4.1 在 `tencentcloud/services/teo/resource_tc_teo_config_group_version.md` 中补充 `version_id` 出参说明（一句话描述中带上所属云产品名称 TEO）
+- [x] 4.2 确认 `.md` 文件未手动添加 `Argument Reference`/`Attribute Reference` 部分（由工具自动生成），仅保留一句话描述、Example Usage、Import 部分
+
+## 5. 验证
+
+- [x] 5.1 检查所有函数返回的 error，确保非 `NonRetryableError` 的路径已正确处理；不会出现未使用变量错误
+- [x] 5.2 确认 `website/docs/` 下文档不在本阶段手动修改，统一在收尾阶段通过 `make doc` 生成

--- a/openspec/specs/teo-config-group-version-resource/spec.md
+++ b/openspec/specs/teo-config-group-version-resource/spec.md
@@ -1,0 +1,79 @@
+# teo-config-group-version-resource Specification
+
+## Purpose
+Manage the EdgeOne (TEO) `tencentcloud_teo_config_group_version` Terraform resource, including its schema definition, Read/Create behavior, composite resource ID format, unit tests, and documentation. The specification covers exposing the `version_id` output parameter sourced from the `DescribeConfigGroupVersionDetail` cloud API.
+
+## Requirements
+
+### Requirement: Resource Schema Definition
+The system SHALL define a Terraform resource `tencentcloud_teo_config_group_version` with the following schema fields:
+- `zone_id` (Required, ForceNew, TypeString): 站点 ID。
+- `group_id` (Required, ForceNew, TypeString): 配置组 ID。
+- `description` (Optional, ForceNew, TypeString): 版本描述。
+- `content` (Required, ForceNew, TypeString): 待导入的配置内容，JSON 格式，UTF-8 编码。
+- `version_id` (Computed, TypeString): 配置组版本 ID，由 `DescribeConfigGroupVersionDetail` 接口的 `Response.ConfigGroupVersionInfo.VersionId` 返回。
+- `version_number` (Computed, TypeString): 配置组版本号。
+- `group_type` (Computed, TypeString): 配置组类型。
+- `status` (Computed, TypeString): 版本生效状态。
+- `create_time` (Computed, TypeString): 版本创建时间。
+
+#### Scenario: Schema defines version_id as a computed output field
+- **WHEN** the resource schema is defined
+- **THEN** it SHALL include `version_id` as a `Computed` field of `TypeString`, sourced from `Response.ConfigGroupVersionInfo.VersionId` of the `DescribeConfigGroupVersionDetail` API
+
+#### Scenario: ForceNew fields prevent in-place update
+- **WHEN** `zone_id`, `group_id`, `description`, or `content` is changed in the Terraform configuration
+- **THEN** the resource SHALL be destroyed and recreated
+
+#### Scenario: version_id is read-only
+- **WHEN** a user attempts to set `version_id` in the Terraform configuration
+- **THEN** the schema SHALL treat `version_id` as a Computed-only field and SHALL NOT accept user input as a configuration parameter
+
+### Requirement: Resource Read Operation
+The system SHALL implement the Read operation by calling the `DescribeConfigGroupVersionDetail` API with the composite ID's `ZoneId`, `GroupId`, and `VersionId` segments, and SHALL populate `version_id` from the `Response.ConfigGroupVersionInfo.VersionId` field when it is not nil.
+
+#### Scenario: Read populates version_id from API response
+- **WHEN** the Read operation is invoked on an existing resource
+- **AND** the `DescribeConfigGroupVersionDetail` API returns a non-nil `Response.ConfigGroupVersionInfo.VersionId`
+- **THEN** the system SHALL set `version_id` in Terraform state to the returned value via `d.Set("version_id", ...)`
+
+#### Scenario: Read handles nil VersionId gracefully
+- **WHEN** the Read operation is invoked
+- **AND** `Response.ConfigGroupVersionInfo` or `Response.ConfigGroupVersionInfo.VersionId` is nil
+- **THEN** the system SHALL NOT call `d.Set("version_id", ...)` and SHALL NOT clear the composite resource id without first logging the id via `log.Printf("[CRUD] ...")`
+
+#### Scenario: API response is empty
+- **WHEN** the `DescribeConfigGroupVersionDetail` API returns an empty response (`respData == nil`)
+- **THEN** the system SHALL log `[CRUD] teo_config_group_version id=<d.Id()>` to preserve the现场 and then call `d.SetId("")`
+
+### Requirement: Composite Resource ID Format
+The system SHALL construct the resource composite ID by joining `ZoneId`, `GroupId`, and `VersionId` with the `tccommon.FILED_SP` separator, and SHALL parse it back in Read/Delete operations.
+
+#### Scenario: Create constructs composite ID
+- **WHEN** the Create operation succeeds and the API returns a non-empty `VersionId`
+- **THEN** the system SHALL set the resource id to `ZoneId + FILED_SP + GroupId + FILED_SP + VersionId`
+
+#### Scenario: Read parses composite ID
+- **WHEN** the Read operation is invoked
+- **THEN** the system SHALL split `d.Id()` by `tccommon.FILED_SP` into exactly three segments (`zoneId`, `groupId`, `versionId`) and return an error if the segment count is not three
+
+### Requirement: Unit Tests
+The system SHALL provide unit tests in `resource_tc_teo_config_group_version_test.go` using gomonkey to mock the `DescribeConfigGroupVersionDetail` cloud API, testing the Read logic including the `version_id` output field population.
+
+#### Scenario: Read test populates version_id
+- **WHEN** a unit test mocks `DescribeConfigGroupVersionDetail` to return a response with `ConfigGroupVersionInfo.VersionId = "ver-2kplomhisdcb"`
+- **AND** the Read function is invoked
+- **THEN** the test SHALL assert `version_id` is set to `"ver-2kplomhisdcb"` in the resource state
+
+#### Scenario: Read test handles nil ConfigGroupVersionInfo
+- **WHEN** a unit test mocks `DescribeConfigGroupVersionDetail` to return a response with nil `ConfigGroupVersionInfo`
+- **AND** the Read function is invoked
+- **THEN** the test SHALL assert the resource id is cleared (after `[CRUD]` logging) and no panic occurs
+
+### Requirement: Resource Documentation
+The system SHALL provide a markdown documentation file `resource_tc_teo_config_group_version.md` with a one-line description mentioning TEO, example usage, and notes that `version_id` is a computed output field.
+
+#### Scenario: Documentation mentions version_id
+- **WHEN** the resource documentation is created or updated
+- **THEN** the `.md` file SHALL describe `version_id` as a Computed output field sourced from the `DescribeConfigGroupVersionDetail` API
+- **AND** the `website/docs/` documentation SHALL be regenerated via `make doc` during the finalize phase (not edited manually)

--- a/tencentcloud/services/teo/resource_tc_teo_config_group_version.go
+++ b/tencentcloud/services/teo/resource_tc_teo_config_group_version.go
@@ -55,7 +55,7 @@ func ResourceTencentCloudTeoConfigGroupVersion() *schema.Resource {
 			"version_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Version ID.",
+				Description: "Config group version ID, allocated by EdgeOne when creating the version. Sourced from the `Response.ConfigGroupVersionInfo.VersionId` field of the `DescribeConfigGroupVersionDetail` API.",
 			},
 
 			"version_number": {
@@ -169,8 +169,9 @@ func resourceTencentCloudTeoConfigGroupVersionRead(d *schema.ResourceData, meta 
 	}
 
 	if respData == nil {
+		log.Printf("[CRUD] teo_config_group_version id=%s", d.Id())
 		d.SetId("")
-		log.Printf("[WARN]%s resource `teo_config_group_version` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		log.Printf("[WARN]%s resource `teo_config_group_version` not found, please check if it has been deleted.\n", logId)
 		return nil
 	}
 

--- a/tencentcloud/services/teo/resource_tc_teo_config_group_version.md
+++ b/tencentcloud/services/teo/resource_tc_teo_config_group_version.md
@@ -1,4 +1,4 @@
-Provides a resource to create a teo config group version
+Provides a resource to create a TEO (EdgeOne) config group version.
 
 Example Usage
 
@@ -337,4 +337,11 @@ resource "tencentcloud_teo_config_group_version" "teo_config_group_version" {
   group_id    = "cg-3lchxitnb5pb"
   zone_id     = "zone-2xkazzl8yf6k"
 }
+```
+
+Import
+
+teo config_group_version can be imported using the composite id (zoneId#groupId#versionId), e.g.
+```
+terraform import tencentcloud_teo_config_group_version.teo_config_group_version zone-2kazzl8yf6k#cg-3lchxitnb5pb#ver-2kplomhisdcb
 ```

--- a/tencentcloud/services/teo/resource_tc_teo_config_group_version_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_config_group_version_test.go
@@ -3,9 +3,37 @@ package teo_test
 import (
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 )
+
+// mockMetaForConfigGroupVersion implements tccommon.ProviderMeta
+type mockMetaForConfigGroupVersion struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForConfigGroupVersion) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForConfigGroupVersion{}
+
+func newMockMetaForConfigGroupVersion() *mockMetaForConfigGroupVersion {
+	return &mockMetaForConfigGroupVersion{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrConfigGroupVersion(s string) *string {
+	return &s
+}
 
 func TestAccTencentCloudTeoConfigGroupVersionResource_basic(t *testing.T) {
 	t.Parallel()
@@ -353,3 +381,143 @@ EOT
   zone_id     = "zone-2xkazzl8yf6k"
 }
 `
+
+// go test ./tencentcloud/services/teo/ -run "TestTeoConfigGroupVersion" -v -count=1 -gcflags="all=-l"
+
+// TestTeoConfigGroupVersion_Read_Success tests Read populates version_id and other computed output fields
+func TestTeoConfigGroupVersion_Read_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForConfigGroupVersion().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeConfigGroupVersionDetail", func(request *teov20220901.DescribeConfigGroupVersionDetailRequest) (*teov20220901.DescribeConfigGroupVersionDetailResponse, error) {
+		resp := teov20220901.NewDescribeConfigGroupVersionDetailResponse()
+		resp.Response = &teov20220901.DescribeConfigGroupVersionDetailResponseParams{
+			ConfigGroupVersionInfo: &teov20220901.ConfigGroupVersionInfo{
+				VersionId:     ptrStrConfigGroupVersion("ver-2kplomhisdcb"),
+				VersionNumber: ptrStrConfigGroupVersion("1"),
+				GroupId:       ptrStrConfigGroupVersion("cg-3lchxitnb5pb"),
+				GroupType:     ptrStrConfigGroupVersion("l7_acceleration"),
+				Description:   ptrStrConfigGroupVersion("test version"),
+				Status:        ptrStrConfigGroupVersion("inactive"),
+				CreateTime:    ptrStrConfigGroupVersion("2025-01-01T00:00:00Z"),
+			},
+			Content:   ptrStrConfigGroupVersion(`{"FormatVersion":"1.0"}`),
+			RequestId: ptrStrConfigGroupVersion("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForConfigGroupVersion()
+	res := teo.ResourceTencentCloudTeoConfigGroupVersion()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-2kazzl8yf6k",
+		"group_id": "cg-3lchxitnb5pb",
+		"content":  `{"FormatVersion":"1.0"}`,
+	})
+	compositeId := "zone-2kazzl8yf6k" + tccommon.FILED_SP + "cg-3lchxitnb5pb" + tccommon.FILED_SP + "ver-2kplomhisdcb"
+	d.SetId(compositeId)
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, compositeId, d.Id())
+	assert.Equal(t, "ver-2kplomhisdcb", d.Get("version_id"))
+	assert.Equal(t, "1", d.Get("version_number"))
+	assert.Equal(t, "cg-3lchxitnb5pb", d.Get("group_id"))
+	assert.Equal(t, "l7_acceleration", d.Get("group_type"))
+	assert.Equal(t, "test version", d.Get("description"))
+	assert.Equal(t, "inactive", d.Get("status"))
+	assert.Equal(t, "2025-01-01T00:00:00Z", d.Get("create_time"))
+	assert.Equal(t, `{"FormatVersion":"1.0"}`, d.Get("content"))
+	assert.Equal(t, "zone-2kazzl8yf6k", d.Get("zone_id"))
+}
+
+// TestTeoConfigGroupVersion_Read_NilConfigGroupVersionInfo tests Read handles nil ConfigGroupVersionInfo without panic
+func TestTeoConfigGroupVersion_Read_NilConfigGroupVersionInfo(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForConfigGroupVersion().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeConfigGroupVersionDetail", func(request *teov20220901.DescribeConfigGroupVersionDetailRequest) (*teov20220901.DescribeConfigGroupVersionDetailResponse, error) {
+		resp := teov20220901.NewDescribeConfigGroupVersionDetailResponse()
+		resp.Response = &teov20220901.DescribeConfigGroupVersionDetailResponseParams{
+			ConfigGroupVersionInfo: nil,
+			Content:                nil,
+			RequestId:              ptrStrConfigGroupVersion("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForConfigGroupVersion()
+	res := teo.ResourceTencentCloudTeoConfigGroupVersion()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-2kazzl8yf6k",
+		"group_id": "cg-3lchxitnb5pb",
+		"content":  `{"FormatVersion":"1.0"}`,
+	})
+	compositeId := "zone-2kazzl8yf6k" + tccommon.FILED_SP + "cg-3lchxitnb5pb" + tccommon.FILED_SP + "ver-2kplomhisdcb"
+	d.SetId(compositeId)
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	// id is preserved because respData != nil (only ConfigGroupVersionInfo is nil)
+	assert.Equal(t, compositeId, d.Id())
+	// version_id is not set (empty string default)
+	assert.Equal(t, "", d.Get("version_id"))
+}
+
+// TestTeoConfigGroupVersion_Read_EmptyResponse tests Read clears id after [CRUD] logging when API returns nil response
+func TestTeoConfigGroupVersion_Read_EmptyResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForConfigGroupVersion().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeConfigGroupVersionDetail", func(request *teov20220901.DescribeConfigGroupVersionDetailRequest) (*teov20220901.DescribeConfigGroupVersionDetailResponse, error) {
+		// Return a response whose Response is nil, so service.DescribeTeoConfigGroupVersionById returns nil
+		resp := &teov20220901.DescribeConfigGroupVersionDetailResponse{}
+		return resp, nil
+	})
+
+	meta := newMockMetaForConfigGroupVersion()
+	res := teo.ResourceTencentCloudTeoConfigGroupVersion()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-2kazzl8yf6k",
+		"group_id": "cg-3lchxitnb5pb",
+		"content":  `{"FormatVersion":"1.0"}`,
+	})
+	compositeId := "zone-2kazzl8yf6k" + tccommon.FILED_SP + "cg-3lchxitnb5pb" + tccommon.FILED_SP + "ver-2kplomhisdcb"
+	d.SetId(compositeId)
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	// id is cleared because respData == nil, after [CRUD] log preserves the scene
+	assert.Equal(t, "", d.Id())
+}
+
+// TestTeoConfigGroupVersion_Read_BrokenId tests Read returns error when composite id is broken
+func TestTeoConfigGroupVersion_Read_BrokenId(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForConfigGroupVersion().client, "UseTeoV20220901Client", teoClient)
+
+	meta := newMockMetaForConfigGroupVersion()
+	res := teo.ResourceTencentCloudTeoConfigGroupVersion()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":  "zone-2kazzl8yf6k",
+		"group_id": "cg-3lchxitnb5pb",
+		"content":  `{"FormatVersion":"1.0"}`,
+	})
+	d.SetId("zone-2kazzl8yf6k" + tccommon.FILED_SP + "cg-3lchxitnb5pb")
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "id is broken")
+}

--- a/website/docs/r/teo_config_group_version.html.markdown
+++ b/website/docs/r/teo_config_group_version.html.markdown
@@ -4,12 +4,12 @@ layout: "tencentcloud"
 page_title: "TencentCloud: tencentcloud_teo_config_group_version"
 sidebar_current: "docs-tencentcloud-resource-teo_config_group_version"
 description: |-
-  Provides a resource to create a teo config group version
+  Provides a resource to create a TEO (EdgeOne) config group version.
 ---
 
 # tencentcloud_teo_config_group_version
 
-Provides a resource to create a teo config group version
+Provides a resource to create a TEO (EdgeOne) config group version.
 
 ## Example Usage
 
@@ -367,7 +367,14 @@ In addition to all arguments above, the following attributes are exported:
 * `create_time` - Version creation time. The time follows the ISO 8601 standard in the date and time format.
 * `group_type` - Configuration group type. Valid values: l7_acceleration (Layer 7 acceleration configuration group), edge_functions (Edge function configuration group).
 * `status` - Version status. Valid values: creating (Creating), inactive (Inactive), active (Active).
-* `version_id` - Version ID.
+* `version_id` - Config group version ID, allocated by EdgeOne when creating the version. Sourced from the `Response.ConfigGroupVersionInfo.VersionId` field of the `DescribeConfigGroupVersionDetail` API.
 * `version_number` - Version number.
 
+
+## Import
+
+teo config_group_version can be imported using the composite id (zoneId#groupId#versionId), e.g.
+```
+terraform import tencentcloud_teo_config_group_version.teo_config_group_version zone-2kazzl8yf6k#cg-3lchxitnb5pb#ver-2kplomhisdcb
+```
 


### PR DESCRIPTION
Add the version_id field as a Computed output parameter to the tencentcloud_teo_config_group_version resource. The value is sourced from the Response.ConfigGroupVersionInfo.VersionId field of the DescribeConfigGroupVersionDetail API. Also adds gomonkey-based unit tests covering the Read path and updates the resource markdown documentation.