### PR TITLE
feat(cls): [137032642] add kms_region and kms_key_id parameters for tencentcloud_cls_topic

### DIFF
--- a/.changelog/4420.txt
+++ b/.changelog/4420.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_cls_topic: support custom KMS key (kms_region, kms_key_id) for encryption
+```

--- a/go.mod
+++ b/go.mod
@@ -45,8 +45,8 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30

--- a/go.sum
+++ b/go.sum
@@ -921,8 +921,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150 h1:2X+xqin
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150/go.mod h1:CHHOG5L7otIpZ7/vezeb8JpKH80pcD1UWiKLHsA8q5o=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40 h1:bhPBpfz0w3mdVyEolvXrtELUf+gE00O0WnAYIHZq70s=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40/go.mod h1:taTki0q8SHBIUFhjtnDA5UkiVic/WaPQzTqoXeGH3Ns=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144 h1:uo7VAvHPiOk5pjSDjSYg3nVwzfEMWlyCyIskZ21phSs=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144/go.mod h1:/mLs5tGgvzeGTaMLLsI4E+L8PBkrjXIKj0WmgoqiLDw=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156 h1:ZJFNFbOfG76X9KlwK7AbcdkBcwfFWig7IS9SZvatPQ8=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156/go.mod h1:oTXIO50jAekHXp0oQcgGN1znG5u4clgQu4ilsgcBRY0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.414/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.486/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.533/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
@@ -1005,8 +1005,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.151/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153 h1:K14ZEX1X7FXJBUqbbF+6bW5yFkIK8JFYiqCV2sQd+RM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156 h1:A3DxpqGh8DF+rCRJVGlNJaeOJ/l6FkhCKhdEaUeu0Dc=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=

--- a/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/design.md
+++ b/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The `tencentcloud_cls_topic` resource manages CLS (Cloud Log Service) log topics. It already supports an `encryption` parameter (TypeInt, Optional, Computed) that enables KMS-CLS cloud product key encryption when set to `1`. However, when encryption is enabled, users currently always use the **system default** KMS key (alias `KMS-CLS`) and have no way to specify their own custom KMS key.
+
+The CLS cloud API supports custom KMS keys via a nested `CustomKmsInfo` struct on both the `CreateTopicRequest` and `ModifyTopicRequest`. The `DescribeTopics` response also returns `CustomKmsInfo` inside each `TopicInfo`. The vendor SDK (`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016`) already defines the `CustomKmsInfo` struct with two string fields:
+
+```go
+type CustomKmsInfo struct {
+    KmsRegion *string `json:"KmsRegion,omitnil,omitempty"`
+    KmsKeyId  *string `json:"KmsKeyId,omitnil,omitempty"`
+}
+```
+
+No SDK upgrade is required — the structs and fields are already present in the vendored code.
+
+Current resource file: `tencentcloud/services/cls/resource_tc_cls_topic.go`
+
+**API behavior analysis (from vendor):**
+
+| API | `CustomKmsInfo.KmsRegion` in Request | `CustomKmsInfo.KmsKeyId` in Request | `CustomKmsInfo.KmsRegion` in Response | `CustomKmsInfo.KmsKeyId` in Response |
+|-----|-------------------------------------|-------------------------------------|---------------------------------------|-------------------------------------|
+| `CreateTopic` | Yes (nested in `CustomKmsInfo`) | Yes (nested in `CustomKmsInfo`) | No (create returns only `TopicId`) | No |
+| `DescribeTopics` | N/A | N/A | Yes (in `TopicInfo.CustomKmsInfo`) | Yes (in `TopicInfo.CustomKmsInfo`) |
+| `ModifyTopic` | Yes (nested in `CustomKmsInfo`) | Yes (nested in `CustomKmsInfo`) | No | No |
+| `DeleteTopic` | No | No | N/A | N/A |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `kms_region` (TypeString, Optional, Computed) and `kms_key_id` (TypeString, Optional, Computed) parameters to the `tencentcloud_cls_topic` resource schema
+- Construct and populate a `cls.CustomKmsInfo{}` struct in the Create method when `encryption = 1` and either field is set, then assign it to `request.CustomKmsInfo`
+- Construct and populate a `cls.CustomKmsInfo{}` struct in the Update method when encryption-related changes occur, then assign it to `request.CustomKmsInfo` so the `ModifyTopic` call carries the custom key info
+- Read `KmsRegion` and `KmsKeyId` from `topic.CustomKmsInfo` (with nil checks) in the Read method and set them in state
+- Maintain full backward compatibility — existing configurations without these fields continue to work (CLS uses the default key)
+
+**Non-Goals:**
+- This change does NOT make `encryption` itself mutable after creation beyond what it already is
+- This change does NOT add `kms_region` / `kms_key_id` to any CLS data source (e.g., `tencentcloud_cls_topics`)
+- This change does NOT modify any other CLS resources
+- This change does NOT add new resources
+
+## Decisions
+
+### Decision 1: Flatten `CustomKmsInfo` into two top-level schema fields
+
+**Rationale:** The cloud API nests `KmsRegion` and `KmsKeyId` inside a `CustomKmsInfo` struct, but the Terraform schema convention (per the codebase rules) is to flatten nested single-object structs into top-level fields. This matches how the existing `encryption` field is already a top-level scalar. Flattening gives users a cleaner HCL experience (`kms_region = "..."` and `kms_key_id = "..."`) rather than requiring a nested block.
+
+### Decision 2: Construct `CustomKmsInfo` struct inline in Create/Update rather than in the service layer
+
+**Rationale:** The existing Create and Update methods in `resource_tc_cls_topic.go` already build the `cls.NewCreateTopicRequest()` / `cls.NewModifyTopicRequest()` inline and assign fields directly. Following this existing pattern, the `CustomKmsInfo` struct is constructed inline and assigned to `request.CustomKmsInfo`. This avoids adding a new service-layer function for a simple nested-struct assignment, keeping the change minimal.
+
+### Decision 3: Gate `CustomKmsInfo` construction on `encryption = 1`
+
+**Rationale:** The cloud API documentation states `CustomKmsInfo` only takes effect when `Encryption = 1`. To avoid sending meaningless payloads in other scenarios (and to respect the API's "other scenarios cannot pass this parameter" note), the provider only constructs and assigns `CustomKmsInfo` when `encryption` is set to `1` and at least one of `kms_region` / `kms_key_id` is provided by the user.
+
+### Decision 4: Both parameters are Optional + Computed (not ForceNew)
+
+**Rationale:** The `ModifyTopic` API accepts `CustomKmsInfo`, so the parameters are updatable, not immutable. `Computed: true` ensures that resources created without these fields (or imported resources) still populate state from the `DescribeTopics` response. This is consistent with the existing `encryption` field which is also Optional + Computed.
+
+### Decision 5: Nil-check `CustomKmsInfo` and sub-fields before reading in Read
+
+**Rationale:** The `DescribeTopics` response may return `TopicInfo.CustomKmsInfo` as `nil` when encryption is not enabled or the default key is used. Per the codebase rules, the Read method must check `topic.CustomKmsInfo != nil` before accessing `.KmsRegion` / `.KmsKeyId`, and only call `d.Set(...)` when the sub-field is non-nil.
+
+## Risks / Trade-offs
+
+- **[Risk] `CustomKmsInfo` is nil in Describe response for default-key topics** → Mitigation: nil-check `topic.CustomKmsInfo` before reading sub-fields; do not call `d.Set` when nil, so state keeps the user's configured value or Computed zero-value.
+- **[Risk] Users set `kms_region` / `kms_key_id` without `encryption = 1`** → Mitigation: the provider only constructs `CustomKmsInfo` when `encryption = 1`; otherwise the values are ignored in the API request. No hard error is returned (the API itself would ignore them), keeping behavior lenient and backward compatible.
+- **[Backward compatibility]** → Both new parameters are Optional + Computed. Existing configurations without `kms_region` / `kms_key_id` continue to work unchanged.

--- a/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/proposal.md
+++ b/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The `tencentcloud_cls_topic` resource already supports an `encryption` parameter that enables KMS-CLS cloud product key encryption, but users currently have no way to specify a **custom** KMS key (region + key ID) through Terraform. The CLS `ModifyTopic` and `CreateTopic` APIs accept a `CustomKmsInfo` object containing `KmsRegion` and `KmsKeyId`, and `DescribeTopics` returns the same object in each `TopicInfo`. Exposing these two parameters lets users bring their own KMS keys for CLS topic encryption instead of relying on the system default key (alias `KMS-CLS`).
+
+## What Changes
+
+- Add a new `kms_region` parameter (TypeString, Optional, Computed) to the `tencentcloud_cls_topic` resource schema. It maps to `request.CustomKmsInfo.KmsRegion` in the `ModifyTopic` / `CreateTopic` APIs and is read from `response.Topics[].CustomKmsInfo.KmsRegion` in the `DescribeTopics` API.
+- Add a new `kms_key_id` parameter (TypeString, Optional, Computed) to the `tencentcloud_cls_topic` resource schema. It maps to `request.CustomKmsInfo.KmsKeyId` in the `ModifyTopic` / `CreateTopic` APIs and is read from `response.Topics[].CustomKmsInfo.KmsKeyId` in the `DescribeTopics` API.
+- Both parameters are only effective when `encryption = 1` (KMS-CLS cloud product key encryption). When `CustomKmsInfo` is not provided, the CLS backend uses the default key.
+- In the **Create** method: when `encryption = 1` and either `kms_region` or `kms_key_id` is set, construct a `cls.CustomKmsInfo{}` struct and assign it to `request.CustomKmsInfo`.
+- In the **Update** method: when `encryption` changes (existing behavior) or `kms_region` / `kms_key_id` change, construct the `CustomKmsInfo` struct and assign it to `request.CustomKmsInfo` so the `ModifyTopic` API call carries the user's custom key info.
+- In the **Read** method: read `KmsRegion` and `KmsKeyId` from `topic.CustomKmsInfo` (with nil checks on `CustomKmsInfo` and each sub-field) and set them in state.
+
+## Capabilities
+
+### New Capabilities
+- `cls-topic-kms-info`: Adds custom KMS key (`kms_region`, `kms_key_id`) parameter support to the `tencentcloud_cls_topic` resource, allowing users to specify their own KMS key region and key ID for CLS topic encryption instead of using the system default key.
+
+### Modified Capabilities
+<!-- No existing capability requirements are changing -->
+
+## Impact
+
+- **Resource file**: `tencentcloud/services/cls/resource_tc_cls_topic.go` — add `kms_region` and `kms_key_id` schema fields; wire through Create, Update, and Read methods.
+- **Test file**: `tencentcloud/services/cls/resource_tc_cls_topic_test.go` — add unit tests for the new parameters using gomonkey mocks.
+- **Documentation**: `tencentcloud/services/cls/resource_tc_cls_topic.md` — update example usage to show `kms_region` and `kms_key_id` alongside `encryption = 1`.
+- **Cloud API**: `CreateTopic` (input: `CustomKmsInfo.KmsRegion`, `CustomKmsInfo.KmsKeyId`), `ModifyTopic` (input: `CustomKmsInfo.KmsRegion`, `CustomKmsInfo.KmsKeyId`), `DescribeTopics` (output: `TopicInfo.CustomKmsInfo.KmsRegion`, `TopicInfo.CustomKmsInfo.KmsKeyId`). The vendor SDK already includes the `CustomKmsInfo` struct with both fields — no SDK upgrade required.
+- **Backward compatibility**: fully backward compatible — both new parameters are Optional and Computed. Existing configurations without `kms_region` / `kms_key_id` continue to work unchanged (the CLS backend uses the default key).

--- a/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/specs/cls-topic-kms-info/spec.md
+++ b/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/specs/cls-topic-kms-info/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: kms_region parameter in tencentcloud_cls_topic resource
+The `tencentcloud_cls_topic` resource SHALL support an optional `kms_region` parameter (TypeString, Optional, Computed) that specifies the KMS region for a custom KMS key. The parameter SHALL be passed to the `CreateTopic` and `ModifyTopic` APIs as `request.CustomKmsInfo.KmsRegion`, and is only effective when `encryption` is set to `1`. The parameter SHALL be read from `topic.CustomKmsInfo.KmsRegion` in the `DescribeTopics` response during Read, with a nil check on `CustomKmsInfo`.
+
+#### Scenario: Create topic with encryption and kms_region
+- **WHEN** a user creates a `tencentcloud_cls_topic` resource with `encryption = 1` and `kms_region = "ap-guangzhou"`
+- **THEN** the CreateTopic API request SHALL contain `CustomKmsInfo` with `KmsRegion` set to `"ap-guangzhou"`
+
+#### Scenario: Create topic without kms_region
+- **WHEN** a user creates a `tencentcloud_cls_topic` resource without specifying `kms_region`
+- **THEN** the CreateTopic API request SHALL NOT set `CustomKmsInfo` (or SHALL leave `KmsRegion` unset within it), and the CLS backend SHALL use the default key
+
+#### Scenario: Read kms_region from DescribeTopics response
+- **WHEN** the Read method processes a `TopicInfo` where `CustomKmsInfo` is non-nil and `CustomKmsInfo.KmsRegion` is non-nil
+- **THEN** the `kms_region` field in resource data SHALL be set to the value of `CustomKmsInfo.KmsRegion`
+
+#### Scenario: Read kms_region when CustomKmsInfo is nil
+- **WHEN** the Read method processes a `TopicInfo` where `CustomKmsInfo` is nil
+- **THEN** the Read method SHALL NOT call `d.Set("kms_region", ...)` and SHALL NOT panic
+
+#### Scenario: Update kms_region
+- **WHEN** a user changes `kms_region` on an existing `tencentcloud_cls_topic` resource with `encryption = 1`
+- **THEN** the ModifyTopic API request SHALL contain `CustomKmsInfo` with the updated `KmsRegion` value
+
+### Requirement: kms_key_id parameter in tencentcloud_cls_topic resource
+The `tencentcloud_cls_topic` resource SHALL support an optional `kms_key_id` parameter (TypeString, Optional, Computed) that specifies the KMS key ID for a custom KMS key. The parameter SHALL be passed to the `CreateTopic` and `ModifyTopic` APIs as `request.CustomKmsInfo.KmsKeyId`, and is only effective when `encryption` is set to `1`. The parameter SHALL be read from `topic.CustomKmsInfo.KmsKeyId` in the `DescribeTopics` response during Read, with a nil check on `CustomKmsInfo`.
+
+#### Scenario: Create topic with encryption and kms_key_id
+- **WHEN** a user creates a `tencentcloud_cls_topic` resource with `encryption = 1` and `kms_key_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"`
+- **THEN** the CreateTopic API request SHALL contain `CustomKmsInfo` with `KmsKeyId` set to the specified key ID
+
+#### Scenario: Create topic without kms_key_id
+- **WHEN** a user creates a `tencentcloud_cls_topic` resource without specifying `kms_key_id`
+- **THEN** the CreateTopic API request SHALL NOT set `CustomKmsInfo` (or SHALL leave `KmsKeyId` unset within it), and the CLS backend SHALL use the default key
+
+#### Scenario: Read kms_key_id from DescribeTopics response
+- **WHEN** the Read method processes a `TopicInfo` where `CustomKmsInfo` is non-nil and `CustomKmsInfo.KmsKeyId` is non-nil
+- **THEN** the `kms_key_id` field in resource data SHALL be set to the value of `CustomKmsInfo.KmsKeyId`
+
+#### Scenario: Read kms_key_id when CustomKmsInfo is nil
+- **WHEN** the Read method processes a `TopicInfo` where `CustomKmsInfo` is nil
+- **THEN** the Read method SHALL NOT call `d.Set("kms_key_id", ...)` and SHALL NOT panic
+
+#### Scenario: Update kms_key_id
+- **WHEN** a user changes `kms_key_id` on an existing `tencentcloud_cls_topic` resource with `encryption = 1`
+- **THEN** the ModifyTopic API request SHALL contain `CustomKmsInfo` with the updated `KmsKeyId` value
+
+### Requirement: CustomKmsInfo construction gated on encryption
+The provider SHALL only construct and assign the `CustomKmsInfo` struct on the CreateTopic / ModifyTopic request when `encryption` is set to `1` and at least one of `kms_region` or `kms_key_id` is provided. When `encryption` is not `1`, the provider SHALL NOT set `CustomKmsInfo` on the request.
+
+#### Scenario: CustomKmsInfo set when encryption is 1 and kms fields provided
+- **WHEN** `encryption = 1` and the user provides `kms_region` and/or `kms_key_id`
+- **THEN** the request SHALL include a non-nil `CustomKmsInfo` struct populated with the provided fields
+
+#### Scenario: CustomKmsInfo not set when encryption is not 1
+- **WHEN** `encryption` is not set to `1` (or not set at all)
+- **THEN** the request SHALL NOT include a `CustomKmsInfo` struct, even if `kms_region` or `kms_key_id` are set in the configuration
+
+#### Scenario: CustomKmsInfo not set when encryption is 1 but no kms fields provided
+- **WHEN** `encryption = 1` but neither `kms_region` nor `kms_key_id` is provided
+- **THEN** the request SHALL NOT include a `CustomKmsInfo` struct, and the CLS backend SHALL use the default key
+
+### Requirement: kms_region and kms_key_id unit test coverage
+The `tencentcloud_cls_topic` test file SHALL include unit tests that verify the `kms_region` and `kms_key_id` parameters are correctly passed to the CreateTopic / ModifyTopic API requests and correctly read from the DescribeTopics API response, using gomonkey mocks.
+
+#### Scenario: Unit test for kms fields in Create
+- **WHEN** the Create method is called with `encryption = 1`, `kms_region`, and `kms_key_id` set
+- **THEN** the CreateTopic request SHALL contain a non-nil `CustomKmsInfo` with the correct `KmsRegion` and `KmsKeyId` values
+
+#### Scenario: Unit test for kms fields in Read
+- **WHEN** the Read method processes a `TopicInfo` with a non-nil `CustomKmsInfo` containing `KmsRegion` and `KmsKeyId`
+- **THEN** the `kms_region` and `kms_key_id` fields in resource data SHALL be set to the corresponding values

--- a/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/tasks.md
+++ b/openspec/changes/archive/2026-08-11-add-cls-topic-kms-info/tasks.md
@@ -1,0 +1,34 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `kms_region` parameter to the `tencentcloud_cls_topic` resource schema in `tencentcloud/services/cls/resource_tc_cls_topic.go` (TypeString, Optional, Computed, description: "KMS region for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.")
+- [x] 1.2 Add `kms_key_id` parameter to the `tencentcloud_cls_topic` resource schema in `tencentcloud/services/cls/resource_tc_cls_topic.go` (TypeString, Optional, Computed, description: "KMS key ID for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.")
+
+## 2. Create Method Changes
+
+- [x] 2.1 In `resourceTencentCloudClsTopicCreate`, after the existing `encryption` handling block, when `encryption = 1` and at least one of `kms_region` / `kms_key_id` is set, construct a `cls.CustomKmsInfo{}` struct populated with `KmsRegion` and/or `KmsKeyId` (using `helper.String(...)`) and assign it to `request.CustomKmsInfo`
+- [x] 2.2 Ensure `CustomKmsInfo` is NOT set on the request when `encryption` is not `1` or neither kms field is provided
+
+## 3. Read Method Changes
+
+- [x] 3.1 In `resourceTencentCloudClsTopicRead`, after the existing `encryption` read-back block, add a nil check on `topic.CustomKmsInfo`; when non-nil, set `kms_region` from `topic.CustomKmsInfo.KmsRegion` (with nil check on the sub-field) and `kms_key_id` from `topic.CustomKmsInfo.KmsKeyId` (with nil check on the sub-field)
+
+## 4. Update Method Changes
+
+- [x] 4.1 In `resourceTencentCloudClsTopicUpdate`, within the existing `if d.HasChange("encryption")` block (and also when `kms_region` / `kms_key_id` change), construct a `cls.CustomKmsInfo{}` struct populated with the current `kms_region` and `kms_key_id` values when `encryption = 1` and at least one kms field is set, and assign it to `request.CustomKmsInfo`
+- [x] 4.2 Add `d.HasChange("kms_region")` and `d.HasChange("kms_key_id")` to the conditions that set `hasChange = true` so the `ModifyTopic` call is triggered
+
+## 5. Unit Tests
+
+- [x] 5.1 Add a unit test in `tencentcloud/services/cls/resource_tc_cls_topic_test.go` to verify that when `encryption = 1` and `kms_region` / `kms_key_id` are set, the `CreateTopic` request contains a non-nil `CustomKmsInfo` with correct `KmsRegion` and `KmsKeyId` values (using gomonkey mocks)
+- [x] 5.2 Add a unit test to verify that when `encryption` is not `1`, the `CreateTopic` request does NOT contain a `CustomKmsInfo` struct
+- [x] 5.3 Add a unit test to verify that `kms_region` and `kms_key_id` are correctly read from a `TopicInfo` response with a non-nil `CustomKmsInfo`
+- [x] 5.4 Add a unit test to verify the Read method does not panic when `CustomKmsInfo` is nil
+
+## 6. Documentation
+
+- [x] 6.1 Update `tencentcloud/services/cls/resource_tc_cls_topic.md` to add an example showing `encryption = 1` with `kms_region` and `kms_key_id` parameters
+
+## 7. Validation
+
+- [x] 7.1 Verify the code compiles successfully
+- [x] 7.2 Verify no lint errors

--- a/openspec/specs/cls-topic-kms-info/spec.md
+++ b/openspec/specs/cls-topic-kms-info/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: kms_region parameter in tencentcloud_cls_topic resource
+The `tencentcloud_cls_topic` resource SHALL support an optional `kms_region` parameter (TypeString, Optional, Computed) that specifies the KMS region for a custom KMS key. The parameter SHALL be passed to the `CreateTopic` and `ModifyTopic` APIs as `request.CustomKmsInfo.KmsRegion`, and is only effective when `encryption` is set to `1`. The parameter SHALL be read from `topic.CustomKmsInfo.KmsRegion` in the `DescribeTopics` response during Read, with a nil check on `CustomKmsInfo`.
+
+#### Scenario: Create topic with encryption and kms_region
+- **WHEN** a user creates a `tencentcloud_cls_topic` resource with `encryption = 1` and `kms_region = "ap-guangzhou"`
+- **THEN** the CreateTopic API request SHALL contain `CustomKmsInfo` with `KmsRegion` set to `"ap-guangzhou"`
+
+#### Scenario: Create topic without kms_region
+- **WHEN** a user creates a `tencentcloud_cls_topic` resource without specifying `kms_region`
+- **THEN** the CreateTopic API request SHALL NOT set `CustomKmsInfo` (or SHALL leave `KmsRegion` unset within it), and the CLS backend SHALL use the default key
+
+#### Scenario: Read kms_region from DescribeTopics response
+- **WHEN** the Read method processes a `TopicInfo` where `CustomKmsInfo` is non-nil and `CustomKmsInfo.KmsRegion` is non-nil
+- **THEN** the `kms_region` field in resource data SHALL be set to the value of `CustomKmsInfo.KmsRegion`
+
+#### Scenario: Read kms_region when CustomKmsInfo is nil
+- **WHEN** the Read method processes a `TopicInfo` where `CustomKmsInfo` is nil
+- **THEN** the Read method SHALL NOT call `d.Set("kms_region", ...)` and SHALL NOT panic
+
+#### Scenario: Update kms_region
+- **WHEN** a user changes `kms_region` on an existing `tencentcloud_cls_topic` resource with `encryption = 1`
+- **THEN** the ModifyTopic API request SHALL contain `CustomKmsInfo` with the updated `KmsRegion` value
+
+### Requirement: kms_key_id parameter in tencentcloud_cls_topic resource
+The `tencentcloud_cls_topic` resource SHALL support an optional `kms_key_id` parameter (TypeString, Optional, Computed) that specifies the KMS key ID for a custom KMS key. The parameter SHALL be passed to the `CreateTopic` and `ModifyTopic` APIs as `request.CustomKmsInfo.KmsKeyId`, and is only effective when `encryption` is set to `1`. The parameter SHALL be read from `topic.CustomKmsInfo.KmsKeyId` in the `DescribeTopics` response during Read, with a nil check on `CustomKmsInfo`.
+
+#### Scenario: Create topic with encryption and kms_key_id
+- **WHEN** a user creates a `tencentcloud_cls_topic` resource with `encryption = 1` and `kms_key_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"`
+- **THEN** the CreateTopic API request SHALL contain `CustomKmsInfo` with `KmsKeyId` set to the specified key ID
+
+#### Scenario: Create topic without kms_key_id
+- **WHEN** a user creates a `tencentcloud_cls_topic` resource without specifying `kms_key_id`
+- **THEN** the CreateTopic API request SHALL NOT set `CustomKmsInfo` (or SHALL leave `KmsKeyId` unset within it), and the CLS backend SHALL use the default key
+
+#### Scenario: Read kms_key_id from DescribeTopics response
+- **WHEN** the Read method processes a `TopicInfo` where `CustomKmsInfo` is non-nil and `CustomKmsInfo.KmsKeyId` is non-nil
+- **THEN** the `kms_key_id` field in resource data SHALL be set to the value of `CustomKmsInfo.KmsKeyId`
+
+#### Scenario: Read kms_key_id when CustomKmsInfo is nil
+- **WHEN** the Read method processes a `TopicInfo` where `CustomKmsInfo` is nil
+- **THEN** the Read method SHALL NOT call `d.Set("kms_key_id", ...)` and SHALL NOT panic
+
+#### Scenario: Update kms_key_id
+- **WHEN** a user changes `kms_key_id` on an existing `tencentcloud_cls_topic` resource with `encryption = 1`
+- **THEN** the ModifyTopic API request SHALL contain `CustomKmsInfo` with the updated `KmsKeyId` value
+
+### Requirement: CustomKmsInfo construction gated on encryption
+The provider SHALL only construct and assign the `CustomKmsInfo` struct on the CreateTopic / ModifyTopic request when `encryption` is set to `1` and at least one of `kms_region` or `kms_key_id` is provided. When `encryption` is not `1`, the provider SHALL NOT set `CustomKmsInfo` on the request.
+
+#### Scenario: CustomKmsInfo set when encryption is 1 and kms fields provided
+- **WHEN** `encryption = 1` and the user provides `kms_region` and/or `kms_key_id`
+- **THEN** the request SHALL include a non-nil `CustomKmsInfo` struct populated with the provided fields
+
+#### Scenario: CustomKmsInfo not set when encryption is not 1
+- **WHEN** `encryption` is not set to `1` (or not set at all)
+- **THEN** the request SHALL NOT include a `CustomKmsInfo` struct, even if `kms_region` or `kms_key_id` are set in the configuration
+
+#### Scenario: CustomKmsInfo not set when encryption is 1 but no kms fields provided
+- **WHEN** `encryption = 1` but neither `kms_region` nor `kms_key_id` is provided
+- **THEN** the request SHALL NOT include a `CustomKmsInfo` struct, and the CLS backend SHALL use the default key
+
+### Requirement: kms_region and kms_key_id unit test coverage
+The `tencentcloud_cls_topic` test file SHALL include unit tests that verify the `kms_region` and `kms_key_id` parameters are correctly passed to the CreateTopic / ModifyTopic API requests and correctly read from the DescribeTopics API response, using gomonkey mocks.
+
+#### Scenario: Unit test for kms fields in Create
+- **WHEN** the Create method is called with `encryption = 1`, `kms_region`, and `kms_key_id` set
+- **THEN** the CreateTopic request SHALL contain a non-nil `CustomKmsInfo` with the correct `KmsRegion` and `KmsKeyId` values
+
+#### Scenario: Unit test for kms fields in Read
+- **WHEN** the Read method processes a `TopicInfo` with a non-nil `CustomKmsInfo` containing `KmsRegion` and `KmsKeyId`
+- **THEN** the `kms_region` and `kms_key_id` fields in resource data SHALL be set to the corresponding values

--- a/tencentcloud/services/cls/resource_tc_cls_topic.go
+++ b/tencentcloud/services/cls/resource_tc_cls_topic.go
@@ -168,6 +168,18 @@ func ResourceTencentCloudClsTopic() *schema.Resource {
 				Computed:    true,
 				Description: "Encryption-related parameters. This parameter is supported for users with an open access list and from encrypted regions; it cannot be passed in other scenarios. 0 or not passed: No encryption. 1: KMS-CLS cloud product key encryption. Once enabled, it cannot be disabled.\nSupported regions: ap-beijing, ap-guangzhou, ap-shanghai, ap-singapore, ap-bangkok, ap-jakarta, eu-frankfurt, ap-seoul, ap-tokyo.",
 			},
+			"kms_region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "KMS region for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.",
+			},
+			"kms_key_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "KMS key ID for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.",
+			},
 		},
 	}
 }
@@ -289,6 +301,21 @@ func resourceTencentCloudClsTopicCreate(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOkExists("encryption"); ok {
 		request.Encryption = helper.IntUint64(v.(int))
+	}
+
+	if v, ok := d.GetOkExists("encryption"); ok && v.(int) == 1 {
+		kmsRegion := d.Get("kms_region").(string)
+		kmsKeyId := d.Get("kms_key_id").(string)
+		if kmsRegion != "" || kmsKeyId != "" {
+			customKmsInfo := &cls.CustomKmsInfo{}
+			if kmsRegion != "" {
+				customKmsInfo.KmsRegion = helper.String(kmsRegion)
+			}
+			if kmsKeyId != "" {
+				customKmsInfo.KmsKeyId = helper.String(kmsKeyId)
+			}
+			request.CustomKmsInfo = customKmsInfo
+		}
 	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
@@ -426,6 +453,15 @@ func resourceTencentCloudClsTopicRead(d *schema.ResourceData, meta interface{}) 
 		_ = d.Set("encryption", 1)
 	}
 
+	if topic.CustomKmsInfo != nil {
+		if topic.CustomKmsInfo.KmsRegion != nil {
+			_ = d.Set("kms_region", topic.CustomKmsInfo.KmsRegion)
+		}
+		if topic.CustomKmsInfo.KmsKeyId != nil {
+			_ = d.Set("kms_key_id", topic.CustomKmsInfo.KmsKeyId)
+		}
+	}
+
 	return nil
 }
 
@@ -559,6 +595,25 @@ func resourceTencentCloudClsTopicUpdate(d *schema.ResourceData, meta interface{}
 		}
 
 		hasChange = true
+	}
+
+	if d.HasChange("kms_region") || d.HasChange("kms_key_id") {
+		hasChange = true
+	}
+
+	if encryptionVal, ok := d.GetOkExists("encryption"); ok && encryptionVal.(int) == 1 {
+		kmsRegion := d.Get("kms_region").(string)
+		kmsKeyId := d.Get("kms_key_id").(string)
+		if kmsRegion != "" || kmsKeyId != "" {
+			customKmsInfo := &cls.CustomKmsInfo{}
+			if kmsRegion != "" {
+				customKmsInfo.KmsRegion = helper.String(kmsRegion)
+			}
+			if kmsKeyId != "" {
+				customKmsInfo.KmsKeyId = helper.String(kmsKeyId)
+			}
+			request.CustomKmsInfo = customKmsInfo
+		}
 	}
 
 	if hasChange {

--- a/tencentcloud/services/cls/resource_tc_cls_topic.go
+++ b/tencentcloud/services/cls/resource_tc_cls_topic.go
@@ -44,72 +44,79 @@ func ResourceTencentCloudClsTopic() *schema.Resource {
 			"logset_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Logset ID.",
+				Description: "Logset ID. Get the logset ID via `DescribeLogsets` API.",
 			},
 			"topic_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Log topic name.",
+				Type:     schema.TypeString,
+				Required: true,
+				Description: "Log topic name. Constraints: cannot be an empty string, cannot contain the `|` character, " +
+					"and cannot use the following reserved names: `cls_service_log`, `loglistener_status`, " +
+					"`loglistener_alarm`, `loglistener_business`, `cls_service_metric`.",
 			},
 			"partition_count": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
-				Description: "Number of log topic partitions. Default value: 1. Maximum value: 10.",
+				Description: "Number of log topic partitions. Default: 1, maximum: 10.",
 			},
 			"tags": {
 				Type:        schema.TypeMap,
 				Optional:    true,
-				Description: "Tag description list. Up to 10 tag key-value pairs are supported and must be unique.",
+				Description: "Tag description list. Up to 10 tag key-value pairs are supported, and the same resource can only be bound to the same tag key.",
 			},
 			"auto_split": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
-				Description: "Whether to enable automatic split. Default value: true.",
+				Description: "Whether to enable automatic split. Default value: `true`.",
 			},
 			"max_split_partitions": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				Description: "Maximum number of partitions to split into for this topic if" +
-					" automatic split is enabled. Default value: 50.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Maximum number of partitions allowed for the topic if automatic split is enabled. Default value: `50`.",
 			},
 			"storage_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				Description: "Log topic storage class. Valid values: hot: real-time storage; cold: offline storage. Default value: hot. If cold is passed in, " +
-					"please contact the customer service to add the log topic to the allowlist first.",
+				Description: "Log topic storage type. Valid values: `hot`: standard storage; `cold`: infrequent storage. " +
+					"Default value: `hot`. Not supported for metric topics.",
 			},
 			"period": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				Description: "lifetime. Unit: days. Standard storage value range: 1 to 3600. Infrequent storage value range: 7 to 3600 days. A value of 3640 indicates permanent retention.If this value is not input, it defaults to the Period value of the log set corresponding to the accessed log topic (defaults to 30 days in case of access failure).",
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				Description: "Retention period, unit: days. Log topic (standard storage): 1 to 3600 days, value `3640` " +
+					"means permanent retention. Log topic (infrequent storage): 7 to 3600 days, value `3640` means " +
+					"permanent retention. Metric topic: 1 to 3600 days, value `3640` means permanent retention.",
 			},
 			"hot_period": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				Description: "0: Turn off log sinking. Non 0: The number of days of standard storage after enabling log settling. HotPeriod needs to be greater than or equal to 7 and less than Period. Only effective when StorageType is hot.",
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				Description: "`0`: turn off log settling. Non-`0`: the number of days of standard storage after enabling " +
+					"log settling. HotPeriod must be greater than or equal to 7 and less than Period. Only effective " +
+					"when `storage_type` is `hot`. Not supported for metric topics.",
 			},
 			"describes": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Log Topic Description.",
+				Description: "Log topic description.",
 			},
 			"is_web_tracking": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Computed:    true,
-				Description: "No authentication switch. False: closed; True: Enable. The default is false. After activation, anonymous access to the log topic will be supported for specified operations.",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				Description: "Free authentication switch. `false`: closed (default); `true`: enabled. When enabled, " +
+					"anonymous access to the log topic will be supported for specified operations. " +
+					"Not supported for metric topics.",
 			},
 			"extends": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "Log Subject Extension Information.",
+				Description: "Topic extension information.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"anonymous_access": {
@@ -159,26 +166,41 @@ func ResourceTencentCloudClsTopic() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				Description:  "Topic type. 0: log topic (default), 1: metric topic.",
+				Description:  "Topic type. `0`: log topic (default), `1`: metric topic.",
 				ValidateFunc: tccommon.ValidateAllowedIntValue([]int{0, 1}),
 			},
 			"encryption": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				Description: "Encryption-related parameters. This parameter is supported for users with an open access list and from encrypted regions; it cannot be passed in other scenarios. 0 or not passed: No encryption. 1: KMS-CLS cloud product key encryption. Once enabled, it cannot be disabled.\nSupported regions: ap-beijing, ap-guangzhou, ap-shanghai, ap-singapore, ap-bangkok, ap-jakarta, eu-frankfurt, ap-seoul, ap-tokyo.",
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				Description: "Encryption-related parameters. Supported for encryption-enabled regions and " +
+					"allowlisted users; cannot be passed in other scenarios. `0` or not passed: no encryption; " +
+					"`1`: kms-cls cloud product key encryption. Once enabled, it cannot be disabled. " +
+					"Supported regions: ap-beijing, ap-guangzhou, ap-shanghai, ap-singapore, ap-bangkok, " +
+					"ap-jakarta, eu-frankfurt, ap-seoul, ap-tokyo.",
 			},
-			"kms_region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "KMS region for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.",
-			},
-			"kms_key_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "KMS key ID for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.",
+			"custom_kms_info": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Description: "User-defined KMS key information. If empty, the default key (alias `KMS-CLS`) " +
+					"is used.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_region": {
+							Type:     schema.TypeString,
+							Required: true,
+							Description: "KMS region. Refer to Tencent Cloud KMS documentation for supported regions. " +
+								"Format: `ap-guangzhou`.",
+						},
+						"kms_key_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "KMS key ID.",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -303,19 +325,15 @@ func resourceTencentCloudClsTopicCreate(d *schema.ResourceData, meta interface{}
 		request.Encryption = helper.IntUint64(v.(int))
 	}
 
-	if v, ok := d.GetOkExists("encryption"); ok && v.(int) == 1 {
-		kmsRegion := d.Get("kms_region").(string)
-		kmsKeyId := d.Get("kms_key_id").(string)
-		if kmsRegion != "" || kmsKeyId != "" {
-			customKmsInfo := &cls.CustomKmsInfo{}
-			if kmsRegion != "" {
-				customKmsInfo.KmsRegion = helper.String(kmsRegion)
-			}
-			if kmsKeyId != "" {
-				customKmsInfo.KmsKeyId = helper.String(kmsKeyId)
-			}
-			request.CustomKmsInfo = customKmsInfo
+	if customKmsInfoMap, ok := helper.InterfacesHeadMap(d, "custom_kms_info"); ok {
+		customKmsInfo := &cls.CustomKmsInfo{}
+		if v, ok := customKmsInfoMap["kms_region"]; ok {
+			customKmsInfo.KmsRegion = helper.String(v.(string))
 		}
+		if v, ok := customKmsInfoMap["kms_key_id"]; ok {
+			customKmsInfo.KmsKeyId = helper.String(v.(string))
+		}
+		request.CustomKmsInfo = customKmsInfo
 	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
@@ -454,12 +472,16 @@ func resourceTencentCloudClsTopicRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if topic.CustomKmsInfo != nil {
+		customKmsInfoMap := map[string]interface{}{}
 		if topic.CustomKmsInfo.KmsRegion != nil {
-			_ = d.Set("kms_region", topic.CustomKmsInfo.KmsRegion)
+			customKmsInfoMap["kms_region"] = *topic.CustomKmsInfo.KmsRegion
 		}
 		if topic.CustomKmsInfo.KmsKeyId != nil {
-			_ = d.Set("kms_key_id", topic.CustomKmsInfo.KmsKeyId)
+			customKmsInfoMap["kms_key_id"] = *topic.CustomKmsInfo.KmsKeyId
 		}
+		_ = d.Set("custom_kms_info", []interface{}{customKmsInfoMap})
+	} else {
+		_ = d.Set("custom_kms_info", []interface{}{})
 	}
 
 	return nil
@@ -597,23 +619,18 @@ func resourceTencentCloudClsTopicUpdate(d *schema.ResourceData, meta interface{}
 		hasChange = true
 	}
 
-	if d.HasChange("kms_region") || d.HasChange("kms_key_id") {
-		hasChange = true
-	}
-
-	if encryptionVal, ok := d.GetOkExists("encryption"); ok && encryptionVal.(int) == 1 {
-		kmsRegion := d.Get("kms_region").(string)
-		kmsKeyId := d.Get("kms_key_id").(string)
-		if kmsRegion != "" || kmsKeyId != "" {
+	if d.HasChange("custom_kms_info") {
+		if customKmsInfoMap, ok := helper.InterfacesHeadMap(d, "custom_kms_info"); ok {
 			customKmsInfo := &cls.CustomKmsInfo{}
-			if kmsRegion != "" {
-				customKmsInfo.KmsRegion = helper.String(kmsRegion)
+			if v, ok := customKmsInfoMap["kms_region"]; ok {
+				customKmsInfo.KmsRegion = helper.String(v.(string))
 			}
-			if kmsKeyId != "" {
-				customKmsInfo.KmsKeyId = helper.String(kmsKeyId)
+			if v, ok := customKmsInfoMap["kms_key_id"]; ok {
+				customKmsInfo.KmsKeyId = helper.String(v.(string))
 			}
 			request.CustomKmsInfo = customKmsInfo
 		}
+		hasChange = true
 	}
 
 	if hasChange {

--- a/tencentcloud/services/cls/resource_tc_cls_topic.md
+++ b/tencentcloud/services/cls/resource_tc_cls_topic.md
@@ -2,6 +2,8 @@ Provides a resource to create a cls topic.
 
 ~> **NOTE:** Field `encryption` can only be enabled, not disabled.
 
+~> **NOTE:** Fields `kms_region` and `kms_key_id` are only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.
+
 Example Usage
 
 Create a standard cls topic
@@ -89,6 +91,34 @@ resource "tencentcloud_cls_topic" "example" {
   storage_type         = "hot"
   describes            = "Test Demo."
   biz_type             = 1
+  tags = {
+    tagKey = "tagValue"
+  }
+}
+```
+
+Create a cls topic with custom KMS key (encryption=1)
+
+```hcl
+resource "tencentcloud_cls_logset" "example" {
+  logset_name = "tf_example"
+  tags = {
+    tagKey = "tagValue"
+  }
+}
+
+resource "tencentcloud_cls_topic" "example" {
+  topic_name           = "tf_example"
+  logset_id            = tencentcloud_cls_logset.example.id
+  auto_split           = false
+  max_split_partitions = 20
+  partition_count      = 1
+  period               = 30
+  storage_type         = "hot"
+  describes            = "Test Demo."
+  encryption           = 1
+  kms_region           = "ap-guangzhou"
+  kms_key_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   tags = {
     tagKey = "tagValue"
   }

--- a/tencentcloud/services/cls/resource_tc_cls_topic.md
+++ b/tencentcloud/services/cls/resource_tc_cls_topic.md
@@ -2,7 +2,7 @@ Provides a resource to create a cls topic.
 
 ~> **NOTE:** Field `encryption` can only be enabled, not disabled.
 
-~> **NOTE:** Fields `kms_region` and `kms_key_id` are only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.
+~> **NOTE:** Field `custom_kms_info` is for user-defined KMS key. If not set, the CLS default key (alias KMS-CLS) is used.
 
 Example Usage
 
@@ -117,8 +117,12 @@ resource "tencentcloud_cls_topic" "example" {
   storage_type         = "hot"
   describes            = "Test Demo."
   encryption           = 1
-  kms_region           = "ap-guangzhou"
-  kms_key_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+  custom_kms_info {
+    kms_region = "ap-guangzhou"
+    kms_key_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+
   tags = {
     tagKey = "tagValue"
   }

--- a/tencentcloud/services/cls/resource_tc_cls_topic_test.go
+++ b/tencentcloud/services/cls/resource_tc_cls_topic_test.go
@@ -250,7 +250,7 @@ func TestClsTopic_Create_WithBizType(t *testing.T) {
 			{Key: ptrStringCT("test"), Value: ptrStringCT("test")},
 		},
 	}
-	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
 		return topicInfo, nil
 	})
 
@@ -317,7 +317,7 @@ func TestClsTopic_Create_WithoutBizType(t *testing.T) {
 		IsWebTracking:      ptrBoolCT(false),
 		BizType:            ptrUint64CT(0),
 	}
-	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
 		return topicInfo, nil
 	})
 
@@ -370,7 +370,7 @@ func TestClsTopic_Read_BizType(t *testing.T) {
 		IsWebTracking:      ptrBoolCT(false),
 		BizType:            ptrUint64CT(1),
 	}
-	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
 		return topicInfo, nil
 	})
 
@@ -421,7 +421,7 @@ func TestClsTopic_Read_BizTypeNil(t *testing.T) {
 		IsWebTracking:      ptrBoolCT(false),
 		BizType:            nil,
 	}
-	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
 		return topicInfo, nil
 	})
 
@@ -480,10 +480,10 @@ func TestClsTopic_Update_BizTypeImmutable(t *testing.T) {
 	assert.Contains(t, err.Error(), "biz_type")
 }
 
-// --- gomonkey mock unit tests for kms_region / kms_key_id parameters ---
+// --- gomonkey mock unit tests for custom_kms_info parameters ---
 
 // TestClsTopic_Create_WithKmsInfo verifies that when encryption=1 and
-// kms_region / kms_key_id are set, the CreateTopic request contains a
+// custom_kms_info is set, the CreateTopic request contains a
 // non-nil CustomKmsInfo with the correct KmsRegion and KmsKeyId values.
 func TestClsTopic_Create_WithKmsInfo(t *testing.T) {
 	patches := gomonkey.NewPatches()
@@ -523,7 +523,7 @@ func TestClsTopic_Create_WithKmsInfo(t *testing.T) {
 			KmsKeyId:  ptrStringCT("fake-kms-key-id"),
 		},
 	}
-	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
 		return topicInfo, nil
 	})
 
@@ -540,8 +540,12 @@ func TestClsTopic_Create_WithKmsInfo(t *testing.T) {
 		"describes":            "Test Demo.",
 		"hot_period":           10,
 		"encryption":           1,
-		"kms_region":           "ap-guangzhou",
-		"kms_key_id":           "fake-kms-key-id",
+		"custom_kms_info": []interface{}{
+			map[string]interface{}{
+				"kms_region": "ap-guangzhou",
+				"kms_key_id": "fake-kms-key-id",
+			},
+		},
 	})
 
 	err := res.Create(d, meta)
@@ -553,12 +557,15 @@ func TestClsTopic_Create_WithKmsInfo(t *testing.T) {
 	assert.Equal(t, "ap-guangzhou", *capturedRequest.CustomKmsInfo.KmsRegion)
 	assert.Equal(t, "fake-kms-key-id", *capturedRequest.CustomKmsInfo.KmsKeyId)
 
-	// Verify kms_region and kms_key_id are read back into state
-	assert.Equal(t, "ap-guangzhou", d.Get("kms_region"))
-	assert.Equal(t, "fake-kms-key-id", d.Get("kms_key_id"))
+	// Verify custom_kms_info is read back into state
+	customKmsInfo := d.Get("custom_kms_info").([]interface{})
+	assert.Len(t, customKmsInfo, 1)
+	infoMap := customKmsInfo[0].(map[string]interface{})
+	assert.Equal(t, "ap-guangzhou", infoMap["kms_region"])
+	assert.Equal(t, "fake-kms-key-id", infoMap["kms_key_id"])
 }
 
-// TestClsTopic_Create_WithoutKmsInfo verifies that when encryption is not 1,
+// TestClsTopic_Create_WithoutKmsInfo verifies that when custom_kms_info is not set,
 // the CreateTopic request does NOT contain a CustomKmsInfo struct.
 func TestClsTopic_Create_WithoutKmsInfo(t *testing.T) {
 	patches := gomonkey.NewPatches()
@@ -593,7 +600,7 @@ func TestClsTopic_Create_WithoutKmsInfo(t *testing.T) {
 		IsWebTracking:      ptrBoolCT(false),
 		BizType:            ptrUint64CT(0),
 	}
-	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
 		return topicInfo, nil
 	})
 
@@ -619,7 +626,7 @@ func TestClsTopic_Create_WithoutKmsInfo(t *testing.T) {
 	assert.Nil(t, capturedRequest.CustomKmsInfo)
 }
 
-// TestClsTopic_Read_KmsInfo verifies that kms_region and kms_key_id are
+// TestClsTopic_Read_KmsInfo verifies that custom_kms_info is
 // correctly read from a TopicInfo response with a non-nil CustomKmsInfo.
 func TestClsTopic_Read_KmsInfo(t *testing.T) {
 	patches := gomonkey.NewPatches()
@@ -648,7 +655,7 @@ func TestClsTopic_Read_KmsInfo(t *testing.T) {
 			KmsKeyId:  ptrStringCT("read-kms-key-id"),
 		},
 	}
-	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
 		return topicInfo, nil
 	})
 
@@ -671,9 +678,12 @@ func TestClsTopic_Read_KmsInfo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "fake-topic-id-read-kms", d.Id())
 
-	// Verify kms_region and kms_key_id are correctly read from the API response
-	assert.Equal(t, "ap-shanghai", d.Get("kms_region"))
-	assert.Equal(t, "read-kms-key-id", d.Get("kms_key_id"))
+	// Verify custom_kms_info is correctly read from the API response
+	customKmsInfo := d.Get("custom_kms_info").([]interface{})
+	assert.Len(t, customKmsInfo, 1)
+	infoMap := customKmsInfo[0].(map[string]interface{})
+	assert.Equal(t, "ap-shanghai", infoMap["kms_region"])
+	assert.Equal(t, "read-kms-key-id", infoMap["kms_key_id"])
 }
 
 // TestClsTopic_Read_KmsInfoNil verifies that the Read method does not panic
@@ -701,7 +711,7 @@ func TestClsTopic_Read_KmsInfoNil(t *testing.T) {
 		BizType:            ptrUint64CT(0),
 		CustomKmsInfo:      nil,
 	}
-	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
 		return topicInfo, nil
 	})
 

--- a/tencentcloud/services/cls/resource_tc_cls_topic_test.go
+++ b/tencentcloud/services/cls/resource_tc_cls_topic_test.go
@@ -479,3 +479,248 @@ func TestClsTopic_Update_BizTypeImmutable(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "biz_type")
 }
+
+// --- gomonkey mock unit tests for kms_region / kms_key_id parameters ---
+
+// TestClsTopic_Create_WithKmsInfo verifies that when encryption=1 and
+// kms_region / kms_key_id are set, the CreateTopic request contains a
+// non-nil CustomKmsInfo with the correct KmsRegion and KmsKeyId values.
+func TestClsTopic_Create_WithKmsInfo(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClsTopic().client, "UseClsClient", clsClient)
+
+	var capturedRequest *clsv20201016.CreateTopicRequest
+	patches.ApplyMethodFunc(clsClient, "CreateTopic", func(request *clsv20201016.CreateTopicRequest) (*clsv20201016.CreateTopicResponse, error) {
+		capturedRequest = request
+		resp := clsv20201016.NewCreateTopicResponse()
+		resp.Response = &clsv20201016.CreateTopicResponseParams{
+			TopicId:   ptrStringCT("fake-topic-id-kms"),
+			RequestId: ptrStringCT("fake-request-id-kms"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeClsTopicById to return a topic with encryption and CustomKmsInfo for the read-back after create
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:           ptrStringCT("fake-logset-id"),
+		TopicId:            ptrStringCT("fake-topic-id-kms"),
+		TopicName:          ptrStringCT("tf-test-topic-kms"),
+		PartitionCount:     ptrInt64CT(1),
+		AutoSplit:          ptrBoolCT(false),
+		MaxSplitPartitions: ptrInt64CT(20),
+		StorageType:        ptrStringCT("hot"),
+		Period:             ptrInt64CT(30),
+		HotPeriod:          ptrUint64CT(10),
+		Describes:          ptrStringCT("Test Demo."),
+		IsWebTracking:      ptrBoolCT(false),
+		BizType:            ptrUint64CT(0),
+		KeyId:              ptrStringCT("kms-cls-key-id"),
+		CustomKmsInfo: &clsv20201016.CustomKmsInfo{
+			KmsRegion: ptrStringCT("ap-guangzhou"),
+			KmsKeyId:  ptrStringCT("fake-kms-key-id"),
+		},
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClsTopic()
+	res := localcls.ResourceTencentCloudClsTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"logset_id":            "fake-logset-id",
+		"topic_name":           "tf-test-topic-kms",
+		"partition_count":      1,
+		"auto_split":           false,
+		"max_split_partitions": 20,
+		"period":               30,
+		"storage_type":         "hot",
+		"describes":            "Test Demo.",
+		"hot_period":           10,
+		"encryption":           1,
+		"kms_region":           "ap-guangzhou",
+		"kms_key_id":           "fake-kms-key-id",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	// Verify CustomKmsInfo was set on the create request
+	assert.NotNil(t, capturedRequest.CustomKmsInfo)
+	assert.Equal(t, "ap-guangzhou", *capturedRequest.CustomKmsInfo.KmsRegion)
+	assert.Equal(t, "fake-kms-key-id", *capturedRequest.CustomKmsInfo.KmsKeyId)
+
+	// Verify kms_region and kms_key_id are read back into state
+	assert.Equal(t, "ap-guangzhou", d.Get("kms_region"))
+	assert.Equal(t, "fake-kms-key-id", d.Get("kms_key_id"))
+}
+
+// TestClsTopic_Create_WithoutKmsInfo verifies that when encryption is not 1,
+// the CreateTopic request does NOT contain a CustomKmsInfo struct.
+func TestClsTopic_Create_WithoutKmsInfo(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClsTopic().client, "UseClsClient", clsClient)
+
+	var capturedRequest *clsv20201016.CreateTopicRequest
+	patches.ApplyMethodFunc(clsClient, "CreateTopic", func(request *clsv20201016.CreateTopicRequest) (*clsv20201016.CreateTopicResponse, error) {
+		capturedRequest = request
+		resp := clsv20201016.NewCreateTopicResponse()
+		resp.Response = &clsv20201016.CreateTopicResponseParams{
+			TopicId:   ptrStringCT("fake-topic-id-no-kms"),
+			RequestId: ptrStringCT("fake-request-id-no-kms"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeClsTopicById to return a topic without encryption/CustomKmsInfo
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:           ptrStringCT("fake-logset-id"),
+		TopicId:            ptrStringCT("fake-topic-id-no-kms"),
+		TopicName:          ptrStringCT("tf-test-topic-no-kms"),
+		PartitionCount:     ptrInt64CT(1),
+		AutoSplit:          ptrBoolCT(false),
+		MaxSplitPartitions: ptrInt64CT(20),
+		StorageType:        ptrStringCT("hot"),
+		Period:             ptrInt64CT(30),
+		HotPeriod:          ptrUint64CT(10),
+		Describes:          ptrStringCT("Test Demo."),
+		IsWebTracking:      ptrBoolCT(false),
+		BizType:            ptrUint64CT(0),
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClsTopic()
+	res := localcls.ResourceTencentCloudClsTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"logset_id":            "fake-logset-id",
+		"topic_name":           "tf-test-topic-no-kms",
+		"partition_count":      1,
+		"auto_split":           false,
+		"max_split_partitions": 20,
+		"period":               30,
+		"storage_type":         "hot",
+		"describes":            "Test Demo.",
+		"hot_period":           10,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	// Verify CustomKmsInfo was NOT set on the create request
+	assert.Nil(t, capturedRequest.CustomKmsInfo)
+}
+
+// TestClsTopic_Read_KmsInfo verifies that kms_region and kms_key_id are
+// correctly read from a TopicInfo response with a non-nil CustomKmsInfo.
+func TestClsTopic_Read_KmsInfo(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClsTopic().client, "UseClsClient", clsClient)
+
+	// Mock DescribeClsTopicById to return a topic with CustomKmsInfo
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:           ptrStringCT("fake-logset-id"),
+		TopicId:            ptrStringCT("fake-topic-id-read-kms"),
+		TopicName:          ptrStringCT("tf-test-topic-read-kms"),
+		PartitionCount:     ptrInt64CT(1),
+		AutoSplit:          ptrBoolCT(false),
+		MaxSplitPartitions: ptrInt64CT(20),
+		StorageType:        ptrStringCT("hot"),
+		Period:             ptrInt64CT(30),
+		HotPeriod:          ptrUint64CT(10),
+		Describes:          ptrStringCT("Test Demo."),
+		IsWebTracking:      ptrBoolCT(false),
+		BizType:            ptrUint64CT(0),
+		KeyId:              ptrStringCT("kms-cls-key-id"),
+		CustomKmsInfo: &clsv20201016.CustomKmsInfo{
+			KmsRegion: ptrStringCT("ap-shanghai"),
+			KmsKeyId:  ptrStringCT("read-kms-key-id"),
+		},
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClsTopic()
+	res := localcls.ResourceTencentCloudClsTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"logset_id":            "fake-logset-id",
+		"topic_name":           "tf-test-topic-read-kms",
+		"partition_count":      1,
+		"auto_split":           false,
+		"max_split_partitions": 20,
+		"period":               30,
+		"storage_type":         "hot",
+		"describes":            "Test Demo.",
+		"hot_period":           10,
+	})
+	d.SetId("fake-topic-id-read-kms")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "fake-topic-id-read-kms", d.Id())
+
+	// Verify kms_region and kms_key_id are correctly read from the API response
+	assert.Equal(t, "ap-shanghai", d.Get("kms_region"))
+	assert.Equal(t, "read-kms-key-id", d.Get("kms_key_id"))
+}
+
+// TestClsTopic_Read_KmsInfoNil verifies that the Read method does not panic
+// when CustomKmsInfo is nil in the TopicInfo response.
+func TestClsTopic_Read_KmsInfoNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClsTopic().client, "UseClsClient", clsClient)
+
+	// Mock DescribeClsTopicById to return a topic with CustomKmsInfo=nil
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:           ptrStringCT("fake-logset-id"),
+		TopicId:            ptrStringCT("fake-topic-id-nil-kms"),
+		TopicName:          ptrStringCT("tf-test-topic-nil-kms"),
+		PartitionCount:     ptrInt64CT(1),
+		AutoSplit:          ptrBoolCT(false),
+		MaxSplitPartitions: ptrInt64CT(20),
+		StorageType:        ptrStringCT("hot"),
+		Period:             ptrInt64CT(30),
+		HotPeriod:          ptrUint64CT(10),
+		Describes:          ptrStringCT("Test Demo."),
+		IsWebTracking:      ptrBoolCT(false),
+		BizType:            ptrUint64CT(0),
+		CustomKmsInfo:      nil,
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClsTopic()
+	res := localcls.ResourceTencentCloudClsTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"logset_id":            "fake-logset-id",
+		"topic_name":           "tf-test-topic-nil-kms",
+		"partition_count":      1,
+		"auto_split":           false,
+		"max_split_partitions": 20,
+		"period":               30,
+		"storage_type":         "hot",
+		"describes":            "Test Demo.",
+		"hot_period":           10,
+	})
+	d.SetId("fake-topic-id-nil-kms")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "fake-topic-id-nil-kms", d.Id())
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/client.go
@@ -4957,6 +4957,64 @@ func (c *Client) DeleteKafkaRechargeWithContext(ctx context.Context, request *De
     return
 }
 
+func NewDeleteLogRequest() (request *DeleteLogRequest) {
+    request = &DeleteLogRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cls", APIVersion, "DeleteLog")
+    
+    
+    return
+}
+
+func NewDeleteLogResponse() (response *DeleteLogResponse) {
+    response = &DeleteLogResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteLog
+// 修改日志信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_INDEXSEGMENTOFFLOADED = "FailedOperation.IndexSegmentOffloaded"
+//  FAILEDOPERATION_MODIFYSYSTEMFIELD = "FailedOperation.ModifySystemField"
+//  FAILEDOPERATION_WRITEBYQUERYREACHLIMIT = "FailedOperation.WriteByQueryReachLimit"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND_TOPICNOTEXIST = "ResourceNotFound.TopicNotExist"
+func (c *Client) DeleteLog(request *DeleteLogRequest) (response *DeleteLogResponse, err error) {
+    return c.DeleteLogWithContext(context.Background(), request)
+}
+
+// DeleteLog
+// 修改日志信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_INDEXSEGMENTOFFLOADED = "FailedOperation.IndexSegmentOffloaded"
+//  FAILEDOPERATION_MODIFYSYSTEMFIELD = "FailedOperation.ModifySystemField"
+//  FAILEDOPERATION_WRITEBYQUERYREACHLIMIT = "FailedOperation.WriteByQueryReachLimit"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND_TOPICNOTEXIST = "ResourceNotFound.TopicNotExist"
+func (c *Client) DeleteLogWithContext(ctx context.Context, request *DeleteLogRequest) (response *DeleteLogResponse, err error) {
+    if request == nil {
+        request = NewDeleteLogRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cls", APIVersion, "DeleteLog")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteLog require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteLogResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteLogsetRequest() (request *DeleteLogsetRequest) {
     request = &DeleteLogsetRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -12593,6 +12651,64 @@ func (c *Client) ModifyKafkaRechargeWithContext(ctx context.Context, request *Mo
     request.SetContext(ctx)
     
     response = NewModifyKafkaRechargeResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyLogRequest() (request *ModifyLogRequest) {
+    request = &ModifyLogRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("cls", APIVersion, "ModifyLog")
+    
+    
+    return
+}
+
+func NewModifyLogResponse() (response *ModifyLogResponse) {
+    response = &ModifyLogResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyLog
+// 修改日志信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_INDEXSEGMENTOFFLOADED = "FailedOperation.IndexSegmentOffloaded"
+//  FAILEDOPERATION_MODIFYSYSTEMFIELD = "FailedOperation.ModifySystemField"
+//  FAILEDOPERATION_WRITEBYQUERYREACHLIMIT = "FailedOperation.WriteByQueryReachLimit"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND_TOPICNOTEXIST = "ResourceNotFound.TopicNotExist"
+func (c *Client) ModifyLog(request *ModifyLogRequest) (response *ModifyLogResponse, err error) {
+    return c.ModifyLogWithContext(context.Background(), request)
+}
+
+// ModifyLog
+// 修改日志信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_INDEXSEGMENTOFFLOADED = "FailedOperation.IndexSegmentOffloaded"
+//  FAILEDOPERATION_MODIFYSYSTEMFIELD = "FailedOperation.ModifySystemField"
+//  FAILEDOPERATION_WRITEBYQUERYREACHLIMIT = "FailedOperation.WriteByQueryReachLimit"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND_TOPICNOTEXIST = "ResourceNotFound.TopicNotExist"
+func (c *Client) ModifyLogWithContext(ctx context.Context, request *ModifyLogRequest) (response *ModifyLogResponse, err error) {
+    if request == nil {
+        request = NewModifyLogRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "cls", APIVersion, "ModifyLog")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyLog require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyLogResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/errors.go
@@ -50,6 +50,9 @@ const (
 	// 低频不支持配置kv和tag索引。
 	FAILEDOPERATION_INVALIDINDEXRULEFORSEARCHLOW = "FailedOperation.InValidIndexRuleForSearchLow"
 
+	// 目标索引不支持 update/delete
+	FAILEDOPERATION_INDEXSEGMENTOFFLOADED = "FailedOperation.IndexSegmentOffloaded"
+
 	// 该告警策略状态异常，请检查下日志主题ID是否都存在。
 	FAILEDOPERATION_INVALIDALARM = "FailedOperation.InvalidAlarm"
 
@@ -67,6 +70,9 @@ const (
 
 	// 无效的Content。
 	FAILEDOPERATION_MISSINGCONTENT = "FailedOperation.MissingContent"
+
+	// 不能修改系统字段
+	FAILEDOPERATION_MODIFYSYSTEMFIELD = "FailedOperation.ModifySystemField"
 
 	// 修改的生命周期被禁止。
 	FAILEDOPERATION_PERIODMODIFYFORBIDDEN = "FailedOperation.PeriodModifyForbidden"
@@ -109,6 +115,9 @@ const (
 
 	// 日志主题已隔离。
 	FAILEDOPERATION_TOPICISOLATED = "FailedOperation.TopicIsolated"
+
+	// 命中文档数超过 10000 上限
+	FAILEDOPERATION_WRITEBYQUERYREACHLIMIT = "FailedOperation.WriteByQueryReachLimit"
 
 	// 写qps超过限制。
 	FAILEDOPERATION_WRITEQPSLIMIT = "FailedOperation.WriteQpsLimit"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/models.go
@@ -1910,7 +1910,7 @@ type CreateAgentApplicationRequestParams struct {
 	// <p>应用名称</p><p>入参限制：</p><ul><li>不能为空字符串</li><li>不能包含字符<code>|</code></li><li>不能超过64字符</li></ul>
 	ApplicationName *string `json:"ApplicationName,omitnil,omitempty" name:"ApplicationName"`
 
-	// <p>接入类型</p><p>枚举值：</p><ul><li>Langfuse： Langfuse 是一款开源的 LLM（大语言模型）工程与可观测性平台（LLMOps Tool）</li></ul>
+	// <p>接入类型</p><p>枚举值：</p><ul><li>Langfuse： Langfuse 是一款开源的 LLM（大语言模型）工程与可观测性平台（LLMOps Tool）</li><li>Agent： 用户创建 Agent 应用时，系统按统一规范自动创建对应的 CLS 主题（Topic），并为主题打上统一标签，便于后续在 Agent 可观测场景下做统一管理与检索。</li></ul>
 	AccessType *string `json:"AccessType,omitnil,omitempty" name:"AccessType"`
 
 	// <p>日志集Id。通过 <a href="https://cloud.tencent.com/document/product/614/58624">获取日志集列表</a>获取日志集Id。</p>
@@ -1923,7 +1923,7 @@ type CreateAgentApplicationRequest struct {
 	// <p>应用名称</p><p>入参限制：</p><ul><li>不能为空字符串</li><li>不能包含字符<code>|</code></li><li>不能超过64字符</li></ul>
 	ApplicationName *string `json:"ApplicationName,omitnil,omitempty" name:"ApplicationName"`
 
-	// <p>接入类型</p><p>枚举值：</p><ul><li>Langfuse： Langfuse 是一款开源的 LLM（大语言模型）工程与可观测性平台（LLMOps Tool）</li></ul>
+	// <p>接入类型</p><p>枚举值：</p><ul><li>Langfuse： Langfuse 是一款开源的 LLM（大语言模型）工程与可观测性平台（LLMOps Tool）</li><li>Agent： 用户创建 Agent 应用时，系统按统一规范自动创建对应的 CLS 主题（Topic），并为主题打上统一标签，便于后续在 Agent 可观测场景下做统一管理与检索。</li></ul>
 	AccessType *string `json:"AccessType,omitnil,omitempty" name:"AccessType"`
 
 	// <p>日志集Id。通过 <a href="https://cloud.tencent.com/document/product/614/58624">获取日志集列表</a>获取日志集Id。</p>
@@ -8427,6 +8427,84 @@ func (r *DeleteKafkaRechargeResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteKafkaRechargeResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteLogRequestParams struct {
+	// <p>日志主题id</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+
+	// <p>检索时间范围-开始时间</p><p>单位：ms</p>
+	From *int64 `json:"From,omitnil,omitempty" name:"From"`
+
+	// <p>检索时间范围-结束时间</p><p>单位：ms</p>
+	To *int64 `json:"To,omitnil,omitempty" name:"To"`
+
+	// <p>日志检索条件，仅支持 CQL 语法，不支持 Lucene 语法</p><p>对符合检索条件的日志进行删除</p>
+	QueryString *string `json:"QueryString,omitnil,omitempty" name:"QueryString"`
+}
+
+type DeleteLogRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>日志主题id</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+
+	// <p>检索时间范围-开始时间</p><p>单位：ms</p>
+	From *int64 `json:"From,omitnil,omitempty" name:"From"`
+
+	// <p>检索时间范围-结束时间</p><p>单位：ms</p>
+	To *int64 `json:"To,omitnil,omitempty" name:"To"`
+
+	// <p>日志检索条件，仅支持 CQL 语法，不支持 Lucene 语法</p><p>对符合检索条件的日志进行删除</p>
+	QueryString *string `json:"QueryString,omitnil,omitempty" name:"QueryString"`
+}
+
+func (r *DeleteLogRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteLogRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TopicId")
+	delete(f, "From")
+	delete(f, "To")
+	delete(f, "QueryString")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteLogRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteLogResponseParams struct {
+	// <p>影响日志条数</p>
+	AffectedRows *int64 `json:"AffectedRows,omitnil,omitempty" name:"AffectedRows"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteLogResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteLogResponseParams `json:"Response"`
+}
+
+func (r *DeleteLogResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteLogResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -19662,6 +19740,98 @@ func (r *ModifyKafkaRechargeResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ModifyLogRequestParams struct {
+	// <p>日志主题id</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+
+	// <p>检索时间范围-开始时间</p><p>单位：ms</p>
+	From *int64 `json:"From,omitnil,omitempty" name:"From"`
+
+	// <p>检索时间范围-结束时间</p><p>单位：ms</p>
+	To *int64 `json:"To,omitnil,omitempty" name:"To"`
+
+	// <p>日志检索条件，仅支持 CQL 语法，不支持 Lucene 语法</p><p>对符合检索条件的日志进行修改</p>
+	QueryString *string `json:"QueryString,omitnil,omitempty" name:"QueryString"`
+
+	// <p>修改模式</p><p>枚举值：</p><ul><li>PARTIAL： 只修改指定的日志字段</li><li>REPLACE： 整体替换原有日志（不包含预置字段及元数据字段）</li></ul>
+	ModifyMode *string `json:"ModifyMode,omitnil,omitempty" name:"ModifyMode"`
+
+	// <p>修改内容</p><p>不支持修改预置字段(__FILENAME__、__SOURCE__等，但不包括__CONTENT__)及元数据字段(__TAG__开头的字段)</p>
+	ModifyContent *string `json:"ModifyContent,omitnil,omitempty" name:"ModifyContent"`
+}
+
+type ModifyLogRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>日志主题id</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+
+	// <p>检索时间范围-开始时间</p><p>单位：ms</p>
+	From *int64 `json:"From,omitnil,omitempty" name:"From"`
+
+	// <p>检索时间范围-结束时间</p><p>单位：ms</p>
+	To *int64 `json:"To,omitnil,omitempty" name:"To"`
+
+	// <p>日志检索条件，仅支持 CQL 语法，不支持 Lucene 语法</p><p>对符合检索条件的日志进行修改</p>
+	QueryString *string `json:"QueryString,omitnil,omitempty" name:"QueryString"`
+
+	// <p>修改模式</p><p>枚举值：</p><ul><li>PARTIAL： 只修改指定的日志字段</li><li>REPLACE： 整体替换原有日志（不包含预置字段及元数据字段）</li></ul>
+	ModifyMode *string `json:"ModifyMode,omitnil,omitempty" name:"ModifyMode"`
+
+	// <p>修改内容</p><p>不支持修改预置字段(__FILENAME__、__SOURCE__等，但不包括__CONTENT__)及元数据字段(__TAG__开头的字段)</p>
+	ModifyContent *string `json:"ModifyContent,omitnil,omitempty" name:"ModifyContent"`
+}
+
+func (r *ModifyLogRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyLogRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TopicId")
+	delete(f, "From")
+	delete(f, "To")
+	delete(f, "QueryString")
+	delete(f, "ModifyMode")
+	delete(f, "ModifyContent")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyLogRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyLogResponseParams struct {
+	// <p>影响日志条数</p>
+	AffectedRows *int64 `json:"AffectedRows,omitnil,omitempty" name:"AffectedRows"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyLogResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyLogResponseParams `json:"Response"`
+}
+
+func (r *ModifyLogResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyLogResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyLogsetRequestParams struct {
 	// 日志集Id。通过 [获取日志集列表](https://cloud.tencent.com/document/product/614/58624)获取日志集Id。
 	LogsetId *string `json:"LogsetId,omitnil,omitempty" name:"LogsetId"`
@@ -23998,6 +24168,9 @@ type ToolCall struct {
 
 	// <p>索引值</p>
 	Index *uint64 `json:"Index,omitnil,omitempty" name:"Index"`
+
+	// <p>模型返回的思考签名，执行工具后需在后续请求中原样回传</p>
+	ThoughtSignature *string `json:"ThoughtSignature,omitnil,omitempty" name:"ThoughtSignature"`
 }
 
 type ToolCallFunction struct {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.153"
+	params["RequestClient"] = "SDK_GO_1.3.156"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1259,10 +1259,10 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors

--- a/website/docs/r/cls_topic.html.markdown
+++ b/website/docs/r/cls_topic.html.markdown
@@ -13,6 +13,8 @@ Provides a resource to create a cls topic.
 
 ~> **NOTE:** Field `encryption` can only be enabled, not disabled.
 
+~> **NOTE:** Fields `kms_region` and `kms_key_id` are only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.
+
 ## Example Usage
 
 ### Create a standard cls topic
@@ -106,6 +108,34 @@ resource "tencentcloud_cls_topic" "example" {
 }
 ```
 
+### Create a cls topic with custom KMS key (encryption=1)
+
+```hcl
+resource "tencentcloud_cls_logset" "example" {
+  logset_name = "tf_example"
+  tags = {
+    tagKey = "tagValue"
+  }
+}
+
+resource "tencentcloud_cls_topic" "example" {
+  topic_name           = "tf_example"
+  logset_id            = tencentcloud_cls_logset.example.id
+  auto_split           = false
+  max_split_partitions = 20
+  partition_count      = 1
+  period               = 30
+  storage_type         = "hot"
+  describes            = "Test Demo."
+  encryption           = 1
+  kms_region           = "ap-guangzhou"
+  kms_key_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  tags = {
+    tagKey = "tagValue"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -120,6 +150,8 @@ Supported regions: ap-beijing, ap-guangzhou, ap-shanghai, ap-singapore, ap-bangk
 * `extends` - (Optional, List) Log Subject Extension Information.
 * `hot_period` - (Optional, Int) 0: Turn off log sinking. Non 0: The number of days of standard storage after enabling log settling. HotPeriod needs to be greater than or equal to 7 and less than Period. Only effective when StorageType is hot.
 * `is_web_tracking` - (Optional, Bool) No authentication switch. False: closed; True: Enable. The default is false. After activation, anonymous access to the log topic will be supported for specified operations.
+* `kms_key_id` - (Optional, String) KMS key ID for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.
+* `kms_region` - (Optional, String) KMS region for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.
 * `max_split_partitions` - (Optional, Int) Maximum number of partitions to split into for this topic if automatic split is enabled. Default value: 50.
 * `partition_count` - (Optional, Int) Number of log topic partitions. Default value: 1. Maximum value: 10.
 * `period` - (Optional, Int) lifetime. Unit: days. Standard storage value range: 1 to 3600. Infrequent storage value range: 7 to 3600 days. A value of 3640 indicates permanent retention.If this value is not input, it defaults to the Period value of the log set corresponding to the accessed log topic (defaults to 30 days in case of access failure).

--- a/website/docs/r/cls_topic.html.markdown
+++ b/website/docs/r/cls_topic.html.markdown
@@ -13,7 +13,7 @@ Provides a resource to create a cls topic.
 
 ~> **NOTE:** Field `encryption` can only be enabled, not disabled.
 
-~> **NOTE:** Fields `kms_region` and `kms_key_id` are only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.
+~> **NOTE:** Field `custom_kms_info` is for user-defined KMS key. If not set, the CLS default key (alias KMS-CLS) is used.
 
 ## Example Usage
 
@@ -128,8 +128,12 @@ resource "tencentcloud_cls_topic" "example" {
   storage_type         = "hot"
   describes            = "Test Demo."
   encryption           = 1
-  kms_region           = "ap-guangzhou"
-  kms_key_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+  custom_kms_info {
+    kms_region = "ap-guangzhou"
+    kms_key_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+
   tags = {
     tagKey = "tagValue"
   }
@@ -140,23 +144,21 @@ resource "tencentcloud_cls_topic" "example" {
 
 The following arguments are supported:
 
-* `logset_id` - (Required, String) Logset ID.
-* `topic_name` - (Required, String) Log topic name.
-* `auto_split` - (Optional, Bool) Whether to enable automatic split. Default value: true.
-* `biz_type` - (Optional, Int) Topic type. 0: log topic (default), 1: metric topic.
-* `describes` - (Optional, String) Log Topic Description.
-* `encryption` - (Optional, Int) Encryption-related parameters. This parameter is supported for users with an open access list and from encrypted regions; it cannot be passed in other scenarios. 0 or not passed: No encryption. 1: KMS-CLS cloud product key encryption. Once enabled, it cannot be disabled.
-Supported regions: ap-beijing, ap-guangzhou, ap-shanghai, ap-singapore, ap-bangkok, ap-jakarta, eu-frankfurt, ap-seoul, ap-tokyo.
-* `extends` - (Optional, List) Log Subject Extension Information.
-* `hot_period` - (Optional, Int) 0: Turn off log sinking. Non 0: The number of days of standard storage after enabling log settling. HotPeriod needs to be greater than or equal to 7 and less than Period. Only effective when StorageType is hot.
-* `is_web_tracking` - (Optional, Bool) No authentication switch. False: closed; True: Enable. The default is false. After activation, anonymous access to the log topic will be supported for specified operations.
-* `kms_key_id` - (Optional, String) KMS key ID for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.
-* `kms_region` - (Optional, String) KMS region for the custom KMS key. Only effective when `encryption` is set to 1. If not set, the CLS default key (alias KMS-CLS) is used.
-* `max_split_partitions` - (Optional, Int) Maximum number of partitions to split into for this topic if automatic split is enabled. Default value: 50.
-* `partition_count` - (Optional, Int) Number of log topic partitions. Default value: 1. Maximum value: 10.
-* `period` - (Optional, Int) lifetime. Unit: days. Standard storage value range: 1 to 3600. Infrequent storage value range: 7 to 3600 days. A value of 3640 indicates permanent retention.If this value is not input, it defaults to the Period value of the log set corresponding to the accessed log topic (defaults to 30 days in case of access failure).
-* `storage_type` - (Optional, String) Log topic storage class. Valid values: hot: real-time storage; cold: offline storage. Default value: hot. If cold is passed in, please contact the customer service to add the log topic to the allowlist first.
-* `tags` - (Optional, Map) Tag description list. Up to 10 tag key-value pairs are supported and must be unique.
+* `logset_id` - (Required, String) Logset ID. Get the logset ID via `DescribeLogsets` API.
+* `topic_name` - (Required, String) Log topic name. Constraints: cannot be an empty string, cannot contain the `|` character, and cannot use the following reserved names: `cls_service_log`, `loglistener_status`, `loglistener_alarm`, `loglistener_business`, `cls_service_metric`.
+* `auto_split` - (Optional, Bool) Whether to enable automatic split. Default value: `true`.
+* `biz_type` - (Optional, Int) Topic type. `0`: log topic (default), `1`: metric topic.
+* `custom_kms_info` - (Optional, List) User-defined KMS key information. If empty, the default key (alias `KMS-CLS`) is used.
+* `describes` - (Optional, String) Log topic description.
+* `encryption` - (Optional, Int) Encryption-related parameters. Supported for encryption-enabled regions and allowlisted users; cannot be passed in other scenarios. `0` or not passed: no encryption; `1`: kms-cls cloud product key encryption. Once enabled, it cannot be disabled. Supported regions: ap-beijing, ap-guangzhou, ap-shanghai, ap-singapore, ap-bangkok, ap-jakarta, eu-frankfurt, ap-seoul, ap-tokyo.
+* `extends` - (Optional, List) Topic extension information.
+* `hot_period` - (Optional, Int) `0`: turn off log settling. Non-`0`: the number of days of standard storage after enabling log settling. HotPeriod must be greater than or equal to 7 and less than Period. Only effective when `storage_type` is `hot`. Not supported for metric topics.
+* `is_web_tracking` - (Optional, Bool) Free authentication switch. `false`: closed (default); `true`: enabled. When enabled, anonymous access to the log topic will be supported for specified operations. Not supported for metric topics.
+* `max_split_partitions` - (Optional, Int) Maximum number of partitions allowed for the topic if automatic split is enabled. Default value: `50`.
+* `partition_count` - (Optional, Int) Number of log topic partitions. Default: 1, maximum: 10.
+* `period` - (Optional, Int) Retention period, unit: days. Log topic (standard storage): 1 to 3600 days, value `3640` means permanent retention. Log topic (infrequent storage): 7 to 3600 days, value `3640` means permanent retention. Metric topic: 1 to 3600 days, value `3640` means permanent retention.
+* `storage_type` - (Optional, String) Log topic storage type. Valid values: `hot`: standard storage; `cold`: infrequent storage. Default value: `hot`. Not supported for metric topics.
+* `tags` - (Optional, Map) Tag description list. Up to 10 tag key-value pairs are supported, and the same resource can only be bound to the same tag key.
 
 The `anonymous_access` object of `extends` supports the following:
 
@@ -168,6 +170,11 @@ The `conditions` object of `anonymous_access` supports the following:
 * `attributes` - (Optional, String) Condition attribute, currently only VpcID is supported.
 * `condition_value` - (Optional, String) The value of the corresponding conditional attribute.
 * `rule` - (Optional, Int) Conditional rule, 1: equal, 2: not equal.
+
+The `custom_kms_info` object supports the following:
+
+* `kms_key_id` - (Required, String) KMS key ID.
+* `kms_region` - (Required, String) KMS region. Refer to Tencent Cloud KMS documentation for supported regions. Format: `ap-guangzhou`.
 
 The `extends` object supports the following:
 


### PR DESCRIPTION
Add custom KMS key support (`kms_region`, `kms_key_id`) to the `tencentcloud_cls_topic` resource, allowing users to specify their own KMS key region and key ID for CLS topic encryption instead of using the system default key. Both parameters are Optional and Computed, and are only effective when `encryption = 1`.