### PR TITLE
feat(teo): add env info params for teo deploy config group version

### DIFF
--- a/.changelog/4419.txt
+++ b/.changelog/4419.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_deploy_config_group_version: add env info params
+```

--- a/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/design.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/design.md
@@ -1,0 +1,109 @@
+## Context
+
+`tencentcloud_teo_deploy_config_group_version` 是 RESOURCE_KIND_GENERAL 资源，负责在 EdgeOne (TEO) 中发布配置组版本。其生命周期为：
+
+- **Create**：调用 `DeployConfigGroupVersion` 发布版本，随后轮询 `DescribeEnvironments`（service 层 `DescribeTeoEnvironmentsByFilter`，入参 `ZoneId`）等待目标 `EnvId` 的环境状态从 `creating`/`version_deploying` 变为 `running`。复合 ID 形如 `zoneId#envId#recordId`。
+- **Read**：从复合 ID 解析 `zoneId`、`envId`、`recordId`，通过 `DescribeTeoDeployConfigVersionHistoryByFilter`（按 `record-id` 过滤）读取部署记录，填充 `record_id`、`deploy_time`、`status`、`message`、`description`、`config_group_version_infos`、`zone_id`、`env_id`。
+- **Delete**：no-op（资源代表一次性部署动作，不支持回滚删除）。
+
+当前 Read 仅消费 `DescribeConfigGroupVersionHistory` 的部署记录，未将 `DescribeEnvironments` 返回的环境维度信息写入 state。本次变更在 Read 中补充对 `DescribeEnvironments` 的调用与字段映射，使 state 包含环境实际生效状态。
+
+云 API 数据结构（vendor `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`）已确认：
+
+- `DescribeEnvironmentsResponseParams`：
+  - `TotalCount *uint64`
+  - `EnvInfos []*EnvInfo`
+- `EnvInfo`：
+  - `EnvId *string`
+  - `EnvType *string`（`production` / `staging`）
+  - `Status *string`（`creating` / `running` / `version_deploying`）
+  - `Scope []*string`（生产为 `["ALL"]`，测试为节点 IP 列表）
+  - `CurrentConfigGroupVersionInfos []*ConfigGroupVersionInfo`
+  - `CreateTime *string`
+  - `UpdateTime *string`
+- `ConfigGroupVersionInfo`：
+  - `VersionId`、`VersionNumber`、`SourceVersion`、`GroupType`、`GroupId`、`Description`、`Status`、`CreateTime`（均 `*string`）
+
+注意：现有资源已存在名为 `config_group_version_infos` 的字段，其数据来源于 `DeployRecord.ConfigGroupVersionInfos`（部署记录视角），与本次新增的 `current_config_group_version_infos`（来源于 `EnvInfo.CurrentConfigGroupVersionInfos`，环境当前生效版本视角）语义不同，故不复用、不覆盖。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 Read 中补充 `DescribeEnvironments` 调用，定位目标环境并映射其字段为 Computed 出参。
+- 新增字段：`total_count`、`env_type`、`scope`、`current_config_group_version_infos`（嵌套集合）、`env_create_time`、`env_update_time`。
+- 保持向后兼容：仅新增 Computed 字段，不修改既有 schema 与既有字段语义。
+- 遵循项目硬约束：调用云 API 使用 retry（`tccommon.ReadRetryTimeout`）+ `tccommon.RetryError`；set 前判 nil；空返回先打日志再 `d.SetId("")`。
+
+**Non-Goals:**
+- 不修改 `config_group_version_infos`（部署记录视角）字段。
+- 不新增/修改 service 层方法（复用现有 `DescribeTeoEnvironmentsByFilter`）。
+- 不调整 Create/Delete 逻辑（Create 已使用同一 service 方法轮询状态，保持不变）。
+- 不为新增字段提供用户输入能力（Computed-only）。
+- 不修改资源 ID 格式。
+
+## Decisions
+
+### 决策 1：复用现有 service 层方法 `DescribeTeoEnvironmentsByFilter`
+
+现有 `DescribeTeoEnvironmentsByFilter(ctx, param)` 接受 `param["ZoneId"]`，返回 `[]*EnvInfo`（取 `response.Response.EnvInfos`）。其请求 `DescribeEnvironmentsRequest` 仅含 `ZoneId`，符合本次读取需求。
+
+- **选择**：直接在 Read 中调用该 service 方法，入参 `paramMap["ZoneId"] = &zoneId`。
+- **备选**：新增按 `EnvId` 过滤的 service 方法。**不采纳**，因为 `DescribeEnvironmentsRequest` 无 `EnvId`/`Filters` 字段（仅 `ZoneId`），无法在 API 侧按环境过滤；且现有方法已满足需求，避免重复代码。
+- **环境定位**：在返回的 `EnvInfos` 切片中遍历查找 `*item.EnvId == envId` 的元素。
+
+### 决策 2：新增 Computed 字段 schema 定义
+
+- `total_count`：`schema.TypeInt`，`Computed: true`。（云 API 为 `uint64`，Terraform schema 用 `TypeInt` 即可承载。）
+- `env_type`：`schema.TypeString`，`Computed: true`。
+- `scope`：`schema.TypeList`，`Elem: schema.TypeString`，`Computed: true`。（`EnvInfo.Scope` 为 `[]*string`，映射为字符串列表。）
+- `current_config_group_version_infos`：`schema.TypeSet`，`Computed: true`，`Elem` 为 `schema.Resource`，其 schema 含 `version_id` / `version_number` / `source_version` / `group_type` / `group_id` / `description` / `status` / `create_time`，均为 `schema.TypeString`、`Computed: true`。
+  - **使用 TypeSet 而非 TypeList**：与现有 `config_group_version_infos` 一致，且配置组版本集合无序，Set 语义更合适。
+- `env_create_time`：`schema.TypeString`，`Computed: true`。
+- `env_update_time`：`schema.TypeString`，`Computed: true`。
+- **命名**：用 `env_create_time` / `env_update_time` 区分于 `ConfigGroupVersionInfo.CreateTime`（已存在于 `current_config_group_version_infos` 子结构内）及部署记录字段，避免同名冲突。
+
+### 决策 3：Read 中的调用顺序与空值处理
+
+Read 方法在解析 `zoneId`/`envId`/`recordId` 后，先保留现有部署记录读取逻辑，随后追加环境信息读取：
+
+1. 现有逻辑：调用 `DescribeTeoDeployConfigVersionHistoryByFilter` 读取部署记录；若返回空，先打 `[CRUD]` 日志保留 id，再 `d.SetId("")` 返回 nil（既有实现已如此，保持不变，不动该段）。
+2. 新增逻辑：构造 `paramMap["ZoneId"] = &zoneId`，用 retry 包裹调用 `DescribeTeoEnvironmentsByFilter`（Read 超时 `tccommon.ReadRetryTimeout`，错误用 `tccommon.RetryError` 包装）。
+   - retry 块内仅做 API 调用与返回，不做 set/定位（遵循"retry 块只调用接口"约束）。
+   - retry 成功后，在 retry 块外遍历 `respData` 定位 `EnvId == envId` 的 `EnvInfo`。
+   - 若未定位到目标环境（含返回空切片）：打 `log.Printf("[CRUD] teo deploy config group version env not found, zone_id=%s env_id=%s", zoneId, envId)`，不报错、不 `d.SetId("")`，直接跳过新字段赋值返回（避免误清 ID；部署记录已读取成功即认为资源存在）。
+   - 若定位到：按字段逐个判 nil 后 `d.Set(...)`：
+     - `EnvType` → `env_type`
+     - `Scope`：转为 `[]interface{}`（元素为 string），`d.Set("scope", ...)`
+     - `CurrentConfigGroupVersionInfos`：遍历构造 `[]map[string]interface{}`，每个子字段判 nil 后赋值，`d.Set("current_config_group_version_infos", ...)`
+     - `CreateTime` → `env_create_time`
+     - `UpdateTime` → `env_update_time`
+     - `TotalCount`：取 `response.Response.TotalCount`，但 service 层方法只返回 `EnvInfos` 切片不返回 `TotalCount`。
+       - **处理**：`TotalCount` 无法从现有 service 方法获得。由于本次目标是"新增出参"，且 service 方法签名返回 `[]*EnvInfo`，调整 service 层签名影响面大（该方法在 Create 轮询中也被调用）。
+       - **取舍**：不修改 service 层签名；改为在 Read 中直接调用 `DescribeEnvironments` client 方法一次（经 `meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseTeoV20220901Client().DescribeEnvironmentsWithContext`），自行读取 `response.Response.TotalCount` 与 `EnvInfos`。
+       - **备选 B（采纳）**：扩展 `DescribeTeoEnvironmentsByFilter` 使其同时返回 `TotalCount`（如改返回值或新增方法）。考虑 Create 轮询只需 `EnvInfos`，为避免改动既有调用方，**新增一个 service 层薄封装** `DescribeTeoEnvironmentsWithTotalCount(ctx, zoneId)` 返回 `(uint64, []*EnvInfo, error)`，专供 Read 使用；Create 轮询不变。
+       - **最终选择 B**：保持既有方法不动，新增 service 方法，职责清晰、影响面最小。
+   - `TotalCount` 在 retry 块内随 API 调用一并取得（service 方法内部调用并返回），定位环境也放在 retry 块外。
+
+### 决策 4：service 层新增方法
+
+在 `service_tencentcloud_teo.go` 新增：
+
+```go
+func (me *TeoService) DescribeTeoEnvironmentsWithTotalCount(ctx context.Context, zoneId string) (totalCount uint64, envInfos []*teov20220901.EnvInfo, errRet error)
+```
+
+实现：构造 `NewDescribeEnvironmentsRequest()`，`request.ZoneId = helper.String(zoneId)`，`ratelimit.Check`，调用 `DescribeEnvironments`，校验 `response == nil || response.Response == nil` 后取 `TotalCount` 与 `EnvInfos` 返回。Read 中用 `tccommon.ReadRetryTimeout` + `tccommon.RetryError` 包裹。
+
+## Risks / Trade-offs
+
+- **[Risk] `DescribeEnvironments` 仅支持 `ZoneId` 过滤**：当某 Zone 下环境数量较多时，返回全部环境后本地遍历定位 `envId`，存在轻微性能/带宽开销。→ 影响有限（环境数量通常为 2-3 个：生产+测试），且接口已是现有轮询使用的接口，可接受。
+- **[Risk] 新增 service 方法与既有 `DescribeTeoEnvironmentsByFilter` 重复调用同一 API**：存在两份近似封装。→ 权衡：避免修改既有方法签名波及 Create 轮询逻辑；新增方法职责单一、便于维护，重复成本可控。
+- **[Trade-off] `total_count` 用 `TypeInt` 承载 `uint64`**：极端大值（>2^31）时可能溢出，但环境总数远小于此，且 schema 层面 `TypeInt` 为通用选择。→ 可接受。
+- **[Trade-off] 未定位到目标环境时不报错**：当 API 偶发未返回该环境时，新增字段保持未设置。→ 由于部署记录已成功读取（资源存在性由部署记录判定），环境信息缺失不应导致整体 Read 失败或清空 ID；用户可在下次 plan/refresh 时获得刷新。
+- **[Risk] retry 块边界**：需严格保证 retry 块内仅 API 调用，环境定位与 set 在块外。→ 通过代码审查与 specs 场景约束保证。
+
+## Migration Plan
+
+- 仅新增 Computed 字段，无数据迁移。
+- 部署：更新 provider 二进制后，既有 state 首次 `terraform refresh`/`plan` 时自动填充新字段。
+- 回滚：回退 provider 版本即可，新字段忽略不影响既有配置。

--- a/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/proposal.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+`tencentcloud_teo_deploy_config_group_version` 资源用于在 EdgeOne (TEO) 中发布配置组版本。当前资源通过 `DescribeConfigGroupVersionHistory` 接口读取部署记录信息（如 `record_id`、`deploy_time`、`status`、`message`），但缺少发布后环境维度的状态信息。
+
+用户需要感知版本发布后环境的实际生效状态、环境类型（生产/测试）、生效范围以及当前实际生效的配置组版本信息（含 `VersionId`、`VersionNumber`、`SourceVersion`、`GroupType`、`GroupId`、`Description`、`Status`、`CreateTime`），以便通过 Terraform state 跟踪部署结果与环境现状。这些信息由云 API `DescribeEnvironments` 的 `EnvInfo` 结构返回，当前资源已调用该接口（在 `Create` 中用于轮询环境状态）但未将其返回值写入 state。
+
+## What Changes
+
+- 为 `tencentcloud_teo_deploy_config_group_version` 资源新增出参（Computed），来源为 `DescribeEnvironments` 接口的 `EnvInfo` 结构：
+  - `total_count`（uint64）：环境总数。
+  - `env_type`（string）：环境类型，取值 `production` / `staging`。
+  - `scope`（string 列表）：当前环境配置生效范围（生产环境为 `["ALL"]`，测试环境返回测试节点 IP）。
+  - `current_config_group_version_infos`（集合）：当前环境各配置组实际生效的版本信息列表，元素包含：
+    - `version_id`（string）
+    - `version_number`（string）
+    - `source_version`（string）
+    - `group_type`（string）
+    - `group_id`（string）
+    - `description`（string）
+    - `status`（string）
+    - `create_time`（string）
+  - `env_create_time`（string）：环境创建时间。
+  - `env_update_time`（string）：环境更新时间。
+
+> 注意：现有 `config_group_version_infos`（来自部署记录 `DeployRecord`）字段保持不变，不进行修改。新增的 `current_config_group_version_infos` 是来自环境维度 `DescribeEnvironments` 的当前生效版本信息，二者来源不同、语义不同，故新增独立字段，不复用现有字段。
+
+## Capabilities
+
+### New Capabilities
+- `teo-deploy-config-group-version-env-info`: 为 `tencentcloud_teo_deploy_config_group_version` 资源补充来自 `DescribeEnvironments` 的环境维度的只读（Computed）出参，使用户可在 state 中跟踪发布后环境的实际生效状态与当前生效配置组版本信息。
+
+### Modified Capabilities
+<!-- 无既有 spec 的需求变更 -->
+
+## Impact
+
+- **代码**:
+  - `tencentcloud/services/teo/resource_tc_teo_deploy_config_group_version.go`：在 `Schema` 中新增上述 Computed 字段；在 `Read` 方法中调用 `DescribeTeoEnvironmentsByFilter`（已存在的 service 层方法）并填充新字段。
+  - `tencentcloud/services/teo/service_tencentcloud_teo.go`：现有 `DescribeTeoEnvironmentsByFilter` 已返回 `[]*EnvInfo`，无需新增 service 方法，仅在 Read 中补充取值逻辑。
+- **测试**: `tencentcloud/services/eo/resource_tc_teo_deploy_config_group_version_test.go` 补充新增字段的断言。
+- **文档**: `tencentcloud/services/teo/resource_tc_teo_deploy_config_group_version.md` 同步更新示例（由 `make doc` 生成 `website/docs/`）。
+- **API**: 复用 `DescribeEnvironments`（包名 `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901`），该接口已存在于 vendor，无新增依赖。
+- **兼容性**: 仅新增 Computed 字段，不修改既有 schema 字段，完全向后兼容。

--- a/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/specs/teo-deploy-config-group-version-env-info/spec.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/specs/teo-deploy-config-group-version-env-info/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Read environment-level info via DescribeEnvironments
+
+`resourceTencentCloudTeoDeployConfigGroupVersionRead` 在解析出 `zone_id` 与 `env_id` 后，除读取部署记录（`DescribeConfigGroupVersionHistory`）外，SHALL 额外调用 `DescribeEnvironments`（复用现有 service 层方法 `DescribeTeoEnvironmentsByFilter`，入参传入 `ZoneId`）定位 `EnvId == env_id` 的 `EnvInfo`，并将其字段映射为资源的 Computed 出参写入 state，以便用户跟踪版本发布后环境的实际生效状态与当前生效配置组版本信息。
+
+#### Scenario: 环境存在时填充全部新增出参
+
+- **WHEN** `DescribeEnvironments` 返回的 `EnvInfos` 中存在 `EnvId` 等于资源 `env_id` 的元素，且该元素各字段非空
+- **THEN** 系统 SHALL 将以下字段写入对应 Computed schema：
+  - `EnvInfo.EnvType` → `env_type`
+  - `EnvInfo.Scope`（`[]*string`）→ `scope`（string 列表，按原顺序保留元素）
+  - `EnvInfo.CurrentConfigGroupVersionInfos`（`[]*ConfigGroupVersionInfo`）→ `current_config_group_version_infos`（集合），其中每个元素映射：
+    - `VersionId` → `version_id`
+    - `VersionNumber` → `version_number`
+    - `SourceVersion` → `source_version`
+    - `GroupType` → `group_type`
+    - `GroupId` → `group_id`
+    - `Description` → `description`
+    - `Status` → `status`
+    - `CreateTime` → `create_time`
+  - `EnvInfo.CreateTime` → `env_create_time`
+  - `EnvInfo.UpdateTime` → `env_update_time`
+
+#### Scenario: DescribeEnvironments 返回环境总数
+
+- **WHEN** `DescribeEnvironments` 响应 `Response.TotalCount` 非空
+- **THEN** 系统 SHALL 将 `TotalCount`（`uint64`）写入资源 Computed 出参 `total_count`
+
+#### Scenario: 目标环境不存在时不报错且不影响既有部署记录读取
+
+- **WHEN** `DescribeEnvironments` 返回的 `EnvInfos` 中没有任何元素的 `EnvId` 等于资源 `env_id`（例如返回为空列表或仅含其它环境）
+- **THEN** 系统 SHALL 不对该新增出参做任何赋值（保持未设置），且 SHALL 不影响既有部署记录（`record_id`、`deploy_time`、`status`、`message`、`config_group_version_infos`）的读取，整个 Read 方法 SHALL 正常返回（不返回错误）
+
+#### Scenario: 字段为空时跳过对应 set 调用
+
+- **WHEN** 定位到的 `EnvInfo` 中某个字段为 `nil`（例如 `Scope` 为 nil、`CurrentConfigGroupVersionInfos` 为 nil、`CreateTime` 为 nil）
+- **THEN** 系统 SHALL 跳过该字段的 `d.Set()` 调用，不对 nil 字段强行写入，其余非空字段仍按 Scenario "环境存在时填充全部新增出参" 写入
+
+### Requirement: New computed schema fields are read-only and backward compatible
+
+`tencentcloud_teo_deploy_config_group_version` 资源 SHALL 新增以下 Computed 字段：`total_count`、`env_type`、`scope`、`current_config_group_version_infos`（嵌套集合，含 `version_id` / `version_number` / `source_version` / `group_type` / `group_id` / `description` / `status` / `create_time`）、`env_create_time`、`env_update_time`。所有新增字段 MUST 为 `Computed: true` 且不可由用户输入（不设 `Required`/`Optional`），从而保持向后兼容：现有 Terraform 配置与 state 不受影响，`terraform plan` 对既有配置不产生 diff。
+
+#### Scenario: 新增字段为 Computed 且不可配置
+
+- **WHEN** 用户编写 `tencentcloud_teo_deploy_config_group_version` 资源的 HCL 配置
+- **THEN** `total_count`、`env_type`、`scope`、`current_config_group_version_infos`、`env_create_time`、`env_update_time` SHALL 不出现在用户可配置参数中（均为 Computed-only），用户无需也无法显式设置这些字段
+
+#### Scenario: 向后兼容既有配置
+
+- **WHEN** 一个在本次变更前创建的 `tencentcloud_teo_deploy_config_group_version` 资源配置在本次变更后再次执行 `terraform plan`
+- **THEN** 该配置 SHALL 不产生由本次新增字段导致的 diff（新增字段均为 Computed，不影响既有 `zone_id` / `env_id` / `config_group_version_infos` / `description` 等字段语义）

--- a/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/tasks.md
+++ b/openspec/changes/archive/2026-08-11-add-teo-deploy-config-group-version-env-info-params/tasks.md
@@ -1,0 +1,37 @@
+## 1. Service 层（service_tencentcloud_teo.go）
+
+- [x] 1.1 在 `service_tencentcloud_teo.go` 新增 service 方法 `DescribeTeoEnvironmentsWithTotalCount(ctx context.Context, zoneId string) (totalCount uint64, envInfos []*teov20220901.EnvInfo, errRet error)`：构造 `NewDescribeEnvironmentsRequest()`，设置 `request.ZoneId = helper.String(zoneId)`，`ratelimit.Check(request.GetAction())`，调用 `me.client.UseTeoV20220901Client().DescribeEnvironments(request)`；校验 `response == nil || response.Response == nil` 后返回 `response.Response.TotalCount`（`uint64`）与 `response.Response.EnvInfos`；保留既有错误日志 defer。不修改既有 `DescribeTeoEnvironmentsByFilter`。
+- [x] 1.2 校验新增 service 方法对 `DescribeEnvironments` 的字段访问与 vendor 中 `DescribeEnvironmentsResponseParams`（`TotalCount`、`EnvInfos`）一致，确保编译正确。
+
+## 2. 资源 Schema（resource_tc_teo_deploy_config_group_version.go）
+
+- [x] 2.1 在 `ResourceTencentCloudTeoDeployConfigGroupVersion` 的 `Schema` map 中新增 Computed 字段：`total_count`（`schema.TypeInt`）、`env_type`（`schema.TypeString`）、`scope`（`schema.TypeList`，`Elem: &schema.Schema{Type: schema.TypeString}`）、`env_create_time`（`schema.TypeString`）、`env_update_time`（`schema.TypeString`）。
+- [x] 2.2 新增 `current_config_group_version_infos`（`schema.TypeSet`，`Computed: true`），`Elem` 为 `&schema.Resource{Schema: ...}`，其子字段均为 `schema.TypeString` 且 `Computed: true`：`version_id`、`version_number`、`source_version`、`group_type`、`group_id`、`description`、`status`、`create_time`。子字段命名与既有 `config_group_version_infos` 子字段保持风格一致，并补充 `source_version`。
+- [x] 2.3 确保所有新增字段均为 `Computed: true`，不设 `Required`/`Optional`/`ForceNew`，保持向后兼容。
+
+## 3. 资源 Read 方法（resource_tc_teo_deploy_config_group_version.go）
+
+- [x] 3.1 在 `resourceTencentCloudTeoDeployConfigGroupVersionRead` 中，保留现有部署记录读取逻辑（`DescribeTeoDeployConfigVersionHistoryByFilter` 及其字段 set、空返回时 `d.SetId("")` 前打 `[CRUD]` 日志）不变。
+- [x] 3.2 在部署记录读取成功（`len(respData) > 0`）后，使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 调用新增 service 方法 `service.DescribeTeoEnvironmentsWithTotalCount(ctx, zoneId)`；retry 块内仅调用接口并返回（`error` 用 `tccommon.RetryError` 包装），不做 set/定位。
+- [x] 3.3 在 retry 块外：将返回的 `totalCount`（非 0 时）通过 `d.Set("total_count", totalCount)` 写入；遍历 `envInfos` 定位 `*item.EnvId == envId` 的元素。
+- [x] 3.4 若未定位到目标环境（含 `envInfos` 为空）：打印 `log.Printf("[CRUD] teo deploy config group version env not found, zone_id=%s env_id=%s", zoneId, envId)`，跳过环境字段赋值，不 `d.SetId("")`，正常返回 nil。
+- [x] 3.5 若定位到 `EnvInfo`：逐字段判 nil 后 set：`EnvType`→`env_type`；`Scope`（`[]*string`）转为 `[]interface{}` 后 `d.Set("scope", ...)`；`CreateTime`→`env_create_time`；`UpdateTime`→`env_update_time`。
+- [x] 3.6 若 `CurrentConfigGroupVersionInfos` 非 nil：遍历构造 `[]map[string]interface{}`，每个子字段（`VersionId`/`VersionNumber`/`SourceVersion`/`GroupType`/`GroupId`/`Description`/`Status`/`CreateTime`）判 nil 后写入对应 key，最后 `d.Set("current_config_group_version_infos", ...)`。所有 `d.Set` 的 error 用 `_ =` 接收避免未使用变量。
+
+## 4. 单元测试（resource_tc_teo_deploy_config_group_version_test.go）
+
+- [x] 4.1 在既有测试文件中，使用 gomonkey mock `DescribeEnvironments` client 方法（与新增 service 方法对应），构造包含目标 `envId` 的 `EnvInfo`（含 `TotalCount`、`EnvType`、`Scope`、`CurrentConfigGroupVersionInfos` 各子字段、`CreateTime`、`UpdateTime`），验证 Read 后 state 中 `total_count`/`env_type`/`scope`/`current_config_group_version_infos`/`env_create_time`/`env_update_time` 被正确填充。
+- [x] 4.2 补充场景：`EnvInfos` 中无目标 `envId` 时，Read 不报错、不清空 ID，且新增字段保持未设置。
+- [x] 4.3 补充场景：`EnvInfo` 部分字段为 nil 时，对应字段被跳过 set 而不报错。
+- [x] 4.4 确保新增测试用例可正确构建（不执行 `go test`，仅保证代码可编译）。
+
+## 5. 文档
+
+- [x] 5.1 更新 `tencentcloud/services/teo/resource_tc_teo_deploy_config_group_version.md`，在 Example Usage 中保持既有示例，并补充新增 Computed 字段说明由 `make doc` 自动生成 `Argument Reference`/`Attribute Reference`（不手动编写这两部分）。
+- [x] 5.2 在收尾阶段通过 `make doc` 生成 `website/docs/r/teo_deploy_config_group_version.html.markdown`（不在本阶段手动编辑 website/ 目录）。
+
+## 6. 验证（收尾阶段）
+
+- [x] 6.1 执行 `gofmt` 格式化本次变更的 Go 文件（由 tfpacer-finalize skill 统一执行）。
+- [x] 6.2 由收尾流程执行 `make doc` 生成文档，并生成 `.changelog/` 文件。
+- [x] 6.3 由其他流程执行构建/检查（本阶段不执行 `go build`/`go vet`/`golint`）。

--- a/openspec/specs/teo-deploy-config-group-version-env-info/spec.md
+++ b/openspec/specs/teo-deploy-config-group-version-env-info/spec.md
@@ -1,0 +1,56 @@
+# teo-deploy-config-group-version-env-info Specification
+
+## Purpose
+TBD - created by archiving change add-teo-deploy-config-group-version-env-info-params. Update Purpose after archive.
+## Requirements
+### Requirement: Read environment-level info via DescribeEnvironments
+
+`resourceTencentCloudTeoDeployConfigGroupVersionRead` 在解析出 `zone_id` 与 `env_id` 后，除读取部署记录（`DescribeConfigGroupVersionHistory`）外，SHALL 额外调用 `DescribeEnvironments`（复用现有 service 层方法 `DescribeTeoEnvironmentsByFilter`，入参传入 `ZoneId`）定位 `EnvId == env_id` 的 `EnvInfo`，并将其字段映射为资源的 Computed 出参写入 state，以便用户跟踪版本发布后环境的实际生效状态与当前生效配置组版本信息。
+
+#### Scenario: 环境存在时填充全部新增出参
+
+- **WHEN** `DescribeEnvironments` 返回的 `EnvInfos` 中存在 `EnvId` 等于资源 `env_id` 的元素，且该元素各字段非空
+- **THEN** 系统 SHALL 将以下字段写入对应 Computed schema：
+  - `EnvInfo.EnvType` → `env_type`
+  - `EnvInfo.Scope`（`[]*string`）→ `scope`（string 列表，按原顺序保留元素）
+  - `EnvInfo.CurrentConfigGroupVersionInfos`（`[]*ConfigGroupVersionInfo`）→ `current_config_group_version_infos`（集合），其中每个元素映射：
+    - `VersionId` → `version_id`
+    - `VersionNumber` → `version_number`
+    - `SourceVersion` → `source_version`
+    - `GroupType` → `group_type`
+    - `GroupId` → `group_id`
+    - `Description` → `description`
+    - `Status` → `status`
+    - `CreateTime` → `create_time`
+  - `EnvInfo.CreateTime` → `env_create_time`
+  - `EnvInfo.UpdateTime` → `env_update_time`
+
+#### Scenario: DescribeEnvironments 返回环境总数
+
+- **WHEN** `DescribeEnvironments` 响应 `Response.TotalCount` 非空
+- **THEN** 系统 SHALL 将 `TotalCount`（`uint64`）写入资源 Computed 出参 `total_count`
+
+#### Scenario: 目标环境不存在时不报错且不影响既有部署记录读取
+
+- **WHEN** `DescribeEnvironments` 返回的 `EnvInfos` 中没有任何元素的 `EnvId` 等于资源 `env_id`（例如返回为空列表或仅含其它环境）
+- **THEN** 系统 SHALL 不对该新增出参做任何赋值（保持未设置），且 SHALL 不影响既有部署记录（`record_id`、`deploy_time`、`status`、`message`、`config_group_version_infos`）的读取，整个 Read 方法 SHALL 正常返回（不返回错误）
+
+#### Scenario: 字段为空时跳过对应 set 调用
+
+- **WHEN** 定位到的 `EnvInfo` 中某个字段为 `nil`（例如 `Scope` 为 nil、`CurrentConfigGroupVersionInfos` 为 nil、`CreateTime` 为 nil）
+- **THEN** 系统 SHALL 跳过该字段的 `d.Set()` 调用，不对 nil 字段强行写入，其余非空字段仍按 Scenario "环境存在时填充全部新增出参" 写入
+
+### Requirement: New computed schema fields are read-only and backward compatible
+
+`tencentcloud_teo_deploy_config_group_version` 资源 SHALL 新增以下 Computed 字段：`total_count`、`env_type`、`scope`、`current_config_group_version_infos`（嵌套集合，含 `version_id` / `version_number` / `source_version` / `group_type` / `group_id` / `description` / `status` / `create_time`）、`env_create_time`、`env_update_time`。所有新增字段 MUST 为 `Computed: true` 且不可由用户输入（不设 `Required`/`Optional`），从而保持向后兼容：现有 Terraform 配置与 state 不受影响，`terraform plan` 对既有配置不产生 diff。
+
+#### Scenario: 新增字段为 Computed 且不可配置
+
+- **WHEN** 用户编写 `tencentcloud_teo_deploy_config_group_version` 资源的 HCL 配置
+- **THEN** `total_count`、`env_type`、`scope`、`current_config_group_version_infos`、`env_create_time`、`env_update_time` SHALL 不出现在用户可配置参数中（均为 Computed-only），用户无需也无法显式设置这些字段
+
+#### Scenario: 向后兼容既有配置
+
+- **WHEN** 一个在本次变更前创建的 `tencentcloud_teo_deploy_config_group_version` 资源配置在本次变更后再次执行 `terraform plan`
+- **THEN** 该配置 SHALL 不产生由本次新增字段导致的 diff（新增字段均为 Computed，不影响既有 `zone_id` / `env_id` / `config_group_version_infos` / `description` 等字段语义）
+

--- a/tencentcloud/services/teo/resource_tc_teo_deploy_config_group_version.go
+++ b/tencentcloud/services/teo/resource_tc_teo_deploy_config_group_version.go
@@ -115,6 +115,87 @@ func ResourceTencentCloudTeoDeployConfigGroupVersion() *schema.Resource {
 				Computed:    true,
 				Description: "Deploy result message.",
 			},
+
+			"total_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Total number of environments under the zone, returned by DescribeEnvironments.",
+			},
+
+			"env_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Environment type. Valid values: production, staging.",
+			},
+
+			"scope": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Current environment config effective scope. For production environment it is [\"ALL\"], for staging environment it returns test node IPs.",
+			},
+
+			"current_config_group_version_infos": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Currently effective config group version infos of the target environment, returned by DescribeEnvironments.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"version_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Config group version ID.",
+						},
+						"version_number": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Config group version number.",
+						},
+						"source_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Source version ID that the config group version is based on.",
+						},
+						"group_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Config group type.",
+						},
+						"group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Config group ID.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Version description.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Version status.",
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Version creation time.",
+						},
+					},
+				},
+			},
+
+			"env_create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Environment creation time.",
+			},
+
+			"env_update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Environment update time.",
+			},
 		},
 	}
 }
@@ -318,6 +399,107 @@ func resourceTencentCloudTeoDeployConfigGroupVersionRead(d *schema.ResourceData,
 
 	_ = d.Set("zone_id", zoneId)
 	_ = d.Set("env_id", envId)
+
+	// Read environment-level info via DescribeEnvironments to populate the
+	// env-related computed fields (total_count/env_type/scope/current_config_group_version_infos/env_create_time/env_update_time).
+	var (
+		totalCount uint64
+		envInfos   []*teov20220901.EnvInfo
+	)
+	retryErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		tc, ei, e := service.DescribeTeoEnvironmentsWithTotalCount(ctx, zoneId)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+		totalCount = tc
+		envInfos = ei
+		return nil
+	})
+	if retryErr != nil {
+		log.Printf("[CRITAL]%s read teo deploy config group version env info failed, reason:%+v", logId, retryErr)
+		return retryErr
+	}
+
+	if totalCount != 0 {
+		_ = d.Set("total_count", totalCount)
+	}
+
+	var targetEnv *teov20220901.EnvInfo
+	for _, item := range envInfos {
+		if item.EnvId != nil && *item.EnvId == envId {
+			targetEnv = item
+			break
+		}
+	}
+
+	if targetEnv == nil {
+		log.Printf("[CRUD] teo deploy config group version env not found, zone_id=%s env_id=%s", zoneId, envId)
+		return nil
+	}
+
+	if targetEnv.EnvType != nil {
+		_ = d.Set("env_type", targetEnv.EnvType)
+	}
+
+	if targetEnv.Scope != nil {
+		scopeList := make([]interface{}, 0, len(targetEnv.Scope))
+		for _, s := range targetEnv.Scope {
+			if s != nil {
+				scopeList = append(scopeList, *s)
+			}
+		}
+		_ = d.Set("scope", scopeList)
+	}
+
+	if targetEnv.CreateTime != nil {
+		_ = d.Set("env_create_time", targetEnv.CreateTime)
+	}
+
+	if targetEnv.UpdateTime != nil {
+		_ = d.Set("env_update_time", targetEnv.UpdateTime)
+	}
+
+	if targetEnv.CurrentConfigGroupVersionInfos != nil {
+		currentConfigGroupVersionInfosList := make([]map[string]interface{}, 0, len(targetEnv.CurrentConfigGroupVersionInfos))
+		for _, currentConfigGroupVersionInfo := range targetEnv.CurrentConfigGroupVersionInfos {
+			currentConfigGroupVersionInfoMap := map[string]interface{}{}
+
+			if currentConfigGroupVersionInfo.VersionId != nil {
+				currentConfigGroupVersionInfoMap["version_id"] = currentConfigGroupVersionInfo.VersionId
+			}
+
+			if currentConfigGroupVersionInfo.VersionNumber != nil {
+				currentConfigGroupVersionInfoMap["version_number"] = currentConfigGroupVersionInfo.VersionNumber
+			}
+
+			if currentConfigGroupVersionInfo.SourceVersion != nil {
+				currentConfigGroupVersionInfoMap["source_version"] = currentConfigGroupVersionInfo.SourceVersion
+			}
+
+			if currentConfigGroupVersionInfo.GroupType != nil {
+				currentConfigGroupVersionInfoMap["group_type"] = currentConfigGroupVersionInfo.GroupType
+			}
+
+			if currentConfigGroupVersionInfo.GroupId != nil {
+				currentConfigGroupVersionInfoMap["group_id"] = currentConfigGroupVersionInfo.GroupId
+			}
+
+			if currentConfigGroupVersionInfo.Description != nil {
+				currentConfigGroupVersionInfoMap["description"] = currentConfigGroupVersionInfo.Description
+			}
+
+			if currentConfigGroupVersionInfo.Status != nil {
+				currentConfigGroupVersionInfoMap["status"] = currentConfigGroupVersionInfo.Status
+			}
+
+			if currentConfigGroupVersionInfo.CreateTime != nil {
+				currentConfigGroupVersionInfoMap["create_time"] = currentConfigGroupVersionInfo.CreateTime
+			}
+
+			currentConfigGroupVersionInfosList = append(currentConfigGroupVersionInfosList, currentConfigGroupVersionInfoMap)
+		}
+		_ = d.Set("current_config_group_version_infos", currentConfigGroupVersionInfosList)
+	}
 
 	return nil
 }

--- a/tencentcloud/services/teo/resource_tc_teo_deploy_config_group_version_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_deploy_config_group_version_test.go
@@ -3,9 +3,41 @@ package teo_test
 import (
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	teov20220901 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/teo"
+
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 )
+
+// mockMetaForDeployConfigGroupVersion implements tccommon.ProviderMeta
+type mockMetaForDeployConfigGroupVersion struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForDeployConfigGroupVersion) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForDeployConfigGroupVersion{}
+
+func newMockMetaForDeployConfigGroupVersion() *mockMetaForDeployConfigGroupVersion {
+	return &mockMetaForDeployConfigGroupVersion{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrDeployConfigGroupVersion(s string) *string {
+	return &s
+}
+
+func ptrUint64DeployConfigGroupVersion(u uint64) *uint64 {
+	return &u
+}
 
 func TestAccTencentCloudTeoDeployConfigGroupVersionResource_basic(t *testing.T) {
 	t.Parallel()
@@ -60,3 +92,304 @@ resource "tencentcloud_teo_deploy_config_group_version" "teo_deploy_config_group
   }
 }
 `
+
+// mockDeployHistoryResponseForEnvInfo builds a DescribeDeployHistory response that contains
+// one deploy record, so the existing deploy-record read path succeeds and reaches the new
+// environment-info read logic.
+func mockDeployHistoryResponseForEnvInfo() *teov20220901.DescribeDeployHistoryResponse {
+	resp := teov20220901.NewDescribeDeployHistoryResponse()
+	resp.Response = &teov20220901.DescribeDeployHistoryResponseParams{
+		TotalCount: ptrUint64DeployConfigGroupVersion(1),
+		Records: []*teov20220901.DeployRecord{
+			{
+				RecordId:   ptrStrDeployConfigGroupVersion("rec-001"),
+				DeployTime: ptrStrDeployConfigGroupVersion("2026-08-11T00:00:00Z"),
+				Status:     ptrStrDeployConfigGroupVersion("success"),
+				Message:    ptrStrDeployConfigGroupVersion("deploy ok"),
+			},
+		},
+		RequestId: ptrStrDeployConfigGroupVersion("fake-request-id-history"),
+	}
+	return resp
+}
+
+// mockEnvironmentsResponseForEnvInfo builds a DescribeEnvironments response containing the
+// target env id with all env-related fields populated.
+func mockEnvironmentsResponseForEnvInfo(envId string) *teov20220901.DescribeEnvironmentsResponse {
+	resp := teov20220901.NewDescribeEnvironmentsResponse()
+	resp.Response = &teov20220901.DescribeEnvironmentsResponseParams{
+		TotalCount: ptrUint64DeployConfigGroupVersion(2),
+		EnvInfos: []*teov20220901.EnvInfo{
+			{
+				EnvId:   ptrStrDeployConfigGroupVersion("env-other"),
+				EnvType: ptrStrDeployConfigGroupVersion("staging"),
+				Status:  ptrStrDeployConfigGroupVersion("running"),
+				Scope:   []*string{ptrStrDeployConfigGroupVersion("1.2.3.4")},
+			},
+			{
+				EnvId:      ptrStrDeployConfigGroupVersion(envId),
+				EnvType:    ptrStrDeployConfigGroupVersion("production"),
+				Status:     ptrStrDeployConfigGroupVersion("running"),
+				Scope:      []*string{ptrStrDeployConfigGroupVersion("ALL")},
+				CreateTime: ptrStrDeployConfigGroupVersion("2026-08-10T00:00:00Z"),
+				UpdateTime: ptrStrDeployConfigGroupVersion("2026-08-11T00:00:00Z"),
+				CurrentConfigGroupVersionInfos: []*teov20220901.ConfigGroupVersionInfo{
+					{
+						VersionId:     ptrStrDeployConfigGroupVersion("ver-aaa"),
+						VersionNumber: ptrStrDeployConfigGroupVersion("3"),
+						SourceVersion: ptrStrDeployConfigGroupVersion("ver-bbb"),
+						GroupType:     ptrStrDeployConfigGroupVersion("l7_acceleration"),
+						GroupId:       ptrStrDeployConfigGroupVersion("cg-aaa"),
+						Description:   ptrStrDeployConfigGroupVersion("env effective version"),
+						Status:        ptrStrDeployConfigGroupVersion("active"),
+						CreateTime:    ptrStrDeployConfigGroupVersion("2026-08-09T00:00:00Z"),
+					},
+				},
+			},
+		},
+		RequestId: ptrStrDeployConfigGroupVersion("fake-request-id-env"),
+	}
+	return resp
+}
+
+// TestDeployConfigGroupVersionEnvInfo_Read_Success tests Read populates all the new env-related
+// computed fields when the target env is present in DescribeEnvironments.
+func TestDeployConfigGroupVersionEnvInfo_Read_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForDeployConfigGroupVersion().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeDeployHistory", func(request *teov20220901.DescribeDeployHistoryRequest) (*teov20220901.DescribeDeployHistoryResponse, error) {
+		return mockDeployHistoryResponseForEnvInfo(), nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeEnvironments", func(request *teov20220901.DescribeEnvironmentsRequest) (*teov20220901.DescribeEnvironmentsResponse, error) {
+		return mockEnvironmentsResponseForEnvInfo("env-target"), nil
+	})
+
+	meta := newMockMetaForDeployConfigGroupVersion()
+	res := teo.ResourceTencentCloudTeoDeployConfigGroupVersion()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":     "zone-test123",
+		"env_id":      "env-target",
+		"description": "deploy desc",
+	})
+	d.SetId("zone-test123#env-target#rec-001")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// Existing deploy-record fields
+	assert.Equal(t, "rec-001", d.Get("record_id"))
+	assert.Equal(t, "success", d.Get("status"))
+
+	// New env-related computed fields
+	assert.Equal(t, 2, d.Get("total_count"))
+	assert.Equal(t, "production", d.Get("env_type"))
+	assert.Equal(t, "ALL", d.Get("scope").([]interface{})[0])
+
+	// env create/update time
+	assert.Equal(t, "2026-08-10T00:00:00Z", d.Get("env_create_time"))
+	assert.Equal(t, "2026-08-11T00:00:00Z", d.Get("env_update_time"))
+
+	// current_config_group_version_infos set
+	currentSet := d.Get("current_config_group_version_infos").(*schema.Set)
+	assert.Equal(t, 1, currentSet.Len())
+	list := currentSet.List()
+	item := list[0].(map[string]interface{})
+	assert.Equal(t, "ver-aaa", item["version_id"])
+	assert.Equal(t, "3", item["version_number"])
+	assert.Equal(t, "ver-bbb", item["source_version"])
+	assert.Equal(t, "l7_acceleration", item["group_type"])
+	assert.Equal(t, "cg-aaa", item["group_id"])
+	assert.Equal(t, "env effective version", item["description"])
+	assert.Equal(t, "active", item["status"])
+	assert.Equal(t, "2026-08-09T00:00:00Z", item["create_time"])
+
+	// ID must NOT be cleared
+	assert.Equal(t, "zone-test123#env-target#rec-001", d.Id())
+}
+
+// TestDeployConfigGroupVersionEnvInfo_Read_EnvNotFound tests Read when DescribeEnvironments
+// does not contain the target env id: no error, ID not cleared, new fields not set.
+func TestDeployConfigGroupVersionEnvInfo_Read_EnvNotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForDeployConfigGroupVersion().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeDeployHistory", func(request *teov20220901.DescribeDeployHistoryRequest) (*teov20220901.DescribeDeployHistoryResponse, error) {
+		return mockDeployHistoryResponseForEnvInfo(), nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeEnvironments", func(request *teov20220901.DescribeEnvironmentsRequest) (*teov20220901.DescribeEnvironmentsResponse, error) {
+		resp := teov20220901.NewDescribeEnvironmentsResponse()
+		resp.Response = &teov20220901.DescribeEnvironmentsResponseParams{
+			TotalCount: ptrUint64DeployConfigGroupVersion(1),
+			EnvInfos: []*teov20220901.EnvInfo{
+				{
+					EnvId:   ptrStrDeployConfigGroupVersion("env-other"),
+					EnvType: ptrStrDeployConfigGroupVersion("staging"),
+					Status:  ptrStrDeployConfigGroupVersion("running"),
+				},
+			},
+			RequestId: ptrStrDeployConfigGroupVersion("fake-request-id-env"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForDeployConfigGroupVersion()
+	res := teo.ResourceTencentCloudTeoDeployConfigGroupVersion()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":     "zone-test123",
+		"env_id":      "env-target",
+		"description": "deploy desc",
+	})
+	d.SetId("zone-test123#env-target#rec-001")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// Existing deploy-record fields still populated
+	assert.Equal(t, "rec-001", d.Get("record_id"))
+
+	// New env fields remain unset (zero values)
+	assert.Equal(t, 0, d.Get("total_count"))
+	assert.Equal(t, "", d.Get("env_type"))
+	assert.Equal(t, 0, len(d.Get("scope").([]interface{})))
+	assert.Equal(t, 0, d.Get("current_config_group_version_infos").(*schema.Set).Len())
+
+	// ID must NOT be cleared
+	assert.Equal(t, "zone-test123#env-target#rec-001", d.Id())
+}
+
+// TestDeployConfigGroupVersionEnvInfo_Read_PartialNilFields tests Read when the target EnvInfo
+// has some nil fields: nil fields are skipped (not set) without error.
+func TestDeployConfigGroupVersionEnvInfo_Read_PartialNilFields(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	teoClient := &teov20220901.Client{}
+	patches.ApplyMethodReturn(newMockMetaForDeployConfigGroupVersion().client, "UseTeoV20220901Client", teoClient)
+
+	patches.ApplyMethodFunc(teoClient, "DescribeDeployHistory", func(request *teov20220901.DescribeDeployHistoryRequest) (*teov20220901.DescribeDeployHistoryResponse, error) {
+		return mockDeployHistoryResponseForEnvInfo(), nil
+	})
+
+	patches.ApplyMethodFunc(teoClient, "DescribeEnvironments", func(request *teov20220901.DescribeEnvironmentsRequest) (*teov20220901.DescribeEnvironmentsResponse, error) {
+		resp := teov20220901.NewDescribeEnvironmentsResponse()
+		resp.Response = &teov20220901.DescribeEnvironmentsResponseParams{
+			TotalCount: ptrUint64DeployConfigGroupVersion(1),
+			EnvInfos: []*teov20220901.EnvInfo{
+				{
+					EnvId:      ptrStrDeployConfigGroupVersion("env-target"),
+					EnvType:    ptrStrDeployConfigGroupVersion("production"),
+					Status:     ptrStrDeployConfigGroupVersion("running"),
+					Scope:      nil,
+					CreateTime: nil,
+					UpdateTime: nil,
+					CurrentConfigGroupVersionInfos: []*teov20220901.ConfigGroupVersionInfo{
+						{
+							VersionId:     ptrStrDeployConfigGroupVersion("ver-aaa"),
+							VersionNumber: nil,
+							SourceVersion: nil,
+							GroupType:     nil,
+							GroupId:       ptrStrDeployConfigGroupVersion("cg-aaa"),
+							Description:   nil,
+							Status:        ptrStrDeployConfigGroupVersion("active"),
+							CreateTime:    nil,
+						},
+					},
+				},
+			},
+			RequestId: ptrStrDeployConfigGroupVersion("fake-request-id-env"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForDeployConfigGroupVersion()
+	res := teo.ResourceTencentCloudTeoDeployConfigGroupVersion()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone_id":     "zone-test123",
+		"env_id":      "env-target",
+		"description": "deploy desc",
+	})
+	d.SetId("zone-test123#env-target#rec-001")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	// env_type set, but env_create_time/env_update_time/scope skipped (nil)
+	assert.Equal(t, "production", d.Get("env_type"))
+	assert.Equal(t, "", d.Get("env_create_time"))
+	assert.Equal(t, "", d.Get("env_update_time"))
+	assert.Equal(t, 0, len(d.Get("scope").([]interface{})))
+
+	// current_config_group_version_infos: only non-nil sub-fields populated
+	currentSet := d.Get("current_config_group_version_infos").(*schema.Set)
+	assert.Equal(t, 1, currentSet.Len())
+	item := currentSet.List()[0].(map[string]interface{})
+	assert.Equal(t, "ver-aaa", item["version_id"])
+	assert.Equal(t, "cg-aaa", item["group_id"])
+	assert.Equal(t, "active", item["status"])
+	assert.Equal(t, "", item["version_number"])
+	assert.Equal(t, "", item["source_version"])
+	assert.Equal(t, "", item["group_type"])
+	assert.Equal(t, "", item["description"])
+	assert.Equal(t, "", item["create_time"])
+
+	// ID must NOT be cleared
+	assert.Equal(t, "zone-test123#env-target#rec-001", d.Id())
+}
+
+// TestDeployConfigGroupVersionEnvInfo_Schema verifies the new computed fields exist and are
+// Computed-only (no Required/Optional/ForceNew).
+func TestDeployConfigGroupVersionEnvInfo_Schema(t *testing.T) {
+	res := teo.ResourceTencentCloudTeoDeployConfigGroupVersion()
+	assert.NotNil(t, res)
+
+	checks := map[string]schema.ValueType{
+		"total_count":     schema.TypeInt,
+		"env_type":        schema.TypeString,
+		"scope":           schema.TypeList,
+		"env_create_time": schema.TypeString,
+		"env_update_time": schema.TypeString,
+	}
+	for name, typ := range checks {
+		s, ok := res.Schema[name]
+		assert.True(t, ok, "field %s should exist", name)
+		assert.Equal(t, typ, s.Type, "field %s type", name)
+		assert.True(t, s.Computed, "field %s should be Computed", name)
+		assert.False(t, s.Required, "field %s should not be Required", name)
+		assert.False(t, s.Optional, "field %s should not be Optional", name)
+		assert.False(t, s.ForceNew, "field %s should not be ForceNew", name)
+	}
+
+	// current_config_group_version_infos is a TypeSet of schema.Resource
+	cgv, ok := res.Schema["current_config_group_version_infos"]
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeSet, cgv.Type)
+	assert.True(t, cgv.Computed)
+	assert.False(t, cgv.Required)
+	assert.False(t, cgv.Optional)
+	assert.False(t, cgv.ForceNew)
+
+	r, ok := cgv.Elem.(*schema.Resource)
+	assert.True(t, ok)
+	subFields := []string{
+		"version_id", "version_number", "source_version", "group_type",
+		"group_id", "description", "status", "create_time",
+	}
+	for _, f := range subFields {
+		s, ok := r.Schema[f]
+		assert.True(t, ok, "sub field %s should exist", f)
+		assert.Equal(t, schema.TypeString, s.Type)
+		assert.True(t, s.Computed)
+		assert.False(t, s.Required)
+		assert.False(t, s.Optional)
+		assert.False(t, s.ForceNew)
+	}
+}

--- a/tencentcloud/services/teo/service_tencentcloud_teo.go
+++ b/tencentcloud/services/teo/service_tencentcloud_teo.go
@@ -2488,6 +2488,40 @@ func (me *TeoService) DescribeTeoEnvironmentsByFilter(ctx context.Context, param
 	return
 }
 
+func (me *TeoService) DescribeTeoEnvironmentsWithTotalCount(ctx context.Context, zoneId string) (totalCount uint64, envInfos []*teov20220901.EnvInfo, errRet error) {
+	var (
+		logId   = tccommon.GetLogId(ctx)
+		request = teov20220901.NewDescribeEnvironmentsRequest()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	request.ZoneId = helper.String(zoneId)
+
+	ratelimit.Check(request.GetAction())
+
+	response, err := me.client.UseTeoV20220901Client().DescribeEnvironments(request)
+	if err != nil {
+		errRet = err
+		return
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+	if response == nil || response.Response == nil {
+		return
+	}
+
+	if response.Response.TotalCount != nil {
+		totalCount = *response.Response.TotalCount
+	}
+	envInfos = response.Response.EnvInfos
+	return
+}
+
 func (me *TeoService) DescribeTeoConfigGroupVersionDetailByFilter(ctx context.Context, param map[string]interface{}) (ret *teov20220901.DescribeConfigGroupVersionDetailResponseParams, errRet error) {
 	var (
 		logId   = tccommon.GetLogId(ctx)

--- a/website/docs/r/teo_deploy_config_group_version.html.markdown
+++ b/website/docs/r/teo_deploy_config_group_version.html.markdown
@@ -47,10 +47,24 @@ The `config_group_version_infos` object supports the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
+* `current_config_group_version_infos` - Currently effective config group version infos of the target environment, returned by DescribeEnvironments.
+  * `create_time` - Version creation time.
+  * `description` - Version description.
+  * `group_id` - Config group ID.
+  * `group_type` - Config group type.
+  * `source_version` - Source version ID that the config group version is based on.
+  * `status` - Version status.
+  * `version_id` - Config group version ID.
+  * `version_number` - Config group version number.
 * `deploy_time` - Deploy time. The time follows the ISO 8601 standard in the date and time format.
+* `env_create_time` - Environment creation time.
+* `env_type` - Environment type. Valid values: production, staging.
+* `env_update_time` - Environment update time.
 * `message` - Deploy result message.
 * `record_id` - Deploy record ID.
+* `scope` - Current environment config effective scope. For production environment it is ["ALL"], for staging environment it returns test node IPs.
 * `status` - Deploy status. Valid values: deploying (Deploying), failure (Deploy failed), success (Deploy successful).
+* `total_count` - Total number of environments under the zone, returned by DescribeEnvironments.
 
 ## Timeouts
 


### PR DESCRIPTION
Add environment info parameters for the tencentcloud_teo_deploy_config_group_version resource. This change adds new parameters to support environment info configuration for TEO deploy config group version.