### PR TITLE
feat(dlc): [137033195] add tags parameter to tencentcloud_dlc_data_engine resource

### DIFF
--- a/.changelog/4421.txt
+++ b/.changelog/4421.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_dlc_data_engine: support binding tags to data engine at creation time
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -55,7 +55,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.132
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.156
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.0.414
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dts v1.3.153

--- a/go.sum
+++ b/go.sum
@@ -996,7 +996,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.125/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.129/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.132/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.135/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.139/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1005,8 +1004,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.151/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153 h1:K14ZEX1X7FXJBUqbbF+6bW5yFkIK8JFYiqCV2sQd+RM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156 h1:A3DxpqGh8DF+rCRJVGlNJaeOJ/l6FkhCKhdEaUeu0Dc=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1031,8 +1031,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633 h1:Ul5iNhXo
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633/go.mod h1:tc6Hvf03M1cBtMC1IKSa5mlOn3kpxWOwhWU1fRy+KEE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673 h1:YyjGLjvPDKNlpbGt89WLFif7TjId0fHzcrGOaHSQRNQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673/go.mod h1:hXPMop1kJFqAvHj+7TyxxxXS/HGUP4SuKx5gGoAl0Zc=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.132 h1:LHD2gW7BiKEDWuvKgYniUcPzb3D+Jv6pJFii0JNz+PQ=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.132/go.mod h1:TX8Cko5rAacJQ0J5Hvg9qCPm7GHTqMtkgV595AuUmoc=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.156 h1:78OGMhGeGrjml9AAqmeqPfCQXiLz/tM9EjoR3+dVPL0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.156/go.mod h1:/CbfEeeufmoAvXiehDi34baOOE9j/tewKIEq69PxxGY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124 h1:atQm8S0BLrr3E+Yn2383KQUEEXpQ6z31MsprAKzMDDE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124/go.mod h1:zxlW9EAn0Hqx6Eub6MMocnHZz/gHundkyI7CdbIhU3o=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.0.414 h1:egwjvOEUKBaxsoRVn/YSEhp2E8qdh77Ous9A/wftDo0=

--- a/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/design.md
+++ b/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The `tencentcloud_dlc_data_engine` resource (in `tencentcloud/services/dlc/resource_tc_dlc_data_engine.go`) manages a DLC (Data Lake Compute) virtual cluster through its full lifecycle. It currently exposes ~25 schema fields covering engine type, cluster sizing, billing, scheduling, and session templates, but provides no way to bind tags at creation.
+
+The cloud SDK (`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125`) already supports tags:
+- `CreateDataEngineRequest.Tags` — `[]*TagInfo` (create-only input). `TagInfo` has `TagKey *string` and `TagValue *string`.
+- `DataEngineInfo.TagList` — `[]*TagInfo` (returned by `DescribeDataEngine` and `DescribeDataEngines`). The resource `Read` uses `DescribeDataEngine` (singular), whose `Response.DataEngine` is a `*DataEngineInfo`, so `TagList` is available there too.
+- `UpdateDataEngineRequest` has **no** `Tags` field — tags cannot be modified after creation.
+
+The existing resource already follows the pattern of treating create-only fields (e.g. `engine_type`, `cluster_type`, `pay_mode`) as immutable: they are listed in `immutableArgs` in `Update`, and several use `ForceNew` / are not wired into the update request. We will follow the same pattern for tags.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose a `tags` block on `tencentcloud_dlc_data_engine` so users can bind tags at creation time via IaC.
+- Keep state in sync by reading `TagList` back during `Read`.
+- Stay fully backward compatible (optional field, no change to existing configurations/state).
+
+**Non-Goals:**
+- Modifying tags on an existing engine in place — the DLC `UpdateDataEngine` API does not support it, so this is intentionally excluded.
+- Adding tags to the DLC data sources (`tencentcloud_dlc_data_engine_network`, session parameters) — out of scope for this change.
+
+## Decisions
+
+### Decision 1: Model `tags` as a TypeList block with `tag_key` / `tag_value` sub-fields
+
+**Choice:** A `schema.TypeList` named `tags`, with an `Elem` `schema.Resource` containing `tag_key` (string, required) and `tag_value` (string, optional).
+
+**Rationale:** This mirrors the cloud API `TagInfo` struct (`TagKey`/`TagValue`) 1:1, matches the naming convention already used in this resource (snake_case schema names mapping to PascalCase SDK fields), and is consistent with how other TencentCloud provider resources represent tag lists. It avoids the special-cased `key=value` map style because DLC tags are a list of `TagInfo` pairs, which maps cleanly to a list block.
+
+**Alternative considered:** A `schema.TypeMap` keyed by tag key. Rejected — the API is a list of `{TagKey, TagValue}` structs (allows repeated keys in the raw API), and a list block preserves ordering and is the established pattern in this codebase.
+
+### Decision 2: Mark `tags` as `ForceNew: true`
+
+**Choice:** The `tags` schema field uses `ForceNew: true`.
+
+**Rationale:** `UpdateDataEngineRequest` has no `Tags` field, so the API cannot update tags. Without `ForceNew`, a change to `tags` would be silently ignored by `Update` (the value would only be sent on the next create). Marking it `ForceNew` makes the behavior explicit: changing tags recreates the engine, matching how the existing code treats other create-only fields (`engine_type`, `cluster_type`, `mode`, etc. are in `immutableArgs`). We will also add `"tags"` to the `immutableArgs` slice in `Update` for consistency with the existing create-only arguments — although `ForceNew` means Terraform plans a recreate before `Update` runs, listing it keeps the guard uniform.
+
+### Decision 3: Populate `request.Tags` from the block in `Create`, and flatten `dataEngine.TagList` in `Read`
+
+**Choice:**
+- In `resourceTencentCloudDlcDataEngineCreate`, iterate the `tags` block with `helper.InterfacesInterfaces`/`d.Get("tags")`, build `[]*dlc.TagInfo`, and assign to `request.Tags`.
+- In `resourceTencentCloudDlcDataEngineRead`, after obtaining `dataEngine` (a `*DataEngineInfo`), flatten `dataEngine.TagList` into a `[]map[string]interface{}` (with `tag_key`/`tag_value` only when non-nil) and `d.Set("tags", ...)`.
+
+**Rationale:** This follows the exact marshalling/unmarshalling pattern already used in this resource for `data_engine_config_pairs` and `session_resource_template.running_time_parameters` (both are TypeList blocks of `DataEngineConfigPair`). Nil checks on response fields follow the project rule that `setXX()` is only called when the response field is non-nil.
+
+## Risks / Trade-offs
+
+- **[Recreation on tag change]** → Mitigation: `ForceNew` is the only correct behavior given the API limitation; it is documented in the field `Description` and in the resource `.md` so users understand changing tags recreates the engine.
+- **[State drift for engines created outside Terraform]** → Mitigation: `Read` flattens `TagList` whenever present and leaves `tags` unset/empty when the API returns no tags (nil), so imported or pre-existing engines refresh cleanly.
+- **[Existing buggy `config_value` assignment in `data_engine_config_pairs`]** → Out of scope; we will not alter unrelated existing code. The new `tags` marshalling will correctly set both `TagKey` and `TagValue`.

--- a/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/proposal.md
+++ b/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The `tencentcloud_dlc_data_engine` resource currently does not support binding tags to a data engine at creation time. Users who rely on tags for cost allocation, access control, or resource grouping must manage tags out-of-band, which breaks the infrastructure-as-code contract and causes state drift.
+
+The DLC `CreateDataEngine` API already accepts a `Tags` input (`[]*TagInfo` with `TagKey`/`TagValue`), and the `DescribeDataEngine`/`DescribeDataEngines` APIs return the bound tags in `DataEngineInfo.TagList`. Exposing these as a Terraform `tags` block lets users declare tags alongside the rest of the engine configuration.
+
+## What Changes
+
+- Add a new `tags` block (TypeList) to the `tencentcloud_dlc_data_engine` resource schema, with `tag_key` and `tag_value` string sub-fields, modeled on the cloud API `TagInfo` structure.
+- In `CreateDataEngine`, map the `tags` block to `request.Tags` (`[]*dlc.TagInfo`).
+- In the resource `Read`, map `DataEngineInfo.TagList` (`[]*dlc.TagInfo`) back into the `tags` block. Note: the current `Read` uses the `DescribeDataEngine` API (singular) which returns the same `DataEngineInfo` type that carries `TagList`.
+- Because `UpdateDataEngine` does **not** support a `Tags` field, mark the `tags` parameter as `ForceNew: true` so that changing tags triggers recreation (consistent with other immutable create-only parameters on this resource).
+
+## Capabilities
+
+### New Capabilities
+- `dlc-data-engine-tags`: Tag binding support for the `tencentcloud_dlc_data_engine` resource — schema, create-time population, read-time synchronization, and ForceNew update constraint.
+
+### Modified Capabilities
+<!-- None — no existing spec for dlc-data-engine. -->
+
+## Impact
+
+- **Affected code:**
+  - `tencentcloud/services/dlc/resource_tc_dlc_data_engine.go` — add `tags` schema field; populate `request.Tags` in `Create`; read `dataEngine.TagList` in `Read`; add `tags` to the `immutableArgs` list in `Update` (it is ForceNew, so Terraform handles recreation, but it is listed for consistency with the existing create-only arguments).
+  - `tencentcloud/services/dlc/resource_tc_dlc_data_engine_test.go` — add unit tests covering tags marshalling and flattening using gomonkey mocks (per project rule for modified resources, extend the existing test suite).
+  - `tencentcloud/services/dlc/resource_tc_dlc_data_engine.md` — document the new `tags` block and example usage.
+- **APIs used:**
+  - `CreateDataEngine` (input `Tags []*TagInfo`) — `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125`
+  - `DescribeDataEngine` (output `DataEngine.TagList []*TagInfo`) — same package
+- **Backward compatibility:** Fully backward compatible. `tags` is `Optional`; existing configurations and state are unaffected. `UpdateDataEngine` lacks a `Tags` field, so `tags` is `ForceNew` (recreation on change), consistent with the resource's existing create-only parameters.
+- **Dependencies:** None new; the vendor SDK already defines `TagInfo`, `CreateDataEngineRequest.Tags`, and `DataEngineInfo.TagList`.

--- a/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/specs/dlc-data-engine-tags/spec.md
+++ b/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/specs/dlc-data-engine-tags/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: dlc_data_engine tags schema definition
+The system SHALL add a `tags` parameter to the `tencentcloud_dlc_data_engine` resource schema to bind tags to a DLC data engine at creation time.
+
+#### Scenario: tags block schema fields
+- **WHEN** the `tencentcloud_dlc_data_engine` resource schema is defined
+- **THEN** it includes a `tags` field of type `schema.TypeList`
+- **AND** the `tags` field is `Optional: true`
+- **AND** the `tags` field is `ForceNew: true` because the DLC `UpdateDataEngine` API does not support modifying tags
+- **AND** the `tags` element is a `schema.Resource` with two string sub-fields: `tag_key` (Required) and `tag_value` (Optional)
+- **AND** the `Description` for `tags` states that changing this parameter will force a new resource
+
+#### Scenario: tag_key sub-field
+- **WHEN** the `tags` element schema is defined
+- **THEN** it contains `tag_key` of type `schema.TypeString` with `Required: true`
+- **AND** the description documents it as the tag key
+
+#### Scenario: tag_value sub-field
+- **WHEN** the `tags` element schema is defined
+- **THEN** it contains `tag_value` of type `schema.TypeString` with `Optional: true`
+- **AND** the description documents it as the tag value
+
+### Requirement: dlc_data_engine tags population on Create
+The system SHALL map the `tags` block to `CreateDataEngineRequest.Tags` when creating a DLC data engine.
+
+#### Scenario: tags passed to CreateDataEngine API
+- **WHEN** the user configures the `tags` block on `tencentcloud_dlc_data_engine` and a create is performed
+- **THEN** for each element in the `tags` list, the system constructs a `dlc.TagInfo` with `TagKey` set from `tag_key` and `TagValue` set from `tag_value`
+- **AND** the constructed `[]*dlc.TagInfo` is assigned to `request.Tags`
+- **AND** when `tag_value` is empty it is still passed as an empty string, matching the cloud API `TagInfo` structure
+
+#### Scenario: tags omitted on create
+- **WHEN** the user does not configure the `tags` block
+- **THEN** `request.Tags` is left as its zero value (nil) so the cloud API applies defaults
+- **AND** resource creation proceeds normally without error
+
+### Requirement: dlc_data_engine tags synchronization on Read
+The system SHALL read `TagList` from the DLC describe response and flatten it into the `tags` block during `Read`.
+
+#### Scenario: tags flattened from TagList
+- **WHEN** the `Read` handler obtains a `DataEngineInfo` with a non-nil `TagList`
+- **THEN** the system builds a `[]map[string]interface{}` where each map carries `tag_key` and `tag_value`
+- **AND** `tag_key` is populated only when `TagInfo.TagKey` is non-nil
+- **AND** `tag_value` is populated only when `TagInfo.TagValue` is non-nil
+- **AND** the list is written to state via `d.Set("tags", ...)`
+
+#### Scenario: TagList is nil or empty
+- **WHEN** the described `DataEngineInfo.TagList` is nil or has length zero
+- **THEN** the system does not populate `tag_key`/`tag_value` entries
+- **AND** the `tags` state is set to an empty list (or left unset) without error
+- **AND** other fields continue to be read normally
+
+### Requirement: dlc_data_engine tags are immutable after creation
+The system SHALL prevent in-place updates of the `tags` parameter.
+
+#### Scenario: ForceNew triggers recreation
+- **WHEN** the user changes the `tags` block in an existing `tencentcloud_dlc_data_engine` configuration
+- **THEN** Terraform plans a destroy-and-recreate because `tags` is `ForceNew: true`
+- **AND** the `Update` handler is not invoked for a `tags`-only change
+
+#### Scenario: tags listed as immutable in Update
+- **WHEN** the `resourceTencentCloudDlcDataEngineUpdate` function builds its `immutableArgs` guard list
+- **THEN** the list includes `"tags"` alongside the other create-only arguments
+- **AND** if a `tags` change somehow reaches `Update`, it returns an error stating the argument cannot be changed
+
+### Requirement: dlc_data_engine tags documentation
+The system SHALL document the `tags` parameter in the resource example markdown.
+
+#### Scenario: tags documented in resource md
+- **WHEN** the resource documentation is generated/updated
+- **THEN** `resource_tc_dlc_data_engine.md` includes the `tags` block in the Example Usage
+- **AND** the example shows a `tags` block with `tag_key` and `tag_value` entries
+- **AND** the `Argument Reference` / `Attribute Reference` sections are left for auto-generation (per project convention, these are not hand-written)
+
+### Requirement: dlc_data_engine tags unit tests
+The system SHALL include unit tests covering the tags marshalling and flattening logic using gomonkey mocks.
+
+#### Scenario: create marshals tags to request
+- **WHEN** a unit test exercises `resourceTencentCloudDlcDataEngineCreate` with a `tags` block configured
+- **THEN** the test mocks the DLC client `CreateDataEngine` and `DescribeDataEngine` calls via gomonkey
+- **AND** the test asserts that `request.Tags` contains the expected `TagInfo` entries with correct `TagKey` and `TagValue`
+
+#### Scenario: read flattens TagList to state
+- **WHEN** a unit test exercises `resourceTencentCloudDlcDataEngineRead` with a `DataEngineInfo` whose `TagList` is populated
+- **THEN** the test asserts that `d.Get("tags")` returns the expected list of `tag_key`/`tag_value` maps
+- **AND** the test covers the nil/empty `TagList` case without error

--- a/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/tasks.md
+++ b/openspec/changes/archive/2026-08-11-add-dlc-data-engine-tags/tasks.md
@@ -1,0 +1,27 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `resource_tc_dlc_data_engine.go` 的 `Schema` map 中新增 `tags` 字段：类型 `schema.TypeList`，`Optional: true`，`ForceNew: true`，`Description` 说明该参数变更会触发重建
+- [x] 1.2 为 `tags` 的 `Elem` (`schema.Resource`) 定义两个子字段：`tag_key`（`schema.TypeString`, `Required: true`）与 `tag_value`（`schema.TypeString`, `Optional: true`），各自补充 `Description`
+
+## 2. 资源 CRUD 实现
+
+- [x] 2.1 在 `resourceTencentCloudDlcDataEngineCreate` 中读取 `tags` 块，遍历构造 `[]*dlc.TagInfo`（`TagKey` 来自 `tag_key`、`TagValue` 来自 `tag_value`），赋值给 `request.Tags`；用户未配置时保持 `request.Tags` 为 nil
+- [x] 2.2 在 `resourceTencentCloudDlcDataEngineRead` 中，当 `dataEngine.TagList` 非 nil 时，将其展平为 `[]map[string]interface{}`（仅当 `TagKey`/`TagValue` 非 nil 时写入对应 `tag_key`/`tag_value`），通过 `d.Set("tags", ...)` 同步状态；`TagList` 为 nil/空时不报错
+- [x] 2.3 在 `resourceTencentCloudDlcDataEngineUpdate` 的 `immutableArgs` 列表中追加 `"tags"`，与现有 create-only 参数保持一致的不可变约束
+- [x] 2.4 确认 `UpdateDataEngineRequest` 无 `Tags` 字段，`Update` 路径不向其传递 tags（由 `ForceNew` 在 plan 阶段处理重建）
+
+## 3. 测试实现
+
+- [x] 3.1 在 `resource_tc_dlc_data_engine_test.go` 中使用 gomonkey mock 云 API，补充 create 路径单测：验证配置 `tags` 后 `request.Tags` 包含期望的 `TagInfo`（正确的 `TagKey`/`TagValue`）
+- [x] 3.2 补充 read 路径单测：mock `DescribeDataEngine` 返回带 `TagList` 的 `DataEngineInfo`，验证 `d.Get("tags")` 展平结果正确；并覆盖 `TagList` 为 nil/空时不报错的场景
+
+## 4. 文档更新
+
+- [x] 4.1 更新 `tencentcloud/services/dlc/resource_tc_dlc_data_engine.md`：在 Example Usage 中补充 `tags` 块示例（含 `tag_key`/`tag_value`），不手写 `Argument Reference`/`Attribute Reference`（由 `make doc` 自动生成）
+- [x] 4.2 收尾阶段通过 `make doc` 生成 `website/docs/` 下文档（不在本步手动编辑 website/）
+
+## 5. 代码正确性检查
+
+- [x] 5.1 校验新增参数 `tags` 仅出现在 `CreateDataEngine` 入参和 `DescribeDataEngine`/`DescribeDataEngines` 出参中，且 `UpdateDataEngine` 不支持 `Tags`，CRUD 各路径的参数与对应云 API 接口一致
+- [x] 5.2 确认 `Read` 中调用 `setXX` 前先判断 `TagList` 及子字段非 nil，符合 nil 检查规则
+- [x] 5.3 确认 `Create` 检查云 API 返回值非空逻辑未受影响，未引入新的未检查 error

--- a/openspec/specs/dlc-data-engine-tags/spec.md
+++ b/openspec/specs/dlc-data-engine-tags/spec.md
@@ -1,0 +1,91 @@
+# dlc-data-engine-tags Specification
+
+## Purpose
+TBD - created by archiving change add-dlc-data-engine-tags. Update Purpose after archive.
+## Requirements
+### Requirement: dlc_data_engine tags schema definition
+The system SHALL add a `tags` parameter to the `tencentcloud_dlc_data_engine` resource schema to bind tags to a DLC data engine at creation time.
+
+#### Scenario: tags block schema fields
+- **WHEN** the `tencentcloud_dlc_data_engine` resource schema is defined
+- **THEN** it includes a `tags` field of type `schema.TypeList`
+- **AND** the `tags` field is `Optional: true`
+- **AND** the `tags` field is `ForceNew: true` because the DLC `UpdateDataEngine` API does not support modifying tags
+- **AND** the `tags` element is a `schema.Resource` with two string sub-fields: `tag_key` (Required) and `tag_value` (Optional)
+- **AND** the `Description` for `tags` states that changing this parameter will force a new resource
+
+#### Scenario: tag_key sub-field
+- **WHEN** the `tags` element schema is defined
+- **THEN** it contains `tag_key` of type `schema.TypeString` with `Required: true`
+- **AND** the description documents it as the tag key
+
+#### Scenario: tag_value sub-field
+- **WHEN** the `tags` element schema is defined
+- **THEN** it contains `tag_value` of type `schema.TypeString` with `Optional: true`
+- **AND** the description documents it as the tag value
+
+### Requirement: dlc_data_engine tags population on Create
+The system SHALL map the `tags` block to `CreateDataEngineRequest.Tags` when creating a DLC data engine.
+
+#### Scenario: tags passed to CreateDataEngine API
+- **WHEN** the user configures the `tags` block on `tencentcloud_dlc_data_engine` and a create is performed
+- **THEN** for each element in the `tags` list, the system constructs a `dlc.TagInfo` with `TagKey` set from `tag_key` and `TagValue` set from `tag_value`
+- **AND** the constructed `[]*dlc.TagInfo` is assigned to `request.Tags`
+- **AND** when `tag_value` is empty it is still passed as an empty string, matching the cloud API `TagInfo` structure
+
+#### Scenario: tags omitted on create
+- **WHEN** the user does not configure the `tags` block
+- **THEN** `request.Tags` is left as its zero value (nil) so the cloud API applies defaults
+- **AND** resource creation proceeds normally without error
+
+### Requirement: dlc_data_engine tags synchronization on Read
+The system SHALL read `TagList` from the DLC describe response and flatten it into the `tags` block during `Read`.
+
+#### Scenario: tags flattened from TagList
+- **WHEN** the `Read` handler obtains a `DataEngineInfo` with a non-nil `TagList`
+- **THEN** the system builds a `[]map[string]interface{}` where each map carries `tag_key` and `tag_value`
+- **AND** `tag_key` is populated only when `TagInfo.TagKey` is non-nil
+- **AND** `tag_value` is populated only when `TagInfo.TagValue` is non-nil
+- **AND** the list is written to state via `d.Set("tags", ...)`
+
+#### Scenario: TagList is nil or empty
+- **WHEN** the described `DataEngineInfo.TagList` is nil or has length zero
+- **THEN** the system does not populate `tag_key`/`tag_value` entries
+- **AND** the `tags` state is set to an empty list (or left unset) without error
+- **AND** other fields continue to be read normally
+
+### Requirement: dlc_data_engine tags are immutable after creation
+The system SHALL prevent in-place updates of the `tags` parameter.
+
+#### Scenario: ForceNew triggers recreation
+- **WHEN** the user changes the `tags` block in an existing `tencentcloud_dlc_data_engine` configuration
+- **THEN** Terraform plans a destroy-and-recreate because `tags` is `ForceNew: true`
+- **AND** the `Update` handler is not invoked for a `tags`-only change
+
+#### Scenario: tags listed as immutable in Update
+- **WHEN** the `resourceTencentCloudDlcDataEngineUpdate` function builds its `immutableArgs` guard list
+- **THEN** the list includes `"tags"` alongside the other create-only arguments
+- **AND** if a `tags` change somehow reaches `Update`, it returns an error stating the argument cannot be changed
+
+### Requirement: dlc_data_engine tags documentation
+The system SHALL document the `tags` parameter in the resource example markdown.
+
+#### Scenario: tags documented in resource md
+- **WHEN** the resource documentation is generated/updated
+- **THEN** `resource_tc_dlc_data_engine.md` includes the `tags` block in the Example Usage
+- **AND** the example shows a `tags` block with `tag_key` and `tag_value` entries
+- **AND** the `Argument Reference` / `Attribute Reference` sections are left for auto-generation (per project convention, these are not hand-written)
+
+### Requirement: dlc_data_engine tags unit tests
+The system SHALL include unit tests covering the tags marshalling and flattening logic using gomonkey mocks.
+
+#### Scenario: create marshals tags to request
+- **WHEN** a unit test exercises `resourceTencentCloudDlcDataEngineCreate` with a `tags` block configured
+- **THEN** the test mocks the DLC client `CreateDataEngine` and `DescribeDataEngine` calls via gomonkey
+- **AND** the test asserts that `request.Tags` contains the expected `TagInfo` entries with correct `TagKey` and `TagValue`
+
+#### Scenario: read flattens TagList to state
+- **WHEN** a unit test exercises `resourceTencentCloudDlcDataEngineRead` with a `DataEngineInfo` whose `TagList` is populated
+- **THEN** the test asserts that `d.Get("tags")` returns the expected list of `tag_key`/`tag_value` maps
+- **AND** the test covers the nil/empty `TagList` case without error
+

--- a/tencentcloud/services/dlc/resource_tc_dlc_data_engine.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_data_engine.go
@@ -308,9 +308,9 @@ func ResourceTencentCloudDlcDataEngine() *schema.Resource {
 			},
 
 			"tags": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
-				ForceNew:    true,
+				Computed:    true,
 				Description: "Tag list. Each tag contains a key-value pair. Changing this parameter will trigger a new resource since the DLC `UpdateDataEngine` API does not support modifying tags.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -537,7 +537,7 @@ func resourceTencentCloudDlcDataEngineCreate(d *schema.ResourceData, meta interf
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
-		for _, item := range v.([]interface{}) {
+		for _, item := range v.(*schema.Set).List() {
 			dMap := item.(map[string]interface{})
 			tagInfo := dlc.TagInfo{}
 			if v, ok := dMap["tag_key"]; ok {

--- a/tencentcloud/services/dlc/resource_tc_dlc_data_engine.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_data_engine.go
@@ -307,6 +307,27 @@ func ResourceTencentCloudDlcDataEngine() *schema.Resource {
 				Description: "Generation of the engine. SuperSQL means the supersql engine while Native means the standard engine. It is SuperSQL by default.",
 			},
 
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Tag list. Each tag contains a key-value pair. Changing this parameter will trigger a new resource since the DLC `UpdateDataEngine` API does not support modifying tags.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag key.",
+						},
+						"tag_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Tag value.",
+						},
+					},
+				},
+			},
+
 			// computed
 			"data_engine_id": {
 				Type:        schema.TypeString,
@@ -513,6 +534,22 @@ func resourceTencentCloudDlcDataEngineCreate(d *schema.ResourceData, meta interf
 
 	if v, ok := d.GetOk("engine_generation"); ok {
 		request.EngineGeneration = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		for _, item := range v.([]interface{}) {
+			dMap := item.(map[string]interface{})
+			tagInfo := dlc.TagInfo{}
+			if v, ok := dMap["tag_key"]; ok {
+				tagInfo.TagKey = helper.String(v.(string))
+			}
+
+			if v, ok := dMap["tag_value"]; ok {
+				tagInfo.TagValue = helper.String(v.(string))
+			}
+
+			request.Tags = append(request.Tags, &tagInfo)
+		}
 	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
@@ -790,6 +827,24 @@ func resourceTencentCloudDlcDataEngineRead(d *schema.ResourceData, meta interfac
 		_ = d.Set("engine_generation", dataEngine.EngineGeneration)
 	}
 
+	if dataEngine.TagList != nil {
+		tagsList := make([]map[string]interface{}, 0, len(dataEngine.TagList))
+		for _, tagInfo := range dataEngine.TagList {
+			tagMap := make(map[string]interface{})
+			if tagInfo.TagKey != nil {
+				tagMap["tag_key"] = *tagInfo.TagKey
+			}
+
+			if tagInfo.TagValue != nil {
+				tagMap["tag_value"] = *tagInfo.TagValue
+			}
+
+			tagsList = append(tagsList, tagMap)
+		}
+
+		_ = d.Set("tags", tagsList)
+	}
+
 	if dataEngine.DataEngineId != nil {
 		_ = d.Set("data_engine_id", dataEngine.DataEngineId)
 	}
@@ -815,7 +870,7 @@ func resourceTencentCloudDlcDataEngineUpdate(d *schema.ResourceData, meta interf
 	immutableArgs := []string{"engine_type", "data_engine_name", "cluster_type", "mode", "default_data_engine", "cidr_block",
 		"pay_mode", "time_span", "time_unit", "auto_renew", "engine_exec_type", "tolerable_queue_time",
 		"resource_type", "data_engine_config_pairs", "image_version_name", "main_cluster_name", "auto_authorization",
-		"engine_network_id", "engine_generation"}
+		"engine_network_id", "engine_generation", "tags"}
 	for _, v := range immutableArgs {
 		if d.HasChange(v) {
 			return fmt.Errorf("argument `%s` cannot be changed", v)

--- a/tencentcloud/services/dlc/resource_tc_dlc_data_engine.md
+++ b/tencentcloud/services/dlc/resource_tc_dlc_data_engine.md
@@ -25,8 +25,8 @@ resource "tencentcloud_dlc_data_engine" "example" {
   }
 
   tags {
-    tag_key   = "owner"
-    tag_value = "tf-example"
+    tag_key   = "createBy"
+    tag_value = "Terraform"
   }
 }
 ```

--- a/tencentcloud/services/dlc/resource_tc_dlc_data_engine.md
+++ b/tencentcloud/services/dlc/resource_tc_dlc_data_engine.md
@@ -23,6 +23,11 @@ resource "tencentcloud_dlc_data_engine" "example" {
     executor_nums        = 1
     executor_size        = "medium"
   }
+
+  tags {
+    tag_key   = "owner"
+    tag_value = "tf-example"
+  }
 }
 ```
 

--- a/tencentcloud/services/dlc/resource_tc_dlc_data_engine_test.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_data_engine_test.go
@@ -70,6 +70,32 @@ func TestAccTencentCloudDlcDataEngineResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccTencentCloudDlcDataEngineResource_tags(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			tcacctest.AccPreCheck(t)
+		},
+		Providers: tcacctest.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDlcDataEngineWithTags,
+				Check: resource.ComposeTestCheckFunc(resource.TestCheckResourceAttrSet("tencentcloud_dlc_data_engine.data_engine", "id"),
+					resource.TestCheckResourceAttr("tencentcloud_dlc_data_engine.data_engine", "tags.#", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_dlc_data_engine.data_engine", "tags.0.tag_key", "owner"),
+					resource.TestCheckResourceAttr("tencentcloud_dlc_data_engine.data_engine", "tags.0.tag_value", "tf-example"),
+				),
+			},
+			{
+				ResourceName:            "tencentcloud_dlc_data_engine.data_engine",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"pay_mode", "size", "time_span", "time_unit"},
+			},
+		},
+	})
+}
+
 const testAccDlcDataEngine = `
 
 resource "tencentcloud_dlc_data_engine" "data_engine" {
@@ -93,6 +119,7 @@ resource "tencentcloud_dlc_data_engine" "data_engine" {
 }
 
 `
+
 const testAccDlcDataEngineUpdate = `
 
 resource "tencentcloud_dlc_data_engine" "data_engine" {
@@ -113,6 +140,35 @@ resource "tencentcloud_dlc_data_engine" "data_engine" {
   auto_suspend = false
   crontab_resume_suspend = 0
   engine_exec_type = "BATCH"
+}
+
+`
+
+const testAccDlcDataEngineWithTags = `
+
+resource "tencentcloud_dlc_data_engine" "data_engine" {
+  engine_type = "spark"
+  data_engine_name = "testSparkTags"
+  cluster_type = "spark_cu"
+  mode = 1
+  auto_resume = false
+  size = 16
+  pay_mode = 0
+  min_clusters = 1
+  max_clusters = 1
+  default_data_engine = false
+  cidr_block = "10.255.0.0/16"
+  message = "test spark with tags"
+  time_span = 1
+  time_unit = "h"
+  auto_suspend = false
+  crontab_resume_suspend = 0
+  engine_exec_type = "BATCH"
+
+  tags {
+    tag_key   = "owner"
+    tag_value = "tf-example"
+  }
 }
 
 `

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.153"
+	params["RequestClient"] = "SDK_GO_1.3.156"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/client.go
@@ -385,6 +385,66 @@ func (c *Client) AlterDMSTableWithContext(ctx context.Context, request *AlterDMS
     return
 }
 
+func NewAlterTableCommentRequest() (request *AlterTableCommentRequest) {
+    request = &AlterTableCommentRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "AlterTableComment")
+    
+    
+    return
+}
+
+func NewAlterTableCommentResponse() (response *AlterTableCommentResponse) {
+    response = &AlterTableCommentResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// AlterTableComment
+// 修改表备注
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_GOVERNERROR = "FailedOperation.GovernError"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+func (c *Client) AlterTableComment(request *AlterTableCommentRequest) (response *AlterTableCommentResponse, err error) {
+    return c.AlterTableCommentWithContext(context.Background(), request)
+}
+
+// AlterTableComment
+// 修改表备注
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_GOVERNERROR = "FailedOperation.GovernError"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+func (c *Client) AlterTableCommentWithContext(ctx context.Context, request *AlterTableCommentRequest) (response *AlterTableCommentResponse, err error) {
+    if request == nil {
+        request = NewAlterTableCommentRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "AlterTableComment")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("AlterTableComment require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewAlterTableCommentResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewAssignMangedTablePropertiesRequest() (request *AssignMangedTablePropertiesRequest) {
     request = &AssignMangedTablePropertiesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -919,6 +979,56 @@ func (c *Client) CancelNotebookSessionStatementBatchWithContext(ctx context.Cont
     return
 }
 
+func NewCancelRayJobRequest() (request *CancelRayJobRequest) {
+    request = &CancelRayJobRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CancelRayJob")
+    
+    
+    return
+}
+
+func NewCancelRayJobResponse() (response *CancelRayJobResponse) {
+    response = &CancelRayJobResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CancelRayJob
+// 根据任务ID取消正在运行的Ray任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CancelRayJob(request *CancelRayJobRequest) (response *CancelRayJobResponse, err error) {
+    return c.CancelRayJobWithContext(context.Background(), request)
+}
+
+// CancelRayJob
+// 根据任务ID取消正在运行的Ray任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CancelRayJobWithContext(ctx context.Context, request *CancelRayJobRequest) (response *CancelRayJobResponse, err error) {
+    if request == nil {
+        request = NewCancelRayJobRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CancelRayJob")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CancelRayJob require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCancelRayJobResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCancelSparkSessionBatchSQLRequest() (request *CancelSparkSessionBatchSQLRequest) {
     request = &CancelSparkSessionBatchSQLRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1403,6 +1513,206 @@ func (c *Client) CheckLockMetaDataWithContext(ctx context.Context, request *Chec
     return
 }
 
+func NewCheckModifyPartitionRequest() (request *CheckModifyPartitionRequest) {
+    request = &CheckModifyPartitionRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CheckModifyPartition")
+    
+    
+    return
+}
+
+func NewCheckModifyPartitionResponse() (response *CheckModifyPartitionResponse) {
+    response = &CheckModifyPartitionResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CheckModifyPartition
+// 变配校验：判断用户的目标配置是否可以执行变配。校验逻辑：对于缩容场景（目标值 < 当前值），检查 default 队列的 min 值是否足够承受缩容差值。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) CheckModifyPartition(request *CheckModifyPartitionRequest) (response *CheckModifyPartitionResponse, err error) {
+    return c.CheckModifyPartitionWithContext(context.Background(), request)
+}
+
+// CheckModifyPartition
+// 变配校验：判断用户的目标配置是否可以执行变配。校验逻辑：对于缩容场景（目标值 < 当前值），检查 default 队列的 min 值是否足够承受缩容差值。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) CheckModifyPartitionWithContext(ctx context.Context, request *CheckModifyPartitionRequest) (response *CheckModifyPartitionResponse, err error) {
+    if request == nil {
+        request = NewCheckModifyPartitionRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CheckModifyPartition")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CheckModifyPartition require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCheckModifyPartitionResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCheckQueueNameRequest() (request *CheckQueueNameRequest) {
+    request = &CheckQueueNameRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CheckQueueName")
+    
+    
+    return
+}
+
+func NewCheckQueueNameResponse() (response *CheckQueueNameResponse) {
+    response = &CheckQueueNameResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CheckQueueName
+// 资源队列名称合法性检测：校验队列名称是否合法，包括非空校验、格式校验（以小写字母开头，只允许小写字母、数字和连字符，长度1~11）和同分区下重名校验。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) CheckQueueName(request *CheckQueueNameRequest) (response *CheckQueueNameResponse, err error) {
+    return c.CheckQueueNameWithContext(context.Background(), request)
+}
+
+// CheckQueueName
+// 资源队列名称合法性检测：校验队列名称是否合法，包括非空校验、格式校验（以小写字母开头，只允许小写字母、数字和连字符，长度1~11）和同分区下重名校验。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) CheckQueueNameWithContext(ctx context.Context, request *CheckQueueNameRequest) (response *CheckQueueNameResponse, err error) {
+    if request == nil {
+        request = NewCheckQueueNameRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CheckQueueName")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CheckQueueName require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCheckQueueNameResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCheckResourceNameRequest() (request *CheckResourceNameRequest) {
+    request = &CheckResourceNameRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CheckResourceName")
+    
+    
+    return
+}
+
+func NewCheckResourceNameResponse() (response *CheckResourceNameResponse) {
+    response = &CheckResourceNameResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CheckResourceName
+// 校验资源名称合法性
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) CheckResourceName(request *CheckResourceNameRequest) (response *CheckResourceNameResponse, err error) {
+    return c.CheckResourceNameWithContext(context.Background(), request)
+}
+
+// CheckResourceName
+// 校验资源名称合法性
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) CheckResourceNameWithContext(ctx context.Context, request *CheckResourceNameRequest) (response *CheckResourceNameResponse, err error) {
+    if request == nil {
+        request = NewCheckResourceNameRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CheckResourceName")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CheckResourceName require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCheckResourceNameResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCopyJobSpecRequest() (request *CopyJobSpecRequest) {
+    request = &CopyJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CopyJobSpec")
+    
+    
+    return
+}
+
+func NewCopyJobSpecResponse() (response *CopyJobSpecResponse) {
+    response = &CopyJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CopyJobSpec
+// 复制一份已有的作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CopyJobSpec(request *CopyJobSpecRequest) (response *CopyJobSpecResponse, err error) {
+    return c.CopyJobSpecWithContext(context.Background(), request)
+}
+
+// CopyJobSpec
+// 复制一份已有的作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CopyJobSpecWithContext(ctx context.Context, request *CopyJobSpecRequest) (response *CopyJobSpecResponse, err error) {
+    if request == nil {
+        request = NewCopyJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CopyJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CopyJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCopyJobSpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateCHDFSBindingProductRequest() (request *CreateCHDFSBindingProductRequest) {
     request = &CreateCHDFSBindingProductRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1457,6 +1767,58 @@ func (c *Client) CreateCHDFSBindingProductWithContext(ctx context.Context, reque
     request.SetContext(ctx)
     
     response = NewCreateCHDFSBindingProductResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateClusterGroupRequest() (request *CreateClusterGroupRequest) {
+    request = &CreateClusterGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateClusterGroup")
+    
+    
+    return
+}
+
+func NewCreateClusterGroupResponse() (response *CreateClusterGroupResponse) {
+    response = &CreateClusterGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateClusterGroup
+// 创建集群组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETERCOMBINATION = "InvalidParameterCombination"
+func (c *Client) CreateClusterGroup(request *CreateClusterGroupRequest) (response *CreateClusterGroupResponse, err error) {
+    return c.CreateClusterGroupWithContext(context.Background(), request)
+}
+
+// CreateClusterGroup
+// 创建集群组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETERCOMBINATION = "InvalidParameterCombination"
+func (c *Client) CreateClusterGroupWithContext(ctx context.Context, request *CreateClusterGroupRequest) (response *CreateClusterGroupResponse, err error) {
+    if request == nil {
+        request = NewCreateClusterGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateClusterGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateClusterGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateClusterGroupResponse()
     err = c.Send(request, response)
     return
 }
@@ -2015,6 +2377,106 @@ func (c *Client) CreateImportTaskWithContext(ctx context.Context, request *Creat
     return
 }
 
+func NewCreateInferenceModelRequest() (request *CreateInferenceModelRequest) {
+    request = &CreateInferenceModelRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateInferenceModel")
+    
+    
+    return
+}
+
+func NewCreateInferenceModelResponse() (response *CreateInferenceModelResponse) {
+    response = &CreateInferenceModelResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateInferenceModel
+// 创建推理模型（模型上传）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateInferenceModel(request *CreateInferenceModelRequest) (response *CreateInferenceModelResponse, err error) {
+    return c.CreateInferenceModelWithContext(context.Background(), request)
+}
+
+// CreateInferenceModel
+// 创建推理模型（模型上传）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateInferenceModelWithContext(ctx context.Context, request *CreateInferenceModelRequest) (response *CreateInferenceModelResponse, err error) {
+    if request == nil {
+        request = NewCreateInferenceModelRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateInferenceModel")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateInferenceModel require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateInferenceModelResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateInferenceServiceRequest() (request *CreateInferenceServiceRequest) {
+    request = &CreateInferenceServiceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateInferenceService")
+    
+    
+    return
+}
+
+func NewCreateInferenceServiceResponse() (response *CreateInferenceServiceResponse) {
+    response = &CreateInferenceServiceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateInferenceService
+// 创建推理服务（含默认部署）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateInferenceService(request *CreateInferenceServiceRequest) (response *CreateInferenceServiceResponse, err error) {
+    return c.CreateInferenceServiceWithContext(context.Background(), request)
+}
+
+// CreateInferenceService
+// 创建推理服务（含默认部署）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateInferenceServiceWithContext(ctx context.Context, request *CreateInferenceServiceRequest) (response *CreateInferenceServiceResponse, err error) {
+    if request == nil {
+        request = NewCreateInferenceServiceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateInferenceService")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateInferenceService require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateInferenceServiceResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateInternalTableRequest() (request *CreateInternalTableRequest) {
     request = &CreateInternalTableRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -2071,6 +2533,242 @@ func (c *Client) CreateInternalTableWithContext(ctx context.Context, request *Cr
     request.SetContext(ctx)
     
     response = NewCreateInternalTableResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateJobSpecRequest() (request *CreateJobSpecRequest) {
+    request = &CreateJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateJobSpec")
+    
+    
+    return
+}
+
+func NewCreateJobSpecResponse() (response *CreateJobSpecResponse) {
+    response = &CreateJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateJobSpec
+// 创建作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateJobSpec(request *CreateJobSpecRequest) (response *CreateJobSpecResponse, err error) {
+    return c.CreateJobSpecWithContext(context.Background(), request)
+}
+
+// CreateJobSpec
+// 创建作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateJobSpecWithContext(ctx context.Context, request *CreateJobSpecRequest) (response *CreateJobSpecResponse, err error) {
+    if request == nil {
+        request = NewCreateJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateJobSpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateLabRequest() (request *CreateLabRequest) {
+    request = &CreateLabRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateLab")
+    
+    
+    return
+}
+
+func NewCreateLabResponse() (response *CreateLabResponse) {
+    response = &CreateLabResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateLab
+// 创建实验室
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateLab(request *CreateLabRequest) (response *CreateLabResponse, err error) {
+    return c.CreateLabWithContext(context.Background(), request)
+}
+
+// CreateLab
+// 创建实验室
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateLabWithContext(ctx context.Context, request *CreateLabRequest) (response *CreateLabResponse, err error) {
+    if request == nil {
+        request = NewCreateLabRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateLab")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateLab require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateLabResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateMetaDatabaseRequest() (request *CreateMetaDatabaseRequest) {
+    request = &CreateMetaDatabaseRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateMetaDatabase")
+    
+    
+    return
+}
+
+func NewCreateMetaDatabaseResponse() (response *CreateMetaDatabaseResponse) {
+    response = &CreateMetaDatabaseResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateMetaDatabase
+// 本接口（CreateMetaDatabase）用于创建元数据库
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_GOVERNERROR = "FailedOperation.GovernError"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCENOTFOUND_SYSTEMCONFIGNOTFOUND = "ResourceNotFound.SystemConfigNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) CreateMetaDatabase(request *CreateMetaDatabaseRequest) (response *CreateMetaDatabaseResponse, err error) {
+    return c.CreateMetaDatabaseWithContext(context.Background(), request)
+}
+
+// CreateMetaDatabase
+// 本接口（CreateMetaDatabase）用于创建元数据库
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_GOVERNERROR = "FailedOperation.GovernError"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCENOTFOUND_SYSTEMCONFIGNOTFOUND = "ResourceNotFound.SystemConfigNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) CreateMetaDatabaseWithContext(ctx context.Context, request *CreateMetaDatabaseRequest) (response *CreateMetaDatabaseResponse, err error) {
+    if request == nil {
+        request = NewCreateMetaDatabaseRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateMetaDatabase")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateMetaDatabase require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateMetaDatabaseResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateModelVersionRequest() (request *CreateModelVersionRequest) {
+    request = &CreateModelVersionRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateModelVersion")
+    
+    
+    return
+}
+
+func NewCreateModelVersionResponse() (response *CreateModelVersionResponse) {
+    response = &CreateModelVersionResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateModelVersion
+// 创建模型新版本
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateModelVersion(request *CreateModelVersionRequest) (response *CreateModelVersionResponse, err error) {
+    return c.CreateModelVersionWithContext(context.Background(), request)
+}
+
+// CreateModelVersion
+// 创建模型新版本
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateModelVersionWithContext(ctx context.Context, request *CreateModelVersionRequest) (response *CreateModelVersionResponse, err error) {
+    if request == nil {
+        request = NewCreateModelVersionRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateModelVersion")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateModelVersion require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateModelVersionResponse()
     err = c.Send(request, response)
     return
 }
@@ -2337,6 +3035,234 @@ func (c *Client) CreateNotebookSessionStatementSupportBatchSQLWithContext(ctx co
     return
 }
 
+func NewCreatePartitionRequest() (request *CreatePartitionRequest) {
+    request = &CreatePartitionRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreatePartition")
+    
+    
+    return
+}
+
+func NewCreatePartitionResponse() (response *CreatePartitionResponse) {
+    response = &CreatePartitionResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreatePartition
+// 新增资源包
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSTATEMENTKINDTYPE = "InvalidParameter.InvalidStatementKindType"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCENOTFOUND_RESULTSAVEPATHNOTFOUND = "ResourceNotFound.ResultSavePathNotFound"
+//  RESOURCENOTFOUND_SESSIONNOTFOUND = "ResourceNotFound.SessionNotFound"
+//  RESOURCENOTFOUND_SESSIONSTATEDEAD = "ResourceNotFound.SessionStateDead"
+func (c *Client) CreatePartition(request *CreatePartitionRequest) (response *CreatePartitionResponse, err error) {
+    return c.CreatePartitionWithContext(context.Background(), request)
+}
+
+// CreatePartition
+// 新增资源包
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSTATEMENTKINDTYPE = "InvalidParameter.InvalidStatementKindType"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCENOTFOUND_RESULTSAVEPATHNOTFOUND = "ResourceNotFound.ResultSavePathNotFound"
+//  RESOURCENOTFOUND_SESSIONNOTFOUND = "ResourceNotFound.SessionNotFound"
+//  RESOURCENOTFOUND_SESSIONSTATEDEAD = "ResourceNotFound.SessionStateDead"
+func (c *Client) CreatePartitionWithContext(ctx context.Context, request *CreatePartitionRequest) (response *CreatePartitionResponse, err error) {
+    if request == nil {
+        request = NewCreatePartitionRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreatePartition")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreatePartition require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreatePartitionResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreatePartitionQueueRequest() (request *CreatePartitionQueueRequest) {
+    request = &CreatePartitionQueueRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreatePartitionQueue")
+    
+    
+    return
+}
+
+func NewCreatePartitionQueueResponse() (response *CreatePartitionQueueResponse) {
+    response = &CreatePartitionQueueResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreatePartitionQueue
+// 新增资源队列：在指定分区下创建一个新的资源队列，支持设置队列名称、描述、资源规格列表和队列类型。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_QUEUENAME = "InvalidParameterValue.QueueName"
+//  INVALIDPARAMETERVALUE_QUOTAEXCEEDED = "InvalidParameterValue.QuotaExceeded"
+//  OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+//  RESOURCEINUSE_QUEUENAME = "ResourceInUse.QueueName"
+//  RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+func (c *Client) CreatePartitionQueue(request *CreatePartitionQueueRequest) (response *CreatePartitionQueueResponse, err error) {
+    return c.CreatePartitionQueueWithContext(context.Background(), request)
+}
+
+// CreatePartitionQueue
+// 新增资源队列：在指定分区下创建一个新的资源队列，支持设置队列名称、描述、资源规格列表和队列类型。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_QUEUENAME = "InvalidParameterValue.QueueName"
+//  INVALIDPARAMETERVALUE_QUOTAEXCEEDED = "InvalidParameterValue.QuotaExceeded"
+//  OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+//  RESOURCEINUSE_QUEUENAME = "ResourceInUse.QueueName"
+//  RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+func (c *Client) CreatePartitionQueueWithContext(ctx context.Context, request *CreatePartitionQueueRequest) (response *CreatePartitionQueueResponse, err error) {
+    if request == nil {
+        request = NewCreatePartitionQueueRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreatePartitionQueue")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreatePartitionQueue require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreatePartitionQueueResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateRayClusterRequest() (request *CreateRayClusterRequest) {
+    request = &CreateRayClusterRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateRayCluster")
+    
+    
+    return
+}
+
+func NewCreateRayClusterResponse() (response *CreateRayClusterResponse) {
+    response = &CreateRayClusterResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateRayCluster
+// 创建集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateRayCluster(request *CreateRayClusterRequest) (response *CreateRayClusterResponse, err error) {
+    return c.CreateRayClusterWithContext(context.Background(), request)
+}
+
+// CreateRayCluster
+// 创建集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateRayClusterWithContext(ctx context.Context, request *CreateRayClusterRequest) (response *CreateRayClusterResponse, err error) {
+    if request == nil {
+        request = NewCreateRayClusterRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateRayCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateRayCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateRayClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateResourceConfigRequest() (request *CreateResourceConfigRequest) {
+    request = &CreateResourceConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateResourceConfig")
+    
+    
+    return
+}
+
+func NewCreateResourceConfigResponse() (response *CreateResourceConfigResponse) {
+    response = &CreateResourceConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateResourceConfig
+// 创建资源配置模板
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateResourceConfig(request *CreateResourceConfigRequest) (response *CreateResourceConfigResponse, err error) {
+    return c.CreateResourceConfigWithContext(context.Background(), request)
+}
+
+// CreateResourceConfig
+// 创建资源配置模板
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateResourceConfigWithContext(ctx context.Context, request *CreateResourceConfigRequest) (response *CreateResourceConfigResponse, err error) {
+    if request == nil {
+        request = NewCreateResourceConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateResourceConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateResourceConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateResourceConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateResultDownloadRequest() (request *CreateResultDownloadRequest) {
     request = &CreateResultDownloadRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -2511,6 +3437,78 @@ func (c *Client) CreateSparkAppWithContext(ctx context.Context, request *CreateS
     request.SetContext(ctx)
     
     response = NewCreateSparkAppResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateSparkAppForTDLCRequest() (request *CreateSparkAppForTDLCRequest) {
+    request = &CreateSparkAppForTDLCRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateSparkAppForTDLC")
+    
+    
+    return
+}
+
+func NewCreateSparkAppForTDLCResponse() (response *CreateSparkAppForTDLCResponse) {
+    response = &CreateSparkAppForTDLCResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateSparkAppForTDLC
+// 创建tdlc spark作业
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_INVALIDAPPFILEFORMAT = "InvalidParameter.InvalidAppFileFormat"
+//  INVALIDPARAMETER_INVALIDDRIVERSIZE = "InvalidParameter.InvalidDriverSize"
+//  INVALIDPARAMETER_INVALIDEXECUTORSIZE = "InvalidParameter.InvalidExecutorSize"
+//  INVALIDPARAMETER_INVALIDFILEPATHFORMAT = "InvalidParameter.InvalidFilePathFormat"
+//  INVALIDPARAMETER_INVALIDROLEARN = "InvalidParameter.InvalidRoleArn"
+//  INVALIDPARAMETER_SPARKJOBNOTUNIQUE = "InvalidParameter.SparkJobNotUnique"
+//  INVALIDPARAMETER_SPARKJOBONLYSUPPORTSPARKBATCHENGINE = "InvalidParameter.SparkJobOnlySupportSparkBatchEngine"
+//  RESOURCEINSUFFICIENT_SPARKJOBINSUFFICIENTRESOURCES = "ResourceInsufficient.SparkJobInsufficientResources"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_SESSIONINSUFFICIENTRESOURCES = "ResourceNotFound.SessionInsufficientResources"
+func (c *Client) CreateSparkAppForTDLC(request *CreateSparkAppForTDLCRequest) (response *CreateSparkAppForTDLCResponse, err error) {
+    return c.CreateSparkAppForTDLCWithContext(context.Background(), request)
+}
+
+// CreateSparkAppForTDLC
+// 创建tdlc spark作业
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_INVALIDAPPFILEFORMAT = "InvalidParameter.InvalidAppFileFormat"
+//  INVALIDPARAMETER_INVALIDDRIVERSIZE = "InvalidParameter.InvalidDriverSize"
+//  INVALIDPARAMETER_INVALIDEXECUTORSIZE = "InvalidParameter.InvalidExecutorSize"
+//  INVALIDPARAMETER_INVALIDFILEPATHFORMAT = "InvalidParameter.InvalidFilePathFormat"
+//  INVALIDPARAMETER_INVALIDROLEARN = "InvalidParameter.InvalidRoleArn"
+//  INVALIDPARAMETER_SPARKJOBNOTUNIQUE = "InvalidParameter.SparkJobNotUnique"
+//  INVALIDPARAMETER_SPARKJOBONLYSUPPORTSPARKBATCHENGINE = "InvalidParameter.SparkJobOnlySupportSparkBatchEngine"
+//  RESOURCEINSUFFICIENT_SPARKJOBINSUFFICIENTRESOURCES = "ResourceInsufficient.SparkJobInsufficientResources"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_SESSIONINSUFFICIENTRESOURCES = "ResourceNotFound.SessionInsufficientResources"
+func (c *Client) CreateSparkAppForTDLCWithContext(ctx context.Context, request *CreateSparkAppForTDLCRequest) (response *CreateSparkAppForTDLCResponse, err error) {
+    if request == nil {
+        request = NewCreateSparkAppForTDLCRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateSparkAppForTDLC")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateSparkAppForTDLC require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateSparkAppForTDLCResponse()
     err = c.Send(request, response)
     return
 }
@@ -3128,6 +4126,7 @@ func NewCreateTaskResponse() (response *CreateTaskResponse) {
 //  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
 //  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
 //  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLCONFIG = "InvalidParameter.InvalidSQLConfig"
 //  INVALIDPARAMETER_INVALIDSQLCONFIGSQL = "InvalidParameter.InvalidSQLConfigSQL"
 //  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
 //  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
@@ -3172,6 +4171,7 @@ func (c *Client) CreateTask(request *CreateTaskRequest) (response *CreateTaskRes
 //  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
 //  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
 //  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLCONFIG = "InvalidParameter.InvalidSQLConfig"
 //  INVALIDPARAMETER_INVALIDSQLCONFIGSQL = "InvalidParameter.InvalidSQLConfigSQL"
 //  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
 //  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
@@ -3779,6 +4779,56 @@ func (c *Client) DeleteCHDFSBindingProductWithContext(ctx context.Context, reque
     return
 }
 
+func NewDeleteClusterGroupRequest() (request *DeleteClusterGroupRequest) {
+    request = &DeleteClusterGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteClusterGroup")
+    
+    
+    return
+}
+
+func NewDeleteClusterGroupResponse() (response *DeleteClusterGroupResponse) {
+    response = &DeleteClusterGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteClusterGroup
+// 删除集群组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteClusterGroup(request *DeleteClusterGroupRequest) (response *DeleteClusterGroupResponse, err error) {
+    return c.DeleteClusterGroupWithContext(context.Background(), request)
+}
+
+// DeleteClusterGroup
+// 删除集群组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteClusterGroupWithContext(ctx context.Context, request *DeleteClusterGroupRequest) (response *DeleteClusterGroupResponse, err error) {
+    if request == nil {
+        request = NewDeleteClusterGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteClusterGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteClusterGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteClusterGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteDataEngineRequest() (request *DeleteDataEngineRequest) {
     request = &DeleteDataEngineRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -3929,6 +4979,192 @@ func (c *Client) DeleteDataMaskStrategyWithContext(ctx context.Context, request 
     return
 }
 
+func NewDeleteJobSpecRequest() (request *DeleteJobSpecRequest) {
+    request = &DeleteJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteJobSpec")
+    
+    
+    return
+}
+
+func NewDeleteJobSpecResponse() (response *DeleteJobSpecResponse) {
+    response = &DeleteJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteJobSpec
+// 根据配置ID删除作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteJobSpec(request *DeleteJobSpecRequest) (response *DeleteJobSpecResponse, err error) {
+    return c.DeleteJobSpecWithContext(context.Background(), request)
+}
+
+// DeleteJobSpec
+// 根据配置ID删除作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteJobSpecWithContext(ctx context.Context, request *DeleteJobSpecRequest) (response *DeleteJobSpecResponse, err error) {
+    if request == nil {
+        request = NewDeleteJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteJobSpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteLabRequest() (request *DeleteLabRequest) {
+    request = &DeleteLabRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteLab")
+    
+    
+    return
+}
+
+func NewDeleteLabResponse() (response *DeleteLabResponse) {
+    response = &DeleteLabResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteLab
+// 删除数据实验室
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABINTRANSITION = "FailedOperation.LabInTransition"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABRUNNING = "FailedOperation.LabRunning"
+func (c *Client) DeleteLab(request *DeleteLabRequest) (response *DeleteLabResponse, err error) {
+    return c.DeleteLabWithContext(context.Background(), request)
+}
+
+// DeleteLab
+// 删除数据实验室
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABINTRANSITION = "FailedOperation.LabInTransition"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABRUNNING = "FailedOperation.LabRunning"
+func (c *Client) DeleteLabWithContext(ctx context.Context, request *DeleteLabRequest) (response *DeleteLabResponse, err error) {
+    if request == nil {
+        request = NewDeleteLabRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteLab")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteLab require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteLabResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteMetaDatabaseRequest() (request *DeleteMetaDatabaseRequest) {
+    request = &DeleteMetaDatabaseRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteMetaDatabase")
+    
+    
+    return
+}
+
+func NewDeleteMetaDatabaseResponse() (response *DeleteMetaDatabaseResponse) {
+    response = &DeleteMetaDatabaseResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteMetaDatabase
+// 本接口（DeleteMetaDatabase）用于一键删除元数据库
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) DeleteMetaDatabase(request *DeleteMetaDatabaseRequest) (response *DeleteMetaDatabaseResponse, err error) {
+    return c.DeleteMetaDatabaseWithContext(context.Background(), request)
+}
+
+// DeleteMetaDatabase
+// 本接口（DeleteMetaDatabase）用于一键删除元数据库
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) DeleteMetaDatabaseWithContext(ctx context.Context, request *DeleteMetaDatabaseRequest) (response *DeleteMetaDatabaseResponse, err error) {
+    if request == nil {
+        request = NewDeleteMetaDatabaseRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteMetaDatabase")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteMetaDatabase require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteMetaDatabaseResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteNativeSparkSessionRequest() (request *DeleteNativeSparkSessionRequest) {
     request = &DeleteNativeSparkSessionRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -4047,6 +5283,222 @@ func (c *Client) DeleteNotebookSessionWithContext(ctx context.Context, request *
     request.SetContext(ctx)
     
     response = NewDeleteNotebookSessionResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeletePartitionQueueRequest() (request *DeletePartitionQueueRequest) {
+    request = &DeletePartitionQueueRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeletePartitionQueue")
+    
+    
+    return
+}
+
+func NewDeletePartitionQueueResponse() (response *DeletePartitionQueueResponse) {
+    response = &DeletePartitionQueueResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeletePartitionQueue
+// 删除资源队列
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_QUEUEIDMISMATCH = "InvalidParameterValue.QueueIdMismatch"
+//  OPERATIONDENIED_DEFAULTQUEUEDELETEFORBIDDEN = "OperationDenied.DefaultQueueDeleteForbidden"
+//  OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+//  RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+//  RESOURCENOTFOUND_PARTITIONQUEUE = "ResourceNotFound.PartitionQueue"
+func (c *Client) DeletePartitionQueue(request *DeletePartitionQueueRequest) (response *DeletePartitionQueueResponse, err error) {
+    return c.DeletePartitionQueueWithContext(context.Background(), request)
+}
+
+// DeletePartitionQueue
+// 删除资源队列
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_QUEUEIDMISMATCH = "InvalidParameterValue.QueueIdMismatch"
+//  OPERATIONDENIED_DEFAULTQUEUEDELETEFORBIDDEN = "OperationDenied.DefaultQueueDeleteForbidden"
+//  OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+//  RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+//  RESOURCENOTFOUND_PARTITIONQUEUE = "ResourceNotFound.PartitionQueue"
+func (c *Client) DeletePartitionQueueWithContext(ctx context.Context, request *DeletePartitionQueueRequest) (response *DeletePartitionQueueResponse, err error) {
+    if request == nil {
+        request = NewDeletePartitionQueueRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeletePartitionQueue")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeletePartitionQueue require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeletePartitionQueueResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteRayClusterRequest() (request *DeleteRayClusterRequest) {
+    request = &DeleteRayClusterRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteRayCluster")
+    
+    
+    return
+}
+
+func NewDeleteRayClusterResponse() (response *DeleteRayClusterResponse) {
+    response = &DeleteRayClusterResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteRayCluster
+// 删除集群
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_QUEUEIDMISMATCH = "InvalidParameterValue.QueueIdMismatch"
+//  OPERATIONDENIED_DEFAULTQUEUEDELETEFORBIDDEN = "OperationDenied.DefaultQueueDeleteForbidden"
+//  OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+//  RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+//  RESOURCENOTFOUND_PARTITIONQUEUE = "ResourceNotFound.PartitionQueue"
+func (c *Client) DeleteRayCluster(request *DeleteRayClusterRequest) (response *DeleteRayClusterResponse, err error) {
+    return c.DeleteRayClusterWithContext(context.Background(), request)
+}
+
+// DeleteRayCluster
+// 删除集群
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_QUEUEIDMISMATCH = "InvalidParameterValue.QueueIdMismatch"
+//  OPERATIONDENIED_DEFAULTQUEUEDELETEFORBIDDEN = "OperationDenied.DefaultQueueDeleteForbidden"
+//  OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+//  RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+//  RESOURCENOTFOUND_PARTITIONQUEUE = "ResourceNotFound.PartitionQueue"
+func (c *Client) DeleteRayClusterWithContext(ctx context.Context, request *DeleteRayClusterRequest) (response *DeleteRayClusterResponse, err error) {
+    if request == nil {
+        request = NewDeleteRayClusterRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteRayCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteRayCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteRayClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteRayJobRequest() (request *DeleteRayJobRequest) {
+    request = &DeleteRayJobRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteRayJob")
+    
+    
+    return
+}
+
+func NewDeleteRayJobResponse() (response *DeleteRayJobResponse) {
+    response = &DeleteRayJobResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteRayJob
+// 根据任务ID删除Ray任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) DeleteRayJob(request *DeleteRayJobRequest) (response *DeleteRayJobResponse, err error) {
+    return c.DeleteRayJobWithContext(context.Background(), request)
+}
+
+// DeleteRayJob
+// 根据任务ID删除Ray任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) DeleteRayJobWithContext(ctx context.Context, request *DeleteRayJobRequest) (response *DeleteRayJobResponse, err error) {
+    if request == nil {
+        request = NewDeleteRayJobRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteRayJob")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteRayJob require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteRayJobResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteResourceConfigRequest() (request *DeleteResourceConfigRequest) {
+    request = &DeleteResourceConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteResourceConfig")
+    
+    
+    return
+}
+
+func NewDeleteResourceConfigResponse() (response *DeleteResourceConfigResponse) {
+    response = &DeleteResourceConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteResourceConfig
+// 删除资源配置模板
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteResourceConfig(request *DeleteResourceConfigRequest) (response *DeleteResourceConfigResponse, err error) {
+    return c.DeleteResourceConfigWithContext(context.Background(), request)
+}
+
+// DeleteResourceConfig
+// 删除资源配置模板
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteResourceConfigWithContext(ctx context.Context, request *DeleteResourceConfigRequest) (response *DeleteResourceConfigResponse, err error) {
+    if request == nil {
+        request = NewDeleteResourceConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteResourceConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteResourceConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteResourceConfigResponse()
     err = c.Send(request, response)
     return
 }
@@ -4631,6 +6083,106 @@ func (c *Client) DescribeAdvancedStoreLocationWithContext(ctx context.Context, r
     request.SetContext(ctx)
     
     response = NewDescribeAdvancedStoreLocationResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeClusterGroupRequest() (request *DescribeClusterGroupRequest) {
+    request = &DescribeClusterGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeClusterGroup")
+    
+    
+    return
+}
+
+func NewDescribeClusterGroupResponse() (response *DescribeClusterGroupResponse) {
+    response = &DescribeClusterGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeClusterGroup
+// 根据集群组 ID 获取集群组详情。支持通过 IncludeDeleted 参数控制是否返回已软删除的记录（用于悬挂 cluster 回显场景）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeClusterGroup(request *DescribeClusterGroupRequest) (response *DescribeClusterGroupResponse, err error) {
+    return c.DescribeClusterGroupWithContext(context.Background(), request)
+}
+
+// DescribeClusterGroup
+// 根据集群组 ID 获取集群组详情。支持通过 IncludeDeleted 参数控制是否返回已软删除的记录（用于悬挂 cluster 回显场景）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeClusterGroupWithContext(ctx context.Context, request *DescribeClusterGroupRequest) (response *DescribeClusterGroupResponse, err error) {
+    if request == nil {
+        request = NewDescribeClusterGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeClusterGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClusterGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeClusterGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeClusterGroupClustersRequest() (request *DescribeClusterGroupClustersRequest) {
+    request = &DescribeClusterGroupClustersRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeClusterGroupClusters")
+    
+    
+    return
+}
+
+func NewDescribeClusterGroupClustersResponse() (response *DescribeClusterGroupClustersResponse) {
+    response = &DescribeClusterGroupClustersResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeClusterGroupClusters
+// 计算组关联 cluster 使用情况响应
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_CLUSTERGROUPNOTFOUND = "FailedOperation.ClusterGroupNotFound"
+func (c *Client) DescribeClusterGroupClusters(request *DescribeClusterGroupClustersRequest) (response *DescribeClusterGroupClustersResponse, err error) {
+    return c.DescribeClusterGroupClustersWithContext(context.Background(), request)
+}
+
+// DescribeClusterGroupClusters
+// 计算组关联 cluster 使用情况响应
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_CLUSTERGROUPNOTFOUND = "FailedOperation.ClusterGroupNotFound"
+func (c *Client) DescribeClusterGroupClustersWithContext(ctx context.Context, request *DescribeClusterGroupClustersRequest) (response *DescribeClusterGroupClustersResponse, err error) {
+    if request == nil {
+        request = NewDescribeClusterGroupClustersRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeClusterGroupClusters")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClusterGroupClusters require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeClusterGroupClustersResponse()
     err = c.Send(request, response)
     return
 }
@@ -5515,6 +7067,66 @@ func (c *Client) DescribeDataMaskStrategiesWithContext(ctx context.Context, requ
     return
 }
 
+func NewDescribeDatabaseRequest() (request *DescribeDatabaseRequest) {
+    request = &DescribeDatabaseRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeDatabase")
+    
+    
+    return
+}
+
+func NewDescribeDatabaseResponse() (response *DescribeDatabaseResponse) {
+    response = &DescribeDatabaseResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDatabase
+// 本接口（DescribeDatabase）,查询数据库详细信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_METASTOREERROR = "FailedOperation.MetastoreError"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  UNSUPPORTEDOPERATION_UNSUPPORTEDDATASOURCECONNECTIONTYPE = "UnsupportedOperation.UnsupportedDatasourceConnectionType"
+func (c *Client) DescribeDatabase(request *DescribeDatabaseRequest) (response *DescribeDatabaseResponse, err error) {
+    return c.DescribeDatabaseWithContext(context.Background(), request)
+}
+
+// DescribeDatabase
+// 本接口（DescribeDatabase）,查询数据库详细信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_METASTOREERROR = "FailedOperation.MetastoreError"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  UNSUPPORTEDOPERATION_UNSUPPORTEDDATASOURCECONNECTIONTYPE = "UnsupportedOperation.UnsupportedDatasourceConnectionType"
+func (c *Client) DescribeDatabaseWithContext(ctx context.Context, request *DescribeDatabaseRequest) (response *DescribeDatabaseResponse, err error) {
+    if request == nil {
+        request = NewDescribeDatabaseRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeDatabase")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDatabase require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDatabaseResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeDatabasesRequest() (request *DescribeDatabasesRequest) {
     request = &DescribeDatabasesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -5803,6 +7415,118 @@ func (c *Client) DescribeEngineUsageInfoWithContext(ctx context.Context, request
     return
 }
 
+func NewDescribeFlowDetailListRequest() (request *DescribeFlowDetailListRequest) {
+    request = &DescribeFlowDetailListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeFlowDetailList")
+    
+    
+    return
+}
+
+func NewDescribeFlowDetailListResponse() (response *DescribeFlowDetailListResponse) {
+    response = &DescribeFlowDetailListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeFlowDetailList
+// 分页查询指定分区的流程详情列表，包含每个流程的基本信息和活动列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) DescribeFlowDetailList(request *DescribeFlowDetailListRequest) (response *DescribeFlowDetailListResponse, err error) {
+    return c.DescribeFlowDetailListWithContext(context.Background(), request)
+}
+
+// DescribeFlowDetailList
+// 分页查询指定分区的流程详情列表，包含每个流程的基本信息和活动列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) DescribeFlowDetailListWithContext(ctx context.Context, request *DescribeFlowDetailListRequest) (response *DescribeFlowDetailListResponse, err error) {
+    if request == nil {
+        request = NewDescribeFlowDetailListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeFlowDetailList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeFlowDetailList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeFlowDetailListResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeFlowListRequest() (request *DescribeFlowListRequest) {
+    request = &DescribeFlowListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeFlowList")
+    
+    
+    return
+}
+
+func NewDescribeFlowListResponse() (response *DescribeFlowListResponse) {
+    response = &DescribeFlowListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeFlowList
+// 查询指定分区的流程列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) DescribeFlowList(request *DescribeFlowListRequest) (response *DescribeFlowListResponse, err error) {
+    return c.DescribeFlowListWithContext(context.Background(), request)
+}
+
+// DescribeFlowList
+// 查询指定分区的流程列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) DescribeFlowListWithContext(ctx context.Context, request *DescribeFlowListRequest) (response *DescribeFlowListResponse, err error) {
+    if request == nil {
+        request = NewDescribeFlowListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeFlowList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeFlowList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeFlowListResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeForbiddenTableProRequest() (request *DescribeForbiddenTableProRequest) {
     request = &DescribeForbiddenTableProRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -6049,6 +7773,190 @@ func (c *Client) DescribeLakeFsTaskResultWithContext(ctx context.Context, reques
     return
 }
 
+func NewDescribeMCPSubUinRequest() (request *DescribeMCPSubUinRequest) {
+    request = &DescribeMCPSubUinRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeMCPSubUin")
+    
+    
+    return
+}
+
+func NewDescribeMCPSubUinResponse() (response *DescribeMCPSubUinResponse) {
+    response = &DescribeMCPSubUinResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeMCPSubUin
+// 获取账户子账户信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) DescribeMCPSubUin(request *DescribeMCPSubUinRequest) (response *DescribeMCPSubUinResponse, err error) {
+    return c.DescribeMCPSubUinWithContext(context.Background(), request)
+}
+
+// DescribeMCPSubUin
+// 获取账户子账户信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) DescribeMCPSubUinWithContext(ctx context.Context, request *DescribeMCPSubUinRequest) (response *DescribeMCPSubUinResponse, err error) {
+    if request == nil {
+        request = NewDescribeMCPSubUinRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeMCPSubUin")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeMCPSubUin require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeMCPSubUinResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeMCPTaskRequest() (request *DescribeMCPTaskRequest) {
+    request = &DescribeMCPTaskRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeMCPTask")
+    
+    
+    return
+}
+
+func NewDescribeMCPTaskResponse() (response *DescribeMCPTaskResponse) {
+    response = &DescribeMCPTaskResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeMCPTask
+// 该接口（DescribeTasks）用于查询任务列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_FILTERSVALUESNUMBEROUTOFLIMIT = "InvalidParameter.FiltersValuesNumberOutOfLimit"
+//  INVALIDPARAMETER_INVALIDFILTERLENGTH = "InvalidParameter.InvalidFilterLength"
+//  INVALIDPARAMETER_INVALIDTIMEFORMAT = "InvalidParameter.InvalidTimeFormat"
+//  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  INVALIDPARAMETER_SQLTASKFILTERSKEYTYPENOTMATH = "InvalidParameter.SQLTaskFiltersKeyTypeNotMath"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  INVALIDPARAMETER_SQLTASKSORTBYTYPENOTMATCH = "InvalidParameter.SQLTaskSortByTypeNotMatch"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeMCPTask(request *DescribeMCPTaskRequest) (response *DescribeMCPTaskResponse, err error) {
+    return c.DescribeMCPTaskWithContext(context.Background(), request)
+}
+
+// DescribeMCPTask
+// 该接口（DescribeTasks）用于查询任务列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_FILTERSVALUESNUMBEROUTOFLIMIT = "InvalidParameter.FiltersValuesNumberOutOfLimit"
+//  INVALIDPARAMETER_INVALIDFILTERLENGTH = "InvalidParameter.InvalidFilterLength"
+//  INVALIDPARAMETER_INVALIDTIMEFORMAT = "InvalidParameter.InvalidTimeFormat"
+//  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  INVALIDPARAMETER_SQLTASKFILTERSKEYTYPENOTMATH = "InvalidParameter.SQLTaskFiltersKeyTypeNotMath"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  INVALIDPARAMETER_SQLTASKSORTBYTYPENOTMATCH = "InvalidParameter.SQLTaskSortByTypeNotMatch"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeMCPTaskWithContext(ctx context.Context, request *DescribeMCPTaskRequest) (response *DescribeMCPTaskResponse, err error) {
+    if request == nil {
+        request = NewDescribeMCPTaskRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeMCPTask")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeMCPTask require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeMCPTaskResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeMCPTaskResultRequest() (request *DescribeMCPTaskResultRequest) {
+    request = &DescribeMCPTaskResultRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeMCPTaskResult")
+    
+    
+    return
+}
+
+func NewDescribeMCPTaskResultResponse() (response *DescribeMCPTaskResultResponse) {
+    response = &DescribeMCPTaskResultResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeMCPTaskResult
+// 获取任务结果查询
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMCPTaskResult(request *DescribeMCPTaskResultRequest) (response *DescribeMCPTaskResultResponse, err error) {
+    return c.DescribeMCPTaskResultWithContext(context.Background(), request)
+}
+
+// DescribeMCPTaskResult
+// 获取任务结果查询
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMCPTaskResultWithContext(ctx context.Context, request *DescribeMCPTaskResultRequest) (response *DescribeMCPTaskResultResponse, err error) {
+    if request == nil {
+        request = NewDescribeMCPTaskResultRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeMCPTaskResult")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeMCPTaskResult require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeMCPTaskResultResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeNativeSparkSessionsRequest() (request *DescribeNativeSparkSessionsRequest) {
     request = &DescribeNativeSparkSessionsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -6072,11 +7980,10 @@ func NewDescribeNativeSparkSessionsResponse() (response *DescribeNativeSparkSess
 // 根据资源组获取spark session列表
 //
 // 可能返回的错误码:
-//  AUTHFAILURE = "AuthFailure"
-//  FAILEDOPERATION = "FailedOperation"
-//  INTERNALERROR = "InternalError"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  OPERATIONDENIED = "OperationDenied"
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
 func (c *Client) DescribeNativeSparkSessions(request *DescribeNativeSparkSessionsRequest) (response *DescribeNativeSparkSessionsResponse, err error) {
     return c.DescribeNativeSparkSessionsWithContext(context.Background(), request)
 }
@@ -6085,11 +7992,10 @@ func (c *Client) DescribeNativeSparkSessions(request *DescribeNativeSparkSession
 // 根据资源组获取spark session列表
 //
 // 可能返回的错误码:
-//  AUTHFAILURE = "AuthFailure"
-//  FAILEDOPERATION = "FailedOperation"
-//  INTERNALERROR = "InternalError"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  OPERATIONDENIED = "OperationDenied"
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
 func (c *Client) DescribeNativeSparkSessionsWithContext(ctx context.Context, request *DescribeNativeSparkSessionsRequest) (response *DescribeNativeSparkSessionsResponse, err error) {
     if request == nil {
         request = NewDescribeNativeSparkSessionsRequest()
@@ -6607,6 +8513,162 @@ func (c *Client) DescribeOtherCHDFSBindingListWithContext(ctx context.Context, r
     return
 }
 
+func NewDescribePartitionDetailRequest() (request *DescribePartitionDetailRequest) {
+    request = &DescribePartitionDetailRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribePartitionDetail")
+    
+    
+    return
+}
+
+func NewDescribePartitionDetailResponse() (response *DescribePartitionDetailResponse) {
+    response = &DescribePartitionDetailResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribePartitionDetail
+// 获取指定资源分区详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribePartitionDetail(request *DescribePartitionDetailRequest) (response *DescribePartitionDetailResponse, err error) {
+    return c.DescribePartitionDetailWithContext(context.Background(), request)
+}
+
+// DescribePartitionDetail
+// 获取指定资源分区详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribePartitionDetailWithContext(ctx context.Context, request *DescribePartitionDetailRequest) (response *DescribePartitionDetailResponse, err error) {
+    if request == nil {
+        request = NewDescribePartitionDetailRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribePartitionDetail")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribePartitionDetail require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribePartitionDetailResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribePartitionQueuesRequest() (request *DescribePartitionQueuesRequest) {
+    request = &DescribePartitionQueuesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribePartitionQueues")
+    
+    
+    return
+}
+
+func NewDescribePartitionQueuesResponse() (response *DescribePartitionQueuesResponse) {
+    response = &DescribePartitionQueuesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribePartitionQueues
+// 查询指定分区的所有队列列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribePartitionQueues(request *DescribePartitionQueuesRequest) (response *DescribePartitionQueuesResponse, err error) {
+    return c.DescribePartitionQueuesWithContext(context.Background(), request)
+}
+
+// DescribePartitionQueues
+// 查询指定分区的所有队列列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribePartitionQueuesWithContext(ctx context.Context, request *DescribePartitionQueuesRequest) (response *DescribePartitionQueuesResponse, err error) {
+    if request == nil {
+        request = NewDescribePartitionQueuesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribePartitionQueues")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribePartitionQueues require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribePartitionQueuesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribePartitionsRequest() (request *DescribePartitionsRequest) {
+    request = &DescribePartitionsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribePartitions")
+    
+    
+    return
+}
+
+func NewDescribePartitionsResponse() (response *DescribePartitionsResponse) {
+    response = &DescribePartitionsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribePartitions
+// 获取分区列表信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribePartitions(request *DescribePartitionsRequest) (response *DescribePartitionsResponse, err error) {
+    return c.DescribePartitionsWithContext(context.Background(), request)
+}
+
+// DescribePartitions
+// 获取分区列表信息
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribePartitionsWithContext(ctx context.Context, request *DescribePartitionsRequest) (response *DescribePartitionsResponse, err error) {
+    if request == nil {
+        request = NewDescribePartitionsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribePartitions")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribePartitions require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribePartitionsResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeResourceGroupUsageInfoRequest() (request *DescribeResourceGroupUsageInfoRequest) {
     request = &DescribeResourceGroupUsageInfoRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -6709,6 +8771,106 @@ func (c *Client) DescribeResultDownloadWithContext(ctx context.Context, request 
     request.SetContext(ctx)
     
     response = NewDescribeResultDownloadResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeSaleRegionsRequest() (request *DescribeSaleRegionsRequest) {
+    request = &DescribeSaleRegionsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeSaleRegions")
+    
+    
+    return
+}
+
+func NewDescribeSaleRegionsResponse() (response *DescribeSaleRegionsResponse) {
+    response = &DescribeSaleRegionsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeSaleRegions
+// 查询可售卖的地域列表，仅返回状态为AVAILABLE的地域
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) DescribeSaleRegions(request *DescribeSaleRegionsRequest) (response *DescribeSaleRegionsResponse, err error) {
+    return c.DescribeSaleRegionsWithContext(context.Background(), request)
+}
+
+// DescribeSaleRegions
+// 查询可售卖的地域列表，仅返回状态为AVAILABLE的地域
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) DescribeSaleRegionsWithContext(ctx context.Context, request *DescribeSaleRegionsRequest) (response *DescribeSaleRegionsResponse, err error) {
+    if request == nil {
+        request = NewDescribeSaleRegionsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeSaleRegions")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeSaleRegions require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeSaleRegionsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeSaleResourceInfoRequest() (request *DescribeSaleResourceInfoRequest) {
+    request = &DescribeSaleResourceInfoRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeSaleResourceInfo")
+    
+    
+    return
+}
+
+func NewDescribeSaleResourceInfoResponse() (response *DescribeSaleResourceInfoResponse) {
+    response = &DescribeSaleResourceInfoResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeSaleResourceInfo
+// 查询当前地域可售卖的资源规格和最大配额
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) DescribeSaleResourceInfo(request *DescribeSaleResourceInfoRequest) (response *DescribeSaleResourceInfoResponse, err error) {
+    return c.DescribeSaleResourceInfoWithContext(context.Background(), request)
+}
+
+// DescribeSaleResourceInfo
+// 查询当前地域可售卖的资源规格和最大配额
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+func (c *Client) DescribeSaleResourceInfoWithContext(ctx context.Context, request *DescribeSaleResourceInfoRequest) (response *DescribeSaleResourceInfoResponse, err error) {
+    if request == nil {
+        request = NewDescribeSaleResourceInfoRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeSaleResourceInfo")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeSaleResourceInfo require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeSaleResourceInfoResponse()
     err = c.Send(request, response)
     return
 }
@@ -8203,7 +10365,7 @@ func NewDescribeTasksResponse() (response *DescribeTasksResponse) {
 }
 
 // DescribeTasks
-// 该接口（DescribleTasks）用于查询任务列表
+// 该接口（DescribeTasks）用于查询任务列表
 //
 // 可能返回的错误码:
 //  INTERNALERROR = "InternalError"
@@ -8221,12 +10383,13 @@ func NewDescribeTasksResponse() (response *DescribeTasksResponse) {
 //  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
 //  INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
 func (c *Client) DescribeTasks(request *DescribeTasksRequest) (response *DescribeTasksResponse, err error) {
     return c.DescribeTasksWithContext(context.Background(), request)
 }
 
 // DescribeTasks
-// 该接口（DescribleTasks）用于查询任务列表
+// 该接口（DescribeTasks）用于查询任务列表
 //
 // 可能返回的错误码:
 //  INTERNALERROR = "InternalError"
@@ -8244,6 +10407,7 @@ func (c *Client) DescribeTasks(request *DescribeTasksRequest) (response *Describ
 //  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
 //  INVALIDPARAMETER_TASKSTATETYPENOTMATH = "InvalidParameter.TaskStateTypeNotMath"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
 func (c *Client) DescribeTasksWithContext(ctx context.Context, request *DescribeTasksRequest) (response *DescribeTasksResponse, err error) {
     if request == nil {
         request = NewDescribeTasksRequest()
@@ -9649,6 +11813,778 @@ func (c *Client) GenerateCreateMangedTableSqlWithContext(ctx context.Context, re
     return
 }
 
+func NewGenerateInternalTableRequest() (request *GenerateInternalTableRequest) {
+    request = &GenerateInternalTableRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GenerateInternalTable")
+    
+    
+    return
+}
+
+func NewGenerateInternalTableResponse() (response *GenerateInternalTableResponse) {
+    response = &GenerateInternalTableResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GenerateInternalTable
+// 建表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) GenerateInternalTable(request *GenerateInternalTableRequest) (response *GenerateInternalTableResponse, err error) {
+    return c.GenerateInternalTableWithContext(context.Background(), request)
+}
+
+// GenerateInternalTable
+// 建表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) GenerateInternalTableWithContext(ctx context.Context, request *GenerateInternalTableRequest) (response *GenerateInternalTableResponse, err error) {
+    if request == nil {
+        request = NewGenerateInternalTableRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GenerateInternalTable")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GenerateInternalTable require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGenerateInternalTableResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetExampleDetailRequest() (request *GetExampleDetailRequest) {
+    request = &GetExampleDetailRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetExampleDetail")
+    
+    
+    return
+}
+
+func NewGetExampleDetailResponse() (response *GetExampleDetailResponse) {
+    response = &GetExampleDetailResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetExampleDetail
+// 根据 exampleId 获取单个案例详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+//  FAILEDOPERATION_EXAMPLENOTFOUND = "FailedOperation.ExampleNotFound"
+func (c *Client) GetExampleDetail(request *GetExampleDetailRequest) (response *GetExampleDetailResponse, err error) {
+    return c.GetExampleDetailWithContext(context.Background(), request)
+}
+
+// GetExampleDetail
+// 根据 exampleId 获取单个案例详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+//  FAILEDOPERATION_EXAMPLENOTFOUND = "FailedOperation.ExampleNotFound"
+func (c *Client) GetExampleDetailWithContext(ctx context.Context, request *GetExampleDetailRequest) (response *GetExampleDetailResponse, err error) {
+    if request == nil {
+        request = NewGetExampleDetailRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetExampleDetail")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetExampleDetail require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetExampleDetailResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetInferenceModelRequest() (request *GetInferenceModelRequest) {
+    request = &GetInferenceModelRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetInferenceModel")
+    
+    
+    return
+}
+
+func NewGetInferenceModelResponse() (response *GetInferenceModelResponse) {
+    response = &GetInferenceModelResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetInferenceModel
+// 获取单个模型详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+//  FAILEDOPERATION_EXAMPLENOTFOUND = "FailedOperation.ExampleNotFound"
+func (c *Client) GetInferenceModel(request *GetInferenceModelRequest) (response *GetInferenceModelResponse, err error) {
+    return c.GetInferenceModelWithContext(context.Background(), request)
+}
+
+// GetInferenceModel
+// 获取单个模型详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+//  FAILEDOPERATION_EXAMPLENOTFOUND = "FailedOperation.ExampleNotFound"
+func (c *Client) GetInferenceModelWithContext(ctx context.Context, request *GetInferenceModelRequest) (response *GetInferenceModelResponse, err error) {
+    if request == nil {
+        request = NewGetInferenceModelRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetInferenceModel")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetInferenceModel require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetInferenceModelResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetInferenceServiceRequest() (request *GetInferenceServiceRequest) {
+    request = &GetInferenceServiceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetInferenceService")
+    
+    
+    return
+}
+
+func NewGetInferenceServiceResponse() (response *GetInferenceServiceResponse) {
+    response = &GetInferenceServiceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetInferenceService
+// 获取单个推理服务详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetInferenceService(request *GetInferenceServiceRequest) (response *GetInferenceServiceResponse, err error) {
+    return c.GetInferenceServiceWithContext(context.Background(), request)
+}
+
+// GetInferenceService
+// 获取单个推理服务详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetInferenceServiceWithContext(ctx context.Context, request *GetInferenceServiceRequest) (response *GetInferenceServiceResponse, err error) {
+    if request == nil {
+        request = NewGetInferenceServiceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetInferenceService")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetInferenceService require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetInferenceServiceResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetJobSpecRequest() (request *GetJobSpecRequest) {
+    request = &GetJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetJobSpec")
+    
+    
+    return
+}
+
+func NewGetJobSpecResponse() (response *GetJobSpecResponse) {
+    response = &GetJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetJobSpec
+// 根据配置ID获取作业配置详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetJobSpec(request *GetJobSpecRequest) (response *GetJobSpecResponse, err error) {
+    return c.GetJobSpecWithContext(context.Background(), request)
+}
+
+// GetJobSpec
+// 根据配置ID获取作业配置详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetJobSpecWithContext(ctx context.Context, request *GetJobSpecRequest) (response *GetJobSpecResponse, err error) {
+    if request == nil {
+        request = NewGetJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetJobSpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetLabDetailRequest() (request *GetLabDetailRequest) {
+    request = &GetLabDetailRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetLabDetail")
+    
+    
+    return
+}
+
+func NewGetLabDetailResponse() (response *GetLabDetailResponse) {
+    response = &GetLabDetailResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetLabDetail
+// 获取实验室详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabDetail(request *GetLabDetailRequest) (response *GetLabDetailResponse, err error) {
+    return c.GetLabDetailWithContext(context.Background(), request)
+}
+
+// GetLabDetail
+// 获取实验室详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabDetailWithContext(ctx context.Context, request *GetLabDetailRequest) (response *GetLabDetailResponse, err error) {
+    if request == nil {
+        request = NewGetLabDetailRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetLabDetail")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetLabDetail require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetLabDetailResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetLabEventRequest() (request *GetLabEventRequest) {
+    request = &GetLabEventRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetLabEvent")
+    
+    
+    return
+}
+
+func NewGetLabEventResponse() (response *GetLabEventResponse) {
+    response = &GetLabEventResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetLabEvent
+// 获取实验室的事件流（基于 K8s Event + CLS 日志）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabEvent(request *GetLabEventRequest) (response *GetLabEventResponse, err error) {
+    return c.GetLabEventWithContext(context.Background(), request)
+}
+
+// GetLabEvent
+// 获取实验室的事件流（基于 K8s Event + CLS 日志）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabEventWithContext(ctx context.Context, request *GetLabEventRequest) (response *GetLabEventResponse, err error) {
+    if request == nil {
+        request = NewGetLabEventRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetLabEvent")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetLabEvent require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetLabEventResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetLabHistoryRequest() (request *GetLabHistoryRequest) {
+    request = &GetLabHistoryRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetLabHistory")
+    
+    
+    return
+}
+
+func NewGetLabHistoryResponse() (response *GetLabHistoryResponse) {
+    response = &GetLabHistoryResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetLabHistory
+// 获取实验室的状态变更历史记录
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabHistory(request *GetLabHistoryRequest) (response *GetLabHistoryResponse, err error) {
+    return c.GetLabHistoryWithContext(context.Background(), request)
+}
+
+// GetLabHistory
+// 获取实验室的状态变更历史记录
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabHistoryWithContext(ctx context.Context, request *GetLabHistoryRequest) (response *GetLabHistoryResponse, err error) {
+    if request == nil {
+        request = NewGetLabHistoryRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetLabHistory")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetLabHistory require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetLabHistoryResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetLabPodYamlRequest() (request *GetLabPodYamlRequest) {
+    request = &GetLabPodYamlRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetLabPodYaml")
+    
+    
+    return
+}
+
+func NewGetLabPodYamlResponse() (response *GetLabPodYamlResponse) {
+    response = &GetLabPodYamlResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetLabPodYaml
+// 获取数据实验室Pod的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabPodYaml(request *GetLabPodYamlRequest) (response *GetLabPodYamlResponse, err error) {
+    return c.GetLabPodYamlWithContext(context.Background(), request)
+}
+
+// GetLabPodYaml
+// 获取数据实验室Pod的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabPodYamlWithContext(ctx context.Context, request *GetLabPodYamlRequest) (response *GetLabPodYamlResponse, err error) {
+    if request == nil {
+        request = NewGetLabPodYamlRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetLabPodYaml")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetLabPodYaml require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetLabPodYamlResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetLabPodsRequest() (request *GetLabPodsRequest) {
+    request = &GetLabPodsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetLabPods")
+    
+    
+    return
+}
+
+func NewGetLabPodsResponse() (response *GetLabPodsResponse) {
+    response = &GetLabPodsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetLabPods
+// 获取数据实验室的Pod列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabPods(request *GetLabPodsRequest) (response *GetLabPodsResponse, err error) {
+    return c.GetLabPodsWithContext(context.Background(), request)
+}
+
+// GetLabPods
+// 获取数据实验室的Pod列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) GetLabPodsWithContext(ctx context.Context, request *GetLabPodsRequest) (response *GetLabPodsResponse, err error) {
+    if request == nil {
+        request = NewGetLabPodsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetLabPods")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetLabPods require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetLabPodsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetLabServiceUrlsRequest() (request *GetLabServiceUrlsRequest) {
+    request = &GetLabServiceUrlsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetLabServiceUrls")
+    
+    
+    return
+}
+
+func NewGetLabServiceUrlsResponse() (response *GetLabServiceUrlsResponse) {
+    response = &GetLabServiceUrlsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetLabServiceUrls
+// 获取实验室ide访问地址
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABNOTRUNNING = "FailedOperation.LabNotRunning"
+func (c *Client) GetLabServiceUrls(request *GetLabServiceUrlsRequest) (response *GetLabServiceUrlsResponse, err error) {
+    return c.GetLabServiceUrlsWithContext(context.Background(), request)
+}
+
+// GetLabServiceUrls
+// 获取实验室ide访问地址
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABNOTRUNNING = "FailedOperation.LabNotRunning"
+func (c *Client) GetLabServiceUrlsWithContext(ctx context.Context, request *GetLabServiceUrlsRequest) (response *GetLabServiceUrlsResponse, err error) {
+    if request == nil {
+        request = NewGetLabServiceUrlsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetLabServiceUrls")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetLabServiceUrls require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetLabServiceUrlsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetLabYamlRequest() (request *GetLabYamlRequest) {
+    request = &GetLabYamlRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetLabYaml")
+    
+    
+    return
+}
+
+func NewGetLabYamlResponse() (response *GetLabYamlResponse) {
+    response = &GetLabYamlResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetLabYaml
+// 获取数据实验室对应的RayCluster YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABNOTRUNNING = "FailedOperation.LabNotRunning"
+func (c *Client) GetLabYaml(request *GetLabYamlRequest) (response *GetLabYamlResponse, err error) {
+    return c.GetLabYamlWithContext(context.Background(), request)
+}
+
+// GetLabYaml
+// 获取数据实验室对应的RayCluster YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABNOTRUNNING = "FailedOperation.LabNotRunning"
+func (c *Client) GetLabYamlWithContext(ctx context.Context, request *GetLabYamlRequest) (response *GetLabYamlResponse, err error) {
+    if request == nil {
+        request = NewGetLabYamlRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetLabYaml")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetLabYaml require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetLabYamlResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetModelConfigRequest() (request *GetModelConfigRequest) {
+    request = &GetModelConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetModelConfig")
+    
+    
+    return
+}
+
+func NewGetModelConfigResponse() (response *GetModelConfigResponse) {
+    response = &GetModelConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetModelConfig
+// 获取模型 config.json 配置（默认最新版本）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetModelConfig(request *GetModelConfigRequest) (response *GetModelConfigResponse, err error) {
+    return c.GetModelConfigWithContext(context.Background(), request)
+}
+
+// GetModelConfig
+// 获取模型 config.json 配置（默认最新版本）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetModelConfigWithContext(ctx context.Context, request *GetModelConfigRequest) (response *GetModelConfigResponse, err error) {
+    if request == nil {
+        request = NewGetModelConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetModelConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetModelConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetModelConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetModelFilesRequest() (request *GetModelFilesRequest) {
+    request = &GetModelFilesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetModelFiles")
+    
+    
+    return
+}
+
+func NewGetModelFilesResponse() (response *GetModelFilesResponse) {
+    response = &GetModelFilesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetModelFiles
+// 获取模型文件树（默认最新版本）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetModelFiles(request *GetModelFilesRequest) (response *GetModelFilesResponse, err error) {
+    return c.GetModelFilesWithContext(context.Background(), request)
+}
+
+// GetModelFiles
+// 获取模型文件树（默认最新版本）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetModelFilesWithContext(ctx context.Context, request *GetModelFilesRequest) (response *GetModelFilesResponse, err error) {
+    if request == nil {
+        request = NewGetModelFilesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetModelFiles")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetModelFiles require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetModelFilesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetModelReadmeRequest() (request *GetModelReadmeRequest) {
+    request = &GetModelReadmeRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetModelReadme")
+    
+    
+    return
+}
+
+func NewGetModelReadmeResponse() (response *GetModelReadmeResponse) {
+    response = &GetModelReadmeResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetModelReadme
+// 获取模型 README 信息（默认最新版本）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetModelReadme(request *GetModelReadmeRequest) (response *GetModelReadmeResponse, err error) {
+    return c.GetModelReadmeWithContext(context.Background(), request)
+}
+
+// GetModelReadme
+// 获取模型 README 信息（默认最新版本）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetModelReadmeWithContext(ctx context.Context, request *GetModelReadmeRequest) (response *GetModelReadmeResponse, err error) {
+    if request == nil {
+        request = NewGetModelReadmeRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetModelReadme")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetModelReadme require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetModelReadmeResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewGetOptimizerPolicyRequest() (request *GetOptimizerPolicyRequest) {
     request = &GetOptimizerPolicyRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -9699,6 +12635,706 @@ func (c *Client) GetOptimizerPolicyWithContext(ctx context.Context, request *Get
     return
 }
 
+func NewGetRayClusterRequest() (request *GetRayClusterRequest) {
+    request = &GetRayClusterRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayCluster")
+    
+    
+    return
+}
+
+func NewGetRayClusterResponse() (response *GetRayClusterResponse) {
+    response = &GetRayClusterResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayCluster
+// 获取Ray集群详情请求
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayCluster(request *GetRayClusterRequest) (response *GetRayClusterResponse, err error) {
+    return c.GetRayClusterWithContext(context.Background(), request)
+}
+
+// GetRayCluster
+// 获取Ray集群详情请求
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayClusterWithContext(ctx context.Context, request *GetRayClusterRequest) (response *GetRayClusterResponse, err error) {
+    if request == nil {
+        request = NewGetRayClusterRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayClusterEventRequest() (request *GetRayClusterEventRequest) {
+    request = &GetRayClusterEventRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayClusterEvent")
+    
+    
+    return
+}
+
+func NewGetRayClusterEventResponse() (response *GetRayClusterEventResponse) {
+    response = &GetRayClusterEventResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayClusterEvent
+// 获取Ray集群的事件流（基于 K8s Event + CLS 日志）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayClusterEvent(request *GetRayClusterEventRequest) (response *GetRayClusterEventResponse, err error) {
+    return c.GetRayClusterEventWithContext(context.Background(), request)
+}
+
+// GetRayClusterEvent
+// 获取Ray集群的事件流（基于 K8s Event + CLS 日志）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayClusterEventWithContext(ctx context.Context, request *GetRayClusterEventRequest) (response *GetRayClusterEventResponse, err error) {
+    if request == nil {
+        request = NewGetRayClusterEventRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayClusterEvent")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayClusterEvent require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayClusterEventResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayClusterHistoryRequest() (request *GetRayClusterHistoryRequest) {
+    request = &GetRayClusterHistoryRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayClusterHistory")
+    
+    
+    return
+}
+
+func NewGetRayClusterHistoryResponse() (response *GetRayClusterHistoryResponse) {
+    response = &GetRayClusterHistoryResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayClusterHistory
+// 获取集群状态历史
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayClusterHistory(request *GetRayClusterHistoryRequest) (response *GetRayClusterHistoryResponse, err error) {
+    return c.GetRayClusterHistoryWithContext(context.Background(), request)
+}
+
+// GetRayClusterHistory
+// 获取集群状态历史
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayClusterHistoryWithContext(ctx context.Context, request *GetRayClusterHistoryRequest) (response *GetRayClusterHistoryResponse, err error) {
+    if request == nil {
+        request = NewGetRayClusterHistoryRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayClusterHistory")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayClusterHistory require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayClusterHistoryResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayClusterPodYamlRequest() (request *GetRayClusterPodYamlRequest) {
+    request = &GetRayClusterPodYamlRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayClusterPodYaml")
+    
+    
+    return
+}
+
+func NewGetRayClusterPodYamlResponse() (response *GetRayClusterPodYamlResponse) {
+    response = &GetRayClusterPodYamlResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayClusterPodYaml
+// 获取集群Pod的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayClusterPodYaml(request *GetRayClusterPodYamlRequest) (response *GetRayClusterPodYamlResponse, err error) {
+    return c.GetRayClusterPodYamlWithContext(context.Background(), request)
+}
+
+// GetRayClusterPodYaml
+// 获取集群Pod的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayClusterPodYamlWithContext(ctx context.Context, request *GetRayClusterPodYamlRequest) (response *GetRayClusterPodYamlResponse, err error) {
+    if request == nil {
+        request = NewGetRayClusterPodYamlRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayClusterPodYaml")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayClusterPodYaml require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayClusterPodYamlResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayClusterPodsRequest() (request *GetRayClusterPodsRequest) {
+    request = &GetRayClusterPodsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayClusterPods")
+    
+    
+    return
+}
+
+func NewGetRayClusterPodsResponse() (response *GetRayClusterPodsResponse) {
+    response = &GetRayClusterPodsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayClusterPods
+// 获取集群的Pod列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) GetRayClusterPods(request *GetRayClusterPodsRequest) (response *GetRayClusterPodsResponse, err error) {
+    return c.GetRayClusterPodsWithContext(context.Background(), request)
+}
+
+// GetRayClusterPods
+// 获取集群的Pod列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) GetRayClusterPodsWithContext(ctx context.Context, request *GetRayClusterPodsRequest) (response *GetRayClusterPodsResponse, err error) {
+    if request == nil {
+        request = NewGetRayClusterPodsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayClusterPods")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayClusterPods require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayClusterPodsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayClusterYamlRequest() (request *GetRayClusterYamlRequest) {
+    request = &GetRayClusterYamlRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayClusterYaml")
+    
+    
+    return
+}
+
+func NewGetRayClusterYamlResponse() (response *GetRayClusterYamlResponse) {
+    response = &GetRayClusterYamlResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayClusterYaml
+// 获取RayCluster的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) GetRayClusterYaml(request *GetRayClusterYamlRequest) (response *GetRayClusterYamlResponse, err error) {
+    return c.GetRayClusterYamlWithContext(context.Background(), request)
+}
+
+// GetRayClusterYaml
+// 获取RayCluster的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) GetRayClusterYamlWithContext(ctx context.Context, request *GetRayClusterYamlRequest) (response *GetRayClusterYamlResponse, err error) {
+    if request == nil {
+        request = NewGetRayClusterYamlRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayClusterYaml")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayClusterYaml require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayClusterYamlResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayJobRequest() (request *GetRayJobRequest) {
+    request = &GetRayJobRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayJob")
+    
+    
+    return
+}
+
+func NewGetRayJobResponse() (response *GetRayJobResponse) {
+    response = &GetRayJobResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayJob
+// 根据任务ID获取Ray任务详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJob(request *GetRayJobRequest) (response *GetRayJobResponse, err error) {
+    return c.GetRayJobWithContext(context.Background(), request)
+}
+
+// GetRayJob
+// 根据任务ID获取Ray任务详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobWithContext(ctx context.Context, request *GetRayJobRequest) (response *GetRayJobResponse, err error) {
+    if request == nil {
+        request = NewGetRayJobRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayJob")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayJob require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayJobResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayJobEventRequest() (request *GetRayJobEventRequest) {
+    request = &GetRayJobEventRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayJobEvent")
+    
+    
+    return
+}
+
+func NewGetRayJobEventResponse() (response *GetRayJobEventResponse) {
+    response = &GetRayJobEventResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayJobEvent
+// 通过 ResourceManager 调用 CLS SearchLog API 查询作业相关日志。不返回总数，使用 Context 进行翻页，ListOver 标识是否还有更多数据。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobEvent(request *GetRayJobEventRequest) (response *GetRayJobEventResponse, err error) {
+    return c.GetRayJobEventWithContext(context.Background(), request)
+}
+
+// GetRayJobEvent
+// 通过 ResourceManager 调用 CLS SearchLog API 查询作业相关日志。不返回总数，使用 Context 进行翻页，ListOver 标识是否还有更多数据。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobEventWithContext(ctx context.Context, request *GetRayJobEventRequest) (response *GetRayJobEventResponse, err error) {
+    if request == nil {
+        request = NewGetRayJobEventRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayJobEvent")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayJobEvent require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayJobEventResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayJobEventLogRequest() (request *GetRayJobEventLogRequest) {
+    request = &GetRayJobEventLogRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayJobEventLog")
+    
+    
+    return
+}
+
+func NewGetRayJobEventLogResponse() (response *GetRayJobEventLogResponse) {
+    response = &GetRayJobEventLogResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayJobEventLog
+// 获取作业事件日志
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobEventLog(request *GetRayJobEventLogRequest) (response *GetRayJobEventLogResponse, err error) {
+    return c.GetRayJobEventLogWithContext(context.Background(), request)
+}
+
+// GetRayJobEventLog
+// 获取作业事件日志
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobEventLogWithContext(ctx context.Context, request *GetRayJobEventLogRequest) (response *GetRayJobEventLogResponse, err error) {
+    if request == nil {
+        request = NewGetRayJobEventLogRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayJobEventLog")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayJobEventLog require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayJobEventLogResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayJobHistoryRequest() (request *GetRayJobHistoryRequest) {
+    request = &GetRayJobHistoryRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayJobHistory")
+    
+    
+    return
+}
+
+func NewGetRayJobHistoryResponse() (response *GetRayJobHistoryResponse) {
+    response = &GetRayJobHistoryResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayJobHistory
+// 根据任务ID获取Ray任务的历史执行记录
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobHistory(request *GetRayJobHistoryRequest) (response *GetRayJobHistoryResponse, err error) {
+    return c.GetRayJobHistoryWithContext(context.Background(), request)
+}
+
+// GetRayJobHistory
+// 根据任务ID获取Ray任务的历史执行记录
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobHistoryWithContext(ctx context.Context, request *GetRayJobHistoryRequest) (response *GetRayJobHistoryResponse, err error) {
+    if request == nil {
+        request = NewGetRayJobHistoryRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayJobHistory")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayJobHistory require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayJobHistoryResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayJobPodYamlRequest() (request *GetRayJobPodYamlRequest) {
+    request = &GetRayJobPodYamlRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayJobPodYaml")
+    
+    
+    return
+}
+
+func NewGetRayJobPodYamlResponse() (response *GetRayJobPodYamlResponse) {
+    response = &GetRayJobPodYamlResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayJobPodYaml
+// 获取Pod的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobPodYaml(request *GetRayJobPodYamlRequest) (response *GetRayJobPodYamlResponse, err error) {
+    return c.GetRayJobPodYamlWithContext(context.Background(), request)
+}
+
+// GetRayJobPodYaml
+// 获取Pod的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobPodYamlWithContext(ctx context.Context, request *GetRayJobPodYamlRequest) (response *GetRayJobPodYamlResponse, err error) {
+    if request == nil {
+        request = NewGetRayJobPodYamlRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayJobPodYaml")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayJobPodYaml require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayJobPodYamlResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayJobPodsRequest() (request *GetRayJobPodsRequest) {
+    request = &GetRayJobPodsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayJobPods")
+    
+    
+    return
+}
+
+func NewGetRayJobPodsResponse() (response *GetRayJobPodsResponse) {
+    response = &GetRayJobPodsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayJobPods
+// 获取作业的Pod列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobPods(request *GetRayJobPodsRequest) (response *GetRayJobPodsResponse, err error) {
+    return c.GetRayJobPodsWithContext(context.Background(), request)
+}
+
+// GetRayJobPods
+// 获取作业的Pod列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobPodsWithContext(ctx context.Context, request *GetRayJobPodsRequest) (response *GetRayJobPodsResponse, err error) {
+    if request == nil {
+        request = NewGetRayJobPodsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayJobPods")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayJobPods require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayJobPodsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetRayJobYamlRequest() (request *GetRayJobYamlRequest) {
+    request = &GetRayJobYamlRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetRayJobYaml")
+    
+    
+    return
+}
+
+func NewGetRayJobYamlResponse() (response *GetRayJobYamlResponse) {
+    response = &GetRayJobYamlResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetRayJobYaml
+// 获取RayJob的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobYaml(request *GetRayJobYamlRequest) (response *GetRayJobYamlResponse, err error) {
+    return c.GetRayJobYamlWithContext(context.Background(), request)
+}
+
+// GetRayJobYaml
+// 获取RayJob的YAML内容
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetRayJobYamlWithContext(ctx context.Context, request *GetRayJobYamlRequest) (response *GetRayJobYamlResponse, err error) {
+    if request == nil {
+        request = NewGetRayJobYamlRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayJobYaml")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetRayJobYaml require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetRayJobYamlResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetResourceConfigRequest() (request *GetResourceConfigRequest) {
+    request = &GetResourceConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "GetResourceConfig")
+    
+    
+    return
+}
+
+func NewGetResourceConfigResponse() (response *GetResourceConfigResponse) {
+    response = &GetResourceConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetResourceConfig
+// 获取资源配置模板详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetResourceConfig(request *GetResourceConfigRequest) (response *GetResourceConfigResponse, err error) {
+    return c.GetResourceConfigWithContext(context.Background(), request)
+}
+
+// GetResourceConfig
+// 获取资源配置模板详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) GetResourceConfigWithContext(ctx context.Context, request *GetResourceConfigRequest) (response *GetResourceConfigResponse, err error) {
+    if request == nil {
+        request = NewGetResourceConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetResourceConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetResourceConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetResourceConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewGrantDLCCatalogAccessRequest() (request *GrantDLCCatalogAccessRequest) {
     request = &GrantDLCCatalogAccessRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -9722,7 +13358,7 @@ func NewGrantDLCCatalogAccessResponse() (response *GrantDLCCatalogAccessResponse
 // 授权访问DLC Catalog
 //
 // 可能返回的错误码:
-//  RESOURCENOTFOUND = "ResourceNotFound"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) GrantDLCCatalogAccess(request *GrantDLCCatalogAccessRequest) (response *GrantDLCCatalogAccessResponse, err error) {
     return c.GrantDLCCatalogAccessWithContext(context.Background(), request)
 }
@@ -9731,7 +13367,7 @@ func (c *Client) GrantDLCCatalogAccess(request *GrantDLCCatalogAccessRequest) (r
 // 授权访问DLC Catalog
 //
 // 可能返回的错误码:
-//  RESOURCENOTFOUND = "ResourceNotFound"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) GrantDLCCatalogAccessWithContext(ctx context.Context, request *GrantDLCCatalogAccessRequest) (response *GrantDLCCatalogAccessResponse, err error) {
     if request == nil {
         request = NewGrantDLCCatalogAccessRequest()
@@ -9772,7 +13408,7 @@ func NewInitializeTCLakeResponse() (response *InitializeTCLakeResponse) {
 // 开通TCLake
 //
 // 可能返回的错误码:
-//  RESOURCENOTFOUND = "ResourceNotFound"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) InitializeTCLake(request *InitializeTCLakeRequest) (response *InitializeTCLakeResponse, err error) {
     return c.InitializeTCLakeWithContext(context.Background(), request)
 }
@@ -9781,7 +13417,7 @@ func (c *Client) InitializeTCLake(request *InitializeTCLakeRequest) (response *I
 // 开通TCLake
 //
 // 可能返回的错误码:
-//  RESOURCENOTFOUND = "ResourceNotFound"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) InitializeTCLakeWithContext(ctx context.Context, request *InitializeTCLakeRequest) (response *InitializeTCLakeResponse, err error) {
     if request == nil {
         request = NewInitializeTCLakeRequest()
@@ -9857,6 +13493,806 @@ func (c *Client) LaunchStandardEngineResourceGroupsWithContext(ctx context.Conte
     request.SetContext(ctx)
     
     response = NewLaunchStandardEngineResourceGroupsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListClusterGroupsRequest() (request *ListClusterGroupsRequest) {
+    request = &ListClusterGroupsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListClusterGroups")
+    
+    
+    return
+}
+
+func NewListClusterGroupsResponse() (response *ListClusterGroupsResponse) {
+    response = &ListClusterGroupsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListClusterGroups
+// 列出所有集群组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) ListClusterGroups(request *ListClusterGroupsRequest) (response *ListClusterGroupsResponse, err error) {
+    return c.ListClusterGroupsWithContext(context.Background(), request)
+}
+
+// ListClusterGroups
+// 列出所有集群组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) ListClusterGroupsWithContext(ctx context.Context, request *ListClusterGroupsRequest) (response *ListClusterGroupsResponse, err error) {
+    if request == nil {
+        request = NewListClusterGroupsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListClusterGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListClusterGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListClusterGroupsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListExampleCategoriesRequest() (request *ListExampleCategoriesRequest) {
+    request = &ListExampleCategoriesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListExampleCategories")
+    
+    
+    return
+}
+
+func NewListExampleCategoriesResponse() (response *ListExampleCategoriesResponse) {
+    response = &ListExampleCategoriesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListExampleCategories
+// 获取所有案例分类
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+func (c *Client) ListExampleCategories(request *ListExampleCategoriesRequest) (response *ListExampleCategoriesResponse, err error) {
+    return c.ListExampleCategoriesWithContext(context.Background(), request)
+}
+
+// ListExampleCategories
+// 获取所有案例分类
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+func (c *Client) ListExampleCategoriesWithContext(ctx context.Context, request *ListExampleCategoriesRequest) (response *ListExampleCategoriesResponse, err error) {
+    if request == nil {
+        request = NewListExampleCategoriesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListExampleCategories")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListExampleCategories require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListExampleCategoriesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListExampleDifficultiesRequest() (request *ListExampleDifficultiesRequest) {
+    request = &ListExampleDifficultiesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListExampleDifficulties")
+    
+    
+    return
+}
+
+func NewListExampleDifficultiesResponse() (response *ListExampleDifficultiesResponse) {
+    response = &ListExampleDifficultiesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListExampleDifficulties
+// 获取所有案例分类
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+func (c *Client) ListExampleDifficulties(request *ListExampleDifficultiesRequest) (response *ListExampleDifficultiesResponse, err error) {
+    return c.ListExampleDifficultiesWithContext(context.Background(), request)
+}
+
+// ListExampleDifficulties
+// 获取所有案例分类
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+func (c *Client) ListExampleDifficultiesWithContext(ctx context.Context, request *ListExampleDifficultiesRequest) (response *ListExampleDifficultiesResponse, err error) {
+    if request == nil {
+        request = NewListExampleDifficultiesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListExampleDifficulties")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListExampleDifficulties require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListExampleDifficultiesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListExampleTagsRequest() (request *ListExampleTagsRequest) {
+    request = &ListExampleTagsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListExampleTags")
+    
+    
+    return
+}
+
+func NewListExampleTagsResponse() (response *ListExampleTagsResponse) {
+    response = &ListExampleTagsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListExampleTags
+// 返回标签去重列表，按出现频次从高到低排序。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+func (c *Client) ListExampleTags(request *ListExampleTagsRequest) (response *ListExampleTagsResponse, err error) {
+    return c.ListExampleTagsWithContext(context.Background(), request)
+}
+
+// ListExampleTags
+// 返回标签去重列表，按出现频次从高到低排序。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+func (c *Client) ListExampleTagsWithContext(ctx context.Context, request *ListExampleTagsRequest) (response *ListExampleTagsResponse, err error) {
+    if request == nil {
+        request = NewListExampleTagsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListExampleTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListExampleTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListExampleTagsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListExamplesRequest() (request *ListExamplesRequest) {
+    request = &ListExamplesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListExamples")
+    
+    
+    return
+}
+
+func NewListExamplesResponse() (response *ListExamplesResponse) {
+    response = &ListExamplesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListExamples
+// 案例列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+func (c *Client) ListExamples(request *ListExamplesRequest) (response *ListExamplesResponse, err error) {
+    return c.ListExamplesWithContext(context.Background(), request)
+}
+
+// ListExamples
+// 案例列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+func (c *Client) ListExamplesWithContext(ctx context.Context, request *ListExamplesRequest) (response *ListExamplesResponse, err error) {
+    if request == nil {
+        request = NewListExamplesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListExamples")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListExamples require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListExamplesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListInferenceEnginesRequest() (request *ListInferenceEnginesRequest) {
+    request = &ListInferenceEnginesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListInferenceEngines")
+    
+    
+    return
+}
+
+func NewListInferenceEnginesResponse() (response *ListInferenceEnginesResponse) {
+    response = &ListInferenceEnginesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListInferenceEngines
+// 列出推理引擎
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) ListInferenceEngines(request *ListInferenceEnginesRequest) (response *ListInferenceEnginesResponse, err error) {
+    return c.ListInferenceEnginesWithContext(context.Background(), request)
+}
+
+// ListInferenceEngines
+// 列出推理引擎
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) ListInferenceEnginesWithContext(ctx context.Context, request *ListInferenceEnginesRequest) (response *ListInferenceEnginesResponse, err error) {
+    if request == nil {
+        request = NewListInferenceEnginesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListInferenceEngines")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListInferenceEngines require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListInferenceEnginesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListInferenceModelsRequest() (request *ListInferenceModelsRequest) {
+    request = &ListInferenceModelsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListInferenceModels")
+    
+    
+    return
+}
+
+func NewListInferenceModelsResponse() (response *ListInferenceModelsResponse) {
+    response = &ListInferenceModelsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListInferenceModels
+// 列出推理模型（支持关键词过滤 + 分页）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListInferenceModels(request *ListInferenceModelsRequest) (response *ListInferenceModelsResponse, err error) {
+    return c.ListInferenceModelsWithContext(context.Background(), request)
+}
+
+// ListInferenceModels
+// 列出推理模型（支持关键词过滤 + 分页）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListInferenceModelsWithContext(ctx context.Context, request *ListInferenceModelsRequest) (response *ListInferenceModelsResponse, err error) {
+    if request == nil {
+        request = NewListInferenceModelsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListInferenceModels")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListInferenceModels require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListInferenceModelsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListInferenceServicesRequest() (request *ListInferenceServicesRequest) {
+    request = &ListInferenceServicesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListInferenceServices")
+    
+    
+    return
+}
+
+func NewListInferenceServicesResponse() (response *ListInferenceServicesResponse) {
+    response = &ListInferenceServicesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListInferenceServices
+// 列出推理服务（支持关键词和状态过滤 + 分页）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListInferenceServices(request *ListInferenceServicesRequest) (response *ListInferenceServicesResponse, err error) {
+    return c.ListInferenceServicesWithContext(context.Background(), request)
+}
+
+// ListInferenceServices
+// 列出推理服务（支持关键词和状态过滤 + 分页）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListInferenceServicesWithContext(ctx context.Context, request *ListInferenceServicesRequest) (response *ListInferenceServicesResponse, err error) {
+    if request == nil {
+        request = NewListInferenceServicesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListInferenceServices")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListInferenceServices require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListInferenceServicesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListJobSpecsRequest() (request *ListJobSpecsRequest) {
+    request = &ListJobSpecsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListJobSpecs")
+    
+    
+    return
+}
+
+func NewListJobSpecsResponse() (response *ListJobSpecsResponse) {
+    response = &ListJobSpecsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListJobSpecs
+// 分页查询作业配置列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListJobSpecs(request *ListJobSpecsRequest) (response *ListJobSpecsResponse, err error) {
+    return c.ListJobSpecsWithContext(context.Background(), request)
+}
+
+// ListJobSpecs
+// 分页查询作业配置列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListJobSpecsWithContext(ctx context.Context, request *ListJobSpecsRequest) (response *ListJobSpecsResponse, err error) {
+    if request == nil {
+        request = NewListJobSpecsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListJobSpecs")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListJobSpecs require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListJobSpecsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListJobsBySpecRequest() (request *ListJobsBySpecRequest) {
+    request = &ListJobsBySpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListJobsBySpec")
+    
+    
+    return
+}
+
+func NewListJobsBySpecResponse() (response *ListJobsBySpecResponse) {
+    response = &ListJobsBySpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListJobsBySpec
+// 分页查询某作业配置下产生的所有作业实例
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListJobsBySpec(request *ListJobsBySpecRequest) (response *ListJobsBySpecResponse, err error) {
+    return c.ListJobsBySpecWithContext(context.Background(), request)
+}
+
+// ListJobsBySpec
+// 分页查询某作业配置下产生的所有作业实例
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListJobsBySpecWithContext(ctx context.Context, request *ListJobsBySpecRequest) (response *ListJobsBySpecResponse, err error) {
+    if request == nil {
+        request = NewListJobsBySpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListJobsBySpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListJobsBySpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListJobsBySpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListLabsRequest() (request *ListLabsRequest) {
+    request = &ListLabsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListLabs")
+    
+    
+    return
+}
+
+func NewListLabsResponse() (response *ListLabsResponse) {
+    response = &ListLabsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListLabs
+// 列出实验室列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListLabs(request *ListLabsRequest) (response *ListLabsResponse, err error) {
+    return c.ListLabsWithContext(context.Background(), request)
+}
+
+// ListLabs
+// 列出实验室列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListLabsWithContext(ctx context.Context, request *ListLabsRequest) (response *ListLabsResponse, err error) {
+    if request == nil {
+        request = NewListLabsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListLabs")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListLabs require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListLabsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListModelVersionsRequest() (request *ListModelVersionsRequest) {
+    request = &ListModelVersionsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListModelVersions")
+    
+    
+    return
+}
+
+func NewListModelVersionsResponse() (response *ListModelVersionsResponse) {
+    response = &ListModelVersionsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListModelVersions
+// 列出模型所有版本
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListModelVersions(request *ListModelVersionsRequest) (response *ListModelVersionsResponse, err error) {
+    return c.ListModelVersionsWithContext(context.Background(), request)
+}
+
+// ListModelVersions
+// 列出模型所有版本
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListModelVersionsWithContext(ctx context.Context, request *ListModelVersionsRequest) (response *ListModelVersionsResponse, err error) {
+    if request == nil {
+        request = NewListModelVersionsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListModelVersions")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListModelVersions require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListModelVersionsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListRayClusterJobsRequest() (request *ListRayClusterJobsRequest) {
+    request = &ListRayClusterJobsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListRayClusterJobs")
+    
+    
+    return
+}
+
+func NewListRayClusterJobsResponse() (response *ListRayClusterJobsResponse) {
+    response = &ListRayClusterJobsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListRayClusterJobs
+// 查询指定 Ray 集群下提交的所有作业，分页返回。底层委托给 ListRayJobs，强制注入 ClusterId 作为过滤条件。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListRayClusterJobs(request *ListRayClusterJobsRequest) (response *ListRayClusterJobsResponse, err error) {
+    return c.ListRayClusterJobsWithContext(context.Background(), request)
+}
+
+// ListRayClusterJobs
+// 查询指定 Ray 集群下提交的所有作业，分页返回。底层委托给 ListRayJobs，强制注入 ClusterId 作为过滤条件。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListRayClusterJobsWithContext(ctx context.Context, request *ListRayClusterJobsRequest) (response *ListRayClusterJobsResponse, err error) {
+    if request == nil {
+        request = NewListRayClusterJobsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListRayClusterJobs")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListRayClusterJobs require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListRayClusterJobsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListRayClustersRequest() (request *ListRayClustersRequest) {
+    request = &ListRayClustersRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListRayClusters")
+    
+    
+    return
+}
+
+func NewListRayClustersResponse() (response *ListRayClustersResponse) {
+    response = &ListRayClustersResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListRayClusters
+// 列出所有集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListRayClusters(request *ListRayClustersRequest) (response *ListRayClustersResponse, err error) {
+    return c.ListRayClustersWithContext(context.Background(), request)
+}
+
+// ListRayClusters
+// 列出所有集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListRayClustersWithContext(ctx context.Context, request *ListRayClustersRequest) (response *ListRayClustersResponse, err error) {
+    if request == nil {
+        request = NewListRayClustersRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListRayClusters")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListRayClusters require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListRayClustersResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListRayJobsRequest() (request *ListRayJobsRequest) {
+    request = &ListRayJobsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListRayJobs")
+    
+    
+    return
+}
+
+func NewListRayJobsResponse() (response *ListRayJobsResponse) {
+    response = &ListRayJobsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListRayJobs
+// 根据集群ID列出所有Ray任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListRayJobs(request *ListRayJobsRequest) (response *ListRayJobsResponse, err error) {
+    return c.ListRayJobsWithContext(context.Background(), request)
+}
+
+// ListRayJobs
+// 根据集群ID列出所有Ray任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListRayJobsWithContext(ctx context.Context, request *ListRayJobsRequest) (response *ListRayJobsResponse, err error) {
+    if request == nil {
+        request = NewListRayJobsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListRayJobs")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListRayJobs require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListRayJobsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListResourceConfigsRequest() (request *ListResourceConfigsRequest) {
+    request = &ListResourceConfigsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListResourceConfigs")
+    
+    
+    return
+}
+
+func NewListResourceConfigsResponse() (response *ListResourceConfigsResponse) {
+    response = &ListResourceConfigsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListResourceConfigs
+// 列出所有资源配置模板
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListResourceConfigs(request *ListResourceConfigsRequest) (response *ListResourceConfigsResponse, err error) {
+    return c.ListResourceConfigsWithContext(context.Background(), request)
+}
+
+// ListResourceConfigs
+// 列出所有资源配置模板
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListResourceConfigsWithContext(ctx context.Context, request *ListResourceConfigsRequest) (response *ListResourceConfigsResponse, err error) {
+    if request == nil {
+        request = NewListResourceConfigsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListResourceConfigs")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListResourceConfigs require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListResourceConfigsResponse()
     err = c.Send(request, response)
     return
 }
@@ -10105,6 +14541,56 @@ func (c *Client) ModifyAdvancedStoreLocationWithContext(ctx context.Context, req
     return
 }
 
+func NewModifyClusterPriorityRequest() (request *ModifyClusterPriorityRequest) {
+    request = &ModifyClusterPriorityRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ModifyClusterPriority")
+    
+    
+    return
+}
+
+func NewModifyClusterPriorityResponse() (response *ModifyClusterPriorityResponse) {
+    response = &ModifyClusterPriorityResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyClusterPriority
+// 修改集群的调度优先级（1-9，数字越大优先级越高）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ModifyClusterPriority(request *ModifyClusterPriorityRequest) (response *ModifyClusterPriorityResponse, err error) {
+    return c.ModifyClusterPriorityWithContext(context.Background(), request)
+}
+
+// ModifyClusterPriority
+// 修改集群的调度优先级（1-9，数字越大优先级越高）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ModifyClusterPriorityWithContext(ctx context.Context, request *ModifyClusterPriorityRequest) (response *ModifyClusterPriorityResponse, err error) {
+    if request == nil {
+        request = NewModifyClusterPriorityRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ModifyClusterPriority")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyClusterPriority require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyClusterPriorityResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyDataEngineDescriptionRequest() (request *ModifyDataEngineDescriptionRequest) {
     request = &ModifyDataEngineDescriptionRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -10229,6 +14715,164 @@ func (c *Client) ModifyGovernEventRuleWithContext(ctx context.Context, request *
     request.SetContext(ctx)
     
     response = NewModifyGovernEventRuleResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyLabPriorityRequest() (request *ModifyLabPriorityRequest) {
+    request = &ModifyLabPriorityRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ModifyLabPriority")
+    
+    
+    return
+}
+
+func NewModifyLabPriorityResponse() (response *ModifyLabPriorityResponse) {
+    response = &ModifyLabPriorityResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyLabPriority
+// 修改实验室的调度优先级（1-9，数字越大优先级越高）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ModifyLabPriority(request *ModifyLabPriorityRequest) (response *ModifyLabPriorityResponse, err error) {
+    return c.ModifyLabPriorityWithContext(context.Background(), request)
+}
+
+// ModifyLabPriority
+// 修改实验室的调度优先级（1-9，数字越大优先级越高）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ModifyLabPriorityWithContext(ctx context.Context, request *ModifyLabPriorityRequest) (response *ModifyLabPriorityResponse, err error) {
+    if request == nil {
+        request = NewModifyLabPriorityRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ModifyLabPriority")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyLabPriority require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyLabPriorityResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyPartitionDescriptionRequest() (request *ModifyPartitionDescriptionRequest) {
+    request = &ModifyPartitionDescriptionRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ModifyPartitionDescription")
+    
+    
+    return
+}
+
+func NewModifyPartitionDescriptionResponse() (response *ModifyPartitionDescriptionResponse) {
+    response = &ModifyPartitionDescriptionResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyPartitionDescription
+// 修改分区描述
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ModifyPartitionDescription(request *ModifyPartitionDescriptionRequest) (response *ModifyPartitionDescriptionResponse, err error) {
+    return c.ModifyPartitionDescriptionWithContext(context.Background(), request)
+}
+
+// ModifyPartitionDescription
+// 修改分区描述
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ModifyPartitionDescriptionWithContext(ctx context.Context, request *ModifyPartitionDescriptionRequest) (response *ModifyPartitionDescriptionResponse, err error) {
+    if request == nil {
+        request = NewModifyPartitionDescriptionRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ModifyPartitionDescription")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyPartitionDescription require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyPartitionDescriptionResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyPartitionQueueRequest() (request *ModifyPartitionQueueRequest) {
+    request = &ModifyPartitionQueueRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ModifyPartitionQueue")
+    
+    
+    return
+}
+
+func NewModifyPartitionQueueResponse() (response *ModifyPartitionQueueResponse) {
+    response = &ModifyPartitionQueueResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyPartitionQueue
+// 编辑资源队列：根据队列ID修改指定资源队列的名称、描述、资源规格列表和队列类型等信息。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_QUEUEIDMISMATCH = "InvalidParameterValue.QueueIdMismatch"
+//  INVALIDPARAMETERVALUE_QUOTAEXCEEDED = "InvalidParameterValue.QuotaExceeded"
+//  OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+//  RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+//  RESOURCENOTFOUND_PARTITIONQUEUE = "ResourceNotFound.PartitionQueue"
+func (c *Client) ModifyPartitionQueue(request *ModifyPartitionQueueRequest) (response *ModifyPartitionQueueResponse, err error) {
+    return c.ModifyPartitionQueueWithContext(context.Background(), request)
+}
+
+// ModifyPartitionQueue
+// 编辑资源队列：根据队列ID修改指定资源队列的名称、描述、资源规格列表和队列类型等信息。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_QUEUEIDMISMATCH = "InvalidParameterValue.QueueIdMismatch"
+//  INVALIDPARAMETERVALUE_QUOTAEXCEEDED = "InvalidParameterValue.QuotaExceeded"
+//  OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+//  RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+//  RESOURCENOTFOUND_PARTITIONQUEUE = "ResourceNotFound.PartitionQueue"
+func (c *Client) ModifyPartitionQueueWithContext(ctx context.Context, request *ModifyPartitionQueueRequest) (response *ModifyPartitionQueueResponse, err error) {
+    if request == nil {
+        request = NewModifyPartitionQueueRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ModifyPartitionQueue")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyPartitionQueue require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyPartitionQueueResponse()
     err = c.Send(request, response)
     return
 }
@@ -10373,6 +15017,80 @@ func (c *Client) ModifySparkAppBatchWithContext(ctx context.Context, request *Mo
     request.SetContext(ctx)
     
     response = NewModifySparkAppBatchResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifySparkAppForTDLCRequest() (request *ModifySparkAppForTDLCRequest) {
+    request = &ModifySparkAppForTDLCRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ModifySparkAppForTDLC")
+    
+    
+    return
+}
+
+func NewModifySparkAppForTDLCResponse() (response *ModifySparkAppForTDLCResponse) {
+    response = &ModifySparkAppForTDLCResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifySparkAppForTDLC
+// 更新tdlc spark作业
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_INVALIDAPPFILEFORMAT = "InvalidParameter.InvalidAppFileFormat"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDDRIVERSIZE = "InvalidParameter.InvalidDriverSize"
+//  INVALIDPARAMETER_INVALIDEXECUTORSIZE = "InvalidParameter.InvalidExecutorSize"
+//  INVALIDPARAMETER_INVALIDFILECOMPRESSIONFORMAT = "InvalidParameter.InvalidFileCompressionFormat"
+//  INVALIDPARAMETER_INVALIDFILEPATHFORMAT = "InvalidParameter.InvalidFilePathFormat"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_SPARKJOBONLYSUPPORTSPARKBATCHENGINE = "InvalidParameter.SparkJobOnlySupportSparkBatchEngine"
+//  RESOURCEINSUFFICIENT_SPARKJOBINSUFFICIENTRESOURCES = "ResourceInsufficient.SparkJobInsufficientResources"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+func (c *Client) ModifySparkAppForTDLC(request *ModifySparkAppForTDLCRequest) (response *ModifySparkAppForTDLCResponse, err error) {
+    return c.ModifySparkAppForTDLCWithContext(context.Background(), request)
+}
+
+// ModifySparkAppForTDLC
+// 更新tdlc spark作业
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_INVALIDAPPFILEFORMAT = "InvalidParameter.InvalidAppFileFormat"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDDRIVERSIZE = "InvalidParameter.InvalidDriverSize"
+//  INVALIDPARAMETER_INVALIDEXECUTORSIZE = "InvalidParameter.InvalidExecutorSize"
+//  INVALIDPARAMETER_INVALIDFILECOMPRESSIONFORMAT = "InvalidParameter.InvalidFileCompressionFormat"
+//  INVALIDPARAMETER_INVALIDFILEPATHFORMAT = "InvalidParameter.InvalidFilePathFormat"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_SPARKJOBONLYSUPPORTSPARKBATCHENGINE = "InvalidParameter.SparkJobOnlySupportSparkBatchEngine"
+//  RESOURCEINSUFFICIENT_SPARKJOBINSUFFICIENTRESOURCES = "ResourceInsufficient.SparkJobInsufficientResources"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+func (c *Client) ModifySparkAppForTDLCWithContext(ctx context.Context, request *ModifySparkAppForTDLCRequest) (response *ModifySparkAppForTDLCResponse, err error) {
+    if request == nil {
+        request = NewModifySparkAppForTDLCRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ModifySparkAppForTDLC")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifySparkAppForTDLC require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifySparkAppForTDLCResponse()
     err = c.Send(request, response)
     return
 }
@@ -10623,6 +15341,130 @@ func (c *Client) PauseStandardEngineResourceGroupsWithContext(ctx context.Contex
     return
 }
 
+func NewQueryDashboardOverviewRequest() (request *QueryDashboardOverviewRequest) {
+    request = &QueryDashboardOverviewRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "QueryDashboardOverview")
+    
+    
+    return
+}
+
+func NewQueryDashboardOverviewResponse() (response *QueryDashboardOverviewResponse) {
+    response = &QueryDashboardOverviewResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// QueryDashboardOverview
+// 返回指定时间范围内所有推理服务的聚合 KPI 值。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
+//  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
+func (c *Client) QueryDashboardOverview(request *QueryDashboardOverviewRequest) (response *QueryDashboardOverviewResponse, err error) {
+    return c.QueryDashboardOverviewWithContext(context.Background(), request)
+}
+
+// QueryDashboardOverview
+// 返回指定时间范围内所有推理服务的聚合 KPI 值。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
+//  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
+func (c *Client) QueryDashboardOverviewWithContext(ctx context.Context, request *QueryDashboardOverviewRequest) (response *QueryDashboardOverviewResponse, err error) {
+    if request == nil {
+        request = NewQueryDashboardOverviewRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "QueryDashboardOverview")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("QueryDashboardOverview require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewQueryDashboardOverviewResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewQueryDashboardServiceListRequest() (request *QueryDashboardServiceListRequest) {
+    request = &QueryDashboardServiceListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "QueryDashboardServiceList")
+    
+    
+    return
+}
+
+func NewQueryDashboardServiceListResponse() (response *QueryDashboardServiceListResponse) {
+    response = &QueryDashboardServiceListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// QueryDashboardServiceList
+// 查询监控大盘服务列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
+//  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
+func (c *Client) QueryDashboardServiceList(request *QueryDashboardServiceListRequest) (response *QueryDashboardServiceListResponse, err error) {
+    return c.QueryDashboardServiceListWithContext(context.Background(), request)
+}
+
+// QueryDashboardServiceList
+// 查询监控大盘服务列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_DBERROR = "InternalError.DBError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
+//  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
+func (c *Client) QueryDashboardServiceListWithContext(ctx context.Context, request *QueryDashboardServiceListRequest) (response *QueryDashboardServiceListResponse, err error) {
+    if request == nil {
+        request = NewQueryDashboardServiceListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "QueryDashboardServiceList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("QueryDashboardServiceList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewQueryDashboardServiceListResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewQueryInternalTableWarehouseRequest() (request *QueryInternalTableWarehouseRequest) {
     request = &QueryInternalTableWarehouseRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -10677,6 +15519,64 @@ func (c *Client) QueryInternalTableWarehouseWithContext(ctx context.Context, req
     request.SetContext(ctx)
     
     response = NewQueryInternalTableWarehouseResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewQueryMonitorOverviewRequest() (request *QueryMonitorOverviewRequest) {
+    request = &QueryMonitorOverviewRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "QueryMonitorOverview")
+    
+    
+    return
+}
+
+func NewQueryMonitorOverviewResponse() (response *QueryMonitorOverviewResponse) {
+    response = &QueryMonitorOverviewResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// QueryMonitorOverview
+// 查询监控概览数据（瞬时值）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) QueryMonitorOverview(request *QueryMonitorOverviewRequest) (response *QueryMonitorOverviewResponse, err error) {
+    return c.QueryMonitorOverviewWithContext(context.Background(), request)
+}
+
+// QueryMonitorOverview
+// 查询监控概览数据（瞬时值）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) QueryMonitorOverviewWithContext(ctx context.Context, request *QueryMonitorOverviewRequest) (response *QueryMonitorOverviewResponse, err error) {
+    if request == nil {
+        request = NewQueryMonitorOverviewRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "QueryMonitorOverview")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("QueryMonitorOverview require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewQueryMonitorOverviewResponse()
     err = c.Send(request, response)
     return
 }
@@ -11037,6 +15937,56 @@ func (c *Client) RestartDataEngineWithContext(ctx context.Context, request *Rest
     return
 }
 
+func NewRestartInferenceServiceRequest() (request *RestartInferenceServiceRequest) {
+    request = &RestartInferenceServiceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "RestartInferenceService")
+    
+    
+    return
+}
+
+func NewRestartInferenceServiceResponse() (response *RestartInferenceServiceResponse) {
+    response = &RestartInferenceServiceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// RestartInferenceService
+// 重启推理服务（操作所有部署）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) RestartInferenceService(request *RestartInferenceServiceRequest) (response *RestartInferenceServiceResponse, err error) {
+    return c.RestartInferenceServiceWithContext(context.Background(), request)
+}
+
+// RestartInferenceService
+// 重启推理服务（操作所有部署）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) RestartInferenceServiceWithContext(ctx context.Context, request *RestartInferenceServiceRequest) (response *RestartInferenceServiceResponse, err error) {
+    if request == nil {
+        request = NewRestartInferenceServiceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "RestartInferenceService")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("RestartInferenceService require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewRestartInferenceServiceResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewRevokeDLCCatalogAccessRequest() (request *RevokeDLCCatalogAccessRequest) {
     request = &RevokeDLCCatalogAccessRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -11060,14 +16010,7 @@ func NewRevokeDLCCatalogAccessResponse() (response *RevokeDLCCatalogAccessRespon
 // 撤销DLC Catalog访问权限
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_NOPERMISSIONTOUSETHEDATAENGINE = "FailedOperation.NoPermissionToUseTheDataEngine"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
-//  RESOURCENOTFOUND_DATAENGINENOTACTIVITY = "ResourceNotFound.DataEngineNotActivity"
-//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
-//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
-//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) RevokeDLCCatalogAccess(request *RevokeDLCCatalogAccessRequest) (response *RevokeDLCCatalogAccessResponse, err error) {
     return c.RevokeDLCCatalogAccessWithContext(context.Background(), request)
 }
@@ -11076,14 +16019,7 @@ func (c *Client) RevokeDLCCatalogAccess(request *RevokeDLCCatalogAccessRequest) 
 // 撤销DLC Catalog访问权限
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_NOPERMISSIONTOUSETHEDATAENGINE = "FailedOperation.NoPermissionToUseTheDataEngine"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
-//  RESOURCENOTFOUND_DATAENGINENOTACTIVITY = "ResourceNotFound.DataEngineNotActivity"
-//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
-//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
-//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) RevokeDLCCatalogAccessWithContext(ctx context.Context, request *RevokeDLCCatalogAccessRequest) (response *RevokeDLCCatalogAccessResponse, err error) {
     if request == nil {
         request = NewRevokeDLCCatalogAccessRequest()
@@ -11203,6 +16139,56 @@ func (c *Client) RollbackDataEngineImageWithContext(ctx context.Context, request
     return
 }
 
+func NewRunJobSpecRequest() (request *RunJobSpecRequest) {
+    request = &RunJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "RunJobSpec")
+    
+    
+    return
+}
+
+func NewRunJobSpecResponse() (response *RunJobSpecResponse) {
+    response = &RunJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// RunJobSpec
+// 基于指定作业配置提交一次作业实例
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) RunJobSpec(request *RunJobSpecRequest) (response *RunJobSpecResponse, err error) {
+    return c.RunJobSpecWithContext(context.Background(), request)
+}
+
+// RunJobSpec
+// 基于指定作业配置提交一次作业实例
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) RunJobSpecWithContext(ctx context.Context, request *RunJobSpecRequest) (response *RunJobSpecResponse, err error) {
+    if request == nil {
+        request = NewRunJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "RunJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("RunJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewRunJobSpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewSetOptimizerPolicyRequest() (request *SetOptimizerPolicyRequest) {
     request = &SetOptimizerPolicyRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -11226,33 +16212,7 @@ func NewSetOptimizerPolicyResponse() (response *SetOptimizerPolicyResponse) {
 // 设置优化策略的接口
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_NOPERMISSIONTOUSETHEDATAENGINE = "FailedOperation.NoPermissionToUseTheDataEngine"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
-//  INVALIDPARAMETER_DATAENGINEEXECTYPENOTMATCH = "InvalidParameter.DataEngineExecTypeNotMatch"
-//  INVALIDPARAMETER_DATAENGINEIMAGEOPERATENOTMATCH = "InvalidParameter.DataEngineImageOperateNotMatch"
-//  INVALIDPARAMETER_DATAENGINEPAYMODETYPENOTMATCH = "InvalidParameter.DataEnginePayModeTypeNotMatch"
-//  INVALIDPARAMETER_DATAENGINETYPENOTMATCH = "InvalidParameter.DataEngineTypeNotMatch"
-//  INVALIDPARAMETER_IMAGECLUSTERPARAMETERSFORMATNOTJSON = "InvalidParameter.ImageClusterParametersFormatNotJson"
-//  INVALIDPARAMETER_IMAGEENGINETYPENOTMATCH = "InvalidParameter.ImageEngineTypeNotMatch"
-//  INVALIDPARAMETER_IMAGEISPUBLICNOTMATCH = "InvalidParameter.ImageIsPublicNotMatch"
-//  INVALIDPARAMETER_IMAGEPARAMETERNOTFOUND = "InvalidParameter.ImageParameterNotFound"
-//  INVALIDPARAMETER_IMAGESESSIONPARAMETERSFORMATNOTJSON = "InvalidParameter.ImageSessionParametersFormatNotJson"
-//  INVALIDPARAMETER_IMAGESTATENOTMATCH = "InvalidParameter.ImageStateNotMatch"
-//  INVALIDPARAMETER_IMAGEUSERRECORDSTYPENOTMATCH = "InvalidParameter.ImageUserRecordsTypeNotMatch"
-//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
-//  RESOURCENOTFOUND_DATAENGINECONFIGINSTANCENOTFOUND = "ResourceNotFound.DataEngineConfigInstanceNotFound"
-//  RESOURCENOTFOUND_DATAENGINECONFIGINSTANCENOTUNIQUE = "ResourceNotFound.DataEngineConfigInstanceNotUnique"
-//  RESOURCENOTFOUND_DATAENGINENOTACTIVITY = "ResourceNotFound.DataEngineNotActivity"
-//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
-//  RESOURCENOTFOUND_DATAENGINENOTMULTIVERSION = "ResourceNotFound.DataEngineNotMultiVersion"
-//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
-//  RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTFOUND = "ResourceNotFound.ImageSessionConfigNotFound"
-//  RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTUNIQUE = "ResourceNotFound.ImageSessionConfigNotUnique"
-//  RESOURCENOTFOUND_IMAGEVERSIONNOTACTIVITY = "ResourceNotFound.ImageVersionNotActivity"
-//  RESOURCENOTFOUND_IMAGEVERSIONNOTUNIQUE = "ResourceNotFound.ImageVersionNotUnique"
-//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) SetOptimizerPolicy(request *SetOptimizerPolicyRequest) (response *SetOptimizerPolicyResponse, err error) {
     return c.SetOptimizerPolicyWithContext(context.Background(), request)
 }
@@ -11261,33 +16221,7 @@ func (c *Client) SetOptimizerPolicy(request *SetOptimizerPolicyRequest) (respons
 // 设置优化策略的接口
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  FAILEDOPERATION_NOPERMISSIONTOUSETHEDATAENGINE = "FailedOperation.NoPermissionToUseTheDataEngine"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
-//  INVALIDPARAMETER_DATAENGINEEXECTYPENOTMATCH = "InvalidParameter.DataEngineExecTypeNotMatch"
-//  INVALIDPARAMETER_DATAENGINEIMAGEOPERATENOTMATCH = "InvalidParameter.DataEngineImageOperateNotMatch"
-//  INVALIDPARAMETER_DATAENGINEPAYMODETYPENOTMATCH = "InvalidParameter.DataEnginePayModeTypeNotMatch"
-//  INVALIDPARAMETER_DATAENGINETYPENOTMATCH = "InvalidParameter.DataEngineTypeNotMatch"
-//  INVALIDPARAMETER_IMAGECLUSTERPARAMETERSFORMATNOTJSON = "InvalidParameter.ImageClusterParametersFormatNotJson"
-//  INVALIDPARAMETER_IMAGEENGINETYPENOTMATCH = "InvalidParameter.ImageEngineTypeNotMatch"
-//  INVALIDPARAMETER_IMAGEISPUBLICNOTMATCH = "InvalidParameter.ImageIsPublicNotMatch"
-//  INVALIDPARAMETER_IMAGEPARAMETERNOTFOUND = "InvalidParameter.ImageParameterNotFound"
-//  INVALIDPARAMETER_IMAGESESSIONPARAMETERSFORMATNOTJSON = "InvalidParameter.ImageSessionParametersFormatNotJson"
-//  INVALIDPARAMETER_IMAGESTATENOTMATCH = "InvalidParameter.ImageStateNotMatch"
-//  INVALIDPARAMETER_IMAGEUSERRECORDSTYPENOTMATCH = "InvalidParameter.ImageUserRecordsTypeNotMatch"
-//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
-//  RESOURCENOTFOUND_DATAENGINECONFIGINSTANCENOTFOUND = "ResourceNotFound.DataEngineConfigInstanceNotFound"
-//  RESOURCENOTFOUND_DATAENGINECONFIGINSTANCENOTUNIQUE = "ResourceNotFound.DataEngineConfigInstanceNotUnique"
-//  RESOURCENOTFOUND_DATAENGINENOTACTIVITY = "ResourceNotFound.DataEngineNotActivity"
-//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
-//  RESOURCENOTFOUND_DATAENGINENOTMULTIVERSION = "ResourceNotFound.DataEngineNotMultiVersion"
-//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
-//  RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTFOUND = "ResourceNotFound.ImageSessionConfigNotFound"
-//  RESOURCENOTFOUND_IMAGESESSIONCONFIGNOTUNIQUE = "ResourceNotFound.ImageSessionConfigNotUnique"
-//  RESOURCENOTFOUND_IMAGEVERSIONNOTACTIVITY = "ResourceNotFound.ImageVersionNotActivity"
-//  RESOURCENOTFOUND_IMAGEVERSIONNOTUNIQUE = "ResourceNotFound.ImageVersionNotUnique"
-//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) SetOptimizerPolicyWithContext(ctx context.Context, request *SetOptimizerPolicyRequest) (response *SetOptimizerPolicyResponse, err error) {
     if request == nil {
         request = NewSetOptimizerPolicyRequest()
@@ -11301,6 +16235,260 @@ func (c *Client) SetOptimizerPolicyWithContext(ctx context.Context, request *Set
     request.SetContext(ctx)
     
     response = NewSetOptimizerPolicyResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewStartLabRequest() (request *StartLabRequest) {
+    request = &StartLabRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StartLab")
+    
+    
+    return
+}
+
+func NewStartLabResponse() (response *StartLabResponse) {
+    response = &StartLabResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StartLab
+// 启动实验室
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) StartLab(request *StartLabRequest) (response *StartLabResponse, err error) {
+    return c.StartLabWithContext(context.Background(), request)
+}
+
+// StartLab
+// 启动实验室
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) StartLabWithContext(ctx context.Context, request *StartLabRequest) (response *StartLabResponse, err error) {
+    if request == nil {
+        request = NewStartLabRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StartLab")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StartLab require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStartLabResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewStartRayClusterRequest() (request *StartRayClusterRequest) {
+    request = &StartRayClusterRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StartRayCluster")
+    
+    
+    return
+}
+
+func NewStartRayClusterResponse() (response *StartRayClusterResponse) {
+    response = &StartRayClusterResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StartRayCluster
+// 启动集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) StartRayCluster(request *StartRayClusterRequest) (response *StartRayClusterResponse, err error) {
+    return c.StartRayClusterWithContext(context.Background(), request)
+}
+
+// StartRayCluster
+// 启动集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) StartRayClusterWithContext(ctx context.Context, request *StartRayClusterRequest) (response *StartRayClusterResponse, err error) {
+    if request == nil {
+        request = NewStartRayClusterRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StartRayCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StartRayCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStartRayClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewStopInferenceServiceRequest() (request *StopInferenceServiceRequest) {
+    request = &StopInferenceServiceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StopInferenceService")
+    
+    
+    return
+}
+
+func NewStopInferenceServiceResponse() (response *StopInferenceServiceResponse) {
+    response = &StopInferenceServiceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StopInferenceService
+// 停止推理服务（操作所有部署）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) StopInferenceService(request *StopInferenceServiceRequest) (response *StopInferenceServiceResponse, err error) {
+    return c.StopInferenceServiceWithContext(context.Background(), request)
+}
+
+// StopInferenceService
+// 停止推理服务（操作所有部署）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) StopInferenceServiceWithContext(ctx context.Context, request *StopInferenceServiceRequest) (response *StopInferenceServiceResponse, err error) {
+    if request == nil {
+        request = NewStopInferenceServiceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StopInferenceService")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StopInferenceService require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStopInferenceServiceResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewStopLabRequest() (request *StopLabRequest) {
+    request = &StopLabRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StopLab")
+    
+    
+    return
+}
+
+func NewStopLabResponse() (response *StopLabResponse) {
+    response = &StopLabResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StopLab
+// 停止实验室
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) StopLab(request *StopLabRequest) (response *StopLabResponse, err error) {
+    return c.StopLabWithContext(context.Background(), request)
+}
+
+// StopLab
+// 停止实验室
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) StopLabWithContext(ctx context.Context, request *StopLabRequest) (response *StopLabResponse, err error) {
+    if request == nil {
+        request = NewStopLabRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StopLab")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StopLab require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStopLabResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewStopRayClusterRequest() (request *StopRayClusterRequest) {
+    request = &StopRayClusterRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StopRayCluster")
+    
+    
+    return
+}
+
+func NewStopRayClusterResponse() (response *StopRayClusterResponse) {
+    response = &StopRayClusterResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StopRayCluster
+// 停止集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) StopRayCluster(request *StopRayClusterRequest) (response *StopRayClusterResponse, err error) {
+    return c.StopRayClusterWithContext(context.Background(), request)
+}
+
+// StopRayCluster
+// 停止集群
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) StopRayClusterWithContext(ctx context.Context, request *StopRayClusterRequest) (response *StopRayClusterResponse, err error) {
+    if request == nil {
+        request = NewStopRayClusterRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StopRayCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StopRayCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStopRayClusterResponse()
     err = c.Send(request, response)
     return
 }
@@ -11677,6 +16865,56 @@ func (c *Client) UnlockMetaDataWithContext(ctx context.Context, request *UnlockM
     return
 }
 
+func NewUpdateClusterGroupRequest() (request *UpdateClusterGroupRequest) {
+    request = &UpdateClusterGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateClusterGroup")
+    
+    
+    return
+}
+
+func NewUpdateClusterGroupResponse() (response *UpdateClusterGroupResponse) {
+    response = &UpdateClusterGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateClusterGroup
+// 更新集群组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) UpdateClusterGroup(request *UpdateClusterGroupRequest) (response *UpdateClusterGroupResponse, err error) {
+    return c.UpdateClusterGroupWithContext(context.Background(), request)
+}
+
+// UpdateClusterGroup
+// 更新集群组
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) UpdateClusterGroupWithContext(ctx context.Context, request *UpdateClusterGroupRequest) (response *UpdateClusterGroupResponse, err error) {
+    if request == nil {
+        request = NewUpdateClusterGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateClusterGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateClusterGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateClusterGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewUpdateDataEngineRequest() (request *UpdateDataEngineRequest) {
     request = &UpdateDataEngineRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -11971,6 +17209,212 @@ func (c *Client) UpdateEngineResourceGroupNetworkConfigInfoWithContext(ctx conte
     return
 }
 
+func NewUpdateInferenceModelRequest() (request *UpdateInferenceModelRequest) {
+    request = &UpdateInferenceModelRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateInferenceModel")
+    
+    
+    return
+}
+
+func NewUpdateInferenceModelResponse() (response *UpdateInferenceModelResponse) {
+    response = &UpdateInferenceModelResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateInferenceModel
+// 更新推理模型（编辑标签、描述、参数量）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateInferenceModel(request *UpdateInferenceModelRequest) (response *UpdateInferenceModelResponse, err error) {
+    return c.UpdateInferenceModelWithContext(context.Background(), request)
+}
+
+// UpdateInferenceModel
+// 更新推理模型（编辑标签、描述、参数量）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateInferenceModelWithContext(ctx context.Context, request *UpdateInferenceModelRequest) (response *UpdateInferenceModelResponse, err error) {
+    if request == nil {
+        request = NewUpdateInferenceModelRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateInferenceModel")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateInferenceModel require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateInferenceModelResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateJobSpecRequest() (request *UpdateJobSpecRequest) {
+    request = &UpdateJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateJobSpec")
+    
+    
+    return
+}
+
+func NewUpdateJobSpecResponse() (response *UpdateJobSpecResponse) {
+    response = &UpdateJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateJobSpec
+// 更新已有作业配置的字段
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER_RESOURCESPECNOTFOUND = "InvalidParameter.ResourceSpecNotFound"
+func (c *Client) UpdateJobSpec(request *UpdateJobSpecRequest) (response *UpdateJobSpecResponse, err error) {
+    return c.UpdateJobSpecWithContext(context.Background(), request)
+}
+
+// UpdateJobSpec
+// 更新已有作业配置的字段
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER_RESOURCESPECNOTFOUND = "InvalidParameter.ResourceSpecNotFound"
+func (c *Client) UpdateJobSpecWithContext(ctx context.Context, request *UpdateJobSpecRequest) (response *UpdateJobSpecResponse, err error) {
+    if request == nil {
+        request = NewUpdateJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateJobSpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateJobSpecPriorityRequest() (request *UpdateJobSpecPriorityRequest) {
+    request = &UpdateJobSpecPriorityRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateJobSpecPriority")
+    
+    
+    return
+}
+
+func NewUpdateJobSpecPriorityResponse() (response *UpdateJobSpecPriorityResponse) {
+    response = &UpdateJobSpecPriorityResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateJobSpecPriority
+// 修改作业配置的调度优先级（1-9，数字越大优先级越高）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateJobSpecPriority(request *UpdateJobSpecPriorityRequest) (response *UpdateJobSpecPriorityResponse, err error) {
+    return c.UpdateJobSpecPriorityWithContext(context.Background(), request)
+}
+
+// UpdateJobSpecPriority
+// 修改作业配置的调度优先级（1-9，数字越大优先级越高）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateJobSpecPriorityWithContext(ctx context.Context, request *UpdateJobSpecPriorityRequest) (response *UpdateJobSpecPriorityResponse, err error) {
+    if request == nil {
+        request = NewUpdateJobSpecPriorityRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateJobSpecPriority")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateJobSpecPriority require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateJobSpecPriorityResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateLabRequest() (request *UpdateLabRequest) {
+    request = &UpdateLabRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateLab")
+    
+    
+    return
+}
+
+func NewUpdateLabResponse() (response *UpdateLabResponse) {
+    response = &UpdateLabResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateLab
+// 更新实验室配置：仅在 CREATED / STOPPED / FAILED 终态可用；变更落 MySQL，下次 Start 按新 spec 创建 K8s 资源
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABNOTUPDATABLE = "FailedOperation.LabNotUpdatable"
+func (c *Client) UpdateLab(request *UpdateLabRequest) (response *UpdateLabResponse, err error) {
+    return c.UpdateLabWithContext(context.Background(), request)
+}
+
+// UpdateLab
+// 更新实验室配置：仅在 CREATED / STOPPED / FAILED 终态可用；变更落 MySQL，下次 Start 按新 spec 创建 K8s 资源
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABNOTUPDATABLE = "FailedOperation.LabNotUpdatable"
+func (c *Client) UpdateLabWithContext(ctx context.Context, request *UpdateLabRequest) (response *UpdateLabResponse, err error) {
+    if request == nil {
+        request = NewUpdateLabRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateLab")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateLab require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateLabResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewUpdateNetworkConnectionRequest() (request *UpdateNetworkConnectionRequest) {
     request = &UpdateNetworkConnectionRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -11994,13 +17438,9 @@ func NewUpdateNetworkConnectionResponse() (response *UpdateNetworkConnectionResp
 // 更新网络配置
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_DBERROR = "InternalError.DBError"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
-//  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
-//  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABNOTUPDATABLE = "FailedOperation.LabNotUpdatable"
 func (c *Client) UpdateNetworkConnection(request *UpdateNetworkConnectionRequest) (response *UpdateNetworkConnectionResponse, err error) {
     return c.UpdateNetworkConnectionWithContext(context.Background(), request)
 }
@@ -12009,13 +17449,9 @@ func (c *Client) UpdateNetworkConnection(request *UpdateNetworkConnectionRequest
 // 更新网络配置
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_DBERROR = "InternalError.DBError"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
-//  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
-//  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+//  FAILEDOPERATION_LABNOTUPDATABLE = "FailedOperation.LabNotUpdatable"
 func (c *Client) UpdateNetworkConnectionWithContext(ctx context.Context, request *UpdateNetworkConnectionRequest) (response *UpdateNetworkConnectionResponse, err error) {
     if request == nil {
         request = NewUpdateNetworkConnectionRequest()
@@ -12029,6 +17465,156 @@ func (c *Client) UpdateNetworkConnectionWithContext(ctx context.Context, request
     request.SetContext(ctx)
     
     response = NewUpdateNetworkConnectionResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateRayClusterRequest() (request *UpdateRayClusterRequest) {
+    request = &UpdateRayClusterRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateRayCluster")
+    
+    
+    return
+}
+
+func NewUpdateRayClusterResponse() (response *UpdateRayClusterResponse) {
+    response = &UpdateRayClusterResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateRayCluster
+// 更新集群配置：仅在 CREATED / STOPPED / FAILED 终态可用；变更落 MySQL，下次 Start 按新 spec 创建 K8s 资源
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateRayCluster(request *UpdateRayClusterRequest) (response *UpdateRayClusterResponse, err error) {
+    return c.UpdateRayClusterWithContext(context.Background(), request)
+}
+
+// UpdateRayCluster
+// 更新集群配置：仅在 CREATED / STOPPED / FAILED 终态可用；变更落 MySQL，下次 Start 按新 spec 创建 K8s 资源
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateRayClusterWithContext(ctx context.Context, request *UpdateRayClusterRequest) (response *UpdateRayClusterResponse, err error) {
+    if request == nil {
+        request = NewUpdateRayClusterRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateRayCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateRayCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateRayClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateRayJobPriorityRequest() (request *UpdateRayJobPriorityRequest) {
+    request = &UpdateRayJobPriorityRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateRayJobPriority")
+    
+    
+    return
+}
+
+func NewUpdateRayJobPriorityResponse() (response *UpdateRayJobPriorityResponse) {
+    response = &UpdateRayJobPriorityResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateRayJobPriority
+// 更新处于 SUBMITTED/PENDING 状态的作业的优先级。仅 SUBMITTED/PENDING 状态的作业允许调整优先级。内部通过调用 Neutrino 的 UpdateJobConfig 接口更新 ENVIRONMENT 配置中的 priority 字段。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateRayJobPriority(request *UpdateRayJobPriorityRequest) (response *UpdateRayJobPriorityResponse, err error) {
+    return c.UpdateRayJobPriorityWithContext(context.Background(), request)
+}
+
+// UpdateRayJobPriority
+// 更新处于 SUBMITTED/PENDING 状态的作业的优先级。仅 SUBMITTED/PENDING 状态的作业允许调整优先级。内部通过调用 Neutrino 的 UpdateJobConfig 接口更新 ENVIRONMENT 配置中的 priority 字段。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateRayJobPriorityWithContext(ctx context.Context, request *UpdateRayJobPriorityRequest) (response *UpdateRayJobPriorityResponse, err error) {
+    if request == nil {
+        request = NewUpdateRayJobPriorityRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateRayJobPriority")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateRayJobPriority require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateRayJobPriorityResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateResourceConfigRequest() (request *UpdateResourceConfigRequest) {
+    request = &UpdateResourceConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateResourceConfig")
+    
+    
+    return
+}
+
+func NewUpdateResourceConfigResponse() (response *UpdateResourceConfigResponse) {
+    response = &UpdateResourceConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateResourceConfig
+// 更新资源配置模板
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateResourceConfig(request *UpdateResourceConfigRequest) (response *UpdateResourceConfigResponse, err error) {
+    return c.UpdateResourceConfigWithContext(context.Background(), request)
+}
+
+// UpdateResourceConfig
+// 更新资源配置模板
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateResourceConfigWithContext(ctx context.Context, request *UpdateResourceConfigRequest) (response *UpdateResourceConfigResponse, err error) {
+    if request == nil {
+        request = NewUpdateResourceConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateResourceConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateResourceConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateResourceConfigResponse()
     err = c.Send(request, response)
     return
 }
@@ -12056,13 +17642,7 @@ func NewUpdateRowFilterResponse() (response *UpdateRowFilterResponse) {
 // 此接口用于更新行过滤规则。注意只能更新过滤规则，不能更新规格对象catalog，database和table。
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_DBERROR = "InternalError.DBError"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
-//  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
-//  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) UpdateRowFilter(request *UpdateRowFilterRequest) (response *UpdateRowFilterResponse, err error) {
     return c.UpdateRowFilterWithContext(context.Background(), request)
 }
@@ -12071,13 +17651,7 @@ func (c *Client) UpdateRowFilter(request *UpdateRowFilterRequest) (response *Upd
 // 此接口用于更新行过滤规则。注意只能更新过滤规则，不能更新规格对象catalog，database和table。
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_DBERROR = "InternalError.DBError"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
-//  RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
-//  RESOURCEUNAVAILABLE_RESOURCEUNAVAILABLECODE_GATEWAYNOTRUNNING = "ResourceUnavailable.ResourceUnavailableCode_GatewayNotRunning"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) UpdateRowFilterWithContext(ctx context.Context, request *UpdateRowFilterRequest) (response *UpdateRowFilterResponse, err error) {
     if request == nil {
         request = NewUpdateRowFilterRequest()

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/errors.go
@@ -44,6 +44,9 @@ const (
 	// 绑定的标签数量超出限制。
 	FAILEDOPERATION_BINDTOOMANYTAGS = "FailedOperation.BindTooManyTags"
 
+	// 集群组不存在
+	FAILEDOPERATION_CLUSTERGROUPNOTFOUND = "FailedOperation.ClusterGroupNotFound"
+
 	// 创建引擎失败。
 	FAILEDOPERATION_CREATEDATAENGINEFAILED = "FailedOperation.CreateDataEngineFailed"
 
@@ -55,6 +58,15 @@ const (
 
 	// 重复的标签键。
 	FAILEDOPERATION_DUPLICATETAGKEY = "FailedOperation.DuplicateTagKey"
+
+	// 案例服务请求失败
+	FAILEDOPERATION_EXAMPLE = "FailedOperation.Example"
+
+	// 案例不存在
+	FAILEDOPERATION_EXAMPLENOTFOUND = "FailedOperation.ExampleNotFound"
+
+	// 外部服务异常
+	FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 
 	// 扣费失败。
 	FAILEDOPERATION_FEEDEDUCTIONFAILED = "FailedOperation.FeeDeductionFailed"
@@ -95,6 +107,21 @@ const (
 	// Invalid NetworkConnectionType
 	FAILEDOPERATION_INVALIDNETWORKCONNECTIONTYPE = "FailedOperation.InvalidNetworkConnectionType"
 
+	// 数据实验室正处于过渡状态：数据实验室正在状态转换中（启动中/停止中/删除中），请稍后重试
+	FAILEDOPERATION_LABINTRANSITION = "FailedOperation.LabInTransition"
+
+	// 数据实验室不存在：数据实验室不存在，请检查数据实验室标识
+	FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+
+	// 实验室未运行
+	FAILEDOPERATION_LABNOTRUNNING = "FailedOperation.LabNotRunning"
+
+	// 数据实验室当前状态不允许修改：仅在停止或异常状态下可修改配置，请先停止数据实验室后重试
+	FAILEDOPERATION_LABNOTUPDATABLE = "FailedOperation.LabNotUpdatable"
+
+	// 数据实验室正在运行中：数据实验室正在运行中，请稍后重试
+	FAILEDOPERATION_LABRUNNING = "FailedOperation.LabRunning"
+
 	// 元数据错误，请重试，或者提交工单联系我们
 	FAILEDOPERATION_METASTOREERROR = "FailedOperation.MetastoreError"
 
@@ -119,6 +146,9 @@ const (
 	// 采购数量超过限制。
 	FAILEDOPERATION_NUMBEREXCEEDLIMIT = "FailedOperation.NumberExceedLimit"
 
+	// 其他异常：服务遇到未知问题，请稍后再试。
+	FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+
 	// 参数校验失败。
 	FAILEDOPERATION_PARAMETERVALIDATIONFAILED = "FailedOperation.ParameterValidationFailed"
 
@@ -133,6 +163,9 @@ const (
 
 	// 语法解析失败，请校验后重试
 	FAILEDOPERATION_SQLTASKPARSEFAILED = "FailedOperation.SQLTaskParseFailed"
+
+	// SQL任务结果超出限制
+	FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
 
 	// 资源已经绑定了同名标签键。
 	FAILEDOPERATION_TAGALREADYATTACHED = "FailedOperation.TagAlreadyAttached"
@@ -398,6 +431,9 @@ const (
 	// SQL解析失败。
 	INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
 
+	// 传入的 SQL 配置参数不合法
+	INVALIDPARAMETER_INVALIDSQLCONFIG = "InvalidParameter.InvalidSQLConfig"
+
 	// 参数校验失败，请调整参数，或者提交工单联系我们
 	INVALIDPARAMETER_INVALIDSQLCONFIGSQL = "InvalidParameter.InvalidSQLConfigSQL"
 
@@ -500,6 +536,9 @@ const (
 	// 权限类型冲突。
 	INVALIDPARAMETER_POLICYTYPECONFLICT = "InvalidParameter.PolicyTypeConflict"
 
+	// 参数错误：资源规格组不存在
+	INVALIDPARAMETER_RESOURCESPECNOTFOUND = "InvalidParameter.ResourceSpecNotFound"
+
 	// SQL脚本Base64解析失败
 	INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
 
@@ -563,8 +602,20 @@ const (
 	// Vpc cidr重叠。
 	INVALIDPARAMETER_VPCCIDROVERLAP = "InvalidParameter.VpcCidrOverlap"
 
+	// 无效参数组合
+	INVALIDPARAMETERCOMBINATION = "InvalidParameterCombination"
+
 	// 参数取值错误。
 	INVALIDPARAMETERVALUE = "InvalidParameterValue"
+
+	// 队列 Id 与 PartitionCode/QueueName 不一致
+	INVALIDPARAMETERVALUE_QUEUEIDMISMATCH = "InvalidParameterValue.QueueIdMismatch"
+
+	// 队列名称格式不合法
+	INVALIDPARAMETERVALUE_QUEUENAME = "InvalidParameterValue.QueueName"
+
+	// 申请资源配额超过分区可用额度
+	INVALIDPARAMETERVALUE_QUOTAEXCEEDED = "InvalidParameterValue.QuotaExceeded"
 
 	// 超过配额限制。
 	LIMITEXCEEDED = "LimitExceeded"
@@ -575,11 +626,20 @@ const (
 	// 操作被拒绝。
 	OPERATIONDENIED = "OperationDenied"
 
+	// 默认队列不允许删除
+	OPERATIONDENIED_DEFAULTQUEUEDELETEFORBIDDEN = "OperationDenied.DefaultQueueDeleteForbidden"
+
+	// 资源分区当前状态不允许该操作
+	OPERATIONDENIED_PARTITIONNOTREADY = "OperationDenied.PartitionNotReady"
+
 	// 地域错误
 	REGIONERROR = "RegionError"
 
 	// 资源被占用。
 	RESOURCEINUSE = "ResourceInUse"
+
+	// 同一分区下队列名称已存在
+	RESOURCEINUSE_QUEUENAME = "ResourceInUse.QueueName"
 
 	// 有SQL任务尚未执行完成。
 	RESOURCEINUSE_UNFINISHEDSQLS = "ResourceInUse.UnfinishedSQLs"
@@ -650,6 +710,12 @@ const (
 	// 该网络连接不存在
 	RESOURCENOTFOUND_NETWORKCONNECTIONNOTFOUND = "ResourceNotFound.NetworkConnectionNotFound"
 
+	// 资源包Partition不存在
+	RESOURCENOTFOUND_PARTITION = "ResourceNotFound.Partition"
+
+	// 资源组不存在
+	RESOURCENOTFOUND_PARTITIONQUEUE = "ResourceNotFound.PartitionQueue"
+
 	// 网关不存在
 	RESOURCENOTFOUND_RESOURCENOTFOUNDCODE_GATEWAYNOTFOUND = "ResourceNotFound.ResourceNotFoundCode_GatewayNotFound"
 
@@ -682,6 +748,9 @@ const (
 
 	// 任务资源不足，请调整driver或executor指定规格大小
 	RESOURCENOTFOUND_SPARKJOBINSUFFICIENTRESOURCES = "ResourceNotFound.SparkJobInsufficientResources"
+
+	// 系统文件错误，请重试，或者提交工单联系我们
+	RESOURCENOTFOUND_SYSTEMCONFIGNOTFOUND = "ResourceNotFound.SystemConfigNotFound"
 
 	// 表不存在，请重试，或者提交工单联系我们
 	RESOURCENOTFOUND_TABLENOTFOUND = "ResourceNotFound.TableNotFound"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/models.go
@@ -563,6 +563,60 @@ func (r *AlterDMSTableResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type AlterTableCommentRequestParams struct {
+	// 修改表的基本信息
+	TableBaseInfo *TableBaseInfo `json:"TableBaseInfo,omitnil,omitempty" name:"TableBaseInfo"`
+}
+
+type AlterTableCommentRequest struct {
+	*tchttp.BaseRequest
+	
+	// 修改表的基本信息
+	TableBaseInfo *TableBaseInfo `json:"TableBaseInfo,omitnil,omitempty" name:"TableBaseInfo"`
+}
+
+func (r *AlterTableCommentRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *AlterTableCommentRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TableBaseInfo")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "AlterTableCommentRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type AlterTableCommentResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type AlterTableCommentResponse struct {
+	*tchttp.BaseResponse
+	Response *AlterTableCommentResponseParams `json:"Response"`
+}
+
+func (r *AlterTableCommentResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *AlterTableCommentResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type AnalysisTaskResults struct {
 	// <p>任务Id</p>
 	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
@@ -1280,6 +1334,60 @@ func (r *CancelNotebookSessionStatementResponse) FromJsonString(s string) error 
 }
 
 // Predefined struct for user
+type CancelRayJobRequestParams struct {
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type CancelRayJobRequest struct {
+	*tchttp.BaseRequest
+	
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *CancelRayJobRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CancelRayJobRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CancelRayJobRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CancelRayJobResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CancelRayJobResponse struct {
+	*tchttp.BaseResponse
+	Response *CancelRayJobResponseParams `json:"Response"`
+}
+
+func (r *CancelRayJobResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CancelRayJobResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CancelSparkSessionBatchSQLRequestParams struct {
 	// 批任务唯一标识
 	BatchId *string `json:"BatchId,omitnil,omitempty" name:"BatchId"`
@@ -1733,6 +1841,295 @@ func (r *CheckLockMetaDataResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type CheckModifyPartitionRequestParams struct {
+	// <p>分区编码</p>
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// <p>目标资源配额列表（计费项+目标数量）</p>
+	TargetResourceQuotaList []*ResourceQuota `json:"TargetResourceQuotaList,omitnil,omitempty" name:"TargetResourceQuotaList"`
+}
+
+type CheckModifyPartitionRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>分区编码</p>
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// <p>目标资源配额列表（计费项+目标数量）</p>
+	TargetResourceQuotaList []*ResourceQuota `json:"TargetResourceQuotaList,omitnil,omitempty" name:"TargetResourceQuotaList"`
+}
+
+func (r *CheckModifyPartitionRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckModifyPartitionRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionCode")
+	delete(f, "TargetResourceQuotaList")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CheckModifyPartitionRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckModifyPartitionResponseParams struct {
+	// <p>是否允许变配：true-允许，false-不允许</p>
+	CanModify *bool `json:"CanModify,omitnil,omitempty" name:"CanModify"`
+
+	// <p>校验失败时的不足资源描述信息列表，校验通过时为null</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MessageList []*MessageItem `json:"MessageList,omitnil,omitempty" name:"MessageList"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CheckModifyPartitionResponse struct {
+	*tchttp.BaseResponse
+	Response *CheckModifyPartitionResponseParams `json:"Response"`
+}
+
+func (r *CheckModifyPartitionResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckModifyPartitionResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckQueueNameRequestParams struct {
+	// 队列名称
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// 分区编码，用于校验同分区下队列名称是否重复
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+}
+
+type CheckQueueNameRequest struct {
+	*tchttp.BaseRequest
+	
+	// 队列名称
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// 分区编码，用于校验同分区下队列名称是否重复
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+}
+
+func (r *CheckQueueNameRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckQueueNameRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "QueueName")
+	delete(f, "PartitionCode")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CheckQueueNameRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckQueueNameResponseParams struct {
+	// 校验是否通过：true-通过，false-不通过
+	IsValid *string `json:"IsValid,omitnil,omitempty" name:"IsValid"`
+
+	// 校验失败原因，校验通过时为空
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CheckQueueNameResponse struct {
+	*tchttp.BaseResponse
+	Response *CheckQueueNameResponseParams `json:"Response"`
+}
+
+func (r *CheckQueueNameResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckQueueNameResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckResourceNameRequestParams struct {
+	// 资源名称
+	ResourceName *string `json:"ResourceName,omitnil,omitempty" name:"ResourceName"`
+}
+
+type CheckResourceNameRequest struct {
+	*tchttp.BaseRequest
+	
+	// 资源名称
+	ResourceName *string `json:"ResourceName,omitnil,omitempty" name:"ResourceName"`
+}
+
+func (r *CheckResourceNameRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckResourceNameRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ResourceName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CheckResourceNameRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckResourceNameResponseParams struct {
+	// 校验是否通过
+	IsValid *string `json:"IsValid,omitnil,omitempty" name:"IsValid"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CheckResourceNameResponse struct {
+	*tchttp.BaseResponse
+	Response *CheckResourceNameResponseParams `json:"Response"`
+}
+
+func (r *CheckResourceNameResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckResourceNameResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+type ClusterGroup struct {
+	// 集群组 ID（系统生成）
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 集群组名称
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// 集群组描述
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 配置
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+
+	// 应用 ID（多租户）
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// 创建者主账号 UIN
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// 创建者子账号 UIN
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 创建时间
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 更新时间
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// 是否已软删除
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Deleted *bool `json:"Deleted,omitnil,omitempty" name:"Deleted"`
+
+	// 删除时间（软删时写入，活跃记录为 null）
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeleteTime *uint64 `json:"DeleteTime,omitnil,omitempty" name:"DeleteTime"`
+}
+
+type ClusterPod struct {
+	// <p>Pod名称</p>
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+
+	// <p>Pod IP</p>
+	PodIp *string `json:"PodIp,omitnil,omitempty" name:"PodIp"`
+
+	// <p>Pod状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>Pod阶段</p>
+	Phase *string `json:"Phase,omitnil,omitempty" name:"Phase"`
+
+	// <p>所属节点</p>
+	NodeName *string `json:"NodeName,omitnil,omitempty" name:"NodeName"`
+
+	// <p>节点IP</p>
+	NodeIp *string `json:"NodeIp,omitnil,omitempty" name:"NodeIp"`
+
+	// <p>命名空间</p>
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// <p>CPU请求</p>
+	CpuRequest *string `json:"CpuRequest,omitnil,omitempty" name:"CpuRequest"`
+
+	// <p>CPU限制</p>
+	CpuLimit *string `json:"CpuLimit,omitnil,omitempty" name:"CpuLimit"`
+
+	// <p>内存请求</p>
+	MemoryRequest *string `json:"MemoryRequest,omitnil,omitempty" name:"MemoryRequest"`
+
+	// <p>内存限制</p>
+	MemoryLimit *string `json:"MemoryLimit,omitnil,omitempty" name:"MemoryLimit"`
+
+	// <p>GPU数量</p>
+	GpuCount *string `json:"GpuCount,omitnil,omitempty" name:"GpuCount"`
+
+	// <p>容器镜像</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>Pod角色(head/worker)</p>
+	Role *string `json:"Role,omitnil,omitempty" name:"Role"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>启动时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+}
+
 type Column struct {
 	// <p>列名称，不区分大小写，最大支持25个字符。</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
@@ -1819,6 +2216,169 @@ type CommonMetrics struct {
 	ProcessedRows *int64 `json:"ProcessedRows,omitnil,omitempty" name:"ProcessedRows"`
 }
 
+// Predefined struct for user
+type CopyJobSpecRequestParams struct {
+	// <p>原配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>新配置名称（可选，留空则自动命名为 &#39;原名-copy&#39;）</p>
+	NewName *string `json:"NewName,omitnil,omitempty" name:"NewName"`
+}
+
+type CopyJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>原配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>新配置名称（可选，留空则自动命名为 &#39;原名-copy&#39;）</p>
+	NewName *string `json:"NewName,omitnil,omitempty" name:"NewName"`
+}
+
+func (r *CopyJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CopyJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	delete(f, "NewName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CopyJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CopyJobSpecResponseParams struct {
+	// <p>配置ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>配置名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置模板是否变更</p>
+	ResourceConfigChanged *bool `json:"ResourceConfigChanged,omitnil,omitempty" name:"ResourceConfigChanged"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>该配置产生的作业实例数量</p>
+	JobInstanceCount *int64 `json:"JobInstanceCount,omitnil,omitempty" name:"JobInstanceCount"`
+
+	// <p>是否有运行中的作业实例</p>
+	HasRunningJobs *bool `json:"HasRunningJobs,omitnil,omitempty" name:"HasRunningJobs"`
+
+	// <p>高级参数配置，json类型</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>默认计算组名称（与 ClusterGroup 等价，新调用方使用 GroupId）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p><p>枚举值：</p><ul><li>RANDOM： 随机分配</li><li>NULL： 无</li></ul>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+
+	// <p>作业提交目标：GROUP（按计算组分派）/ CLUSTER（指定集群）/ SERVERLESS（按 Serverless 拉起）</p><p>枚举值：</p><ul><li>GROUP： 按计算组分派</li><li>CLUSTER： 指定集群</li><li>SERVERLESS： 按 Serverless 拉起</li></ul>
+	SubmissionTarget *string `json:"SubmissionTarget,omitnil,omitempty" name:"SubmissionTarget"`
+
+	// <p>集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>集群名称</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CopyJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *CopyJobSpecResponseParams `json:"Response"`
+}
+
+func (r *CopyJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CopyJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type CoreInfo struct {
 	// 时间戳(毫秒)数组
 	Timestamp []*int64 `json:"Timestamp,omitnil,omitempty" name:"Timestamp"`
@@ -1835,6 +2395,17 @@ type CosPermission struct {
 	// 权限【"read","write"】
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Permissions []*string `json:"Permissions,omitnil,omitempty" name:"Permissions"`
+}
+
+type CpuSummaryItem struct {
+	// <p>CPU 总核数（headCpu + cpu × replicas 的总和）</p>
+	TotalCpuCores *int64 `json:"TotalCpuCores,omitnil,omitempty" name:"TotalCpuCores"`
+
+	// <p>内存总量（headMem + mem × replicas 的总和，单位 GB）</p>
+	TotalMemoryGB *int64 `json:"TotalMemoryGB,omitnil,omitempty" name:"TotalMemoryGB"`
+
+	// <p>运行中的副本总数</p>
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
 }
 
 // Predefined struct for user
@@ -1919,6 +2490,110 @@ func (r *CreateCHDFSBindingProductResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateCHDFSBindingProductResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateClusterGroupRequestParams struct {
+	// <p>集群组名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群组描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>集群组配置</p>
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+}
+
+type CreateClusterGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群组名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群组描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>集群组配置</p>
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+}
+
+func (r *CreateClusterGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateClusterGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "Config")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateClusterGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateClusterGroupResponseParams struct {
+	// <p>集群组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群组名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群组描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>应用 ID（多租户）</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者主账号 UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建者子账号 UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>修改时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>集群组配置</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+
+	// <p>是否已软删除</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Deleted *bool `json:"Deleted,omitnil,omitempty" name:"Deleted"`
+
+	// <p>删除时间（软删时写入，活跃记录为 null）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeleteTime *uint64 `json:"DeleteTime,omitnil,omitempty" name:"DeleteTime"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateClusterGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateClusterGroupResponseParams `json:"Response"`
+}
+
+func (r *CreateClusterGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateClusterGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2851,6 +3526,463 @@ func (r *CreateImportTaskResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type CreateInferenceModelRequestParams struct {
+	// <p>模型名称（最长 256）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型类型（如 LLM、Embedding、Reranker、ASR、TTS 等）</p>
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>初始版本号（必填，如 v1、v1.5）</p>
+	InitialVersion *string `json:"InitialVersion,omitnil,omitempty" name:"InitialVersion"`
+
+	// <p>模型提供方</p>
+	Provider *string `json:"Provider,omitnil,omitempty" name:"Provider"`
+
+	// <p>模型描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模型参数量（如 7B、1.5B）</p>
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>模型标签列表</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>模型存储 URI（可选，如 cos://bucket-name/models/name/）</p>
+	StorageUri *string `json:"StorageUri,omitnil,omitempty" name:"StorageUri"`
+
+	// <p>是否使用用户自带存储桶（默认 false 表示平台托管）</p>
+	UseCustomStorage *bool `json:"UseCustomStorage,omitnil,omitempty" name:"UseCustomStorage"`
+
+	// <p>任务类型列表（如 [&quot;Text Generation&quot;, &quot;Embedding&quot;]）</p>
+	Tasks []*string `json:"Tasks,omitnil,omitempty" name:"Tasks"`
+
+	// <p>模型 UID（可选，前端预先生成的 UID，不传则后端自动生成）</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+}
+
+type CreateInferenceModelRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型名称（最长 256）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型类型（如 LLM、Embedding、Reranker、ASR、TTS 等）</p>
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>初始版本号（必填，如 v1、v1.5）</p>
+	InitialVersion *string `json:"InitialVersion,omitnil,omitempty" name:"InitialVersion"`
+
+	// <p>模型提供方</p>
+	Provider *string `json:"Provider,omitnil,omitempty" name:"Provider"`
+
+	// <p>模型描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模型参数量（如 7B、1.5B）</p>
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>模型标签列表</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>模型存储 URI（可选，如 cos://bucket-name/models/name/）</p>
+	StorageUri *string `json:"StorageUri,omitnil,omitempty" name:"StorageUri"`
+
+	// <p>是否使用用户自带存储桶（默认 false 表示平台托管）</p>
+	UseCustomStorage *bool `json:"UseCustomStorage,omitnil,omitempty" name:"UseCustomStorage"`
+
+	// <p>任务类型列表（如 [&quot;Text Generation&quot;, &quot;Embedding&quot;]）</p>
+	Tasks []*string `json:"Tasks,omitnil,omitempty" name:"Tasks"`
+
+	// <p>模型 UID（可选，前端预先生成的 UID，不传则后端自动生成）</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+}
+
+func (r *CreateInferenceModelRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateInferenceModelRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "ModelType")
+	delete(f, "InitialVersion")
+	delete(f, "Provider")
+	delete(f, "Description")
+	delete(f, "ParameterSize")
+	delete(f, "Tags")
+	delete(f, "StorageUri")
+	delete(f, "UseCustomStorage")
+	delete(f, "Tasks")
+	delete(f, "ModelUid")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateInferenceModelRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateInferenceModelResponseParams struct {
+	// <p>模型ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelId *string `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型提供方</p>
+	Provider *string `json:"Provider,omitnil,omitempty" name:"Provider"`
+
+	// <p>模型描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模型类型</p>
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>参数大小</p>
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>模型标签</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>最新版本</p>
+	LatestVersion *string `json:"LatestVersion,omitnil,omitempty" name:"LatestVersion"`
+
+	// <p>版本总数</p>
+	VersionCount *int64 `json:"VersionCount,omitnil,omitempty" name:"VersionCount"`
+
+	// <p>关联的推理服务数量</p>
+	ServiceCount *int64 `json:"ServiceCount,omitnil,omitempty" name:"ServiceCount"`
+
+	// <p>是否有存储</p>
+	HasStorage *bool `json:"HasStorage,omitnil,omitempty" name:"HasStorage"`
+
+	// <p>是否使用用户自带存储桶</p>
+	HasCustomStorage *bool `json:"HasCustomStorage,omitnil,omitempty" name:"HasCustomStorage"`
+
+	// <p>存储后端类型</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
+
+	// <p>是否内置模型</p>
+	BuiltIn *bool `json:"BuiltIn,omitnil,omitempty" name:"BuiltIn"`
+
+	// <p>任务类型列表</p>
+	Tasks []*string `json:"Tasks,omitnil,omitempty" name:"Tasks"`
+
+	// <p>APPID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建时间</p>
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>Sub UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateInferenceModelResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateInferenceModelResponseParams `json:"Response"`
+}
+
+func (r *CreateInferenceModelResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateInferenceModelResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateInferenceServiceRequestParams struct {
+	// <p>推理服务名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型 UID（业务级唯一标识）</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>推理引擎（vllm / xgboost）</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>副本数</p>
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>资源分区 ID（目标 K8s 集群分区）</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>Ray Serve 部署镜像</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>模型标识符（OpenAI 兼容 API 中的 model 字段）</p>
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>队列名（K8s namespace）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>部署名称（可选，未提供时自动生成）</p>
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>模型版本（如 v1, v2），未提供时使用最新版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>ray head 是否开始高可用（是否申请 redis 实例用于 head 连接）</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>高级参数（JSON 字符串，可选）</p>
+	AdvancedParams *string `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// <p>镜像拉取策略（默认 IfNotPresent）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>是否启用弹性伸缩</p>
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>最小副本数（启用弹性伸缩时生效，0 表示缩容到 0）</p>
+	MinReplicas *int64 `json:"MinReplicas,omitnil,omitempty" name:"MinReplicas"`
+
+	// <p>最大副本数（启用弹性伸缩时生效）</p>
+	MaxReplicas *int64 `json:"MaxReplicas,omitnil,omitempty" name:"MaxReplicas"`
+
+	// <p>Autoscaler 配置（JSON 字符串）</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>ApiKeyIds</p>
+	ApiKeyIds []*string `json:"ApiKeyIds,omitnil,omitempty" name:"ApiKeyIds"`
+}
+
+type CreateInferenceServiceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理服务名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型 UID（业务级唯一标识）</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>推理引擎（vllm / xgboost）</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>副本数</p>
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>资源分区 ID（目标 K8s 集群分区）</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>Ray Serve 部署镜像</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>模型标识符（OpenAI 兼容 API 中的 model 字段）</p>
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>队列名（K8s namespace）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>部署名称（可选，未提供时自动生成）</p>
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>模型版本（如 v1, v2），未提供时使用最新版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>ray head 是否开始高可用（是否申请 redis 实例用于 head 连接）</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>高级参数（JSON 字符串，可选）</p>
+	AdvancedParams *string `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// <p>镜像拉取策略（默认 IfNotPresent）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>是否启用弹性伸缩</p>
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>最小副本数（启用弹性伸缩时生效，0 表示缩容到 0）</p>
+	MinReplicas *int64 `json:"MinReplicas,omitnil,omitempty" name:"MinReplicas"`
+
+	// <p>最大副本数（启用弹性伸缩时生效）</p>
+	MaxReplicas *int64 `json:"MaxReplicas,omitnil,omitempty" name:"MaxReplicas"`
+
+	// <p>Autoscaler 配置（JSON 字符串）</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>ApiKeyIds</p>
+	ApiKeyIds []*string `json:"ApiKeyIds,omitnil,omitempty" name:"ApiKeyIds"`
+}
+
+func (r *CreateInferenceServiceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateInferenceServiceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "ModelUid")
+	delete(f, "Engine")
+	delete(f, "Replicas")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Image")
+	delete(f, "ModelIdentifier")
+	delete(f, "Queue")
+	delete(f, "DeploymentName")
+	delete(f, "ModelVersion")
+	delete(f, "HeadHighAvailabilityEnabled")
+	delete(f, "AdvancedParams")
+	delete(f, "ImagePullPolicy")
+	delete(f, "AutoscalingEnabled")
+	delete(f, "MinReplicas")
+	delete(f, "MaxReplicas")
+	delete(f, "AutoscalerOptions")
+	delete(f, "ApiKeyIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateInferenceServiceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateInferenceServiceResponseParams struct {
+	// <p>服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的模型ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelId *uint64 `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>关联的模型UID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>关联的模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>关联的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>模型标识符（OpenAI 兼容 API 中的 model 字段）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>关联模型的类型（LLM / VLM / Embedding / Reranker / TTS / ASR / CV / NLP / ML）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>服务状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>服务端点URL</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndpointUrl *string `json:"EndpointUrl,omitnil,omitempty" name:"EndpointUrl"`
+
+	// <p>OpenAI 兼容统一入口 URL（通过 API-Key 路由，适用于 LLM/Embedding/Reranker）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedEndpointUrl *string `json:"UnifiedEndpointUrl,omitnil,omitempty" name:"UnifiedEndpointUrl"`
+
+	// <p>KServe V2 协议统一入口 URL（通过 API-Key + model name 路由，适用于 XGBoost 等传统 ML 模型）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedV2EndpointUrl *string `json:"UnifiedV2EndpointUrl,omitnil,omitempty" name:"UnifiedV2EndpointUrl"`
+
+	// <p>ray head 是否开启高可用</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>应用ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号UIN</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>部署数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentCount *int64 `json:"DeploymentCount,omitnil,omitempty" name:"DeploymentCount"`
+
+	// <p>是否存在至少一个运行中的部署</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasRunningDeployment *bool `json:"HasRunningDeployment,omitnil,omitempty" name:"HasRunningDeployment"`
+
+	// <p>是否启用 API-Key 鉴权</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthEnabled *bool `json:"ApiKeyAuthEnabled,omitnil,omitempty" name:"ApiKeyAuthEnabled"`
+
+	// <p>是否强制开启 API-Key 鉴权（生产环境为 true，不允许关闭）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthForceEnabled *bool `json:"ApiKeyAuthForceEnabled,omitnil,omitempty" name:"ApiKeyAuthForceEnabled"`
+
+	// <p>是否跳过 TLS 证书验证（自签证书场景，前端 curl 命令需加 -k 参数）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SkipTlsVerify *bool `json:"SkipTlsVerify,omitnil,omitempty" name:"SkipTlsVerify"`
+
+	// <p>API Key 绑定结果（success 表示成功，其他为错误信息）</p>
+	ApiKeyBindMessage *string `json:"ApiKeyBindMessage,omitnil,omitempty" name:"ApiKeyBindMessage"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>运行中部署的 CPU 资源汇总</p>
+	CpuResourceSummary *CpuSummaryItem `json:"CpuResourceSummary,omitnil,omitempty" name:"CpuResourceSummary"`
+
+	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateInferenceServiceResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateInferenceServiceResponseParams `json:"Response"`
+}
+
+func (r *CreateInferenceServiceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateInferenceServiceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CreateInternalTableRequestParams struct {
 	// 表基本信息
 	TableBaseInfo *TableBaseInfo `json:"TableBaseInfo,omitnil,omitempty" name:"TableBaseInfo"`
@@ -2925,6 +4057,803 @@ func (r *CreateInternalTableResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateInternalTableResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateJobSpecRequestParams struct {
+	// <p>入口命令不能为空</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>配置名称（可选，不填则自动生成）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源配置模板ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>作业包来源类型（Local: 本地上传, Cos: 用户自有 COS 桶地址）；缺省时按 Local 处理</p>
+	JobPackageSource *string `json:"JobPackageSource,omitnil,omitempty" name:"JobPackageSource"`
+
+	// <p>高级参数json</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>默认计算组名称（与 ClusterId 互斥；与老字段 ClusterGroup 等价，新调用方优先使用 GroupId）</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥，同时非空将返回 InvalidParameter.ClusterAndGroupConflict）</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p><p>枚举值：</p><ul><li>RANDOM： 随机分配</li></ul>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+}
+
+type CreateJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>入口命令不能为空</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>配置名称（可选，不填则自动生成）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源配置模板ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>作业包来源类型（Local: 本地上传, Cos: 用户自有 COS 桶地址）；缺省时按 Local 处理</p>
+	JobPackageSource *string `json:"JobPackageSource,omitnil,omitempty" name:"JobPackageSource"`
+
+	// <p>高级参数json</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>默认计算组名称（与 ClusterId 互斥；与老字段 ClusterGroup 等价，新调用方优先使用 GroupId）</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥，同时非空将返回 InvalidParameter.ClusterAndGroupConflict）</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p><p>枚举值：</p><ul><li>RANDOM： 随机分配</li></ul>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+}
+
+func (r *CreateJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Entrypoint")
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "Image")
+	delete(f, "ImagePullType")
+	delete(f, "ImagePullPolicy")
+	delete(f, "ResourceConfig")
+	delete(f, "RuntimeEnv")
+	delete(f, "Catalog")
+	delete(f, "AutoscalerOptions")
+	delete(f, "ResourcePartitionId")
+	delete(f, "ResourceConfigId")
+	delete(f, "Queue")
+	delete(f, "JobPackage")
+	delete(f, "JobPackageName")
+	delete(f, "JobPackageSource")
+	delete(f, "AdvancedOptions")
+	delete(f, "GroupId")
+	delete(f, "ClusterId")
+	delete(f, "Priority")
+	delete(f, "Tags")
+	delete(f, "DispatchStrategy")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateJobSpecResponseParams struct {
+	// <p>配置ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>配置名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>资源配置模板ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置模板是否变更</p>
+	ResourceConfigChanged *bool `json:"ResourceConfigChanged,omitnil,omitempty" name:"ResourceConfigChanged"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>作业包来源类型（Local: 本地上传, Cos: 用户自有 COS 桶地址）；缺省时按 Local 处理</p>
+	JobPackageSource *string `json:"JobPackageSource,omitnil,omitempty" name:"JobPackageSource"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>该配置下未进入终态的作业实例数量</p>
+	JobInstanceCount *int64 `json:"JobInstanceCount,omitnil,omitempty" name:"JobInstanceCount"`
+
+	// <p>是否有运行中的作业实例</p>
+	HasRunningJobs *bool `json:"HasRunningJobs,omitnil,omitempty" name:"HasRunningJobs"`
+
+	// <p>高级参数json</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>默认计算组名称（与 ClusterGroup 等价，新调用方使用 GroupId）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p><p>枚举值：</p><ul><li>RANDOM： 随机分配</li></ul>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+
+	// <p>作业提交目标</p><p>枚举值：</p><ul><li>GROUP： 按计算组分派</li></ul>
+	SubmissionTarget *string `json:"SubmissionTarget,omitnil,omitempty" name:"SubmissionTarget"`
+
+	// <p>计算组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>集群名称</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateJobSpecResponseParams `json:"Response"`
+}
+
+func (r *CreateJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateLabRequestParams struct {
+	// <p>数据实验室名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>数据实验室描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>存储卷和挂载卷配置</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>服务类型列表(VSCODE, JUPYTER, WEBSHELL)，不填则使用默认配置</p>
+	ServiceTypes []*string `json:"ServiceTypes,omitnil,omitempty" name:"ServiceTypes"`
+
+	// <p>案例ID，当 startMode=EXAMPLE 时必填</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>案例代码包地址，当 startMode=EXAMPLE 时填写</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>Lab sidecar 镜像拉取策略（Always, IfNotPresent, Never）</p>
+	LabImagePullPolicy *string `json:"LabImagePullPolicy,omitnil,omitempty" name:"LabImagePullPolicy"`
+
+	// <p>高级参数（扁平 Key-Value 的 JSON 字符串），Key 以 spec. 开头，按 RayCluster CRD 下钻；详见 ADVANCED_CLUSTER_OPTIONS_DESIGN.md</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+}
+
+type CreateLabRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>数据实验室描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>存储卷和挂载卷配置</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>服务类型列表(VSCODE, JUPYTER, WEBSHELL)，不填则使用默认配置</p>
+	ServiceTypes []*string `json:"ServiceTypes,omitnil,omitempty" name:"ServiceTypes"`
+
+	// <p>案例ID，当 startMode=EXAMPLE 时必填</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>案例代码包地址，当 startMode=EXAMPLE 时填写</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>Lab sidecar 镜像拉取策略（Always, IfNotPresent, Never）</p>
+	LabImagePullPolicy *string `json:"LabImagePullPolicy,omitnil,omitempty" name:"LabImagePullPolicy"`
+
+	// <p>高级参数（扁平 Key-Value 的 JSON 字符串），Key 以 spec. 开头，按 RayCluster CRD 下钻；详见 ADVANCED_CLUSTER_OPTIONS_DESIGN.md</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+}
+
+func (r *CreateLabRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateLabRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "LabImage")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Queue")
+	delete(f, "Description")
+	delete(f, "Image")
+	delete(f, "ImagePullPolicy")
+	delete(f, "ResourceConfig")
+	delete(f, "ResourceConfigId")
+	delete(f, "Catalog")
+	delete(f, "GroupId")
+	delete(f, "ServiceTypes")
+	delete(f, "ExampleId")
+	delete(f, "CodeArchiveUrl")
+	delete(f, "LabImagePullPolicy")
+	delete(f, "AdvancedOptions")
+	delete(f, "Priority")
+	delete(f, "Tags")
+	delete(f, "PersistentWorkDir")
+	delete(f, "EnableToken")
+	delete(f, "ImagePullType")
+	delete(f, "LabImagePullType")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateLabRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateLabResponseParams struct {
+	// <p>案例模板ID（从案例创建时返回）</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>代码包/工程归档地址</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>数据实验室服务入口（服务类型 -&gt; 访问地址）</p>
+	Services []*TypeKVPair `json:"Services,omitnil,omitempty" name:"Services"`
+
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>高级参数（扁平 Key-Value 的 JSON 字符串），Key 以 spec. 开头，按 RayCluster CRD 下钻；详见 ADVANCED_CLUSTER_OPTIONS_DESIGN.md</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateLabResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateLabResponseParams `json:"Response"`
+}
+
+func (r *CreateLabResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateLabResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateMetaDatabaseRequestParams struct {
+	// 数据源名称，默认DataLakeCatalog
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
+
+	// 元数据库基本信息
+	MetaDatabaseInfo *MetaDatabaseInfo `json:"MetaDatabaseInfo,omitnil,omitempty" name:"MetaDatabaseInfo"`
+
+	// 数据治理配置项
+	GovernPolicy *DataGovernPolicy `json:"GovernPolicy,omitnil,omitempty" name:"GovernPolicy"`
+
+	// 智能数据治理配置
+	SmartPolicy *SmartPolicy `json:"SmartPolicy,omitnil,omitempty" name:"SmartPolicy"`
+}
+
+type CreateMetaDatabaseRequest struct {
+	*tchttp.BaseRequest
+	
+	// 数据源名称，默认DataLakeCatalog
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
+
+	// 元数据库基本信息
+	MetaDatabaseInfo *MetaDatabaseInfo `json:"MetaDatabaseInfo,omitnil,omitempty" name:"MetaDatabaseInfo"`
+
+	// 数据治理配置项
+	GovernPolicy *DataGovernPolicy `json:"GovernPolicy,omitnil,omitempty" name:"GovernPolicy"`
+
+	// 智能数据治理配置
+	SmartPolicy *SmartPolicy `json:"SmartPolicy,omitnil,omitempty" name:"SmartPolicy"`
+}
+
+func (r *CreateMetaDatabaseRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateMetaDatabaseRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DatasourceConnectionName")
+	delete(f, "MetaDatabaseInfo")
+	delete(f, "GovernPolicy")
+	delete(f, "SmartPolicy")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateMetaDatabaseRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateMetaDatabaseResponseParams struct {
+	// 本批次提交的任务的批次Id
+	BatchId *string `json:"BatchId,omitnil,omitempty" name:"BatchId"`
+
+	// 任务Id集合，按照执行顺序排列
+	TaskIdSet []*string `json:"TaskIdSet,omitnil,omitempty" name:"TaskIdSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateMetaDatabaseResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateMetaDatabaseResponseParams `json:"Response"`
+}
+
+func (r *CreateMetaDatabaseResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateMetaDatabaseResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateModelVersionRequestParams struct {
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型版本号</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>版本说明</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>该版本的存储 URI（可选，如 cos://bucket-name/models/name/v2/）</p>
+	StorageUri *string `json:"StorageUri,omitnil,omitempty" name:"StorageUri"`
+
+	// <p>是否使用用户自带存储桶（默认 false 表示平台托管）</p>
+	UseCustomStorage *bool `json:"UseCustomStorage,omitnil,omitempty" name:"UseCustomStorage"`
+}
+
+type CreateModelVersionRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型版本号</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>版本说明</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>该版本的存储 URI（可选，如 cos://bucket-name/models/name/v2/）</p>
+	StorageUri *string `json:"StorageUri,omitnil,omitempty" name:"StorageUri"`
+
+	// <p>是否使用用户自带存储桶（默认 false 表示平台托管）</p>
+	UseCustomStorage *bool `json:"UseCustomStorage,omitnil,omitempty" name:"UseCustomStorage"`
+}
+
+func (r *CreateModelVersionRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateModelVersionRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	delete(f, "ModelVersion")
+	delete(f, "Description")
+	delete(f, "StorageUri")
+	delete(f, "UseCustomStorage")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateModelVersionRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateModelVersionResponseParams struct {
+	// <p>版本ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	VersionId *string `json:"VersionId,omitnil,omitempty" name:"VersionId"`
+
+	// <p>关联的模型ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelId *string `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>该版本的存储 URI</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	StorageUri *string `json:"StorageUri,omitnil,omitempty" name:"StorageUri"`
+
+	// <p>版本说明</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>关联的推理服务列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	LinkedServices []*LinkedServiceInfo `json:"LinkedServices,omitnil,omitempty" name:"LinkedServices"`
+
+	// <p>模型版本号</p>
+	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
+
+	// <p>是否使用用户自带存储桶（true=用户自带桶，false=平台托管）</p>
+	UseCustomStorage *bool `json:"UseCustomStorage,omitnil,omitempty" name:"UseCustomStorage"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateModelVersionResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateModelVersionResponseParams `json:"Response"`
+}
+
+func (r *CreateModelVersionResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateModelVersionResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -3252,6 +5181,529 @@ func (r *CreateNotebookSessionStatementSupportBatchSQLResponse) FromJsonString(s
 }
 
 // Predefined struct for user
+type CreatePartitionQueueRequestParams struct {
+	// <p>分区编码</p>
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// <p>队列名称</p>
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// <p>资源规格列表，定义队列的资源类型及大小范围</p>
+	ResourceUsages []*ResourceUsage `json:"ResourceUsages,omitnil,omitempty" name:"ResourceUsages"`
+
+	// <p>队列类型：1-独占型，2-共享型</p>
+	QueueType *int64 `json:"QueueType,omitnil,omitempty" name:"QueueType"`
+
+	// <p>队列描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+}
+
+type CreatePartitionQueueRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>分区编码</p>
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// <p>队列名称</p>
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// <p>资源规格列表，定义队列的资源类型及大小范围</p>
+	ResourceUsages []*ResourceUsage `json:"ResourceUsages,omitnil,omitempty" name:"ResourceUsages"`
+
+	// <p>队列类型：1-独占型，2-共享型</p>
+	QueueType *int64 `json:"QueueType,omitnil,omitempty" name:"QueueType"`
+
+	// <p>队列描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+}
+
+func (r *CreatePartitionQueueRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreatePartitionQueueRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionCode")
+	delete(f, "QueueName")
+	delete(f, "ResourceUsages")
+	delete(f, "QueueType")
+	delete(f, "Description")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreatePartitionQueueRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreatePartitionQueueResponseParams struct {
+	// <p>新创建的资源队列ID</p>
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreatePartitionQueueResponse struct {
+	*tchttp.BaseResponse
+	Response *CreatePartitionQueueResponseParams `json:"Response"`
+}
+
+func (r *CreatePartitionQueueResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreatePartitionQueueResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreatePartitionRequestParams struct {
+	// <p>交易类型：purchase-新购，renew-续费，modify-变配</p>
+	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
+
+	// <p>付费模式：0-后付费，1-预付费</p>
+	PayMode *uint64 `json:"PayMode,omitnil,omitempty" name:"PayMode"`
+
+	// <p>资源配额列表（计费项+数量）</p>
+	ResourceQuotaList []*ResourceQuota `json:"ResourceQuotaList,omitnil,omitempty" name:"ResourceQuotaList"`
+
+	// <p>时间大小，预付费时为购买月数，后付费时为3600</p>
+	TimeSpan *int64 `json:"TimeSpan,omitnil,omitempty" name:"TimeSpan"`
+
+	// <p>时间单位，预付费为m（月），后付费为s（秒）</p>
+	TimeUnit *string `json:"TimeUnit,omitnil,omitempty" name:"TimeUnit"`
+
+	// <p>自动续费标志：0-默认，1-自动续费，2-不自动续费（仅预付费有效）</p>
+	AutoRenewFlag *uint64 `json:"AutoRenewFlag,omitnil,omitempty" name:"AutoRenewFlag"`
+
+	// <p>弹性资源池名称，用于订单页展示</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>队列描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+}
+
+type CreatePartitionRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>交易类型：purchase-新购，renew-续费，modify-变配</p>
+	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
+
+	// <p>付费模式：0-后付费，1-预付费</p>
+	PayMode *uint64 `json:"PayMode,omitnil,omitempty" name:"PayMode"`
+
+	// <p>资源配额列表（计费项+数量）</p>
+	ResourceQuotaList []*ResourceQuota `json:"ResourceQuotaList,omitnil,omitempty" name:"ResourceQuotaList"`
+
+	// <p>时间大小，预付费时为购买月数，后付费时为3600</p>
+	TimeSpan *int64 `json:"TimeSpan,omitnil,omitempty" name:"TimeSpan"`
+
+	// <p>时间单位，预付费为m（月），后付费为s（秒）</p>
+	TimeUnit *string `json:"TimeUnit,omitnil,omitempty" name:"TimeUnit"`
+
+	// <p>自动续费标志：0-默认，1-自动续费，2-不自动续费（仅预付费有效）</p>
+	AutoRenewFlag *uint64 `json:"AutoRenewFlag,omitnil,omitempty" name:"AutoRenewFlag"`
+
+	// <p>弹性资源池名称，用于订单页展示</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>队列描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+}
+
+func (r *CreatePartitionRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreatePartitionRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ActionType")
+	delete(f, "PayMode")
+	delete(f, "ResourceQuotaList")
+	delete(f, "TimeSpan")
+	delete(f, "TimeUnit")
+	delete(f, "AutoRenewFlag")
+	delete(f, "Name")
+	delete(f, "Description")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreatePartitionRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreatePartitionResponseParams struct {
+	// <p>子订单号</p>
+	DealName *string `json:"DealName,omitnil,omitempty" name:"DealName"`
+
+	// <p>大订单号</p>
+	BigDealId *string `json:"BigDealId,omitnil,omitempty" name:"BigDealId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreatePartitionResponse struct {
+	*tchttp.BaseResponse
+	Response *CreatePartitionResponseParams `json:"Response"`
+}
+
+func (r *CreatePartitionResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreatePartitionResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateRayClusterRequestParams struct {
+	// <p>集群名称（可选，不填写则默认使用集群ID）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>资源配置</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>存储卷和挂载卷配置</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+type CreateRayClusterRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群名称（可选，不填写则默认使用集群ID）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>资源配置</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>存储卷和挂载卷配置</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+func (r *CreateRayClusterRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateRayClusterRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "GroupId")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Queue")
+	delete(f, "Image")
+	delete(f, "ImagePullPolicy")
+	delete(f, "ImagePullType")
+	delete(f, "ResourceConfig")
+	delete(f, "ResourceConfigId")
+	delete(f, "Catalog")
+	delete(f, "AdvancedOptions")
+	delete(f, "Priority")
+	delete(f, "Tags")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateRayClusterRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateRayClusterResponseParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateRayClusterResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateRayClusterResponseParams `json:"Response"`
+}
+
+func (r *CreateRayClusterResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateRayClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateResourceConfigRequestParams struct {
+	// 模板名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// 描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// Head节点配置
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// Worker节点配置
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+
+	// 模板类型，不填默认是Ray
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+}
+
+type CreateResourceConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 模板名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// 描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// Head节点配置
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// Worker节点配置
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+
+	// 模板类型，不填默认是Ray
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+}
+
+func (r *CreateResourceConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateResourceConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "Head")
+	delete(f, "Worker")
+	delete(f, "Type")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateResourceConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateResourceConfigResponseParams struct {
+	// 模板ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 模板名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// 描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 模板类型
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// Head节点配置
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// Worker节点配置
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+
+	// 创建时间
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 更新时间
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// 应用ID
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// 创建者UIN
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// 子用户UIN
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateResourceConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateResourceConfigResponseParams `json:"Response"`
+}
+
+func (r *CreateResourceConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateResourceConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CreateResultDownloadRequestParams struct {
 	// 查询结果任务Id
 	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
@@ -3394,6 +5846,266 @@ func (r *CreateScriptResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateScriptResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateSparkAppForTDLCRequestParams struct {
+	// <p>spark作业名</p>
+	AppName *string `json:"AppName,omitnil,omitempty" name:"AppName"`
+
+	// <p>spark作业类型，1代表spark jar作业，2代表spark streaming作业</p>
+	AppType *int64 `json:"AppType,omitnil,omitempty" name:"AppType"`
+
+	// <p>执行spark作业的数据引擎名称</p>
+	DataEngine *string `json:"DataEngine,omitnil,omitempty" name:"DataEngine"`
+
+	// <p>spark作业程序包文件路径</p>
+	AppFile *string `json:"AppFile,omitnil,omitempty" name:"AppFile"`
+
+	// <p>数据访问策略，CAM Role arn，控制台通过数据作业—&gt;作业配置获取，SDK通过DescribeUserRoles接口获取对应的值；</p>
+	RoleArn *int64 `json:"RoleArn,omitnil,omitempty" name:"RoleArn"`
+
+	// <p>指定的Driver规格，当前支持：small（默认，1cu）、medium（2cu）、large（4cu）、xlarge（8cu）</p>
+	AppDriverSize *string `json:"AppDriverSize,omitnil,omitempty" name:"AppDriverSize"`
+
+	// <p>指定的Executor规格，当前支持：small（默认，1cu）、medium（2cu）、large（4cu）、xlarge（8cu）</p>
+	AppExecutorSize *string `json:"AppExecutorSize,omitnil,omitempty" name:"AppExecutorSize"`
+
+	// <p>spark作业executor个数</p>
+	AppExecutorNums *int64 `json:"AppExecutorNums,omitnil,omitempty" name:"AppExecutorNums"`
+
+	// <p>该字段已下线，请使用字段Datasource</p>
+	Eni *string `json:"Eni,omitnil,omitempty" name:"Eni"`
+
+	// <p>spark作业程序包是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocal *string `json:"IsLocal,omitnil,omitempty" name:"IsLocal"`
+
+	// <p>spark作业主类</p>
+	MainClass *string `json:"MainClass,omitnil,omitempty" name:"MainClass"`
+
+	// <p>spark配置，以换行符分隔</p>
+	AppConf *string `json:"AppConf,omitnil,omitempty" name:"AppConf"`
+
+	// <p>spark 作业依赖jar包是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalJars *string `json:"IsLocalJars,omitnil,omitempty" name:"IsLocalJars"`
+
+	// <p>spark 作业依赖jar包（--jars），以逗号分隔</p>
+	AppJars *string `json:"AppJars,omitnil,omitempty" name:"AppJars"`
+
+	// <p>spark作业依赖文件资源是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalFiles *string `json:"IsLocalFiles,omitnil,omitempty" name:"IsLocalFiles"`
+
+	// <p>spark作业依赖文件资源（--files）（非jar、zip），以逗号分隔</p>
+	AppFiles *string `json:"AppFiles,omitnil,omitempty" name:"AppFiles"`
+
+	// <p>spark作业程序入参，空格分割</p>
+	CmdArgs *string `json:"CmdArgs,omitnil,omitempty" name:"CmdArgs"`
+
+	// <p>最大重试次数，只对spark流任务生效</p>
+	MaxRetries *int64 `json:"MaxRetries,omitnil,omitempty" name:"MaxRetries"`
+
+	// <p>数据源名称</p>
+	DataSource *string `json:"DataSource,omitnil,omitempty" name:"DataSource"`
+
+	// <p>pyspark：依赖上传方式，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalPythonFiles *string `json:"IsLocalPythonFiles,omitnil,omitempty" name:"IsLocalPythonFiles"`
+
+	// <p>pyspark作业依赖python资源（--py-files），支持py/zip/egg等归档格式，多文件以逗号分隔</p>
+	AppPythonFiles *string `json:"AppPythonFiles,omitnil,omitempty" name:"AppPythonFiles"`
+
+	// <p>spark作业依赖archives资源是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalArchives *string `json:"IsLocalArchives,omitnil,omitempty" name:"IsLocalArchives"`
+
+	// <p>spark作业依赖archives资源（--archives），支持tar.gz/tgz/tar等归档格式，以逗号分隔</p>
+	AppArchives *string `json:"AppArchives,omitnil,omitempty" name:"AppArchives"`
+
+	// <p>Spark Image 版本号</p>
+	SparkImage *string `json:"SparkImage,omitnil,omitempty" name:"SparkImage"`
+
+	// <p>Spark Image 版本名称</p>
+	SparkImageVersion *string `json:"SparkImageVersion,omitnil,omitempty" name:"SparkImageVersion"`
+
+	// <p>指定的Executor数量（最大值），默认为1，当开启动态分配有效，若未开启，则该值等于AppExecutorNums</p>
+	AppExecutorMaxNumbers *int64 `json:"AppExecutorMaxNumbers,omitnil,omitempty" name:"AppExecutorMaxNumbers"`
+
+	// <p>关联dlc查询脚本id</p>
+	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+
+	// <p>任务资源配置是否继承集群模板，0（默认）不继承，1：继承</p>
+	IsInherit *uint64 `json:"IsInherit,omitnil,omitempty" name:"IsInherit"`
+
+	// <p>是否使用session脚本的sql运行任务：false：否，true：是</p>
+	IsSessionStarted *bool `json:"IsSessionStarted,omitnil,omitempty" name:"IsSessionStarted"`
+
+	// <p>依赖包信息</p>
+	DependencyPackages []*DependencyPackage `json:"DependencyPackages,omitnil,omitempty" name:"DependencyPackages"`
+}
+
+type CreateSparkAppForTDLCRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>spark作业名</p>
+	AppName *string `json:"AppName,omitnil,omitempty" name:"AppName"`
+
+	// <p>spark作业类型，1代表spark jar作业，2代表spark streaming作业</p>
+	AppType *int64 `json:"AppType,omitnil,omitempty" name:"AppType"`
+
+	// <p>执行spark作业的数据引擎名称</p>
+	DataEngine *string `json:"DataEngine,omitnil,omitempty" name:"DataEngine"`
+
+	// <p>spark作业程序包文件路径</p>
+	AppFile *string `json:"AppFile,omitnil,omitempty" name:"AppFile"`
+
+	// <p>数据访问策略，CAM Role arn，控制台通过数据作业—&gt;作业配置获取，SDK通过DescribeUserRoles接口获取对应的值；</p>
+	RoleArn *int64 `json:"RoleArn,omitnil,omitempty" name:"RoleArn"`
+
+	// <p>指定的Driver规格，当前支持：small（默认，1cu）、medium（2cu）、large（4cu）、xlarge（8cu）</p>
+	AppDriverSize *string `json:"AppDriverSize,omitnil,omitempty" name:"AppDriverSize"`
+
+	// <p>指定的Executor规格，当前支持：small（默认，1cu）、medium（2cu）、large（4cu）、xlarge（8cu）</p>
+	AppExecutorSize *string `json:"AppExecutorSize,omitnil,omitempty" name:"AppExecutorSize"`
+
+	// <p>spark作业executor个数</p>
+	AppExecutorNums *int64 `json:"AppExecutorNums,omitnil,omitempty" name:"AppExecutorNums"`
+
+	// <p>该字段已下线，请使用字段Datasource</p>
+	Eni *string `json:"Eni,omitnil,omitempty" name:"Eni"`
+
+	// <p>spark作业程序包是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocal *string `json:"IsLocal,omitnil,omitempty" name:"IsLocal"`
+
+	// <p>spark作业主类</p>
+	MainClass *string `json:"MainClass,omitnil,omitempty" name:"MainClass"`
+
+	// <p>spark配置，以换行符分隔</p>
+	AppConf *string `json:"AppConf,omitnil,omitempty" name:"AppConf"`
+
+	// <p>spark 作业依赖jar包是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalJars *string `json:"IsLocalJars,omitnil,omitempty" name:"IsLocalJars"`
+
+	// <p>spark 作业依赖jar包（--jars），以逗号分隔</p>
+	AppJars *string `json:"AppJars,omitnil,omitempty" name:"AppJars"`
+
+	// <p>spark作业依赖文件资源是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalFiles *string `json:"IsLocalFiles,omitnil,omitempty" name:"IsLocalFiles"`
+
+	// <p>spark作业依赖文件资源（--files）（非jar、zip），以逗号分隔</p>
+	AppFiles *string `json:"AppFiles,omitnil,omitempty" name:"AppFiles"`
+
+	// <p>spark作业程序入参，空格分割</p>
+	CmdArgs *string `json:"CmdArgs,omitnil,omitempty" name:"CmdArgs"`
+
+	// <p>最大重试次数，只对spark流任务生效</p>
+	MaxRetries *int64 `json:"MaxRetries,omitnil,omitempty" name:"MaxRetries"`
+
+	// <p>数据源名称</p>
+	DataSource *string `json:"DataSource,omitnil,omitempty" name:"DataSource"`
+
+	// <p>pyspark：依赖上传方式，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalPythonFiles *string `json:"IsLocalPythonFiles,omitnil,omitempty" name:"IsLocalPythonFiles"`
+
+	// <p>pyspark作业依赖python资源（--py-files），支持py/zip/egg等归档格式，多文件以逗号分隔</p>
+	AppPythonFiles *string `json:"AppPythonFiles,omitnil,omitempty" name:"AppPythonFiles"`
+
+	// <p>spark作业依赖archives资源是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalArchives *string `json:"IsLocalArchives,omitnil,omitempty" name:"IsLocalArchives"`
+
+	// <p>spark作业依赖archives资源（--archives），支持tar.gz/tgz/tar等归档格式，以逗号分隔</p>
+	AppArchives *string `json:"AppArchives,omitnil,omitempty" name:"AppArchives"`
+
+	// <p>Spark Image 版本号</p>
+	SparkImage *string `json:"SparkImage,omitnil,omitempty" name:"SparkImage"`
+
+	// <p>Spark Image 版本名称</p>
+	SparkImageVersion *string `json:"SparkImageVersion,omitnil,omitempty" name:"SparkImageVersion"`
+
+	// <p>指定的Executor数量（最大值），默认为1，当开启动态分配有效，若未开启，则该值等于AppExecutorNums</p>
+	AppExecutorMaxNumbers *int64 `json:"AppExecutorMaxNumbers,omitnil,omitempty" name:"AppExecutorMaxNumbers"`
+
+	// <p>关联dlc查询脚本id</p>
+	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+
+	// <p>任务资源配置是否继承集群模板，0（默认）不继承，1：继承</p>
+	IsInherit *uint64 `json:"IsInherit,omitnil,omitempty" name:"IsInherit"`
+
+	// <p>是否使用session脚本的sql运行任务：false：否，true：是</p>
+	IsSessionStarted *bool `json:"IsSessionStarted,omitnil,omitempty" name:"IsSessionStarted"`
+
+	// <p>依赖包信息</p>
+	DependencyPackages []*DependencyPackage `json:"DependencyPackages,omitnil,omitempty" name:"DependencyPackages"`
+}
+
+func (r *CreateSparkAppForTDLCRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateSparkAppForTDLCRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "AppName")
+	delete(f, "AppType")
+	delete(f, "DataEngine")
+	delete(f, "AppFile")
+	delete(f, "RoleArn")
+	delete(f, "AppDriverSize")
+	delete(f, "AppExecutorSize")
+	delete(f, "AppExecutorNums")
+	delete(f, "Eni")
+	delete(f, "IsLocal")
+	delete(f, "MainClass")
+	delete(f, "AppConf")
+	delete(f, "IsLocalJars")
+	delete(f, "AppJars")
+	delete(f, "IsLocalFiles")
+	delete(f, "AppFiles")
+	delete(f, "CmdArgs")
+	delete(f, "MaxRetries")
+	delete(f, "DataSource")
+	delete(f, "IsLocalPythonFiles")
+	delete(f, "AppPythonFiles")
+	delete(f, "IsLocalArchives")
+	delete(f, "AppArchives")
+	delete(f, "SparkImage")
+	delete(f, "SparkImageVersion")
+	delete(f, "AppExecutorMaxNumbers")
+	delete(f, "SessionId")
+	delete(f, "IsInherit")
+	delete(f, "IsSessionStarted")
+	delete(f, "DependencyPackages")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateSparkAppForTDLCRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateSparkAppForTDLCResponseParams struct {
+	// <p>App唯一标识</p>
+	SparkAppId *string `json:"SparkAppId,omitnil,omitempty" name:"SparkAppId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateSparkAppForTDLCResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateSparkAppForTDLCResponseParams `json:"Response"`
+}
+
+func (r *CreateSparkAppForTDLCResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateSparkAppForTDLCResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -3659,26 +6371,26 @@ func (r *CreateSparkAppResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateSparkAppTaskRequestParams struct {
-	// spark作业名
+	// <p>spark作业名</p>
 	JobName *string `json:"JobName,omitnil,omitempty" name:"JobName"`
 
-	// spark作业程序入参，以空格分隔；一般用于周期性调用使用
+	// <p>spark作业程序入参，以空格分隔；一般用于周期性调用使用</p>
 	CmdArgs *string `json:"CmdArgs,omitnil,omitempty" name:"CmdArgs"`
 
-	// 任务来源信息
+	// <p>任务来源信息</p>
 	SourceInfo []*KVPair `json:"SourceInfo,omitnil,omitempty" name:"SourceInfo"`
 }
 
 type CreateSparkAppTaskRequest struct {
 	*tchttp.BaseRequest
 	
-	// spark作业名
+	// <p>spark作业名</p>
 	JobName *string `json:"JobName,omitnil,omitempty" name:"JobName"`
 
-	// spark作业程序入参，以空格分隔；一般用于周期性调用使用
+	// <p>spark作业程序入参，以空格分隔；一般用于周期性调用使用</p>
 	CmdArgs *string `json:"CmdArgs,omitnil,omitempty" name:"CmdArgs"`
 
-	// 任务来源信息
+	// <p>任务来源信息</p>
 	SourceInfo []*KVPair `json:"SourceInfo,omitnil,omitempty" name:"SourceInfo"`
 }
 
@@ -3705,10 +6417,10 @@ func (r *CreateSparkAppTaskRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateSparkAppTaskResponseParams struct {
-	// 批Id
+	// <p>批Id</p>
 	BatchId *string `json:"BatchId,omitnil,omitempty" name:"BatchId"`
 
-	// 任务Id
+	// <p>任务Id</p>
 	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -6192,6 +8904,103 @@ func (r *DeleteCHDFSBindingProductResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DeleteClusterGroupRequestParams struct {
+	// <p>集群组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>是否强制删除（Detach 模式）；false=Block（默认），true=Detach</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
+}
+
+type DeleteClusterGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>是否强制删除（Detach 模式）；false=Block（默认），true=Detach</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
+}
+
+func (r *DeleteClusterGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteClusterGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Force")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteClusterGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteClusterGroupResponseParams struct {
+	// <p>集群组 ID（系统生成）</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群组名称（同一 AppId 下唯一）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群组描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>集群组配置</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+
+	// <p>应用 ID（多租户）</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者主账号 UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建者子账号 UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>创建时间</p>
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>是否已软删除（false=活跃, true=已删除）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Deleted *bool `json:"Deleted,omitnil,omitempty" name:"Deleted"`
+
+	// <p>删除时间（软删时写入，活跃记录为 null）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeleteTime *int64 `json:"DeleteTime,omitnil,omitempty" name:"DeleteTime"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteClusterGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteClusterGroupResponseParams `json:"Response"`
+}
+
+func (r *DeleteClusterGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteClusterGroupResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DeleteDataEngineRequestParams struct {
 	// <p>删除虚拟集群的名称数组</p>
 	DataEngineNames []*string `json:"DataEngineNames,omitnil,omitempty" name:"DataEngineNames"`
@@ -6296,6 +9105,181 @@ func (r *DeleteDataMaskStrategyResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteDataMaskStrategyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteJobSpecRequestParams struct {
+	// 配置ID
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+type DeleteJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// 配置ID
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+func (r *DeleteJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteJobSpecResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteJobSpecResponseParams `json:"Response"`
+}
+
+func (r *DeleteJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteLabRequestParams struct {
+	// <p>工作区ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type DeleteLabRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>工作区ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *DeleteLabRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteLabRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteLabRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteLabResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteLabResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteLabResponseParams `json:"Response"`
+}
+
+func (r *DeleteLabResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteLabResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteMetaDatabaseRequestParams struct {
+	// 数据库名称
+	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
+
+	// 数据源名称，默认DataLakeCatalog
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
+}
+
+type DeleteMetaDatabaseRequest struct {
+	*tchttp.BaseRequest
+	
+	// 数据库名称
+	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
+
+	// 数据源名称，默认DataLakeCatalog
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
+}
+
+func (r *DeleteMetaDatabaseRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteMetaDatabaseRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DatabaseName")
+	delete(f, "DatasourceConnectionName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteMetaDatabaseRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteMetaDatabaseResponseParams struct {
+	// 本批次提交的任务的批次Id
+	BatchId *string `json:"BatchId,omitnil,omitempty" name:"BatchId"`
+
+	// 任务Id集合，按照执行顺序排列
+	TaskIdSet []*string `json:"TaskIdSet,omitnil,omitempty" name:"TaskIdSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteMetaDatabaseResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteMetaDatabaseResponseParams `json:"Response"`
+}
+
+func (r *DeleteMetaDatabaseResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteMetaDatabaseResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -6418,6 +9402,236 @@ func (r *DeleteNotebookSessionResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteNotebookSessionResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeletePartitionQueueRequestParams struct {
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 队列名称
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// 队列ID
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type DeletePartitionQueueRequest struct {
+	*tchttp.BaseRequest
+	
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 队列名称
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// 队列ID
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *DeletePartitionQueueRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeletePartitionQueueRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionCode")
+	delete(f, "QueueName")
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeletePartitionQueueRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeletePartitionQueueResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeletePartitionQueueResponse struct {
+	*tchttp.BaseResponse
+	Response *DeletePartitionQueueResponseParams `json:"Response"`
+}
+
+func (r *DeletePartitionQueueResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeletePartitionQueueResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteRayClusterRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type DeleteRayClusterRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *DeleteRayClusterRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteRayClusterRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteRayClusterRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteRayClusterResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteRayClusterResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteRayClusterResponseParams `json:"Response"`
+}
+
+func (r *DeleteRayClusterResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteRayClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteRayJobRequestParams struct {
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type DeleteRayJobRequest struct {
+	*tchttp.BaseRequest
+	
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *DeleteRayJobRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteRayJobRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteRayJobRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteRayJobResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteRayJobResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteRayJobResponseParams `json:"Response"`
+}
+
+func (r *DeleteRayJobResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteRayJobResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteResourceConfigRequestParams struct {
+	// 模板ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type DeleteResourceConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 模板ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *DeleteResourceConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteResourceConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteResourceConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteResourceConfigResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteResourceConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteResourceConfigResponseParams `json:"Response"`
+}
+
+func (r *DeleteResourceConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteResourceConfigResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -7018,6 +10232,174 @@ func (r *DescribeAdvancedStoreLocationResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeAdvancedStoreLocationResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterGroupClustersRequestParams struct {
+	// <p>计算组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>返回样例 ClusterId 的最大数量（默认 5）</p>
+	SampleLimit *int64 `json:"SampleLimit,omitnil,omitempty" name:"SampleLimit"`
+
+	// <p>Cluster 状态列表</p><p>枚举值：</p><ul><li>running： 运行中</li></ul>
+	Status []*string `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+type DescribeClusterGroupClustersRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>计算组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>返回样例 ClusterId 的最大数量（默认 5）</p>
+	SampleLimit *int64 `json:"SampleLimit,omitnil,omitempty" name:"SampleLimit"`
+
+	// <p>Cluster 状态列表</p><p>枚举值：</p><ul><li>running： 运行中</li></ul>
+	Status []*string `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+func (r *DescribeClusterGroupClustersRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterGroupClustersRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "SampleLimit")
+	delete(f, "Status")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeClusterGroupClustersRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterGroupClustersResponseParams struct {
+	// <p>活跃 cluster 总数</p>
+	Count *uint64 `json:"Count,omitnil,omitempty" name:"Count"`
+
+	// <p>前 N 个样例</p>
+	SampleClusters []*RayClusterEntity `json:"SampleClusters,omitnil,omitempty" name:"SampleClusters"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeClusterGroupClustersResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeClusterGroupClustersResponseParams `json:"Response"`
+}
+
+func (r *DescribeClusterGroupClustersResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterGroupClustersResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterGroupRequestParams struct {
+	// <p>集群组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>是否包含已软删除的记录（默认 false，仅返回活跃记录；true 时允许返回 deleted=1 的记录，用于悬挂 cluster 回显场景）</p>
+	IncludeDeleted *bool `json:"IncludeDeleted,omitnil,omitempty" name:"IncludeDeleted"`
+}
+
+type DescribeClusterGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>是否包含已软删除的记录（默认 false，仅返回活跃记录；true 时允许返回 deleted=1 的记录，用于悬挂 cluster 回显场景）</p>
+	IncludeDeleted *bool `json:"IncludeDeleted,omitnil,omitempty" name:"IncludeDeleted"`
+}
+
+func (r *DescribeClusterGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "IncludeDeleted")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeClusterGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterGroupResponseParams struct {
+	// <p>集群组 ID（系统生成）</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群组名称（同一 AppId 下唯一）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群组描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>集群组配置</p>
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+
+	// <p>应用 ID（多租户）</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者主账号 UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建者子账号 UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>是否已软删除（false=活跃，true=已删除）</p>
+	Deleted *bool `json:"Deleted,omitnil,omitempty" name:"Deleted"`
+
+	// <p>删除时间（软删时写入，活跃记录为 null）</p>
+	DeleteTime *uint64 `json:"DeleteTime,omitnil,omitempty" name:"DeleteTime"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeClusterGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeClusterGroupResponseParams `json:"Response"`
+}
+
+func (r *DescribeClusterGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -8372,6 +11754,70 @@ func (r *DescribeDataMaskStrategiesResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeDatabaseRequestParams struct {
+	// 数据库名称
+	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
+
+	// 数据连接名称，不填默认为DataLakeCatalog
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
+}
+
+type DescribeDatabaseRequest struct {
+	*tchttp.BaseRequest
+	
+	// 数据库名称
+	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
+
+	// 数据连接名称，不填默认为DataLakeCatalog
+	DatasourceConnectionName *string `json:"DatasourceConnectionName,omitnil,omitempty" name:"DatasourceConnectionName"`
+}
+
+func (r *DescribeDatabaseRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDatabaseRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DatabaseName")
+	delete(f, "DatasourceConnectionName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDatabaseRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDatabaseResponseParams struct {
+	// 数据库信息
+	DatabaseInfo *DatabaseResponseInfo `json:"DatabaseInfo,omitnil,omitempty" name:"DatabaseInfo"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDatabaseResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDatabaseResponseParams `json:"Response"`
+}
+
+func (r *DescribeDatabaseResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDatabaseResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeDatabasesRequestParams struct {
 	// 返回数量，默认为10，最大值为100。
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
@@ -8824,6 +12270,154 @@ func (r *DescribeEngineUsageInfoResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeFlowDetailListRequestParams struct {
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 页码，从1开始，默认为1
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页返回数量，默认为10
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type DescribeFlowDetailListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 页码，从1开始，默认为1
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页返回数量，默认为10
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *DescribeFlowDetailListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeFlowDetailListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionCode")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeFlowDetailListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeFlowDetailListResponseParams struct {
+	// 流程详情列表
+	FlowDetailList []*FlowDetail `json:"FlowDetailList,omitnil,omitempty" name:"FlowDetailList"`
+
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeFlowDetailListResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeFlowDetailListResponseParams `json:"Response"`
+}
+
+func (r *DescribeFlowDetailListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeFlowDetailListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeFlowListRequestParams struct {
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 页码，从1开始，默认为1
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页返回数量，默认为10
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type DescribeFlowListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 页码，从1开始，默认为1
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页返回数量，默认为10
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *DescribeFlowListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeFlowListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionCode")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeFlowListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeFlowListResponseParams struct {
+	// 流程列表
+	FlowInfoList []*FlowInfo `json:"FlowInfoList,omitnil,omitempty" name:"FlowInfoList"`
+
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeFlowListResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeFlowListResponseParams `json:"Response"`
+}
+
+func (r *DescribeFlowListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeFlowListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeForbiddenTableProRequestParams struct {
 
 }
@@ -9034,6 +12628,174 @@ func (r *DescribeLakeFsTaskResultResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeLakeFsTaskResultResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMCPSubUinRequestParams struct {
+
+}
+
+type DescribeMCPSubUinRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *DescribeMCPSubUinRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMCPSubUinRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMCPSubUinRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMCPSubUinResponseParams struct {
+	// <p>子 Uin</p>
+	Subuin *string `json:"Subuin,omitnil,omitempty" name:"Subuin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeMCPSubUinResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeMCPSubUinResponseParams `json:"Response"`
+}
+
+func (r *DescribeMCPSubUinResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMCPSubUinResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMCPTaskRequestParams struct {
+	// <p>任务 ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+type DescribeMCPTaskRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>任务 ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+func (r *DescribeMCPTaskRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMCPTaskRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TaskId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMCPTaskRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMCPTaskResponseParams struct {
+	// <p>任务详细信息</p>
+	TaskInfo *MCPTaskInfo `json:"TaskInfo,omitnil,omitempty" name:"TaskInfo"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeMCPTaskResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeMCPTaskResponseParams `json:"Response"`
+}
+
+func (r *DescribeMCPTaskResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMCPTaskResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMCPTaskResultRequestParams struct {
+	// <p>任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+type DescribeMCPTaskResultRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+func (r *DescribeMCPTaskResultRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMCPTaskResultRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TaskId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMCPTaskResultRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMCPTaskResultResponseParams struct {
+	// <p>任务结果信息</p>
+	TaskResult *MCPTaskResultInfo `json:"TaskResult,omitnil,omitempty" name:"TaskResult"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeMCPTaskResultResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeMCPTaskResultResponseParams `json:"Response"`
+}
+
+func (r *DescribeMCPTaskResultResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMCPTaskResultResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -9766,6 +13528,235 @@ func (r *DescribeOtherCHDFSBindingListResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribePartitionDetailRequestParams struct {
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+}
+
+type DescribePartitionDetailRequest struct {
+	*tchttp.BaseRequest
+	
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+}
+
+func (r *DescribePartitionDetailRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribePartitionDetailRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionCode")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribePartitionDetailRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribePartitionDetailResponseParams struct {
+	// 分区详情
+	PartitionDetail *PartitionDetail `json:"PartitionDetail,omitnil,omitempty" name:"PartitionDetail"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribePartitionDetailResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribePartitionDetailResponseParams `json:"Response"`
+}
+
+func (r *DescribePartitionDetailResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribePartitionDetailResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribePartitionQueuesRequestParams struct {
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 排序字段列表
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// 筛选条件列表
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 页码
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页返回数量
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type DescribePartitionQueuesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 排序字段列表
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// 筛选条件列表
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 页码
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页返回数量
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *DescribePartitionQueuesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribePartitionQueuesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionCode")
+	delete(f, "SortFields")
+	delete(f, "Filters")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribePartitionQueuesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribePartitionQueuesResponseParams struct {
+	// 队列列表
+	QueueList []*QueueInfo `json:"QueueList,omitnil,omitempty" name:"QueueList"`
+
+	// 默认队列信息
+	DefaultQueue *QueueInfo `json:"DefaultQueue,omitnil,omitempty" name:"DefaultQueue"`
+
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribePartitionQueuesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribePartitionQueuesResponseParams `json:"Response"`
+}
+
+func (r *DescribePartitionQueuesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribePartitionQueuesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribePartitionsRequestParams struct {
+	// 页码，从1开始，默认为1
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页返回数量，默认为10
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 排序字段列表，按数组顺序依次应用，可选
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// 筛选条件列表，多个条件之间为AND关系，可选
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+type DescribePartitionsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 页码，从1开始，默认为1
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页返回数量，默认为10
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 排序字段列表，按数组顺序依次应用，可选
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// 筛选条件列表，多个条件之间为AND关系，可选
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+}
+
+func (r *DescribePartitionsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribePartitionsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "SortFields")
+	delete(f, "Filters")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribePartitionsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribePartitionsResponseParams struct {
+	// 资源包列表
+	Partitions []*PartitionInfo `json:"Partitions,omitnil,omitempty" name:"Partitions"`
+
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribePartitionsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribePartitionsResponseParams `json:"Response"`
+}
+
+func (r *DescribePartitionsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribePartitionsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeResourceGroupUsageInfoRequestParams struct {
 	// 资源组ID
 	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
@@ -9897,6 +13888,114 @@ func (r *DescribeResultDownloadResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeResultDownloadResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeSaleRegionsRequestParams struct {
+
+}
+
+type DescribeSaleRegionsRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *DescribeSaleRegionsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeSaleRegionsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeSaleRegionsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeSaleRegionsResponseParams struct {
+	// 可售卖地域列表
+	RegionList []*RegionInfo `json:"RegionList,omitnil,omitempty" name:"RegionList"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeSaleRegionsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeSaleRegionsResponseParams `json:"Response"`
+}
+
+func (r *DescribeSaleRegionsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeSaleRegionsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeSaleResourceInfoRequestParams struct {
+
+}
+
+type DescribeSaleResourceInfoRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *DescribeSaleResourceInfoRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeSaleResourceInfoRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeSaleResourceInfoRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeSaleResourceInfoResponseParams struct {
+	// 可售卖资源规格列表
+	SaleResourceInfoList []*ResourceSaleInfo `json:"SaleResourceInfoList,omitnil,omitempty" name:"SaleResourceInfoList"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeSaleResourceInfoResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeSaleResourceInfoResponseParams `json:"Response"`
+}
+
+func (r *DescribeSaleResourceInfoResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeSaleResourceInfoResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -11383,78 +15482,68 @@ func (r *DescribeTaskDetailResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTaskListRequestParams struct {
-	// 返回数量，默认为10，最大值为100。
+	// <p>返回数量，默认为10，最大值为100。</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。
-	// task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。
-	// task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。
-	// task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。
-	// task-operator- string （子uin过滤）
-	// task-kind - string （任务类型过滤）
+	// <p>过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。<br>task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。<br>task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。<br>task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。<br>task-operator- string （子uin过滤）<br>task-kind - string （任务类型过滤）</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）
+	// <p>排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）</p>
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
 
-	// 排序方式，desc表示正序，asc表示反序， 默认为asc。
+	// <p>排序方式，desc表示正序，asc表示反序， 默认为asc。</p>
 	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
 
-	// 起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻
+	// <p>起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻</p>
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻
+	// <p>结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 数据引擎名称，用于筛选
+	// <p>数据引擎名称，用于筛选</p>
 	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
 
-	// spark引擎资源组名称
+	// <p>spark引擎资源组名称</p>
 	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
 
-	// 引擎id列表
+	// <p>引擎id列表</p>
 	HouseIds []*string `json:"HouseIds,omitnil,omitempty" name:"HouseIds"`
 }
 
 type DescribeTaskListRequest struct {
 	*tchttp.BaseRequest
 	
-	// 返回数量，默认为10，最大值为100。
+	// <p>返回数量，默认为10，最大值为100。</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。
-	// task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。
-	// task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。
-	// task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。
-	// task-operator- string （子uin过滤）
-	// task-kind - string （任务类型过滤）
+	// <p>过滤条件，如下支持的过滤类型，传参Name应为以下其中一个,其中task-id支持最大50个过滤个数，其他过滤参数支持的总数不超过5个。<br>task-id - String - （任务ID准确过滤）task-id取值形如：e386471f-139a-4e59-877f-50ece8135b99。<br>task-state - String - （任务状态过滤）取值范围 0(初始化)， 1(运行中)， 2(成功)， -1(失败)。<br>task-sql-keyword - String - （SQL语句关键字模糊过滤）取值形如：DROP TABLE。<br>task-operator- string （子uin过滤）<br>task-kind - string （任务类型过滤）</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）
+	// <p>排序字段，支持如下字段类型，create-time（创建时间，默认）、update-time（更新时间）</p>
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
 
-	// 排序方式，desc表示正序，asc表示反序， 默认为asc。
+	// <p>排序方式，desc表示正序，asc表示反序， 默认为asc。</p>
 	Sorting *string `json:"Sorting,omitnil,omitempty" name:"Sorting"`
 
-	// 起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻
+	// <p>起始时间点，格式为yyyy-mm-dd HH:MM:SS。默认为45天前的当前时刻</p>
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻
+	// <p>结束时间点，格式为yyyy-mm-dd HH:MM:SS时间跨度在(0,30天]，支持最近45天数据查询。默认为当前时刻</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 数据引擎名称，用于筛选
+	// <p>数据引擎名称，用于筛选</p>
 	DataEngineName *string `json:"DataEngineName,omitnil,omitempty" name:"DataEngineName"`
 
-	// spark引擎资源组名称
+	// <p>spark引擎资源组名称</p>
 	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
 
-	// 引擎id列表
+	// <p>引擎id列表</p>
 	HouseIds []*string `json:"HouseIds,omitnil,omitempty" name:"HouseIds"`
 }
 
@@ -11488,10 +15577,10 @@ func (r *DescribeTaskListRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeTaskListResponseParams struct {
-	// 任务对象列表。
+	// <p>任务对象列表。</p>
 	TaskList []*TaskFullRespInfo `json:"TaskList,omitnil,omitempty" name:"TaskList"`
 
-	// 实例总数。
+	// <p>实例总数。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -13859,6 +17948,23 @@ type ElasticsearchInfo struct {
 	ServiceInfo []*IpPortPair `json:"ServiceInfo,omitnil,omitempty" name:"ServiceInfo"`
 }
 
+type EngineCapabilities struct {
+	// <p>GPU 是否可选</p>
+	GpuOptional *bool `json:"GpuOptional,omitnil,omitempty" name:"GpuOptional"`
+
+	// <p>是否支持并行配置</p>
+	SupportsParallelConfig *bool `json:"SupportsParallelConfig,omitnil,omitempty" name:"SupportsParallelConfig"`
+
+	// <p>是否支持远程代码</p>
+	SupportsRemoteCode *bool `json:"SupportsRemoteCode,omitnil,omitempty" name:"SupportsRemoteCode"`
+
+	// <p>GPU 显存配置键名</p>
+	GpuMemoryKey *string `json:"GpuMemoryKey,omitnil,omitempty" name:"GpuMemoryKey"`
+
+	// <p>并行配置键名列表</p>
+	ParallelKeys []*ParallelKeyMapping `json:"ParallelKeys,omitnil,omitempty" name:"ParallelKeys"`
+}
+
 type EngineNetworkInfo struct {
 	// 引擎网络名字
 	// 注意：此字段可能返回 null，表示取不到有效值。
@@ -13926,6 +18032,128 @@ type EngineSessionImage struct {
 	SparkImageTag *string `json:"SparkImageTag,omitnil,omitempty" name:"SparkImageTag"`
 }
 
+type Env struct {
+	// <p>名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>值</p>
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
+type EventItem struct {
+	// <p>事件时间（Unix 时间戳，毫秒）</p>
+	EventTime *int64 `json:"EventTime,omitnil,omitempty" name:"EventTime"`
+
+	// <p>组件名称，来源于 event.involvedObject.kind</p>
+	Component *string `json:"Component,omitnil,omitempty" name:"Component"`
+
+	// <p>事件级别，来源于 event.type 的原始值（如 Normal、Warning）</p>
+	Level *string `json:"Level,omitnil,omitempty" name:"Level"`
+
+	// <p>事件内容，来源于 event.message</p>
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+
+	// <p>关联的 K8s 对象名称，来源于 event.involvedObject.name</p>
+	InvolvedObjectName *string `json:"InvolvedObjectName,omitnil,omitempty" name:"InvolvedObjectName"`
+
+	// <p>事件来源组件，来源于 event.source.component</p>
+	SourceComponent *string `json:"SourceComponent,omitnil,omitempty" name:"SourceComponent"`
+
+	// <p>事件原因，来源于 event.reason</p>
+	Reason *string `json:"Reason,omitnil,omitempty" name:"Reason"`
+}
+
+type EventLogItem struct {
+	// 事件时间（Unix 时间戳，秒级）
+	EventTime *uint64 `json:"EventTime,omitnil,omitempty" name:"EventTime"`
+
+	// 组件名称
+	Component *string `json:"Component,omitnil,omitempty" name:"Component"`
+
+	// 日志级别（INFO/WARN/ERROR）
+	Level *string `json:"Level,omitnil,omitempty" name:"Level"`
+
+	// 事件内容
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+}
+
+type ExampleCategories struct {
+	// <p>分类名称</p>
+	Categories *string `json:"Categories,omitnil,omitempty" name:"Categories"`
+}
+
+type ExampleDifficulties struct {
+	// <p>案例难度</p>
+	Difficulty *string `json:"Difficulty,omitnil,omitempty" name:"Difficulty"`
+}
+
+type ExampleEntity struct {
+	// <p>ID</p>
+	Id *uint64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>案例ID</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>标题</p>
+	Title *string `json:"Title,omitnil,omitempty" name:"Title"`
+
+	// <p>描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>README</p>
+	Readme *string `json:"Readme,omitnil,omitempty" name:"Readme"`
+
+	// <p>案例归档URL</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>图片URL</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>实验室镜像地址</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>资源配置</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>分类</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
+
+	// <p>标签</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>案例热度</p>
+	Popularity *int64 `json:"Popularity,omitnil,omitempty" name:"Popularity"`
+
+	// <p>难度</p>
+	Difficulty *string `json:"Difficulty,omitnil,omitempty" name:"Difficulty"`
+
+	// <p>预估时间（分钟）</p>
+	EstimatedTime *int64 `json:"EstimatedTime,omitnil,omitempty" name:"EstimatedTime"`
+
+	// <p>排序</p>
+	SortOrder *int64 `json:"SortOrder,omitnil,omitempty" name:"SortOrder"`
+
+	// <p>是否启用</p>
+	IsEnabled *bool `json:"IsEnabled,omitnil,omitempty" name:"IsEnabled"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>是否删除</p>
+	Deleted *int64 `json:"Deleted,omitnil,omitempty" name:"Deleted"`
+}
+
+type ExampleTag struct {
+	// <p>案例标签名称</p>
+	Tag *string `json:"Tag,omitnil,omitempty" name:"Tag"`
+
+	// <p>标签数量</p>
+	Count *int64 `json:"Count,omitnil,omitempty" name:"Count"`
+}
+
 type Execution struct {
 	// 自动生成SQL语句。
 	SQL *string `json:"SQL,omitnil,omitempty" name:"SQL"`
@@ -13945,6 +18173,27 @@ type FavorInfo struct {
 	Table *string `json:"Table,omitnil,omitempty" name:"Table"`
 }
 
+type FileNode struct {
+	// <p>文件/目录名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>节点类型：file 或 directory</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>文件大小（字节），目录为 null</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Size *int64 `json:"Size,omitnil,omitempty" name:"Size"`
+
+	// <p>子节点列表（仅目录有效）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Children []*FileNode `json:"Children,omitnil,omitempty" name:"Children"`
+
+	// <p>文件最后修改时间（毫秒时间戳）</p><p>单位：ms</p>
+	LastModifyTime *int64 `json:"LastModifyTime,omitnil,omitempty" name:"LastModifyTime"`
+}
+
 type Filter struct {
 	// 筛选字段名，对应实体属性名（驼峰命名）
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
@@ -13954,6 +18203,59 @@ type Filter struct {
 
 	// 筛选值列表，EQ/NE/GT/GE/LT/LE/LIKE取第一个值，IN使用完整列表
 	Values []*string `json:"Values,omitnil,omitempty" name:"Values"`
+}
+
+type FlowActivityDetail struct {
+	// <p>活动编码</p>
+	ActivityCode *string `json:"ActivityCode,omitnil,omitempty" name:"ActivityCode"`
+
+	// <p>活动状态</p>
+	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>耗时（秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Duration *int64 `json:"Duration,omitnil,omitempty" name:"Duration"`
+}
+
+type FlowDetail struct {
+	// <p>流程ID（数据库主键）</p>
+	FlowId *int64 `json:"FlowId,omitnil,omitempty" name:"FlowId"`
+
+	// <p>Temporal Workflow ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	WorkFlowId *string `json:"WorkFlowId,omitnil,omitempty" name:"WorkFlowId"`
+
+	// <p>流程编码</p>
+	WorkFlowCode *string `json:"WorkFlowCode,omitnil,omitempty" name:"WorkFlowCode"`
+
+	// <p>流程进度，0~100</p>
+	Progress *int64 `json:"Progress,omitnil,omitempty" name:"Progress"`
+
+	// <p>流程状态</p>
+	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>流程活动列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Activities []*FlowActivityDetail `json:"Activities,omitnil,omitempty" name:"Activities"`
+}
+
+type FlowInfo struct {
+	// <p>流程ID</p>
+	FlowId *int64 `json:"FlowId,omitnil,omitempty" name:"FlowId"`
+
+	// <p>流程编码</p>
+	WorkFlowCode *string `json:"WorkFlowCode,omitnil,omitempty" name:"WorkFlowCode"`
+
+	// <p>流程状态</p>
+	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
 }
 
 type GPUInfo struct {
@@ -14094,6 +18396,1489 @@ func (r *GenerateCreateMangedTableSqlResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type GenerateInternalTableRequestParams struct {
+	// 表基本信息
+	TableBaseInfo *TableBaseInfo `json:"TableBaseInfo,omitnil,omitempty" name:"TableBaseInfo"`
+
+	// 字段信息
+	Columns []*TColumn `json:"Columns,omitnil,omitempty" name:"Columns"`
+
+	// 分区信息
+	Partitions []*TPartition `json:"Partitions,omitnil,omitempty" name:"Partitions"`
+
+	// 属性
+	Properties []*Property `json:"Properties,omitnil,omitempty" name:"Properties"`
+
+	// V2 upsert表 upsert键
+	UpsertKeys []*string `json:"UpsertKeys,omitnil,omitempty" name:"UpsertKeys"`
+}
+
+type GenerateInternalTableRequest struct {
+	*tchttp.BaseRequest
+	
+	// 表基本信息
+	TableBaseInfo *TableBaseInfo `json:"TableBaseInfo,omitnil,omitempty" name:"TableBaseInfo"`
+
+	// 字段信息
+	Columns []*TColumn `json:"Columns,omitnil,omitempty" name:"Columns"`
+
+	// 分区信息
+	Partitions []*TPartition `json:"Partitions,omitnil,omitempty" name:"Partitions"`
+
+	// 属性
+	Properties []*Property `json:"Properties,omitnil,omitempty" name:"Properties"`
+
+	// V2 upsert表 upsert键
+	UpsertKeys []*string `json:"UpsertKeys,omitnil,omitempty" name:"UpsertKeys"`
+}
+
+func (r *GenerateInternalTableRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GenerateInternalTableRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TableBaseInfo")
+	delete(f, "Columns")
+	delete(f, "Partitions")
+	delete(f, "Properties")
+	delete(f, "UpsertKeys")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GenerateInternalTableRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GenerateInternalTableResponseParams struct {
+	// 返回sql
+	Execution *Execution `json:"Execution,omitnil,omitempty" name:"Execution"`
+
+	// 是否tciceberg
+	IsTIcebergSql *bool `json:"IsTIcebergSql,omitnil,omitempty" name:"IsTIcebergSql"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GenerateInternalTableResponse struct {
+	*tchttp.BaseResponse
+	Response *GenerateInternalTableResponseParams `json:"Response"`
+}
+
+func (r *GenerateInternalTableResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GenerateInternalTableResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetExampleDetailRequestParams struct {
+	// <p>案例ID</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+}
+
+type GetExampleDetailRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>案例ID</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+}
+
+func (r *GetExampleDetailRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetExampleDetailRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ExampleId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetExampleDetailRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetExampleDetailResponseParams struct {
+	// <p>ID</p>
+	Id *uint64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>案例ID</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>标题</p>
+	Title *string `json:"Title,omitnil,omitempty" name:"Title"`
+
+	// <p>描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>README</p>
+	Readme *string `json:"Readme,omitnil,omitempty" name:"Readme"`
+
+	// <p>案例归档URL</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>图片URL</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>实验室镜像</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>资源配置</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>分类</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
+
+	// <p>案例标签</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>难度</p>
+	Difficulty *string `json:"Difficulty,omitnil,omitempty" name:"Difficulty"`
+
+	// <p>预估时间（分钟）</p>
+	EstimatedTime *int64 `json:"EstimatedTime,omitnil,omitempty" name:"EstimatedTime"`
+
+	// <p>排序</p>
+	SortOrder *int64 `json:"SortOrder,omitnil,omitempty" name:"SortOrder"`
+
+	// <p>是否启用</p>
+	IsEnabled *bool `json:"IsEnabled,omitnil,omitempty" name:"IsEnabled"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>是否删除</p>
+	Deleted *int64 `json:"Deleted,omitnil,omitempty" name:"Deleted"`
+
+	// <p>案例热度</p>
+	Popularity *int64 `json:"Popularity,omitnil,omitempty" name:"Popularity"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetExampleDetailResponse struct {
+	*tchttp.BaseResponse
+	Response *GetExampleDetailResponseParams `json:"Response"`
+}
+
+func (r *GetExampleDetailResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetExampleDetailResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetInferenceModelRequestParams struct {
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+}
+
+type GetInferenceModelRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+}
+
+func (r *GetInferenceModelRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetInferenceModelRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetInferenceModelRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetInferenceModelResponseParams struct {
+	// <p>模型ID</p>
+	ModelId *string `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型提供方</p>
+	Provider *string `json:"Provider,omitnil,omitempty" name:"Provider"`
+
+	// <p>模型描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模型类型</p>
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>模型参数量</p>
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>模型标签列表</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>最新版本号</p>
+	LatestVersion *string `json:"LatestVersion,omitnil,omitempty" name:"LatestVersion"`
+
+	// <p>版本总数</p>
+	VersionCount *int64 `json:"VersionCount,omitnil,omitempty" name:"VersionCount"`
+
+	// <p>关联的推理服务数量</p>
+	ServiceCount *int64 `json:"ServiceCount,omitnil,omitempty" name:"ServiceCount"`
+
+	// <p>是否有存储</p>
+	HasStorage *bool `json:"HasStorage,omitnil,omitempty" name:"HasStorage"`
+
+	// <p>存储地域</p>
+	StorageRegion *string `json:"StorageRegion,omitnil,omitempty" name:"StorageRegion"`
+
+	// <p>是否使用用户自带存储桶</p>
+	HasCustomStorage *bool `json:"HasCustomStorage,omitnil,omitempty" name:"HasCustomStorage"`
+
+	// <p>存储后端类型</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
+
+	// <p>是否内置模型</p>
+	BuiltIn *bool `json:"BuiltIn,omitnil,omitempty" name:"BuiltIn"`
+
+	// <p>任务类型列表</p>
+	Tasks []*string `json:"Tasks,omitnil,omitempty" name:"Tasks"`
+
+	// <p>模型支持的推理引擎列表</p>
+	SupportedEngines []*string `json:"SupportedEngines,omitnil,omitempty" name:"SupportedEngines"`
+
+	// <p>UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>APPID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建时间</p>
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>Sub UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetInferenceModelResponse struct {
+	*tchttp.BaseResponse
+	Response *GetInferenceModelResponseParams `json:"Response"`
+}
+
+func (r *GetInferenceModelResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetInferenceModelResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetInferenceServiceRequestParams struct {
+	// <p>ServiceId</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+type GetInferenceServiceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>ServiceId</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+func (r *GetInferenceServiceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetInferenceServiceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetInferenceServiceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetInferenceServiceResponseParams struct {
+	// <p>ServiceId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的模型UID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>关联的模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>关联的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>模型标识符（OpenAI 兼容 API 中的 model 字段）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>关联模型的类型（LLM / VLM / Embedding / Reranker / TTS / ASR / CV / NLP / ML）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>服务状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>服务端点URL</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndpointUrl *string `json:"EndpointUrl,omitnil,omitempty" name:"EndpointUrl"`
+
+	// <p>OpenAI 兼容统一入口 URL（通过 API-Key 路由，适用于 LLM/Embedding/Reranker）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedEndpointUrl *string `json:"UnifiedEndpointUrl,omitnil,omitempty" name:"UnifiedEndpointUrl"`
+
+	// <p>KServe V2 协议统一入口 URL（通过 API-Key + model name 路由，适用于 XGBoost 等传统 ML 模型）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedV2EndpointUrl *string `json:"UnifiedV2EndpointUrl,omitnil,omitempty" name:"UnifiedV2EndpointUrl"`
+
+	// <p>应用ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号UIN</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>部署数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentCount *int64 `json:"DeploymentCount,omitnil,omitempty" name:"DeploymentCount"`
+
+	// <p>是否存在至少一个运行中的部署</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasRunningDeployment *bool `json:"HasRunningDeployment,omitnil,omitempty" name:"HasRunningDeployment"`
+
+	// <p>Ray Dashboard 访问地址（通过 Ingress 代理）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RayDashboardUrl *string `json:"RayDashboardUrl,omitnil,omitempty" name:"RayDashboardUrl"`
+
+	// <p>是否启用 API-Key 鉴权</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthEnabled *bool `json:"ApiKeyAuthEnabled,omitnil,omitempty" name:"ApiKeyAuthEnabled"`
+
+	// <p>是否强制开启 API-Key 鉴权（生产环境为 true，不允许关闭）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthForceEnabled *bool `json:"ApiKeyAuthForceEnabled,omitnil,omitempty" name:"ApiKeyAuthForceEnabled"`
+
+	// <p>是否跳过 TLS 证书验证（自签证书场景，前端 curl 命令需加 -k 参数）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SkipTlsVerify *bool `json:"SkipTlsVerify,omitnil,omitempty" name:"SkipTlsVerify"`
+
+	// <p>运行中部署的 GPU 资源汇总</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GpuResourceSummary []*GpuSummaryItem `json:"GpuResourceSummary,omitnil,omitempty" name:"GpuResourceSummary"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>运行中部署的 CPU 资源汇总</p>
+	CpuResourceSummary *CpuSummaryItem `json:"CpuResourceSummary,omitnil,omitempty" name:"CpuResourceSummary"`
+
+	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetInferenceServiceResponse struct {
+	*tchttp.BaseResponse
+	Response *GetInferenceServiceResponseParams `json:"Response"`
+}
+
+func (r *GetInferenceServiceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetInferenceServiceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetJobSpecRequestParams struct {
+	// <p>配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+type GetJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+func (r *GetJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetJobSpecResponseParams struct {
+	// <p>配置ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>配置名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置模板是否变更</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceConfigChanged *bool `json:"ResourceConfigChanged,omitnil,omitempty" name:"ResourceConfigChanged"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>作业包来源类型（Local: 本地上传, Cos: 用户自有 COS 桶地址）；缺省时按 Local 处理</p>
+	JobPackageSource *string `json:"JobPackageSource,omitnil,omitempty" name:"JobPackageSource"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>该配置产生的作业实例数量</p>
+	JobInstanceCount *int64 `json:"JobInstanceCount,omitnil,omitempty" name:"JobInstanceCount"`
+
+	// <p>是否有运行中的作业实例</p>
+	HasRunningJobs *bool `json:"HasRunningJobs,omitnil,omitempty" name:"HasRunningJobs"`
+
+	// <p>高级参数json</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>默认计算组名称（与 ClusterGroup 等价，新调用方使用 GroupId）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p><p>枚举值：</p><ul><li>RANDOM： 随机分配</li></ul>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+
+	// <p>作业提交目标</p><p>枚举值：</p><ul><li>GROUP： 按计算组分派</li></ul>
+	SubmissionTarget *string `json:"SubmissionTarget,omitnil,omitempty" name:"SubmissionTarget"`
+
+	// <p>计算组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>集群名称</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *GetJobSpecResponseParams `json:"Response"`
+}
+
+func (r *GetJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabDetailRequestParams struct {
+	// <p>工作区ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type GetLabDetailRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>工作区ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *GetLabDetailRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabDetailRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetLabDetailRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabDetailResponseParams struct {
+	// <p>案例模板ID（startMode=EXAMPLE 时使用）</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>代码包/工程归档地址</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>数据实验室服务入口（服务类型 -&gt; 访问地址）</p>
+	Services []*TypeKVPair `json:"Services,omitnil,omitempty" name:"Services"`
+
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>状态详情/错误信息</p>
+	StatusMessage *string `json:"StatusMessage,omitnil,omitempty" name:"StatusMessage"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>高级参数（扁平 Key-Value 的 JSON 字符串），Key 以 spec. 开头，按 RayCluster CRD 下钻；详见 ADVANCED_CLUSTER_OPTIONS_DESIGN.md</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>停止时间（最近一次停止/休眠）</p>
+	StopTime *uint64 `json:"StopTime,omitnil,omitempty" name:"StopTime"`
+
+	// <p>删除时间</p>
+	DeleteTime *uint64 `json:"DeleteTime,omitnil,omitempty" name:"DeleteTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetLabDetailResponse struct {
+	*tchttp.BaseResponse
+	Response *GetLabDetailResponseParams `json:"Response"`
+}
+
+func (r *GetLabDetailResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabDetailResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabEventRequestParams struct {
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type GetLabEventRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *GetLabEventRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabEventRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetLabEventRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabEventResponseParams struct {
+	// <p>是否已经返回所有符合条件的日志，true 表示已全部返回</p>
+	ListOver *bool `json:"ListOver,omitnil,omitempty" name:"ListOver"`
+
+	// <p>事件列表</p>
+	Events []*EventItem `json:"Events,omitnil,omitempty" name:"Events"`
+
+	// <p>事件开始时间</p><p>单位：毫秒</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>事件结束时间</p><p>单位：毫秒</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetLabEventResponse struct {
+	*tchttp.BaseResponse
+	Response *GetLabEventResponseParams `json:"Response"`
+}
+
+func (r *GetLabEventResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabEventResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabHistoryRequestParams struct {
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type GetLabHistoryRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *GetLabHistoryRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabHistoryRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetLabHistoryRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabHistoryResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>集群状态历史详情列表</p>
+	Items []*RayClusterHistory `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetLabHistoryResponse struct {
+	*tchttp.BaseResponse
+	Response *GetLabHistoryResponseParams `json:"Response"`
+}
+
+func (r *GetLabHistoryResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabHistoryResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabPodYamlRequestParams struct {
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>Pod名称</p>
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+}
+
+type GetLabPodYamlRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>Pod名称</p>
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+}
+
+func (r *GetLabPodYamlRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabPodYamlRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "PodName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetLabPodYamlRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabPodYamlResponseParams struct {
+	// <p>Pod YAML</p>
+	Yaml *string `json:"Yaml,omitnil,omitempty" name:"Yaml"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetLabPodYamlResponse struct {
+	*tchttp.BaseResponse
+	Response *GetLabPodYamlResponseParams `json:"Response"`
+}
+
+func (r *GetLabPodYamlResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabPodYamlResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabPodsRequestParams struct {
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type GetLabPodsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *GetLabPodsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabPodsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetLabPodsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabPodsResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>集群的Pod列表</p>
+	Items []*ClusterPod `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetLabPodsResponse struct {
+	*tchttp.BaseResponse
+	Response *GetLabPodsResponseParams `json:"Response"`
+}
+
+func (r *GetLabPodsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabPodsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabServiceUrlsRequestParams struct {
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type GetLabServiceUrlsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *GetLabServiceUrlsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabServiceUrlsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetLabServiceUrlsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabServiceUrlsResponseParams struct {
+	// <p>数据实验室服务入口（服务类型 -&gt; 访问地址）</p>
+	ServiceUrls []*KVPair `json:"ServiceUrls,omitnil,omitempty" name:"ServiceUrls"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetLabServiceUrlsResponse struct {
+	*tchttp.BaseResponse
+	Response *GetLabServiceUrlsResponseParams `json:"Response"`
+}
+
+func (r *GetLabServiceUrlsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabServiceUrlsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabYamlRequestParams struct {
+	// <p>数据实验室Id</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type GetLabYamlRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室Id</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *GetLabYamlRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabYamlRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetLabYamlRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetLabYamlResponseParams struct {
+	// <p>RayCluster YAML</p>
+	Yaml *string `json:"Yaml,omitnil,omitempty" name:"Yaml"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetLabYamlResponse struct {
+	*tchttp.BaseResponse
+	Response *GetLabYamlResponseParams `json:"Response"`
+}
+
+func (r *GetLabYamlResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetLabYamlResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetModelConfigRequestParams struct {
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+}
+
+type GetModelConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+}
+
+func (r *GetModelConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetModelConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	delete(f, "ModelVersion")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetModelConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetModelConfigResponseParams struct {
+	// <p>模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>config.json 原始内容（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ConfigJson *string `json:"ConfigJson,omitnil,omitempty" name:"ConfigJson"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetModelConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *GetModelConfigResponseParams `json:"Response"`
+}
+
+func (r *GetModelConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetModelConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetModelFilesRequestParams struct {
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+}
+
+type GetModelFilesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+}
+
+func (r *GetModelFilesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetModelFilesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	delete(f, "ModelVersion")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetModelFilesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetModelFilesResponseParams struct {
+	// <p>模型ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelId *int64 `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>文件树根节点列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Files []*FileNode `json:"Files,omitnil,omitempty" name:"Files"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetModelFilesResponse struct {
+	*tchttp.BaseResponse
+	Response *GetModelFilesResponseParams `json:"Response"`
+}
+
+func (r *GetModelFilesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetModelFilesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetModelReadmeRequestParams struct {
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+}
+
+type GetModelReadmeRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+}
+
+func (r *GetModelReadmeRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetModelReadmeRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	delete(f, "ModelVersion")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetModelReadmeRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetModelReadmeResponseParams struct {
+	// <p>模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>模型提供方</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Provider *string `json:"Provider,omitnil,omitempty" name:"Provider"`
+
+	// <p>模型类型</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>参数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>是否是内置模型</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	BuiltIn *bool `json:"BuiltIn,omitnil,omitempty" name:"BuiltIn"`
+
+	// <p>README 内容（Markdown 格式）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Readme *string `json:"Readme,omitnil,omitempty" name:"Readme"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetModelReadmeResponse struct {
+	*tchttp.BaseResponse
+	Response *GetModelReadmeResponseParams `json:"Response"`
+}
+
+func (r *GetModelReadmeResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetModelReadmeResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type GetOptimizerPolicyRequestParams struct {
 	// 策略描述
 	SmartPolicy *SmartPolicy `json:"SmartPolicy,omitnil,omitempty" name:"SmartPolicy"`
@@ -14148,6 +19933,1329 @@ func (r *GetOptimizerPolicyResponse) ToJsonString() string {
 // because it has no param check, nor strict type check
 func (r *GetOptimizerPolicyResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterEventRequestParams struct {
+	// <p>Ray集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>翻页上下文，首次查询不传，后续翻页传入上一次返回的 Context 值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+}
+
+type GetRayClusterEventRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>Ray集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>翻页上下文，首次查询不传，后续翻页传入上一次返回的 Context 值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+}
+
+func (r *GetRayClusterEventRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterEventRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "SortFields")
+	delete(f, "Context")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayClusterEventRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterEventResponseParams struct {
+	// <p>翻页上下文，下一次分页请求时传入此值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+
+	// <p>是否已经返回所有符合条件的日志，true 表示已全部返回</p>
+	ListOver *bool `json:"ListOver,omitnil,omitempty" name:"ListOver"`
+
+	// <p>事件列表</p>
+	Events []*EventItem `json:"Events,omitnil,omitempty" name:"Events"`
+
+	// <p>事件开始时间</p><p>单位：毫秒</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>事件结束时间</p><p>单位：毫秒</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayClusterEventResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayClusterEventResponseParams `json:"Response"`
+}
+
+func (r *GetRayClusterEventResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterEventResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterHistoryRequestParams struct {
+	// <p>集群/数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type GetRayClusterHistoryRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群/数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *GetRayClusterHistoryRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterHistoryRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayClusterHistoryRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterHistoryResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>集群状态历史详情列表</p>
+	Items []*RayClusterHistory `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayClusterHistoryResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayClusterHistoryResponseParams `json:"Response"`
+}
+
+func (r *GetRayClusterHistoryResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterHistoryResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterPodYamlRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>Pod名称</p>
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+}
+
+type GetRayClusterPodYamlRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>Pod名称</p>
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+}
+
+func (r *GetRayClusterPodYamlRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterPodYamlRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "PodName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayClusterPodYamlRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterPodYamlResponseParams struct {
+	// <p>Pod YAML</p>
+	Yaml *string `json:"Yaml,omitnil,omitempty" name:"Yaml"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayClusterPodYamlResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayClusterPodYamlResponseParams `json:"Response"`
+}
+
+func (r *GetRayClusterPodYamlResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterPodYamlResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterPodsRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>起始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>截止时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件列表</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type GetRayClusterPodsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>起始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>截止时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件列表</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *GetRayClusterPodsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterPodsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayClusterPodsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterPodsResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>集群的Pod列表</p>
+	Items []*ClusterPod `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayClusterPodsResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayClusterPodsResponseParams `json:"Response"`
+}
+
+func (r *GetRayClusterPodsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterPodsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type GetRayClusterRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *GetRayClusterRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayClusterRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterResponseParams struct {
+	// <p>获取Ray集群详情请求</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>状态详情/错误信息</p>
+	StatusMessage *string `json:"StatusMessage,omitnil,omitempty" name:"StatusMessage"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>停止时间（最近一次停止/休眠）</p>
+	StopTime *uint64 `json:"StopTime,omitnil,omitempty" name:"StopTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayClusterResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayClusterResponseParams `json:"Response"`
+}
+
+func (r *GetRayClusterResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterYamlRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type GetRayClusterYamlRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *GetRayClusterYamlRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterYamlRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayClusterYamlRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayClusterYamlResponseParams struct {
+	// <p>RayCluster YAML</p>
+	Yaml *string `json:"Yaml,omitnil,omitempty" name:"Yaml"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayClusterYamlResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayClusterYamlResponseParams `json:"Response"`
+}
+
+func (r *GetRayClusterYamlResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayClusterYamlResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobEventLogRequestParams struct {
+	// ray-jobID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 开始时间
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 结束时间
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 排序字段列表（列表字段）
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type GetRayJobEventLogRequest struct {
+	*tchttp.BaseRequest
+	
+	// ray-jobID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 开始时间
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 结束时间
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 排序字段列表（列表字段）
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *GetRayJobEventLogRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobEventLogRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayJobEventLogRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobEventLogResponseParams struct {
+	// 事件总数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 事件列表
+	Events []*EventLogItem `json:"Events,omitnil,omitempty" name:"Events"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 总页数
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayJobEventLogResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayJobEventLogResponseParams `json:"Response"`
+}
+
+func (r *GetRayJobEventLogResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobEventLogResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobEventRequestParams struct {
+	// <p>ray-job ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>翻页上下文，首次查询不传，后续翻页传入上一次返回的 Context 值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+
+	// <p>分页大小</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>事件类型过滤，仅允许 ASCII 字母（如 Normal、Warning）</p>
+	EventType *string `json:"EventType,omitnil,omitempty" name:"EventType"`
+}
+
+type GetRayJobEventRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>ray-job ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>翻页上下文，首次查询不传，后续翻页传入上一次返回的 Context 值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+
+	// <p>分页大小</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>事件类型过滤，仅允许 ASCII 字母（如 Normal、Warning）</p>
+	EventType *string `json:"EventType,omitnil,omitempty" name:"EventType"`
+}
+
+func (r *GetRayJobEventRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobEventRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "SortFields")
+	delete(f, "Context")
+	delete(f, "PageSize")
+	delete(f, "EventType")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayJobEventRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobEventResponseParams struct {
+	// <p>翻页上下文，下一次分页请求时传入此值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+
+	// <p>是否已经返回所有符合条件的日志，true 表示已全部返回</p>
+	ListOver *bool `json:"ListOver,omitnil,omitempty" name:"ListOver"`
+
+	// <p>事件列表</p>
+	Events []*RayJobEventItem `json:"Events,omitnil,omitempty" name:"Events"`
+
+	// <p>事件开始时间</p><p>单位：毫秒</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>事件结束时间</p><p>单位：毫秒</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayJobEventResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayJobEventResponseParams `json:"Response"`
+}
+
+func (r *GetRayJobEventResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobEventResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobHistoryRequestParams struct {
+	// ray-jobID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type GetRayJobHistoryRequest struct {
+	*tchttp.BaseRequest
+	
+	// ray-jobID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *GetRayJobHistoryRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobHistoryRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayJobHistoryRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobHistoryResponseParams struct {
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 总页数
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 作业状态历史列表
+	Items []*JobStatusHistory `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayJobHistoryResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayJobHistoryResponseParams `json:"Response"`
+}
+
+func (r *GetRayJobHistoryResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobHistoryResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobPodYamlRequestParams struct {
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// Pod名称
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+}
+
+type GetRayJobPodYamlRequest struct {
+	*tchttp.BaseRequest
+	
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// Pod名称
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+}
+
+func (r *GetRayJobPodYamlRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobPodYamlRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "PodName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayJobPodYamlRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobPodYamlResponseParams struct {
+	// Pod Yaml
+	Yaml *string `json:"Yaml,omitnil,omitempty" name:"Yaml"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayJobPodYamlResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayJobPodYamlResponseParams `json:"Response"`
+}
+
+func (r *GetRayJobPodYamlResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobPodYamlResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobPodsRequestParams struct {
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 提交时间起始过滤-时间戳（毫秒，可选
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒，可选）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 过滤条件（列表名称）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 排序字段列表
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type GetRayJobPodsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 提交时间起始过滤-时间戳（毫秒，可选
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒，可选）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 过滤条件（列表名称）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 排序字段列表
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *GetRayJobPodsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobPodsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayJobPodsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobPodsResponseParams struct {
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 总页数
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 作业pod列表
+	Items []*JobPodEntity `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayJobPodsResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayJobPodsResponseParams `json:"Response"`
+}
+
+func (r *GetRayJobPodsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobPodsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobRequestParams struct {
+	// <p>任务ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type GetRayJobRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>任务ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *GetRayJobRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayJobRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobResponseParams struct {
+	// <p>任务ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>任务状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>任务名称</p>
+	JobName *string `json:"JobName,omitnil,omitempty" name:"JobName"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户主账号UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建账号</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>运行时间(ms)</p>
+	RunningTime *int64 `json:"RunningTime,omitnil,omitempty" name:"RunningTime"`
+
+	// <p>完成时间</p>
+	FinishTime *uint64 `json:"FinishTime,omitnil,omitempty" name:"FinishTime"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>失败原因/错误信息</p>
+	ErrorMessage *string `json:"ErrorMessage,omitnil,omitempty" name:"ErrorMessage"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>来源配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>来源配置名称</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>高级参数，JSON 字符串（透传到 Neutrino）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>业务来源标识（调用上下文，长度上限 64，禁止控制字符）</p>
+	JobSource *string `json:"JobSource,omitnil,omitempty" name:"JobSource"`
+
+	// <p>集群名称</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayJobResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayJobResponseParams `json:"Response"`
+}
+
+func (r *GetRayJobResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobYamlRequestParams struct {
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type GetRayJobYamlRequest struct {
+	*tchttp.BaseRequest
+	
+	// 任务ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *GetRayJobYamlRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobYamlRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayJobYamlRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetRayJobYamlResponseParams struct {
+	// RayJob YAML
+	Yaml *string `json:"Yaml,omitnil,omitempty" name:"Yaml"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetRayJobYamlResponse struct {
+	*tchttp.BaseResponse
+	Response *GetRayJobYamlResponseParams `json:"Response"`
+}
+
+func (r *GetRayJobYamlResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetRayJobYamlResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetResourceConfigRequestParams struct {
+	// 模板ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type GetResourceConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 模板ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *GetResourceConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetResourceConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetResourceConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetResourceConfigResponseParams struct {
+	// 模板ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 模板名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// 描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 模板类型
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// Head节点配置
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// Worker节点配置
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+
+	// 创建时间
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 更新时间
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// 应用ID
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// 创建者UIN
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// 子用户UIN
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetResourceConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *GetResourceConfigResponseParams `json:"Response"`
+}
+
+func (r *GetResourceConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetResourceConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+type GpuSummaryItem struct {
+
 }
 
 // Predefined struct for user
@@ -14238,6 +21346,50 @@ type GroupInfo struct {
 
 	// 策略类型
 	StrategyType *string `json:"StrategyType,omitnil,omitempty" name:"StrategyType"`
+}
+
+type HeadSpecDTO struct {
+	// <p>head/worker名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>Pod CPU核数</p>
+	PodCpu *int64 `json:"PodCpu,omitnil,omitempty" name:"PodCpu"`
+
+	// <p>Pod 内存大小</p>
+	PodMem *int64 `json:"PodMem,omitnil,omitempty" name:"PodMem"`
+
+	// <p>GPU类型</p>
+	GpuType *string `json:"GpuType,omitnil,omitempty" name:"GpuType"`
+
+	// <p>GPU数量</p>
+	GpuNum *int64 `json:"GpuNum,omitnil,omitempty" name:"GpuNum"`
+
+	// <p>环境变量列表</p>
+	Envs []*Env `json:"Envs,omitnil,omitempty" name:"Envs"`
+
+	// <p>标签列表</p>
+	Labels []*Label `json:"Labels,omitnil,omitempty" name:"Labels"`
+
+	// <p>资源标签列表（用于追加到 headGroupSpec/workerGroupSpec 的 resources map 中，对应 Ray/K8s 的自定义资源声明），Value 必须为字符串形式的整数</p>
+	ResourcesLabels []*Label `json:"ResourcesLabels,omitnil,omitempty" name:"ResourcesLabels"`
+
+	// <p>Pod数量</p>
+	PodNum *int64 `json:"PodNum,omitnil,omitempty" name:"PodNum"`
+
+	// <p>是否支持高级可用</p>
+	HighAvailability *bool `json:"HighAvailability,omitnil,omitempty" name:"HighAvailability"`
+
+	// <p>资源类型,CPU,GPU</p>
+	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
+
+	// <p>机型</p>
+	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
+
+	// <p>规格数量</p>
+	Spec *int64 `json:"Spec,omitnil,omitempty" name:"Spec"`
+
+	// <p>资源ID(唯一)</p>
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
 }
 
 type HiveInfo struct {
@@ -14346,6 +21498,230 @@ type IcebergTablePartition struct {
 	Location *LocationInfo `json:"Location,omitnil,omitempty" name:"Location"`
 }
 
+type InferenceEngineInfo struct {
+	// <p>引擎标识符</p>
+	EngineId *string `json:"EngineId,omitnil,omitempty" name:"EngineId"`
+
+	// <p>引擎名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>引擎版本</p>
+	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
+
+	// <p>引擎描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>标签列表</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>支持的模型类型</p>
+	ModelTypes []*string `json:"ModelTypes,omitnil,omitempty" name:"ModelTypes"`
+
+	// <p>是否独占，如果为 true，表示自定义模型看不到这个推理引擎，通常用于自研内置模型</p>
+	Exclusive *bool `json:"Exclusive,omitnil,omitempty" name:"Exclusive"`
+
+	// <p>是否启用</p>
+	Enabled *bool `json:"Enabled,omitnil,omitempty" name:"Enabled"`
+
+	// <p>引擎能力声明</p>
+	Capabilities *EngineCapabilities `json:"Capabilities,omitnil,omitempty" name:"Capabilities"`
+}
+
+type InferenceModelInfo struct {
+	// <p>Model ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelId *string `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>模型业务唯一标识</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型提供方</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Provider *string `json:"Provider,omitnil,omitempty" name:"Provider"`
+
+	// <p>模型描述</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模型类型</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>支持的引擎</p>
+	SupportedEngines []*string `json:"SupportedEngines,omitnil,omitempty" name:"SupportedEngines"`
+
+	// <p>参数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>模型标签</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>最新版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	LatestVersion *string `json:"LatestVersion,omitnil,omitempty" name:"LatestVersion"`
+
+	// <p>版本总数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	VersionCount *int64 `json:"VersionCount,omitnil,omitempty" name:"VersionCount"`
+
+	// <p>关联的推理服务数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceCount *int64 `json:"ServiceCount,omitnil,omitempty" name:"ServiceCount"`
+
+	// <p>是否有存储（内置模型和用户上传模型均为 true）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasStorage *bool `json:"HasStorage,omitnil,omitempty" name:"HasStorage"`
+
+	// <p>存储地域</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	StorageRegion *string `json:"StorageRegion,omitnil,omitempty" name:"StorageRegion"`
+
+	// <p>是否使用用户自带存储桶</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasCustomStorage *bool `json:"HasCustomStorage,omitnil,omitempty" name:"HasCustomStorage"`
+
+	// <p>存储后端类型（如 COS、GOOSEFS、CFSTURBO）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
+
+	// <p>是否是内置模型</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	BuiltIn *bool `json:"BuiltIn,omitnil,omitempty" name:"BuiltIn"`
+
+	// <p>任务类型列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Tasks []*string `json:"Tasks,omitnil,omitempty" name:"Tasks"`
+
+	// <p>云账户的 APP ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>云账户的 UIN</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>云账户的 Sub UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+}
+
+type InferenceServiceInfo struct {
+	// <p>服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的模型ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelId *uint64 `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>关联的模型UID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>关联的模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>关联的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>模型标识符（OpenAI 兼容 API 中的 model 字段）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>关联模型的类型（LLM / VLM / Embedding / Reranker / TTS / ASR / CV / NLP / ML）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>服务状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>服务端点URL</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndpointUrl *string `json:"EndpointUrl,omitnil,omitempty" name:"EndpointUrl"`
+
+	// <p>OpenAI 兼容统一入口 URL（通过 API-Key 路由，适用于 LLM/Embedding/Reranker）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedEndpointUrl *string `json:"UnifiedEndpointUrl,omitnil,omitempty" name:"UnifiedEndpointUrl"`
+
+	// <p>KServe V2 协议统一入口 URL（通过 API-Key + model name 路由，适用于 XGBoost 等传统 ML 模型）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedV2EndpointUrl *string `json:"UnifiedV2EndpointUrl,omitnil,omitempty" name:"UnifiedV2EndpointUrl"`
+
+	// <p>应用ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号UIN</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>部署数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentCount *int64 `json:"DeploymentCount,omitnil,omitempty" name:"DeploymentCount"`
+
+	// <p>是否存在至少一个运行中的部署</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasRunningDeployment *bool `json:"HasRunningDeployment,omitnil,omitempty" name:"HasRunningDeployment"`
+
+	// <p>Ray Dashboard 访问地址（通过 Ingress 代理）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RayDashboardUrl *string `json:"RayDashboardUrl,omitnil,omitempty" name:"RayDashboardUrl"`
+
+	// <p>是否启用 API-Key 鉴权</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthEnabled *bool `json:"ApiKeyAuthEnabled,omitnil,omitempty" name:"ApiKeyAuthEnabled"`
+
+	// <p>是否强制开启 API-Key 鉴权（生产环境为 true，不允许关闭）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthForceEnabled *bool `json:"ApiKeyAuthForceEnabled,omitnil,omitempty" name:"ApiKeyAuthForceEnabled"`
+
+	// <p>是否跳过 TLS 证书验证（自签证书场景，前端 curl 命令需加 -k 参数）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SkipTlsVerify *bool `json:"SkipTlsVerify,omitnil,omitempty" name:"SkipTlsVerify"`
+
+	// <p>运行中部署的 GPU 资源汇总</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GpuResourceSummary []*GpuSummaryItem `json:"GpuResourceSummary,omitnil,omitempty" name:"GpuResourceSummary"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>运行中部署的 CPU 资源汇总</p>
+	CpuResourceSummary *CpuSummaryItem `json:"CpuResourceSummary,omitnil,omitempty" name:"CpuResourceSummary"`
+
+	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+}
+
 // Predefined struct for user
 type InitializeTCLakeRequestParams struct {
 
@@ -14435,6 +21811,189 @@ type JobLogResult struct {
 	PkgLogId *string `json:"PkgLogId,omitnil,omitempty" name:"PkgLogId"`
 }
 
+type JobPodEntity struct {
+	// Pod名称
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+
+	// Pod IP
+	PodIp *string `json:"PodIp,omitnil,omitempty" name:"PodIp"`
+
+	// Pod状态
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// Pod阶段
+	Phase *string `json:"Phase,omitnil,omitempty" name:"Phase"`
+
+	// 所属节点
+	NodeName *string `json:"NodeName,omitnil,omitempty" name:"NodeName"`
+
+	// 节点IP
+	NodeIp *string `json:"NodeIp,omitnil,omitempty" name:"NodeIp"`
+
+	// 命名空间
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// CPU请求
+	CpuRequest *string `json:"CpuRequest,omitnil,omitempty" name:"CpuRequest"`
+
+	// CPU限制
+	CpuLimit *string `json:"CpuLimit,omitnil,omitempty" name:"CpuLimit"`
+
+	// 内存请求
+	MemoryRequest *string `json:"MemoryRequest,omitnil,omitempty" name:"MemoryRequest"`
+
+	// 内存限制
+	MemoryLimit *string `json:"MemoryLimit,omitnil,omitempty" name:"MemoryLimit"`
+
+	// GPU数量
+	GpuCount *string `json:"GpuCount,omitnil,omitempty" name:"GpuCount"`
+
+	// 容器镜像
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// Pod角色(head/worker)
+	Role *string `json:"Role,omitnil,omitempty" name:"Role"`
+
+	// 创建时间
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 启动时间
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+}
+
+type JobSpec struct {
+	// <p>配置ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>配置名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>ResourceConfigId</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置模板是否变更</p>
+	ResourceConfigChanged *bool `json:"ResourceConfigChanged,omitnil,omitempty" name:"ResourceConfigChanged"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>集群组Id</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>集群id</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>默认计算组名称</p>
+	ClusterGroup *string `json:"ClusterGroup,omitnil,omitempty" name:"ClusterGroup"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>优先级</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>该配置产生的作业实例数量</p>
+	JobInstanceCount *int64 `json:"JobInstanceCount,omitnil,omitempty" name:"JobInstanceCount"`
+
+	// <p>是否有运行中的作业实例</p>
+	HasRunningJobs *bool `json:"HasRunningJobs,omitnil,omitempty" name:"HasRunningJobs"`
+
+	// <p>高级参数，JSON 字符串</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+
+	// <p>作业提交目标：GROUP（按计算组分派）/ CLUSTER（指定集群）/ SERVERLESS（按 Serverless 拉起）</p>
+	SubmissionTarget *string `json:"SubmissionTarget,omitnil,omitempty" name:"SubmissionTarget"`
+
+	// <p>集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>集群名称</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+}
+
+type JobStatusHistory struct {
+	// 历史记录ID
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 作业ID
+	JobId *string `json:"JobId,omitnil,omitempty" name:"JobId"`
+
+	// 作业名称
+	JobName *string `json:"JobName,omitnil,omitempty" name:"JobName"`
+
+	// 源状态
+	FromState *string `json:"FromState,omitnil,omitempty" name:"FromState"`
+
+	// 目标状态
+	ToState *string `json:"ToState,omitnil,omitempty" name:"ToState"`
+
+	// 触发事件
+	Event *string `json:"Event,omitnil,omitempty" name:"Event"`
+
+	// 消息
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+
+	// 转换时间（毫秒时间戳）
+	TransitionTime *uint64 `json:"TransitionTime,omitnil,omitempty" name:"TransitionTime"`
+}
+
 type KVPair struct {
 	// <p>配置的key值</p>
 	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
@@ -14460,6 +22019,134 @@ type KerberosInfo struct {
 
 	// 服务主体
 	ServicePrincipal *string `json:"ServicePrincipal,omitnil,omitempty" name:"ServicePrincipal"`
+}
+
+type LabResponse struct {
+	// <p>案例模板ID（startMode=EXAMPLE 时使用）</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>代码包/工程归档地址</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>数据实验室服务入口（服务类型 -&gt; 访问地址）</p>
+	Services []*TypeKVPair `json:"Services,omitnil,omitempty" name:"Services"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>Lab sidecar 镜像拉取策略（Always, IfNotPresent, Never）</p>
+	LabImagePullPolicy *string `json:"LabImagePullPolicy,omitnil,omitempty" name:"LabImagePullPolicy"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>状态详情/错误信息</p>
+	StatusMessage *string `json:"StatusMessage,omitnil,omitempty" name:"StatusMessage"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>所属集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>高级参数（扁平 Key-Value 的 JSON 字符串），Key 以 spec. 开头，按 RayCluster CRD 下钻；详见 ADVANCED_CLUSTER_OPTIONS_DESIGN.md</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>停止时间（最近一次停止/休眠）</p>
+	StopTime *uint64 `json:"StopTime,omitnil,omitempty" name:"StopTime"`
+
+	// <p>删除时间</p>
+	DeleteTime *uint64 `json:"DeleteTime,omitnil,omitempty" name:"DeleteTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>Token 认证密钥（开启 token 认证时由系统生成）</p>
+	Token *string `json:"Token,omitnil,omitempty" name:"Token"`
+}
+
+type Label struct {
+	// <p>名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>值</p>
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
 }
 
 type LakeFileSystemToken struct {
@@ -14563,6 +22250,1628 @@ func (r *LaunchStandardEngineResourceGroupsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *LaunchStandardEngineResourceGroupsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+type LinkedServiceInfo struct {
+	// <p>服务 UID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+}
+
+// Predefined struct for user
+type ListClusterGroupsRequestParams struct {
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>提交时间起始过滤-时间戳（毫秒，可选）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>提交时间截止过滤-时间戳（毫秒，可选）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListClusterGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>提交时间起始过滤-时间戳（毫秒，可选）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>提交时间截止过滤-时间戳（毫秒，可选）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListClusterGroupsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListClusterGroupsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListClusterGroupsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListClusterGroupsResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>集群组列表</p>
+	Items []*ClusterGroup `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListClusterGroupsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListClusterGroupsResponseParams `json:"Response"`
+}
+
+func (r *ListClusterGroupsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListClusterGroupsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListExampleCategoriesRequestParams struct {
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type ListExampleCategoriesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *ListExampleCategoriesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListExampleCategoriesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListExampleCategoriesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListExampleCategoriesResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>分类列表</p>
+	Items []*ExampleCategories `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListExampleCategoriesResponse struct {
+	*tchttp.BaseResponse
+	Response *ListExampleCategoriesResponseParams `json:"Response"`
+}
+
+func (r *ListExampleCategoriesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListExampleCategoriesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListExampleDifficultiesRequestParams struct {
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type ListExampleDifficultiesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *ListExampleDifficultiesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListExampleDifficultiesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListExampleDifficultiesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListExampleDifficultiesResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>分类列表</p>
+	Items []*ExampleDifficulties `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListExampleDifficultiesResponse struct {
+	*tchttp.BaseResponse
+	Response *ListExampleDifficultiesResponseParams `json:"Response"`
+}
+
+func (r *ListExampleDifficultiesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListExampleDifficultiesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListExampleTagsRequestParams struct {
+	// <p>案例标签</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
+}
+
+type ListExampleTagsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>案例标签</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
+}
+
+func (r *ListExampleTagsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListExampleTagsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Category")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListExampleTagsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListExampleTagsResponseParams struct {
+	// <p>标签总数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页显示标签数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>标签实体</p>
+	Items []*ExampleTag `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListExampleTagsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListExampleTagsResponseParams `json:"Response"`
+}
+
+func (r *ListExampleTagsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListExampleTagsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListExamplesRequestParams struct {
+	// <p>分类</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
+
+	// <p>关键词</p>
+	Keyword *string `json:"Keyword,omitnil,omitempty" name:"Keyword"`
+
+	// <p>标签数组，多个标签 AND 关系；与 Category/Keyword 之间也是 AND</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>DEFAULT（sort_order ASC, create_time DESC）/ POPULARITY（按热度降序），非法值降级为 DEFAULT</p>
+	OrderBy *string `json:"OrderBy,omitnil,omitempty" name:"OrderBy"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type ListExamplesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>分类</p>
+	Category *string `json:"Category,omitnil,omitempty" name:"Category"`
+
+	// <p>关键词</p>
+	Keyword *string `json:"Keyword,omitnil,omitempty" name:"Keyword"`
+
+	// <p>标签数组，多个标签 AND 关系；与 Category/Keyword 之间也是 AND</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>DEFAULT（sort_order ASC, create_time DESC）/ POPULARITY（按热度降序），非法值降级为 DEFAULT</p>
+	OrderBy *string `json:"OrderBy,omitnil,omitempty" name:"OrderBy"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *ListExamplesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListExamplesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Category")
+	delete(f, "Keyword")
+	delete(f, "Tags")
+	delete(f, "OrderBy")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListExamplesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListExamplesResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>案例管理列表</p>
+	Items []*ExampleEntity `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListExamplesResponse struct {
+	*tchttp.BaseResponse
+	Response *ListExamplesResponseParams `json:"Response"`
+}
+
+func (r *ListExamplesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListExamplesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListInferenceEnginesRequestParams struct {
+	// <p>当前页码</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页的数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤-时间戳（毫秒，可选）</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-时间戳（毫秒，可选）</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListInferenceEnginesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>当前页码</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页的数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤-时间戳（毫秒，可选）</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-时间戳（毫秒，可选）</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListInferenceEnginesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListInferenceEnginesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListInferenceEnginesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListInferenceEnginesResponseParams struct {
+	// <p>数据列表</p>
+	Items []*InferenceEngineInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页的数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总的页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListInferenceEnginesResponse struct {
+	*tchttp.BaseResponse
+	Response *ListInferenceEnginesResponseParams `json:"Response"`
+}
+
+func (r *ListInferenceEnginesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListInferenceEnginesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListInferenceModelsRequestParams struct {
+	// <p>页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤器</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>模型参数最小值</p>
+	ParameterSizeMin *float64 `json:"ParameterSizeMin,omitnil,omitempty" name:"ParameterSizeMin"`
+
+	// <p>模型参数最大值</p>
+	ParameterSizeMax *float64 `json:"ParameterSizeMax,omitnil,omitempty" name:"ParameterSizeMax"`
+}
+
+type ListInferenceModelsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤器</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>模型参数最小值</p>
+	ParameterSizeMin *float64 `json:"ParameterSizeMin,omitnil,omitempty" name:"ParameterSizeMin"`
+
+	// <p>模型参数最大值</p>
+	ParameterSizeMax *float64 `json:"ParameterSizeMax,omitnil,omitempty" name:"ParameterSizeMax"`
+}
+
+func (r *ListInferenceModelsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListInferenceModelsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	delete(f, "ParameterSizeMin")
+	delete(f, "ParameterSizeMax")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListInferenceModelsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListInferenceModelsResponseParams struct {
+	// <p>推理模型列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Items []*InferenceModelInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>总记录数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListInferenceModelsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListInferenceModelsResponseParams `json:"Response"`
+}
+
+func (r *ListInferenceModelsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListInferenceModelsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListInferenceServicesRequestParams struct {
+	// <p>页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤-时间戳（毫秒，可选）</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-时间戳（毫秒，可选）</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListInferenceServicesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤-时间戳（毫秒，可选）</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-时间戳（毫秒，可选）</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListInferenceServicesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListInferenceServicesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListInferenceServicesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListInferenceServicesResponseParams struct {
+	// <p>推理服务列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Items []*InferenceServiceInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>总记录数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListInferenceServicesResponse struct {
+	*tchttp.BaseResponse
+	Response *ListInferenceServicesResponseParams `json:"Response"`
+}
+
+func (r *ListInferenceServicesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListInferenceServicesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListJobSpecsRequestParams struct {
+	// <p>页数</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>创建时间范围 - 开始时间（时间戳（毫秒））</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间范围 - 结束时间（时间戳（毫秒））</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListJobSpecsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>页数</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>创建时间范围 - 开始时间（时间戳（毫秒））</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间范围 - 结束时间（时间戳（毫秒））</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListJobSpecsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListJobSpecsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "Filters")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListJobSpecsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListJobSpecsResponseParams struct {
+	// <p>总数量</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页数</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>作业配置列表</p>
+	Items []*JobSpec `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListJobSpecsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListJobSpecsResponseParams `json:"Response"`
+}
+
+func (r *ListJobSpecsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListJobSpecsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListJobsBySpecRequestParams struct {
+	// 配置ID
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 提交时间起始过滤-时间戳（毫秒，可选）
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒，可选）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 过滤条件
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 排序字段列表
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListJobsBySpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// 配置ID
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 提交时间起始过滤-时间戳（毫秒，可选）
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒，可选）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 过滤条件
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 排序字段列表
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListJobsBySpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListJobsBySpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListJobsBySpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListJobsBySpecResponseParams struct {
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 总页数
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 数据列表
+	Items []*RayJobSubmitEntity `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListJobsBySpecResponse struct {
+	*tchttp.BaseResponse
+	Response *ListJobsBySpecResponseParams `json:"Response"`
+}
+
+func (r *ListJobsBySpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListJobsBySpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListLabsRequestParams struct {
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListLabsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListLabsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListLabsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListLabsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListLabsResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>数据实验室列表</p>
+	Items []*LabResponse `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListLabsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListLabsResponseParams `json:"Response"`
+}
+
+func (r *ListLabsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListLabsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListModelVersionsRequestParams struct {
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>创建时间起始过滤-毫秒时间戳</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-毫秒时间戳</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>额外过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>页码（默认1）</p><p>取值范围：[1, 2147483647]</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认200）</p><p>取值范围：[1, 2147483647]</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type ListModelVersionsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>创建时间起始过滤-毫秒时间戳</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-毫秒时间戳</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>额外过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>页码（默认1）</p><p>取值范围：[1, 2147483647]</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认200）</p><p>取值范围：[1, 2147483647]</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *ListModelVersionsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListModelVersionsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListModelVersionsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListModelVersionsResponseParams struct {
+	// <p>模型版本列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Items []*ModelVersionInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>模型总数量</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前多少页</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>当前页模型数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>结果总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListModelVersionsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListModelVersionsResponseParams `json:"Response"`
+}
+
+func (r *ListModelVersionsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListModelVersionsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListRayClusterJobsRequestParams struct {
+	// 集群ID（必填）
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页数量
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 额外过滤条件（ClusterId 已由外层单独传入，无需再在此处指定）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 提交时间起始过滤-时间戳（毫秒，可选）
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒，可选）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 排序字段列表
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListRayClusterJobsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 集群ID（必填）
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页数量
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 额外过滤条件（ClusterId 已由外层单独传入，无需再在此处指定）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 提交时间起始过滤-时间戳（毫秒，可选）
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒，可选）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 排序字段列表
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListRayClusterJobsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListRayClusterJobsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "Filters")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListRayClusterJobsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListRayClusterJobsResponseParams struct {
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 每页数量
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 总页数
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 该集群下的Ray作业列表
+	Items []*RayJobSubmitEntity `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListRayClusterJobsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListRayClusterJobsResponseParams `json:"Response"`
+}
+
+func (r *ListRayClusterJobsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListRayClusterJobsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListRayClustersRequestParams struct {
+	// <p>起始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>截止时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件列表</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListRayClustersRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>起始时间（毫秒时间戳）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>截止时间（毫秒时间戳）</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件列表</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListRayClustersRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListRayClustersRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListRayClustersRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListRayClustersResponseParams struct {
+	// <p>总记录数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>Ray cluster列表</p>
+	Items []*RayClusterEntity `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListRayClustersResponse struct {
+	*tchttp.BaseResponse
+	Response *ListRayClustersResponseParams `json:"Response"`
+}
+
+func (r *ListRayClustersResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListRayClustersResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListRayJobsRequestParams struct {
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 过滤条件列表（列表的字段名称）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 提交时间起始过滤-时间戳（毫秒，可选）
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒，可选）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 排序字段列表（列表字段）
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListRayJobsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 过滤条件列表（列表的字段名称）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 提交时间起始过滤-时间戳（毫秒，可选）
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒，可选）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 排序字段列表（列表字段）
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListRayJobsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListRayJobsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "Filters")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListRayJobsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListRayJobsResponseParams struct {
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 总页数
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// ray作业列表
+	Items []*RayJobSubmitEntity `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListRayJobsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListRayJobsResponseParams `json:"Response"`
+}
+
+func (r *ListRayJobsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListRayJobsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListResourceConfigsRequestParams struct {
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 过滤条件列表（列表字段名称）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 提交时间起始过滤-时间戳（毫秒）
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 排序字段列表（列表字段名称）
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListResourceConfigsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 过滤条件列表（列表字段名称）
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 提交时间起始过滤-时间戳（毫秒）
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 提交时间截止过滤-时间戳（毫秒）
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 排序字段列表（列表字段名称）
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListResourceConfigsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListResourceConfigsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "Filters")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListResourceConfigsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListResourceConfigsResponseParams struct {
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 总页数
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 资源配置模板列表
+	Items []*ResourceConfig `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListResourceConfigsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListResourceConfigsResponseParams `json:"Response"`
+}
+
+func (r *ListResourceConfigsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListResourceConfigsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -14881,6 +24190,182 @@ func (r *LockMetaDataResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type MCPTaskInfo struct {
+	// <p>任务 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>BatchId</p>
+	BatchId *string `json:"BatchId,omitnil,omitempty" name:"BatchId"`
+
+	// <p>状态</p>
+	State *int64 `json:"State,omitnil,omitempty" name:"State"`
+
+	// <p>任务类型</p>
+	TaskType *string `json:"TaskType,omitnil,omitempty" name:"TaskType"`
+
+	// <p>任务类型</p>
+	TaskKind *string `json:"TaskKind,omitnil,omitempty" name:"TaskKind"`
+
+	// <p>引擎详情</p>
+	EngineTypeDetail *string `json:"EngineTypeDetail,omitnil,omitempty" name:"EngineTypeDetail"`
+
+	// <p>SQL 类型</p>
+	SQLType *string `json:"SQLType,omitnil,omitempty" name:"SQLType"`
+
+	// <p>SQL</p>
+	SQL *string `json:"SQL,omitnil,omitempty" name:"SQL"`
+
+	// <p>是否截断</p>
+	IsSQLCutOff *bool `json:"IsSQLCutOff,omitnil,omitempty" name:"IsSQLCutOff"`
+
+	// <p>数据库名称</p>
+	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
+
+	// <p>引擎 ID</p>
+	DataEngineId *string `json:"DataEngineId,omitnil,omitempty" name:"DataEngineId"`
+
+	// <p>资源组名称</p>
+	ResourceGroupName *string `json:"ResourceGroupName,omitnil,omitempty" name:"ResourceGroupName"`
+
+	// <p>JobId</p>
+	SparkJobId *string `json:"SparkJobId,omitnil,omitempty" name:"SparkJobId"`
+
+	// <p>Job 名称</p>
+	SparkJobName *string `json:"SparkJobName,omitnil,omitempty" name:"SparkJobName"`
+
+	// <p>操作人 Uin</p>
+	OperateUin *string `json:"OperateUin,omitnil,omitempty" name:"OperateUin"`
+
+	// <p>创建时间</p>
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>开始时间</p>
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p>
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>引擎耗时</p><p>单位：毫秒</p>
+	UsedTime *int64 `json:"UsedTime,omitnil,omitempty" name:"UsedTime"`
+
+	// <p>执行总耗时</p><p>单位：毫秒</p>
+	TotalTime *int64 `json:"TotalTime,omitnil,omitempty" name:"TotalTime"`
+
+	// <p>进度</p>
+	Progress *int64 `json:"Progress,omitnil,omitempty" name:"Progress"`
+
+	// <p>输出信息</p>
+	OutputMessage *string `json:"OutputMessage,omitnil,omitempty" name:"OutputMessage"`
+
+	// <p>结果集</p>
+	DataSet *string `json:"DataSet,omitnil,omitempty" name:"DataSet"`
+}
+
+type MCPTaskResultInfo struct {
+	// <p>任务 ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>状态</p>
+	State *int64 `json:"State,omitnil,omitempty" name:"State"`
+
+	// <p>结果集 Schema</p>
+	ResultSchema []*Column `json:"ResultSchema,omitnil,omitempty" name:"ResultSchema"`
+
+	// <p>结果集</p>
+	ResultSet *string `json:"ResultSet,omitnil,omitempty" name:"ResultSet"`
+
+	// <p>是否还有其他结果</p>
+	NextToken *string `json:"NextToken,omitnil,omitempty" name:"NextToken"`
+
+	// <p>影响行数</p>
+	RowAffectInfo *string `json:"RowAffectInfo,omitnil,omitempty" name:"RowAffectInfo"`
+
+	// <p>输出信息</p>
+	OutputMessage *string `json:"OutputMessage,omitnil,omitempty" name:"OutputMessage"`
+
+	// <p>展示 format</p>
+	DisplayFormat *string `json:"DisplayFormat,omitnil,omitempty" name:"DisplayFormat"`
+
+	// <p>能否下载</p>
+	CanDownload *bool `json:"CanDownload,omitnil,omitempty" name:"CanDownload"`
+
+	// <p>结果花费时间</p><p>单位：毫秒</p>
+	QueryResultTime *float64 `json:"QueryResultTime,omitnil,omitempty" name:"QueryResultTime"`
+
+	// <p>是否超大</p>
+	IsResultOversize *bool `json:"IsResultOversize,omitnil,omitempty" name:"IsResultOversize"`
+}
+
+type MessageItem struct {
+	// <p>计费项标识</p>
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
+
+	// <p>校验失败描述信息</p>
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+}
+
+type MetaDatabaseInfo struct {
+	// 数据库名称。
+	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
+
+	// 数据库描述信息，长度 0~2048。
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Comment *string `json:"Comment,omitnil,omitempty" name:"Comment"`
+}
+
+type MetricsData struct {
+	// <p>每秒请求数（QPS）</p>
+	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
+
+	// <p>错误率（0~1）</p>
+	ErrorRate *float64 `json:"ErrorRate,omitnil,omitempty" name:"ErrorRate"`
+
+	// <p>P95 延迟（毫秒）</p>
+	P95LatencyMs *float64 `json:"P95LatencyMs,omitnil,omitempty" name:"P95LatencyMs"`
+
+	// <p>P99 延迟（毫秒）</p>
+	P99LatencyMs *float64 `json:"P99LatencyMs,omitnil,omitempty" name:"P99LatencyMs"`
+
+	// <p>队列深度（排队中的请求数）</p>
+	QueueDepth *float64 `json:"QueueDepth,omitnil,omitempty" name:"QueueDepth"`
+
+	// <p>TTFT P99 延迟（毫秒，仅 vLLM）</p>
+	TimeToFirstTokenP99Ms *float64 `json:"TimeToFirstTokenP99Ms,omitnil,omitempty" name:"TimeToFirstTokenP99Ms"`
+
+	// <p>TPOT P99 延迟（毫秒，仅 vLLM）</p>
+	TimePerOutputTokenP99Ms *float64 `json:"TimePerOutputTokenP99Ms,omitnil,omitempty" name:"TimePerOutputTokenP99Ms"`
+
+	// <p>Token 吞吐量（tokens/s，仅 vLLM）</p>
+	TokenThroughput *float64 `json:"TokenThroughput,omitnil,omitempty" name:"TokenThroughput"`
+
+	// <p>GPU 利用率（0~100，百分比）</p>
+	GpuUtilization *float64 `json:"GpuUtilization,omitnil,omitempty" name:"GpuUtilization"`
+
+	// <p>GPU 显存已用（MB）</p>
+	GpuMemoryUsedMB *float64 `json:"GpuMemoryUsedMB,omitnil,omitempty" name:"GpuMemoryUsedMB"`
+
+	// <p>GPU 显存总量（MB）</p>
+	GpuMemoryTotalMB *float64 `json:"GpuMemoryTotalMB,omitnil,omitempty" name:"GpuMemoryTotalMB"`
+
+	// <p>CPU 利用率（0~100，百分比）</p>
+	CpuUtilization *float64 `json:"CpuUtilization,omitnil,omitempty" name:"CpuUtilization"`
+
+	// <p>内存已用（字节）</p>
+	MemoryUsedBytes *float64 `json:"MemoryUsedBytes,omitnil,omitempty" name:"MemoryUsedBytes"`
+
+	// <p>内存总量（字节）</p>
+	MemoryTotalBytes *float64 `json:"MemoryTotalBytes,omitnil,omitempty" name:"MemoryTotalBytes"`
+
+	// <p>网络接收速度（MB/s）</p>
+	NetworkReceiveMBPerSecond *float64 `json:"NetworkReceiveMBPerSecond,omitnil,omitempty" name:"NetworkReceiveMBPerSecond"`
+
+	// <p>网络发送速度（MB/s）</p>
+	NetworkSendMBPerSecond *float64 `json:"NetworkSendMBPerSecond,omitnil,omitempty" name:"NetworkSendMBPerSecond"`
+}
+
 type MixedTablePartitions struct {
 	// 数据表格式
 	TableFormat *string `json:"TableFormat,omitnil,omitempty" name:"TableFormat"`
@@ -14896,6 +24381,43 @@ type MixedTablePartitions struct {
 
 	// hive表分区信息
 	HivePartitions []*HiveTablePartition `json:"HivePartitions,omitnil,omitempty" name:"HivePartitions"`
+}
+
+type ModelVersionInfo struct {
+	// <p>版本ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	VersionId *string `json:"VersionId,omitnil,omitempty" name:"VersionId"`
+
+	// <p>关联的模型ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelId *string `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>版本号（如 v1, v2）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
+
+	// <p>该版本的存储 URI</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	StorageUri *string `json:"StorageUri,omitnil,omitempty" name:"StorageUri"`
+
+	// <p>版本说明</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>关联的推理服务列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	LinkedServices []*LinkedServiceInfo `json:"LinkedServices,omitnil,omitempty" name:"LinkedServices"`
+
+	// <p>是否使用用户自带存储桶（true=用户自带桶，false=平台托管）</p>
+	UseCustomStorage *bool `json:"UseCustomStorage,omitnil,omitempty" name:"UseCustomStorage"`
 }
 
 // Predefined struct for user
@@ -14956,6 +24478,136 @@ func (r *ModifyAdvancedStoreLocationResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyAdvancedStoreLocationResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyClusterPriorityRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+}
+
+type ModifyClusterPriorityRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+}
+
+func (r *ModifyClusterPriorityRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyClusterPriorityRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Priority")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyClusterPriorityRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyClusterPriorityResponseParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子账号UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyClusterPriorityResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyClusterPriorityResponseParams `json:"Response"`
+}
+
+func (r *ModifyClusterPriorityResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyClusterPriorityResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -15072,6 +24724,322 @@ func (r *ModifyGovernEventRuleResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ModifyLabPriorityRequestParams struct {
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+}
+
+type ModifyLabPriorityRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+}
+
+func (r *ModifyLabPriorityRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyLabPriorityRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Priority")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyLabPriorityRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyLabPriorityResponseParams struct {
+	// <p>案例模板ID（startMode=EXAMPLE 时使用）</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>代码包/工程归档地址</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>数据实验室服务入口（服务类型 -&gt; 访问地址）</p>
+	Services []*TypeKVPair `json:"Services,omitnil,omitempty" name:"Services"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>状态详情/错误信息</p>
+	StatusMessage *string `json:"StatusMessage,omitnil,omitempty" name:"StatusMessage"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>所属集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>高级参数（扁平 Key-Value 的 JSON 字符串），Key 以 spec. 开头，按 RayCluster CRD 下钻；详见 ADVANCED_CLUSTER_OPTIONS_DESIGN.md</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>停止时间（最近一次停止/休眠）</p>
+	StopTime *uint64 `json:"StopTime,omitnil,omitempty" name:"StopTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyLabPriorityResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyLabPriorityResponseParams `json:"Response"`
+}
+
+func (r *ModifyLabPriorityResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyLabPriorityResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyPartitionDescriptionRequestParams struct {
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 分区描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+}
+
+type ModifyPartitionDescriptionRequest struct {
+	*tchttp.BaseRequest
+	
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 分区描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+}
+
+func (r *ModifyPartitionDescriptionRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyPartitionDescriptionRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionCode")
+	delete(f, "Description")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyPartitionDescriptionRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyPartitionDescriptionResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyPartitionDescriptionResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyPartitionDescriptionResponseParams `json:"Response"`
+}
+
+func (r *ModifyPartitionDescriptionResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyPartitionDescriptionResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyPartitionQueueRequestParams struct {
+	// 资源队列ID
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 队列名称
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// 队列描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 资源规格列表，定义队列的资源类型及大小范围
+	ResourceUsages []*ResourceUsage `json:"ResourceUsages,omitnil,omitempty" name:"ResourceUsages"`
+
+	// 队列类型：1-独占型，2-共享型
+	QueueType *int64 `json:"QueueType,omitnil,omitempty" name:"QueueType"`
+}
+
+type ModifyPartitionQueueRequest struct {
+	*tchttp.BaseRequest
+	
+	// 资源队列ID
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 分区编码
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// 队列名称
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// 队列描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 资源规格列表，定义队列的资源类型及大小范围
+	ResourceUsages []*ResourceUsage `json:"ResourceUsages,omitnil,omitempty" name:"ResourceUsages"`
+
+	// 队列类型：1-独占型，2-共享型
+	QueueType *int64 `json:"QueueType,omitnil,omitempty" name:"QueueType"`
+}
+
+func (r *ModifyPartitionQueueRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyPartitionQueueRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "PartitionCode")
+	delete(f, "QueueName")
+	delete(f, "Description")
+	delete(f, "ResourceUsages")
+	delete(f, "QueueType")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyPartitionQueueRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyPartitionQueueResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyPartitionQueueResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyPartitionQueueResponseParams `json:"Response"`
+}
+
+func (r *ModifyPartitionQueueResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyPartitionQueueResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifySparkAppBatchRequestParams struct {
 	// 需要批量修改的Spark作业任务ID列表
 	SparkAppId []*string `json:"SparkAppId,omitnil,omitempty" name:"SparkAppId"`
@@ -15164,6 +25132,270 @@ func (r *ModifySparkAppBatchResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifySparkAppBatchResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifySparkAppForTDLCRequestParams struct {
+	// <p>spark作业名</p>
+	AppName *string `json:"AppName,omitnil,omitempty" name:"AppName"`
+
+	// <p>spark作业类型，1代表spark jar作业，2代表spark streaming作业</p>
+	AppType *int64 `json:"AppType,omitnil,omitempty" name:"AppType"`
+
+	// <p>执行spark作业的数据引擎名称</p>
+	DataEngine *string `json:"DataEngine,omitnil,omitempty" name:"DataEngine"`
+
+	// <p>spark作业程序包文件路径</p>
+	AppFile *string `json:"AppFile,omitnil,omitempty" name:"AppFile"`
+
+	// <p>数据访问策略，CAM Role arn</p>
+	RoleArn *int64 `json:"RoleArn,omitnil,omitempty" name:"RoleArn"`
+
+	// <p>指定的Driver规格，当前支持：small（默认，1cu）、medium（2cu）、large（4cu）、xlarge（8cu）</p>
+	AppDriverSize *string `json:"AppDriverSize,omitnil,omitempty" name:"AppDriverSize"`
+
+	// <p>指定的Executor规格，当前支持：small（默认，1cu）、medium（2cu）、large（4cu）、xlarge（8cu）</p>
+	AppExecutorSize *string `json:"AppExecutorSize,omitnil,omitempty" name:"AppExecutorSize"`
+
+	// <p>spark作业executor个数</p>
+	AppExecutorNums *int64 `json:"AppExecutorNums,omitnil,omitempty" name:"AppExecutorNums"`
+
+	// <p>spark作业Id</p>
+	SparkAppId *string `json:"SparkAppId,omitnil,omitempty" name:"SparkAppId"`
+
+	// <p>该字段已下线，请使用字段Datasource</p>
+	Eni *string `json:"Eni,omitnil,omitempty" name:"Eni"`
+
+	// <p>spark作业程序包是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocal *string `json:"IsLocal,omitnil,omitempty" name:"IsLocal"`
+
+	// <p>spark作业主类</p>
+	MainClass *string `json:"MainClass,omitnil,omitempty" name:"MainClass"`
+
+	// <p>spark配置，以换行符分隔</p>
+	AppConf *string `json:"AppConf,omitnil,omitempty" name:"AppConf"`
+
+	// <p>spark 作业依赖jar包是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalJars *string `json:"IsLocalJars,omitnil,omitempty" name:"IsLocalJars"`
+
+	// <p>spark 作业依赖jar包（--jars），以逗号分隔</p>
+	AppJars *string `json:"AppJars,omitnil,omitempty" name:"AppJars"`
+
+	// <p>spark作业依赖文件资源是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalFiles *string `json:"IsLocalFiles,omitnil,omitempty" name:"IsLocalFiles"`
+
+	// <p>spark作业依赖文件资源（--files）（非jar、zip），以逗号分隔</p>
+	AppFiles *string `json:"AppFiles,omitnil,omitempty" name:"AppFiles"`
+
+	// <p>pyspark：依赖上传方式，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalPythonFiles *string `json:"IsLocalPythonFiles,omitnil,omitempty" name:"IsLocalPythonFiles"`
+
+	// <p>pyspark作业依赖python资源（--py-files），支持py/zip/egg等归档格式，多文件以逗号分隔</p>
+	AppPythonFiles *string `json:"AppPythonFiles,omitnil,omitempty" name:"AppPythonFiles"`
+
+	// <p>spark作业程序入参</p>
+	CmdArgs *string `json:"CmdArgs,omitnil,omitempty" name:"CmdArgs"`
+
+	// <p>最大重试次数，只对spark流任务生效</p>
+	MaxRetries *int64 `json:"MaxRetries,omitnil,omitempty" name:"MaxRetries"`
+
+	// <p>数据源名</p>
+	DataSource *string `json:"DataSource,omitnil,omitempty" name:"DataSource"`
+
+	// <p>spark作业依赖archives资源是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalArchives *string `json:"IsLocalArchives,omitnil,omitempty" name:"IsLocalArchives"`
+
+	// <p>spark作业依赖archives资源（--archives），支持tar.gz/tgz/tar等归档格式，以逗号分隔</p>
+	AppArchives *string `json:"AppArchives,omitnil,omitempty" name:"AppArchives"`
+
+	// <p>Spark Image 版本号</p>
+	SparkImage *string `json:"SparkImage,omitnil,omitempty" name:"SparkImage"`
+
+	// <p>Spark Image 版本名称</p>
+	SparkImageVersion *string `json:"SparkImageVersion,omitnil,omitempty" name:"SparkImageVersion"`
+
+	// <p>指定的Executor数量（最大值），默认为1，当开启动态分配有效，若未开启，则该值等于AppExecutorNums</p>
+	AppExecutorMaxNumbers *int64 `json:"AppExecutorMaxNumbers,omitnil,omitempty" name:"AppExecutorMaxNumbers"`
+
+	// <p>关联dlc查询脚本</p>
+	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+
+	// <p>任务资源配置是否继承集群配置模板：0（默认）不继承、1：继承</p>
+	IsInherit *uint64 `json:"IsInherit,omitnil,omitempty" name:"IsInherit"`
+
+	// <p>是否使用session脚本的sql运行任务：false：否，true：是</p>
+	IsSessionStarted *bool `json:"IsSessionStarted,omitnil,omitempty" name:"IsSessionStarted"`
+
+	// <p>标准引擎依赖包</p>
+	DependencyPackages []*DependencyPackage `json:"DependencyPackages,omitnil,omitempty" name:"DependencyPackages"`
+}
+
+type ModifySparkAppForTDLCRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>spark作业名</p>
+	AppName *string `json:"AppName,omitnil,omitempty" name:"AppName"`
+
+	// <p>spark作业类型，1代表spark jar作业，2代表spark streaming作业</p>
+	AppType *int64 `json:"AppType,omitnil,omitempty" name:"AppType"`
+
+	// <p>执行spark作业的数据引擎名称</p>
+	DataEngine *string `json:"DataEngine,omitnil,omitempty" name:"DataEngine"`
+
+	// <p>spark作业程序包文件路径</p>
+	AppFile *string `json:"AppFile,omitnil,omitempty" name:"AppFile"`
+
+	// <p>数据访问策略，CAM Role arn</p>
+	RoleArn *int64 `json:"RoleArn,omitnil,omitempty" name:"RoleArn"`
+
+	// <p>指定的Driver规格，当前支持：small（默认，1cu）、medium（2cu）、large（4cu）、xlarge（8cu）</p>
+	AppDriverSize *string `json:"AppDriverSize,omitnil,omitempty" name:"AppDriverSize"`
+
+	// <p>指定的Executor规格，当前支持：small（默认，1cu）、medium（2cu）、large（4cu）、xlarge（8cu）</p>
+	AppExecutorSize *string `json:"AppExecutorSize,omitnil,omitempty" name:"AppExecutorSize"`
+
+	// <p>spark作业executor个数</p>
+	AppExecutorNums *int64 `json:"AppExecutorNums,omitnil,omitempty" name:"AppExecutorNums"`
+
+	// <p>spark作业Id</p>
+	SparkAppId *string `json:"SparkAppId,omitnil,omitempty" name:"SparkAppId"`
+
+	// <p>该字段已下线，请使用字段Datasource</p>
+	Eni *string `json:"Eni,omitnil,omitempty" name:"Eni"`
+
+	// <p>spark作业程序包是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocal *string `json:"IsLocal,omitnil,omitempty" name:"IsLocal"`
+
+	// <p>spark作业主类</p>
+	MainClass *string `json:"MainClass,omitnil,omitempty" name:"MainClass"`
+
+	// <p>spark配置，以换行符分隔</p>
+	AppConf *string `json:"AppConf,omitnil,omitempty" name:"AppConf"`
+
+	// <p>spark 作业依赖jar包是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalJars *string `json:"IsLocalJars,omitnil,omitempty" name:"IsLocalJars"`
+
+	// <p>spark 作业依赖jar包（--jars），以逗号分隔</p>
+	AppJars *string `json:"AppJars,omitnil,omitempty" name:"AppJars"`
+
+	// <p>spark作业依赖文件资源是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalFiles *string `json:"IsLocalFiles,omitnil,omitempty" name:"IsLocalFiles"`
+
+	// <p>spark作业依赖文件资源（--files）（非jar、zip），以逗号分隔</p>
+	AppFiles *string `json:"AppFiles,omitnil,omitempty" name:"AppFiles"`
+
+	// <p>pyspark：依赖上传方式，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalPythonFiles *string `json:"IsLocalPythonFiles,omitnil,omitempty" name:"IsLocalPythonFiles"`
+
+	// <p>pyspark作业依赖python资源（--py-files），支持py/zip/egg等归档格式，多文件以逗号分隔</p>
+	AppPythonFiles *string `json:"AppPythonFiles,omitnil,omitempty" name:"AppPythonFiles"`
+
+	// <p>spark作业程序入参</p>
+	CmdArgs *string `json:"CmdArgs,omitnil,omitempty" name:"CmdArgs"`
+
+	// <p>最大重试次数，只对spark流任务生效</p>
+	MaxRetries *int64 `json:"MaxRetries,omitnil,omitempty" name:"MaxRetries"`
+
+	// <p>数据源名</p>
+	DataSource *string `json:"DataSource,omitnil,omitempty" name:"DataSource"`
+
+	// <p>spark作业依赖archives资源是否本地上传，cos：存放与cos，lakefs：本地上传（控制台使用，该方式不支持直接接口调用）</p>
+	IsLocalArchives *string `json:"IsLocalArchives,omitnil,omitempty" name:"IsLocalArchives"`
+
+	// <p>spark作业依赖archives资源（--archives），支持tar.gz/tgz/tar等归档格式，以逗号分隔</p>
+	AppArchives *string `json:"AppArchives,omitnil,omitempty" name:"AppArchives"`
+
+	// <p>Spark Image 版本号</p>
+	SparkImage *string `json:"SparkImage,omitnil,omitempty" name:"SparkImage"`
+
+	// <p>Spark Image 版本名称</p>
+	SparkImageVersion *string `json:"SparkImageVersion,omitnil,omitempty" name:"SparkImageVersion"`
+
+	// <p>指定的Executor数量（最大值），默认为1，当开启动态分配有效，若未开启，则该值等于AppExecutorNums</p>
+	AppExecutorMaxNumbers *int64 `json:"AppExecutorMaxNumbers,omitnil,omitempty" name:"AppExecutorMaxNumbers"`
+
+	// <p>关联dlc查询脚本</p>
+	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
+
+	// <p>任务资源配置是否继承集群配置模板：0（默认）不继承、1：继承</p>
+	IsInherit *uint64 `json:"IsInherit,omitnil,omitempty" name:"IsInherit"`
+
+	// <p>是否使用session脚本的sql运行任务：false：否，true：是</p>
+	IsSessionStarted *bool `json:"IsSessionStarted,omitnil,omitempty" name:"IsSessionStarted"`
+
+	// <p>标准引擎依赖包</p>
+	DependencyPackages []*DependencyPackage `json:"DependencyPackages,omitnil,omitempty" name:"DependencyPackages"`
+}
+
+func (r *ModifySparkAppForTDLCRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifySparkAppForTDLCRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "AppName")
+	delete(f, "AppType")
+	delete(f, "DataEngine")
+	delete(f, "AppFile")
+	delete(f, "RoleArn")
+	delete(f, "AppDriverSize")
+	delete(f, "AppExecutorSize")
+	delete(f, "AppExecutorNums")
+	delete(f, "SparkAppId")
+	delete(f, "Eni")
+	delete(f, "IsLocal")
+	delete(f, "MainClass")
+	delete(f, "AppConf")
+	delete(f, "IsLocalJars")
+	delete(f, "AppJars")
+	delete(f, "IsLocalFiles")
+	delete(f, "AppFiles")
+	delete(f, "IsLocalPythonFiles")
+	delete(f, "AppPythonFiles")
+	delete(f, "CmdArgs")
+	delete(f, "MaxRetries")
+	delete(f, "DataSource")
+	delete(f, "IsLocalArchives")
+	delete(f, "AppArchives")
+	delete(f, "SparkImage")
+	delete(f, "SparkImageVersion")
+	delete(f, "AppExecutorMaxNumbers")
+	delete(f, "SessionId")
+	delete(f, "IsInherit")
+	delete(f, "IsSessionStarted")
+	delete(f, "DependencyPackages")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifySparkAppForTDLCRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifySparkAppForTDLCResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifySparkAppForTDLCResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifySparkAppForTDLCResponseParams `json:"Response"`
+}
+
+func (r *ModifySparkAppForTDLCResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifySparkAppForTDLCResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -16006,6 +26238,22 @@ type OtherDatasourceConnection struct {
 	Location *DatasourceConnectionLocation `json:"Location,omitnil,omitempty" name:"Location"`
 }
 
+type OverviewItem struct {
+	// <p>图表类型（与请求中的 ChartTypes 对应）</p>
+	ChartType *string `json:"ChartType,omitnil,omitempty" name:"ChartType"`
+
+	// <p>当前瞬时值（如 QPS=15.2、延迟=120.5ms、利用率=85.0%）。查询失败或无数据时为 null</p>
+	Value *float64 `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
+type ParallelKeyMapping struct {
+	// <p>并行类型</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>该并行类型对应的参数 key 列表</p>
+	Keys []*string `json:"Keys,omitnil,omitempty" name:"Keys"`
+}
+
 type Param struct {
 	// 参数key，例如：
 	ConfigItem *string `json:"ConfigItem,omitnil,omitempty" name:"ConfigItem"`
@@ -16036,6 +26284,83 @@ type Partition struct {
 
 	// 创建时间
 	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+}
+
+type PartitionDetail struct {
+	// <p>分区编码</p>
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// <p>分区名称</p>
+	PartitionName *string `json:"PartitionName,omitnil,omitempty" name:"PartitionName"`
+
+	// <p>分区描述</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>地域</p>
+	Region *int64 `json:"Region,omitnil,omitempty" name:"Region"`
+
+	// <p>产品信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ProductInfo *string `json:"ProductInfo,omitnil,omitempty" name:"ProductInfo"`
+
+	// <p>资源池编码</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePoolCode *string `json:"ResourcePoolCode,omitnil,omitempty" name:"ResourcePoolCode"`
+
+	// <p>资源配额列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceQuota []*ResourceQuota `json:"ResourceQuota,omitnil,omitempty" name:"ResourceQuota"`
+
+	// <p>付费模式</p>
+	PayMode *int64 `json:"PayMode,omitnil,omitempty" name:"PayMode"`
+
+	// <p>续费标志</p>
+	RenewFlag *int64 `json:"RenewFlag,omitnil,omitempty" name:"RenewFlag"`
+
+	// <p>调度器类型</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Scheduler *string `json:"Scheduler,omitnil,omitempty" name:"Scheduler"`
+
+	// <p>状态</p>
+	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+type PartitionInfo struct {
+	// <p>分区名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>分区编码</p>
+	PartitionCode *string `json:"PartitionCode,omitnil,omitempty" name:"PartitionCode"`
+
+	// <p>描述</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>状态：11-发货中，1-运行中，2-隔离中，3-已销毁</p>
+	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>队列数量</p>
+	QueueCount *int64 `json:"QueueCount,omitnil,omitempty" name:"QueueCount"`
+
+	// <p>资源配置（配额）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceQuota []*ResourceQuota `json:"ResourceQuota,omitnil,omitempty" name:"ResourceQuota"`
+
+	// <p>计费类型：1-包年包月，0-按量计费</p>
+	PayMode *int64 `json:"PayMode,omitnil,omitempty" name:"PayMode"`
+
+	// <p>创建时间</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>过期时间</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ExpireTime *string `json:"ExpireTime,omitnil,omitempty" name:"ExpireTime"`
 }
 
 // Predefined struct for user
@@ -16094,6 +26419,23 @@ func (r *PauseStandardEngineResourceGroupsResponse) ToJsonString() string {
 // because it has no param check, nor strict type check
 func (r *PauseStandardEngineResourceGroupsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
+}
+
+type PersistentWorkDir struct {
+	// <p>是否启用持久化工作目录；为空或 false 时沿用 emptyDir 行为</p>
+	Enabled *bool `json:"Enabled,omitnil,omitempty" name:"Enabled"`
+
+	// <p>持久化存储类型：COS / CFS</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>COS Bucket 名称（Type=COS 时必填）</p>
+	Bucket *string `json:"Bucket,omitnil,omitempty" name:"Bucket"`
+
+	// <p>CFS 文件系统 ID（Type=CFS 时必填）</p>
+	FileSystemId *string `json:"FileSystemId,omitnil,omitempty" name:"FileSystemId"`
+
+	// <p>Bucket / 文件系统下的子路径，必须以 &#39;/&#39; 开头且不含 &#39;..&#39;</p>
+	VolumeSubPath *string `json:"VolumeSubPath,omitnil,omitempty" name:"VolumeSubPath"`
 }
 
 type Policy struct {
@@ -16221,6 +26563,166 @@ type PythonSparkImage struct {
 }
 
 // Predefined struct for user
+type QueryDashboardOverviewRequestParams struct {
+	// <p>时间范围起始（Unix 时间戳，秒）</p>
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>时间范围结束（Unix 时间戳，秒）</p>
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+}
+
+type QueryDashboardOverviewRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>时间范围起始（Unix 时间戳，秒）</p>
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>时间范围结束（Unix 时间戳，秒）</p>
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+}
+
+func (r *QueryDashboardOverviewRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *QueryDashboardOverviewRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "QueryDashboardOverviewRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type QueryDashboardOverviewResponseParams struct {
+	// <p>时间范围内所有服务的总 QPS（每秒请求数）均值</p><p>单位：请求每秒</p>
+	TotalRequestsPerSecond *float64 `json:"TotalRequestsPerSecond,omitnil,omitempty" name:"TotalRequestsPerSecond"`
+
+	// <p>时间范围内全局 P99 延迟均值（毫秒）</p><p>单位：毫秒</p>
+	AverageP99LatencyMs *float64 `json:"AverageP99LatencyMs,omitnil,omitempty" name:"AverageP99LatencyMs"`
+
+	// <p>时间范围内全局错误率均值（0~1，如 0.02 表示 2%）</p><p>取值范围：[0, 1]</p>
+	ErrorRate *float64 `json:"ErrorRate,omitnil,omitempty" name:"ErrorRate"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type QueryDashboardOverviewResponse struct {
+	*tchttp.BaseResponse
+	Response *QueryDashboardOverviewResponseParams `json:"Response"`
+}
+
+func (r *QueryDashboardOverviewResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *QueryDashboardOverviewResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type QueryDashboardServiceListRequestParams struct {
+	// <p>页码（默认1）</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认20）</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件。支持的过滤字段：Keyword（服务名称/模型名称模糊搜索）、Status（服务状态精确匹配，如 Running）、Engine（推理引擎匹配，如 vllm，用于 LLM 推理专项 tab，只要服务有至少一个 deployment 的 engine 匹配即返回）、ResourcePartitionId（资源分区精确匹配）</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表（全局排序，支持按指标字段排序）</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type QueryDashboardServiceListRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>页码（默认1）</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认20）</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件。支持的过滤字段：Keyword（服务名称/模型名称模糊搜索）、Status（服务状态精确匹配，如 Running）、Engine（推理引擎匹配，如 vllm，用于 LLM 推理专项 tab，只要服务有至少一个 deployment 的 engine 匹配即返回）、ResourcePartitionId（资源分区精确匹配）</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表（全局排序，支持按指标字段排序）</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *QueryDashboardServiceListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *QueryDashboardServiceListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "QueryDashboardServiceListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type QueryDashboardServiceListResponseParams struct {
+	// <p>匹配过滤条件的服务总数</p>
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *uint64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>服务监控指标列表</p>
+	Items []*ServiceMetricsItem `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type QueryDashboardServiceListResponse struct {
+	*tchttp.BaseResponse
+	Response *QueryDashboardServiceListResponseParams `json:"Response"`
+}
+
+func (r *QueryDashboardServiceListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *QueryDashboardServiceListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type QueryInternalTableWarehouseRequestParams struct {
 	// 库名
 	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
@@ -16288,6 +26790,70 @@ func (r *QueryInternalTableWarehouseResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *QueryInternalTableWarehouseResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type QueryMonitorOverviewRequestParams struct {
+	// <p>图表类型列表（批量查询多个指标的当前值）</p>
+	ChartTypes []*string `json:"ChartTypes,omitnil,omitempty" name:"ChartTypes"`
+
+	// <p>推理服务 ID（业务唯一标识）</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+type QueryMonitorOverviewRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>图表类型列表（批量查询多个指标的当前值）</p>
+	ChartTypes []*string `json:"ChartTypes,omitnil,omitempty" name:"ChartTypes"`
+
+	// <p>推理服务 ID（业务唯一标识）</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+func (r *QueryMonitorOverviewRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *QueryMonitorOverviewRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ChartTypes")
+	delete(f, "ServiceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "QueryMonitorOverviewRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type QueryMonitorOverviewResponseParams struct {
+	// <p>概览数据项列表，每项对应一个请求的 ChartType</p>
+	Items []*OverviewItem `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type QueryMonitorOverviewResponse struct {
+	*tchttp.BaseResponse
+	Response *QueryMonitorOverviewResponseParams `json:"Response"`
+}
+
+func (r *QueryMonitorOverviewResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *QueryMonitorOverviewResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -16467,6 +27033,257 @@ func (r *QueryTaskCostDetailResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type QueueInfo struct {
+	// <p>队列ID</p>
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>队列名称</p>
+	QueueName *string `json:"QueueName,omitnil,omitempty" name:"QueueName"`
+
+	// <p>资源用量列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceUsage []*ResourceUsage `json:"ResourceUsage,omitnil,omitempty" name:"ResourceUsage"`
+
+	// <p>队列描述</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>是否为默认队列</p>
+	IsDefault *int64 `json:"IsDefault,omitnil,omitempty" name:"IsDefault"`
+
+	// <p>队列类型：1-独占型，2-共享型</p>
+	QueueType *int64 `json:"QueueType,omitnil,omitempty" name:"QueueType"`
+}
+
+type RayClusterEntity struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>状态详情/错误信息</p>
+	StatusMessage *string `json:"StatusMessage,omitnil,omitempty" name:"StatusMessage"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>停止时间（最近一次停止/休眠）</p>
+	StopTime *uint64 `json:"StopTime,omitnil,omitempty" name:"StopTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+type RayClusterHistory struct {
+	// <p>历史记录ID</p>
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群/数据实验室ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>集群/数据实验室名称</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+
+	// <p>源状态</p>
+	FromState *string `json:"FromState,omitnil,omitempty" name:"FromState"`
+
+	// <p>目标状态</p>
+	ToState *string `json:"ToState,omitnil,omitempty" name:"ToState"`
+
+	// <p>触发事件</p>
+	Event *string `json:"Event,omitnil,omitempty" name:"Event"`
+
+	// <p>消息</p>
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+
+	// <p>转换时间（毫秒时间戳）</p>
+	TransitionTime *int64 `json:"TransitionTime,omitnil,omitempty" name:"TransitionTime"`
+}
+
+type RayJobEventItem struct {
+	// <p>事件时间（Unix 时间戳，毫秒）</p>
+	EventTime *uint64 `json:"EventTime,omitnil,omitempty" name:"EventTime"`
+
+	// <p>组件名称，来源于 event.involvedObject.kind</p>
+	Component *string `json:"Component,omitnil,omitempty" name:"Component"`
+
+	// <p>事件级别，来源于 event.type 的原始值（如 Normal、Warning）</p>
+	Level *string `json:"Level,omitnil,omitempty" name:"Level"`
+
+	// <p>事件内容，来源于 event.message</p>
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+
+	// <p>关联的 K8s 对象名称，来源于 event.involvedObject.name</p>
+	InvolvedObjectName *string `json:"InvolvedObjectName,omitnil,omitempty" name:"InvolvedObjectName"`
+
+	// <p>事件来源组件，来源于 event.source.component</p>
+	SourceComponent *string `json:"SourceComponent,omitnil,omitempty" name:"SourceComponent"`
+
+	// <p>事件原因，来源于 event.reason</p>
+	Reason *string `json:"Reason,omitnil,omitempty" name:"Reason"`
+}
+
+type RayJobSubmitEntity struct {
+	// <p>任务ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>任务状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>任务名称</p>
+	JobName *string `json:"JobName,omitnil,omitempty" name:"JobName"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户主账号UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>运行时间(ms)</p>
+	RunningTime *int64 `json:"RunningTime,omitnil,omitempty" name:"RunningTime"`
+
+	// <p>完成时间</p>
+	FinishTime *uint64 `json:"FinishTime,omitnil,omitempty" name:"FinishTime"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>失败原因/错误信息</p>
+	ErrorMessage *string `json:"ErrorMessage,omitnil,omitempty" name:"ErrorMessage"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>来源配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>来源配置名称</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>高级参数，JSON 字符串（透传到 Neutrino）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>作业来源（如 RAY_JOB / RAY_SERVE / 平台直提交等）</p>
+	JobSource *string `json:"JobSource,omitnil,omitempty" name:"JobSource"`
+}
+
+type RegionInfo struct {
+	// <p>地域编码，如 ap-chongqing</p>
+	RegionCode *string `json:"RegionCode,omitnil,omitempty" name:"RegionCode"`
+
+	// <p>地域名称，如 重庆</p>
+	RegionName *string `json:"RegionName,omitnil,omitempty" name:"RegionName"`
+
+	// <p>地域状态：AVAILABLE-可用，UNAVAILABLE-不可用</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
 // Predefined struct for user
 type RegisterThirdPartyAccessUserRequestParams struct {
 
@@ -16600,6 +27417,14 @@ func (r *RenewDataEngineResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type ReplicaInfo struct {
+	// <p>期望副本数</p>
+	Desired *uint64 `json:"Desired,omitnil,omitempty" name:"Desired"`
+
+	// <p>可用（就绪）副本数</p>
+	Available *uint64 `json:"Available,omitnil,omitempty" name:"Available"`
+}
+
 // Predefined struct for user
 type ReportHeartbeatMetaDataRequestParams struct {
 	// 数据源名称
@@ -16673,6 +27498,41 @@ type ResourceConf struct {
 	Parallelism *int64 `json:"Parallelism,omitnil,omitempty" name:"Parallelism"`
 }
 
+type ResourceConfig struct {
+	// <p>模板ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>模板名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模板类型(ray,spark)</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>Head节点配置</p>
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// <p>Worker节点配置</p>
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+}
+
 type ResourceInfo struct {
 	// 归属类型
 	AttributionType *string `json:"AttributionType,omitnil,omitempty" name:"AttributionType"`
@@ -16698,6 +27558,63 @@ type ResourceInfo struct {
 
 	// 资源配置信息
 	ResourceConf *ResourceConf `json:"ResourceConf,omitnil,omitempty" name:"ResourceConf"`
+}
+
+type ResourceQuota struct {
+	// <p>可售卖资源规格</p>
+	ResourceSpec *ResourceSpec `json:"ResourceSpec,omitnil,omitempty" name:"ResourceSpec"`
+
+	// <p>配额数量</p><p>请注意，CPU类型计费项为32的整数倍，GPU类型计费项为1的整数倍。</p>
+	Quota *int64 `json:"Quota,omitnil,omitempty" name:"Quota"`
+}
+
+type ResourceSaleInfo struct {
+	// <p>可售卖资源规格</p>
+	ResourceSpec *ResourceSpec `json:"ResourceSpec,omitnil,omitempty" name:"ResourceSpec"`
+
+	// <p>规格步长</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Step *int64 `json:"Step,omitnil,omitempty" name:"Step"`
+
+	// <p>最大资源数量，仅GU有值</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MaxSpec *int64 `json:"MaxSpec,omitnil,omitempty" name:"MaxSpec"`
+}
+
+type ResourceSpec struct {
+	// <p>资源包类型</p>
+	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
+
+	// <p>机型，例如X40/T20，仅GU有值</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
+
+	// <p>四层计费项</p><p>枚举值：</p><ul><li>sv_dlc_standard_cu_standard_cu： 标准型cpu，最小单位32</li><li>sv_dlc_high_memory_cu_high_memory_cu： 高内存型cpu，最小单位32</li><li>sv_dlc_gn7_gn75xlarge80： T4，最小单位1</li><li>sv_dlc_gn10xp_gn10xp2xlarge40： V100，最小单位1</li></ul><p>若您想要了解更多的计费规格和产品细节，欢迎联系我们。</p>
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
+
+	// <p>规格描述</p>
+	SpecDesc *string `json:"SpecDesc,omitnil,omitempty" name:"SpecDesc"`
+
+	// <p>规格，格式为 {gpu}:{cpu}:{mem}:{vram}</p>
+	Spec *string `json:"Spec,omitnil,omitempty" name:"Spec"`
+
+	// <p>GPU类型</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GpuType *string `json:"GpuType,omitnil,omitempty" name:"GpuType"`
+
+	// <p>单个物理节点上该计费项对应的最大 GPU 卡数，CPU / HM_CPU 恒为 0</p>
+	MaxCardPerNode *int64 `json:"MaxCardPerNode,omitnil,omitempty" name:"MaxCardPerNode"`
+}
+
+type ResourceUsage struct {
+	// <p>资源规格</p>
+	ResourceSpec *ResourceSpec `json:"ResourceSpec,omitnil,omitempty" name:"ResourceSpec"`
+
+	// <p>最小用量</p>
+	Min *int64 `json:"Min,omitnil,omitempty" name:"Min"`
+
+	// <p>最大用量</p>
+	Max *int64 `json:"Max,omitnil,omitempty" name:"Max"`
 }
 
 // Predefined struct for user
@@ -16758,6 +27675,149 @@ func (r *RestartDataEngineResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *RestartDataEngineResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type RestartInferenceServiceRequestParams struct {
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+type RestartInferenceServiceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+func (r *RestartInferenceServiceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *RestartInferenceServiceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RestartInferenceServiceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type RestartInferenceServiceResponseParams struct {
+	// <p>推理服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的模型UID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>关联的模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>关联的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>模型标识符（OpenAI 兼容 API 中的 model 字段）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>关联模型的类型（LLM / VLM / Embedding / Reranker / TTS / ASR / CV / NLP / ML）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>服务状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>服务端点URL</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndpointUrl *string `json:"EndpointUrl,omitnil,omitempty" name:"EndpointUrl"`
+
+	// <p>OpenAI 兼容统一入口 URL（通过 API-Key 路由，适用于 LLM/Embedding/Reranker）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedEndpointUrl *string `json:"UnifiedEndpointUrl,omitnil,omitempty" name:"UnifiedEndpointUrl"`
+
+	// <p>KServe V2 协议统一入口 URL（通过 API-Key + model name 路由，适用于 XGBoost 等传统 ML 模型）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedV2EndpointUrl *string `json:"UnifiedV2EndpointUrl,omitnil,omitempty" name:"UnifiedV2EndpointUrl"`
+
+	// <p>应用ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号UIN</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>部署数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentCount *int64 `json:"DeploymentCount,omitnil,omitempty" name:"DeploymentCount"`
+
+	// <p>是否存在至少一个运行中的部署</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasRunningDeployment *bool `json:"HasRunningDeployment,omitnil,omitempty" name:"HasRunningDeployment"`
+
+	// <p>是否启用 API-Key 鉴权</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthEnabled *bool `json:"ApiKeyAuthEnabled,omitnil,omitempty" name:"ApiKeyAuthEnabled"`
+
+	// <p>是否强制开启 API-Key 鉴权（生产环境为 true，不允许关闭）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthForceEnabled *bool `json:"ApiKeyAuthForceEnabled,omitnil,omitempty" name:"ApiKeyAuthForceEnabled"`
+
+	// <p>是否跳过 TLS 证书验证（自签证书场景，前端 curl 命令需加 -k 参数）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SkipTlsVerify *bool `json:"SkipTlsVerify,omitnil,omitempty" name:"SkipTlsVerify"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>运行中部署的 CPU 资源汇总</p>
+	CpuResourceSummary *CpuSummaryItem `json:"CpuResourceSummary,omitnil,omitempty" name:"CpuResourceSummary"`
+
+	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type RestartInferenceServiceResponse struct {
+	*tchttp.BaseResponse
+	Response *RestartInferenceServiceResponseParams `json:"Response"`
+}
+
+func (r *RestartInferenceServiceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *RestartInferenceServiceResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -16883,6 +27943,150 @@ func (r *RollbackDataEngineImageResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type RunJobSpecRequestParams struct {
+	// <p>配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>外部工作流引擎业务键 flowId</p>
+	FlowId *string `json:"FlowId,omitnil,omitempty" name:"FlowId"`
+
+	// <p>外部工作流引擎业务键 executionId</p>
+	ExecutionId *string `json:"ExecutionId,omitnil,omitempty" name:"ExecutionId"`
+
+	// <p>业务来源标识（调用上下文，长度上限 64，禁止控制字符）</p>
+	JobSource *string `json:"JobSource,omitnil,omitempty" name:"JobSource"`
+}
+
+type RunJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>外部工作流引擎业务键 flowId</p>
+	FlowId *string `json:"FlowId,omitnil,omitempty" name:"FlowId"`
+
+	// <p>外部工作流引擎业务键 executionId</p>
+	ExecutionId *string `json:"ExecutionId,omitnil,omitempty" name:"ExecutionId"`
+
+	// <p>业务来源标识（调用上下文，长度上限 64，禁止控制字符）</p>
+	JobSource *string `json:"JobSource,omitnil,omitempty" name:"JobSource"`
+}
+
+func (r *RunJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *RunJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	delete(f, "FlowId")
+	delete(f, "ExecutionId")
+	delete(f, "JobSource")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RunJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type RunJobSpecResponseParams struct {
+	// <p>任务ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>任务状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>任务名称</p>
+	JobName *string `json:"JobName,omitnil,omitempty" name:"JobName"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>运行时间(ms)</p>
+	RunningTime *int64 `json:"RunningTime,omitnil,omitempty" name:"RunningTime"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>来源配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>来源配置名称</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>高级参数</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>业务来源标识（调用上下文，长度上限 64，禁止控制字符）</p>
+	JobSource *string `json:"JobSource,omitnil,omitempty" name:"JobSource"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type RunJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *RunJobSpecResponseParams `json:"Response"`
+}
+
+func (r *RunJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *RunJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type SQLTask struct {
 	// base64加密后的SQL语句
 	SQL *string `json:"SQL,omitnil,omitempty" name:"SQL"`
@@ -16928,6 +28132,32 @@ type Script struct {
 
 	// 更新时间戳， 单位：ms。
 	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+}
+
+type ServiceMetricsItem struct {
+	// <p>服务 UID，服务唯一标识</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>服务显示名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>服务状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>推理引擎</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>模型名称</p>
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>OpenAI 兼容的模型标识符</p>
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>副本信息</p>
+	Replicas *ReplicaInfo `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>监控指标数据</p>
+	Metrics *MetricsData `json:"Metrics,omitnil,omitempty" name:"Metrics"`
 }
 
 type SessionResourceTemplate struct {
@@ -17103,6 +28333,14 @@ type Sort struct {
 
 	// 是否按照ASC排序，否则DESC排序
 	Asc *bool `json:"Asc,omitnil,omitempty" name:"Asc"`
+}
+
+type SortField struct {
+	// 排序字段名，对应实体属性名（驼峰命名）
+	Field *string `json:"Field,omitnil,omitempty" name:"Field"`
+
+	// 排序方向：ASC（升序）或DESC（降序），默认ASC
+	Order *string `json:"Order,omitnil,omitempty" name:"Order"`
 }
 
 type SortOrder struct {
@@ -17518,6 +28756,291 @@ type StandardEngineResourceGroupInfo struct {
 	LaunchTime *string `json:"LaunchTime,omitnil,omitempty" name:"LaunchTime"`
 }
 
+// Predefined struct for user
+type StartLabRequestParams struct {
+	// <p>工作区ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type StartLabRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>工作区ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *StartLabRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StartLabRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StartLabRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StartLabResponseParams struct {
+	// <p>案例模板ID（startMode=EXAMPLE 时使用）</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>代码包/工程归档地址</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>数据实验室服务入口（服务类型 -&gt; 访问地址）</p>
+	Services []*TypeKVPair `json:"Services,omitnil,omitempty" name:"Services"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>所属集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>高级参数（扁平 Key-Value 的 JSON 字符串），Key 以 spec. 开头，按 RayCluster CRD 下钻；详见 ADVANCED_CLUSTER_OPTIONS_DESIGN.md</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StartLabResponse struct {
+	*tchttp.BaseResponse
+	Response *StartLabResponseParams `json:"Response"`
+}
+
+func (r *StartLabResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StartLabResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StartRayClusterRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type StartRayClusterRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *StartRayClusterRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StartRayClusterRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StartRayClusterRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StartRayClusterResponseParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子账号UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>停止时间（最近一次停止/休眠）</p>
+	StopTime *uint64 `json:"StopTime,omitnil,omitempty" name:"StopTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StartRayClusterResponse struct {
+	*tchttp.BaseResponse
+	Response *StartRayClusterResponseParams `json:"Response"`
+}
+
+func (r *StartRayClusterResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StartRayClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type StatementInformation struct {
 	// SQL任务唯一ID
 	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
@@ -17550,6 +29073,410 @@ type StatementOutput struct {
 
 	// SQL类型任务结果返回
 	SQLResult *string `json:"SQLResult,omitnil,omitempty" name:"SQLResult"`
+}
+
+// Predefined struct for user
+type StopInferenceServiceRequestParams struct {
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+type StopInferenceServiceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+func (r *StopInferenceServiceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopInferenceServiceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StopInferenceServiceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopInferenceServiceResponseParams struct {
+	// <p>推理服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的模型UID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>关联的模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>关联的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>模型标识符（OpenAI 兼容 API 中的 model 字段）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>关联模型的类型（LLM / VLM / Embedding / Reranker / TTS / ASR / CV / NLP / ML）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>服务状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>服务端点URL</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndpointUrl *string `json:"EndpointUrl,omitnil,omitempty" name:"EndpointUrl"`
+
+	// <p>OpenAI 兼容统一入口 URL（通过 API-Key 路由，适用于 LLM/Embedding/Reranker）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedEndpointUrl *string `json:"UnifiedEndpointUrl,omitnil,omitempty" name:"UnifiedEndpointUrl"`
+
+	// <p>KServe V2 协议统一入口 URL（通过 API-Key + model name 路由，适用于 XGBoost 等传统 ML 模型）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedV2EndpointUrl *string `json:"UnifiedV2EndpointUrl,omitnil,omitempty" name:"UnifiedV2EndpointUrl"`
+
+	// <p>应用ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号UIN</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>部署数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentCount *int64 `json:"DeploymentCount,omitnil,omitempty" name:"DeploymentCount"`
+
+	// <p>是否存在至少一个运行中的部署</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasRunningDeployment *bool `json:"HasRunningDeployment,omitnil,omitempty" name:"HasRunningDeployment"`
+
+	// <p>是否启用 API-Key 鉴权</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthEnabled *bool `json:"ApiKeyAuthEnabled,omitnil,omitempty" name:"ApiKeyAuthEnabled"`
+
+	// <p>是否强制开启 API-Key 鉴权（生产环境为 true，不允许关闭）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthForceEnabled *bool `json:"ApiKeyAuthForceEnabled,omitnil,omitempty" name:"ApiKeyAuthForceEnabled"`
+
+	// <p>是否跳过 TLS 证书验证（自签证书场景，前端 curl 命令需加 -k 参数）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SkipTlsVerify *bool `json:"SkipTlsVerify,omitnil,omitempty" name:"SkipTlsVerify"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>运行中部署的 CPU 资源汇总</p>
+	CpuResourceSummary *CpuSummaryItem `json:"CpuResourceSummary,omitnil,omitempty" name:"CpuResourceSummary"`
+
+	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StopInferenceServiceResponse struct {
+	*tchttp.BaseResponse
+	Response *StopInferenceServiceResponseParams `json:"Response"`
+}
+
+func (r *StopInferenceServiceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopInferenceServiceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopLabRequestParams struct {
+	// <p>工作区ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type StopLabRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>工作区ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *StopLabRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopLabRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StopLabRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopLabResponseParams struct {
+	// <p>案例模板ID（startMode=EXAMPLE 时使用）</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>数据实验室服务入口（服务类型 -&gt; 访问地址）</p>
+	Services []*TypeKVPair `json:"Services,omitnil,omitempty" name:"Services"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>高级参数（扁平 Key-Value 的 JSON 字符串），Key 以 spec. 开头，按 RayCluster CRD 下钻；详见 ADVANCED_CLUSTER_OPTIONS_DESIGN.md</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>Token 认证密钥（开启 token 认证时由系统生成）</p>
+	Token *string `json:"Token,omitnil,omitempty" name:"Token"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StopLabResponse struct {
+	*tchttp.BaseResponse
+	Response *StopLabResponseParams `json:"Response"`
+}
+
+func (r *StopLabResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopLabResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopRayClusterRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+type StopRayClusterRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+}
+
+func (r *StopRayClusterRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopRayClusterRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StopRayClusterRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopRayClusterResponseParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子账号UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属集群组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>Dashboard URL / 历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>启动时间（最近一次启动）</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>停止时间（最近一次停止/休眠）</p>
+	StopTime *uint64 `json:"StopTime,omitnil,omitempty" name:"StopTime"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StopRayClusterResponse struct {
+	*tchttp.BaseResponse
+	Response *StopRayClusterResponseParams `json:"Response"`
+}
+
+func (r *StopRayClusterResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopRayClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 type StreamingStatistics struct {
@@ -17972,6 +29899,14 @@ type TableResponseInfo struct {
 	InputFormatShort *string `json:"InputFormatShort,omitnil,omitempty" name:"InputFormatShort"`
 }
 
+type Tag struct {
+	// 标签键
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
+
+	// 标签值
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
+}
+
 type TagInfo struct {
 	// 标签键
 	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
@@ -18229,6 +30164,9 @@ type TaskFullRespInfo struct {
 
 	// <p>排队时间</p><p>单位：毫秒</p>
 	QueueTime *int64 `json:"QueueTime,omitnil,omitempty" name:"QueueTime"`
+
+	// <p>资源组类型</p>
+	ResourceGroupType *string `json:"ResourceGroupType,omitnil,omitempty" name:"ResourceGroupType"`
 }
 
 type TaskMonitorInfo struct {
@@ -18519,6 +30457,16 @@ type TextFile struct {
 	Regex *string `json:"Regex,omitnil,omitempty" name:"Regex"`
 }
 
+type TypeKVPair struct {
+	// <p>key值</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// <p>value值</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
 type UDFPolicyInfo struct {
 	// 权限类型
 	// 示例：select，alter，drop
@@ -18697,6 +30645,116 @@ func (r *UnlockMetaDataResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *UnlockMetaDataResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateClusterGroupRequestParams struct {
+	// <p>集群组 ID（定位要更新的集群组）</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群组名称（可选，为空则保持原名）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群组描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>集群组配置</p>
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+}
+
+type UpdateClusterGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群组 ID（定位要更新的集群组）</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群组名称（可选，为空则保持原名）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群组描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>集群组配置</p>
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+}
+
+func (r *UpdateClusterGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateClusterGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "Config")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateClusterGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateClusterGroupResponseParams struct {
+	// <p>集群组 ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群组名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群组描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>集群组配置</p>
+	Config *string `json:"Config,omitnil,omitempty" name:"Config"`
+
+	// <p>应用 ID（多租户）</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者主账号 UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建者子账号 UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>是否已软删除</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Deleted *bool `json:"Deleted,omitnil,omitempty" name:"Deleted"`
+
+	// <p>删除时间（软删时写入，活跃记录为 null）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeleteTime *uint64 `json:"DeleteTime,omitnil,omitempty" name:"DeleteTime"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateClusterGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateClusterGroupResponseParams `json:"Response"`
+}
+
+func (r *UpdateClusterGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateClusterGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -19065,6 +31123,878 @@ func (r *UpdateEngineResourceGroupNetworkConfigInfoResponse) FromJsonString(s st
 }
 
 // Predefined struct for user
+type UpdateInferenceModelRequestParams struct {
+	// <p>推理模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型名称（可选，不传则不修改）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型描述（可选）</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模型参数量（可选，如 7B、1.5B）</p>
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>模型标签列表（可选）</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+type UpdateInferenceModelRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型名称（可选，不传则不修改）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型描述（可选）</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模型参数量（可选，如 7B、1.5B）</p>
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>模型标签列表（可选）</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+func (r *UpdateInferenceModelRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateInferenceModelRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "ParameterSize")
+	delete(f, "Tags")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateInferenceModelRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateInferenceModelResponseParams struct {
+	// <p>推理模型ID</p>
+	ModelId *string `json:"ModelId,omitnil,omitempty" name:"ModelId"`
+
+	// <p>推理模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>模型名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>模型提供方</p>
+	Provider *string `json:"Provider,omitnil,omitempty" name:"Provider"`
+
+	// <p>模型描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>模型类型</p>
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>模型参数量</p>
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>标签</p>
+	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>最新版本号</p>
+	LatestVersion *string `json:"LatestVersion,omitnil,omitempty" name:"LatestVersion"`
+
+	// <p>版本总数</p>
+	VersionCount *int64 `json:"VersionCount,omitnil,omitempty" name:"VersionCount"`
+
+	// <p>关联的推理服务数量</p>
+	ServiceCount *int64 `json:"ServiceCount,omitnil,omitempty" name:"ServiceCount"`
+
+	// <p>是否有存储</p>
+	HasStorage *bool `json:"HasStorage,omitnil,omitempty" name:"HasStorage"`
+
+	// <p>是否使用用户自带存储桶</p>
+	HasCustomStorage *bool `json:"HasCustomStorage,omitnil,omitempty" name:"HasCustomStorage"`
+
+	// <p>存储后端类型</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
+
+	// <p>是否内置模型</p>
+	BuiltIn *bool `json:"BuiltIn,omitnil,omitempty" name:"BuiltIn"`
+
+	// <p>任务类型列表</p>
+	Tasks []*string `json:"Tasks,omitnil,omitempty" name:"Tasks"`
+
+	// <p>APPID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建时间</p>
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>SUB UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateInferenceModelResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateInferenceModelResponseParams `json:"Response"`
+}
+
+func (r *UpdateInferenceModelResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateInferenceModelResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateJobSpecPriorityRequestParams struct {
+	// <p>配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+}
+
+type UpdateJobSpecPriorityRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+}
+
+func (r *UpdateJobSpecPriorityRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateJobSpecPriorityRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	delete(f, "Priority")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateJobSpecPriorityRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateJobSpecPriorityResponseParams struct {
+	// <p>配置ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>配置名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置模板是否变更</p>
+	ResourceConfigChanged *bool `json:"ResourceConfigChanged,omitnil,omitempty" name:"ResourceConfigChanged"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>默认计算组 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>集群分派策略（本期仅支持 RANDOM；NULL 时退化为依赖 ClusterGroup 配置兜底）</p>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>该配置下未进入终态的作业实例数量</p>
+	JobInstanceCount *int64 `json:"JobInstanceCount,omitnil,omitempty" name:"JobInstanceCount"`
+
+	// <p>是否有运行中的作业实例</p>
+	HasRunningJobs *bool `json:"HasRunningJobs,omitnil,omitempty" name:"HasRunningJobs"`
+
+	// <p>高级参数，JSON 字符串（内容为 Key-Value 对象）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>作业包来源类型（Local: 本地上传, Cos: 用户自有 COS 桶地址）；缺时按 Local 处理</p>
+	JobPackageSource *string `json:"JobPackageSource,omitnil,omitempty" name:"JobPackageSource"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateJobSpecPriorityResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateJobSpecPriorityResponseParams `json:"Response"`
+}
+
+func (r *UpdateJobSpecPriorityResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateJobSpecPriorityResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateJobSpecRequestParams struct {
+	// <p>配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>配置名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源配置模板ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>作业包来源类型（Local: 本地上传, Cos: 用户自有 COS 桶地址）；缺省时按 Local 处理</p>
+	JobPackageSource *string `json:"JobPackageSource,omitnil,omitempty" name:"JobPackageSource"`
+
+	// <p>高级参数json</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>默认计算组名称（与 ClusterId 互斥；与老字段 ClusterGroup 等价，新调用方优先使用 GroupId）</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥，同时非空将返回 InvalidParameter.ClusterAndGroupConflict）</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p><p>枚举值：</p><ul><li>RANDOM： 随机分配</li></ul>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+}
+
+type UpdateJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>配置名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源配置模板ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>作业包来源类型（Local: 本地上传, Cos: 用户自有 COS 桶地址）；缺省时按 Local 处理</p>
+	JobPackageSource *string `json:"JobPackageSource,omitnil,omitempty" name:"JobPackageSource"`
+
+	// <p>高级参数json</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>默认计算组名称（与 ClusterId 互斥；与老字段 ClusterGroup 等价，新调用方优先使用 GroupId）</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥，同时非空将返回 InvalidParameter.ClusterAndGroupConflict）</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p><p>枚举值：</p><ul><li>RANDOM： 随机分配</li></ul>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+}
+
+func (r *UpdateJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	delete(f, "Entrypoint")
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "Image")
+	delete(f, "ImagePullType")
+	delete(f, "ImagePullPolicy")
+	delete(f, "ResourceConfig")
+	delete(f, "RuntimeEnv")
+	delete(f, "Catalog")
+	delete(f, "AutoscalerOptions")
+	delete(f, "ResourcePartitionId")
+	delete(f, "ResourceConfigId")
+	delete(f, "Queue")
+	delete(f, "JobPackage")
+	delete(f, "JobPackageName")
+	delete(f, "JobPackageSource")
+	delete(f, "AdvancedOptions")
+	delete(f, "GroupId")
+	delete(f, "ClusterId")
+	delete(f, "Priority")
+	delete(f, "Tags")
+	delete(f, "DispatchStrategy")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateJobSpecResponseParams struct {
+	// <p>配置ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>配置名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>配置描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（Builtin: 内置, Custom: 自定义）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>运行时环境配置(JSON)</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>弹性伸缩配置(JSON)</p>
+	AutoscalerOptions *string `json:"AutoscalerOptions,omitnil,omitempty" name:"AutoscalerOptions"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置模板是否变更</p>
+	ResourceConfigChanged *bool `json:"ResourceConfigChanged,omitnil,omitempty" name:"ResourceConfigChanged"`
+
+	// <p>默认资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>默认队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>作业包URL</p>
+	JobPackage *string `json:"JobPackage,omitnil,omitempty" name:"JobPackage"`
+
+	// <p>作业包名称</p>
+	JobPackageName *string `json:"JobPackageName,omitnil,omitempty" name:"JobPackageName"`
+
+	// <p>作业包来源类型（Local: 本地上传, Cos: 用户自有 COS 桶地址）；缺省时按 Local 处理</p>
+	JobPackageSource *string `json:"JobPackageSource,omitnil,omitempty" name:"JobPackageSource"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>该配置产生的作业实例数量</p>
+	JobInstanceCount *int64 `json:"JobInstanceCount,omitnil,omitempty" name:"JobInstanceCount"`
+
+	// <p>是否有运行中的作业实例</p>
+	HasRunningJobs *bool `json:"HasRunningJobs,omitnil,omitempty" name:"HasRunningJobs"`
+
+	// <p>高级参数json</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>默认计算组名称（与 ClusterGroup 等价，新调用方使用 GroupId）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>默认集群 ID（与 GroupId 互斥）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>集群分派策略</p><p>枚举值：</p><ul><li>RANDOM： 随机分配</li></ul>
+	DispatchStrategy *string `json:"DispatchStrategy,omitnil,omitempty" name:"DispatchStrategy"`
+
+	// <p>作业提交目标</p><p>枚举值：</p><ul><li>GROUP： 按计算组分派</li></ul>
+	SubmissionTarget *string `json:"SubmissionTarget,omitnil,omitempty" name:"SubmissionTarget"`
+
+	// <p>计算组名称</p>
+	GroupName *string `json:"GroupName,omitnil,omitempty" name:"GroupName"`
+
+	// <p>集群名称</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateJobSpecResponseParams `json:"Response"`
+}
+
+func (r *UpdateJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateLabRequestParams struct {
+	// <p>数据实验室名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>数据实验室描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>案例ID，当 startMode=EXAMPLE 时必填</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>案例代码包地址，当 startMode=EXAMPLE 时填写</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>Lab sidecar 镜像拉取策略（Always, IfNotPresent, Never）</p>
+	LabImagePullPolicy *string `json:"LabImagePullPolicy,omitnil,omitempty" name:"LabImagePullPolicy"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+}
+
+type UpdateLabRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>数据实验室名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>数据实验室描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>案例ID，当 startMode=EXAMPLE 时必填</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>案例代码包地址，当 startMode=EXAMPLE 时填写</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>Lab sidecar 镜像拉取策略（Always, IfNotPresent, Never）</p>
+	LabImagePullPolicy *string `json:"LabImagePullPolicy,omitnil,omitempty" name:"LabImagePullPolicy"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+}
+
+func (r *UpdateLabRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateLabRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "LabImage")
+	delete(f, "Description")
+	delete(f, "Image")
+	delete(f, "ImagePullPolicy")
+	delete(f, "ResourceConfigId")
+	delete(f, "GroupId")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Queue")
+	delete(f, "ExampleId")
+	delete(f, "CodeArchiveUrl")
+	delete(f, "LabImagePullPolicy")
+	delete(f, "Priority")
+	delete(f, "EnableToken")
+	delete(f, "Tags")
+	delete(f, "PersistentWorkDir")
+	delete(f, "ImagePullType")
+	delete(f, "LabImagePullType")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateLabRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateLabResponseParams struct {
+	// <p>案例模板ID（startMode=EXAMPLE 时使用）</p>
+	ExampleId *string `json:"ExampleId,omitnil,omitempty" name:"ExampleId"`
+
+	// <p>代码包/工程归档地址</p>
+	CodeArchiveUrl *string `json:"CodeArchiveUrl,omitnil,omitempty" name:"CodeArchiveUrl"`
+
+	// <p>数据实验室服务入口（服务类型 -&gt; 访问地址）</p>
+	Services []*TypeKVPair `json:"Services,omitnil,omitempty" name:"Services"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>Lab sidecar 镜像拉取策略（Always, IfNotPresent, Never）</p>
+	LabImagePullPolicy *string `json:"LabImagePullPolicy,omitnil,omitempty" name:"LabImagePullPolicy"`
+
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>持久化工作目录配置（可选）。启用后将 COS/CFS 指定路径挂载到容器内 /workspace 工作目录，与现有 Catalog 的卷配置互斥（不允许同时在 Catalog 中显式声明 MountPath=/workspace）。</p>
+	PersistentWorkDir *PersistentWorkDir `json:"PersistentWorkDir,omitnil,omitempty" name:"PersistentWorkDir"`
+
+	// <p>是否开启token认证</p>
+	EnableToken *bool `json:"EnableToken,omitnil,omitempty" name:"EnableToken"`
+
+	// <p>Lab sidecar 镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	LabImagePullType *string `json:"LabImagePullType,omitnil,omitempty" name:"LabImagePullType"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateLabResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateLabResponseParams `json:"Response"`
+}
+
+func (r *UpdateLabResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateLabResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type UpdateNetworkConnectionRequestParams struct {
 	// 网络配置描述
 	NetworkConnectionDesc *string `json:"NetworkConnectionDesc,omitnil,omitempty" name:"NetworkConnectionDesc"`
@@ -19122,6 +32052,476 @@ func (r *UpdateNetworkConnectionResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *UpdateNetworkConnectionResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateRayClusterRequestParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群名称（可选，不填写则默认使用集群ID）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>资源配置</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>存储卷和挂载卷配置</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+type UpdateRayClusterRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>集群名称（可选，不填写则默认使用集群ID）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>资源配置</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>存储卷和挂载卷配置</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+func (r *UpdateRayClusterRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateRayClusterRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "GroupId")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Queue")
+	delete(f, "Image")
+	delete(f, "ImagePullPolicy")
+	delete(f, "ImagePullType")
+	delete(f, "ResourceConfig")
+	delete(f, "ResourceConfigId")
+	delete(f, "Catalog")
+	delete(f, "AdvancedOptions")
+	delete(f, "Priority")
+	delete(f, "Tags")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateRayClusterRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateRayClusterResponseParams struct {
+	// <p>集群ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>资源类型：CLUSTER-普通集群；WORKSPACE-数据实验室（开发入口）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>集群名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>集群描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子用户UIN</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>子用户名称（由聚合层通过 CAM 接口回填）</p>
+	SubAccountName *string `json:"SubAccountName,omitnil,omitempty" name:"SubAccountName"`
+
+	// <p>集群状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>计算组 ID</p>
+	GroupId *string `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源配置ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>高级参数（规范化后的扁平 KV JSON）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateRayClusterResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateRayClusterResponseParams `json:"Response"`
+}
+
+func (r *UpdateRayClusterResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateRayClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateRayJobPriorityRequestParams struct {
+	// <p>任务ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+}
+
+type UpdateRayJobPriorityRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>任务ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+}
+
+func (r *UpdateRayJobPriorityRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateRayJobPriorityRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Priority")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateRayJobPriorityRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateRayJobPriorityResponseParams struct {
+	// <p>任务ID</p>
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>所属资源分区ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>默认资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>所属队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>任务状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>入口命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>任务名称</p>
+	JobName *string `json:"JobName,omitnil,omitempty" name:"JobName"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>用户主账号UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建账号</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>历史记录链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>运行时间(ms)</p>
+	RunningTime *int64 `json:"RunningTime,omitnil,omitempty" name:"RunningTime"`
+
+	// <p>完成时间</p>
+	FinishTime *uint64 `json:"FinishTime,omitnil,omitempty" name:"FinishTime"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>资源配置(JSON)</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>存储卷和挂载卷配置(JSON)</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>来源配置ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>标签列表（TagKey-TagValue），用于将资源与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>业务来源标识（调用上下文，长度上限 64，禁止控制字符）</p>
+	JobSource *string `json:"JobSource,omitnil,omitempty" name:"JobSource"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateRayJobPriorityResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateRayJobPriorityResponseParams `json:"Response"`
+}
+
+func (r *UpdateRayJobPriorityResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateRayJobPriorityResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateResourceConfigRequestParams struct {
+	// 资源配置模板Id
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 模板名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// 描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// Head节点配置
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// Worker节点配置
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+
+	// 模板类型(不传默认Ray)
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+}
+
+type UpdateResourceConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 资源配置模板Id
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 模板名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// 描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// Head节点配置
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// Worker节点配置
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+
+	// 模板类型(不传默认Ray)
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+}
+
+func (r *UpdateResourceConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateResourceConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Name")
+	delete(f, "Description")
+	delete(f, "Head")
+	delete(f, "Worker")
+	delete(f, "Type")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateResourceConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateResourceConfigResponseParams struct {
+	// 模板ID
+	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 模板名称
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// 描述
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// Head节点配置
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// Worker节点配置
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+
+	// 创建时间
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 更新时间
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// 模板类型
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// 应用ID
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// 创建者UIN
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// 子用户UIN
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateResourceConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateResourceConfigResponseParams `json:"Response"`
+}
+
+func (r *UpdateResourceConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateResourceConfigResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -20064,6 +33464,53 @@ type WorkGroups struct {
 
 	// 工作组总数
 	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+}
+
+type WorkerSpecDTO struct {
+	// <p>worker名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>Pod CPU核数</p>
+	PodCpu *int64 `json:"PodCpu,omitnil,omitempty" name:"PodCpu"`
+
+	// <p>Pod 内存大小</p>
+	PodMem *int64 `json:"PodMem,omitnil,omitempty" name:"PodMem"`
+
+	// <p>GPU类型</p>
+	GpuType *string `json:"GpuType,omitnil,omitempty" name:"GpuType"`
+
+	// <p>GPU数量</p>
+	GpuNum *int64 `json:"GpuNum,omitnil,omitempty" name:"GpuNum"`
+
+	// <p>环境变量列表</p>
+	Envs []*Env `json:"Envs,omitnil,omitempty" name:"Envs"`
+
+	// <p>标签列表</p>
+	Labels []*Label `json:"Labels,omitnil,omitempty" name:"Labels"`
+
+	// <p>资源标签列表（用于追加到 headGroupSpec/workerGroupSpec 的 resources map 中，对应 Ray/K8s 的自定义资源声明），Value 必须为字符串形式的整数</p>
+	ResourcesLabels []*Label `json:"ResourcesLabels,omitnil,omitempty" name:"ResourcesLabels"`
+
+	// <p>最小Pod数量</p>
+	MinPodNum *int64 `json:"MinPodNum,omitnil,omitempty" name:"MinPodNum"`
+
+	// <p>最大Pod数量</p>
+	MaxPodNum *int64 `json:"MaxPodNum,omitnil,omitempty" name:"MaxPodNum"`
+
+	// <p>是否开启弹性伸缩（true=开启，false/null=关闭）。开启后按 MinPodNum/MaxPodNum 弹性伸缩，关闭则按固定副本数运行</p>
+	EnableAutoScaling *bool `json:"EnableAutoScaling,omitnil,omitempty" name:"EnableAutoScaling"`
+
+	// <p>资源类型,CPU,GPU</p>
+	ResourceType *string `json:"ResourceType,omitnil,omitempty" name:"ResourceType"`
+
+	// <p>机型，例如X40/T20</p>
+	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
+
+	// <p>规格数量</p>
+	Spec *int64 `json:"Spec,omitnil,omitempty" name:"Spec"`
+
+	// <p>资源ID(唯一)</p>
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
 }
 
 type WrittenAdvancePolicy struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.144
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1306,7 +1306,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc/v20180410
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb/v20180411
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.132
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.156
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124

--- a/website/docs/r/dlc_data_engine.html.markdown
+++ b/website/docs/r/dlc_data_engine.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 * `resource_type` - (Optional, String) The resource type. Valid values: `Standard_CU` (standard) and `Memory_CU` (memory).
 * `session_resource_template` - (Optional, List) The session resource configuration template for a Spark job cluster.
 * `size` - (Optional, Int) Cluster size. Required when updating.
-* `tags` - (Optional, List, ForceNew) Tag list. Each tag contains a key-value pair. Changing this parameter will trigger a new resource since the DLC `UpdateDataEngine` API does not support modifying tags.
+* `tags` - (Optional, Set) Tag list. Each tag contains a key-value pair. Changing this parameter will trigger a new resource since the DLC `UpdateDataEngine` API does not support modifying tags.
 * `time_span` - (Optional, Int) The usage duration of the resource. Postpaid: Fill in 3,600 as a fixed figure; prepaid: fill in a figure equal to or bigger than 1 which means purchasing resources for one month. The maximum figure is not bigger than 120. The default value is 1.
 * `time_unit` - (Optional, String) The unit of the resource period. Valid values: `s` (default) for the postpaid mode and `m` for the prepaid mode.
 * `tolerable_queue_time` - (Optional, Int) The task queue time limit, which defaults to 0. When the actual queue time exceeds the value set here, scale-out may be triggered. Setting this parameter to 0 represents that scale-out may be triggered immediately after a task queues up.

--- a/website/docs/r/dlc_data_engine.html.markdown
+++ b/website/docs/r/dlc_data_engine.html.markdown
@@ -34,6 +34,11 @@ resource "tencentcloud_dlc_data_engine" "example" {
     executor_nums        = 1
     executor_size        = "medium"
   }
+
+  tags {
+    tag_key   = "owner"
+    tag_value = "tf-example"
+  }
 }
 ```
 
@@ -70,6 +75,7 @@ The following arguments are supported:
 * `resource_type` - (Optional, String) The resource type. Valid values: `Standard_CU` (standard) and `Memory_CU` (memory).
 * `session_resource_template` - (Optional, List) The session resource configuration template for a Spark job cluster.
 * `size` - (Optional, Int) Cluster size. Required when updating.
+* `tags` - (Optional, List, ForceNew) Tag list. Each tag contains a key-value pair. Changing this parameter will trigger a new resource since the DLC `UpdateDataEngine` API does not support modifying tags.
 * `time_span` - (Optional, Int) The usage duration of the resource. Postpaid: Fill in 3,600 as a fixed figure; prepaid: fill in a figure equal to or bigger than 1 which means purchasing resources for one month. The maximum figure is not bigger than 120. The default value is 1.
 * `time_unit` - (Optional, String) The unit of the resource period. Valid values: `s` (default) for the postpaid mode and `m` for the prepaid mode.
 * `tolerable_queue_time` - (Optional, Int) The task queue time limit, which defaults to 0. When the actual queue time exceeds the value set here, scale-out may be triggered. Setting this parameter to 0 represents that scale-out may be triggered immediately after a task queues up.
@@ -97,6 +103,11 @@ The `session_resource_template` object supports the following:
 * `executor_nums` - (Optional, Int) The executor count. The minimum value is 1 and the maximum value is less than the cluster specification.
 * `executor_size` - (Optional, String) The executor size. Valid values for the standard resource type: `small`, `medium`, `large`, and `xlarge`. Valid values for the memory resource type: `m.small`, `m.medium`, `m.large`, and `m.xlarge`.
 * `running_time_parameters` - (Optional, List) The running time parameters of the session resource configuration template for a Spark job cluster.
+
+The `tags` object supports the following:
+
+* `tag_key` - (Required, String) Tag key.
+* `tag_value` - (Optional, String) Tag value.
 
 ## Attributes Reference
 

--- a/website/docs/r/dlc_data_engine.html.markdown
+++ b/website/docs/r/dlc_data_engine.html.markdown
@@ -36,8 +36,8 @@ resource "tencentcloud_dlc_data_engine" "example" {
   }
 
   tags {
-    tag_key   = "owner"
-    tag_value = "tf-example"
+    tag_key   = "createBy"
+    tag_value = "Terraform"
   }
 }
 ```


### PR DESCRIPTION
Add a new `tags` block to the `tencentcloud_dlc_data_engine` resource schema to bind tags to a DLC data engine at creation time. The `tags` block is mapped to the `CreateDataEngine` API `Tags` field (`[]*TagInfo`), and read back from `DataEngineInfo.TagList` in the resource Read. Since the DLC `UpdateDataEngine` API does not support modifying tags, the `tags` parameter is marked as `ForceNew` and listed in the `immutableArgs` guard list in Update. Includes schema definition, create-time population, read-time synchronization, unit tests, and resource documentation.