### PR TITLE
feat(vpc): [136032196] add tags parameter to tencentcloud_vpc_private_nat_gateway resource

### DIFF
--- a/.changelog/4427.txt
+++ b/.changelog/4427.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_vpc_private_nat_gateway: support tags parameter
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -99,7 +99,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tse v1.0.857
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tsf v1.0.674
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod v1.3.127
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.62
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.157
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.144
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wedata v1.3.30
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wss v1.0.199

--- a/go.sum
+++ b/go.sum
@@ -973,7 +973,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.45/go.mod h
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.49/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.58/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.61/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.62/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.68/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.73/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.80/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1004,8 +1003,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.151/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156 h1:A3DxpqGh8DF+rCRJVGlNJaeOJ/l6FkhCKhdEaUeu0Dc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157 h1:sGxZxR4mE1Qi2Qs57PwR+8aiSCZD4tbmoTdIdhD3c9g=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1139,8 +1139,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vdb v1.3.27 h1:YDCMEDmY
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vdb v1.3.27/go.mod h1:+8MbS4MPUuAyul4UNl/cyG646iUgReluVI/fwd+RtqA=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod v1.3.127 h1:kgR/Ne2fr01B2cm2YSNEeuzF2yd72u8R77E2yGBZhK8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod v1.3.127/go.mod h1:+oOGhfokqQkNyoii/2S/DwWyAtIPLreQDYnnyOWg7oU=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.62 h1:Ti+oLfsMykxEKgFGTZKOomyvxzvld5LROsPZwuyKFkI=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.62/go.mod h1:I8H8+QiUCf4zrnqPn/h0Je7dM6EQ7VBdswWiAZLeiyY=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.157 h1:kEp5/qa/Hk1h6m4ilTRWcpdmZ1zdQCqt0C4eeE/DNgI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.157/go.mod h1:kWaC9eOACWZSoaSjWcucvnQ98NQMOnoZe3WK1OL0hVE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.144 h1:yGX3PQ7qOzU8RfduwYGRUGG324qBf1AqoSim+maum3o=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.144/go.mod h1:zfQey2gXSAV6+GJITKz+OJLLWve3Xau/ID+4ZxvXHL4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/wedata v1.3.30 h1:Al75RJni0l4n+1A8k16LezyOTGRRn7q11e56aa9bpyc=

--- a/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/design.md
+++ b/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`tencentcloud_vpc_private_nat_gateway` 资源（`resource_tc_vpc_private_nat_gateway.go`）当前管理私网 NAT 网关的创建、读取、更新和删除，但未暴露 tags 参数。云 API `CreatePrivateNatGateway` 已支持 `Tags []*Tag` 入参（`Tag` 结构包含 `Key` 和 `Value`），`DescribePrivateNatGateways` 返回的 `PrivateNatGateway.TagSet` 也已包含 `[]*Tag`。因此具备在 Terraform 中支持 tags 的条件。
+
+现有资源 schema 使用扁平结构，已有字段：`nat_gateway_name`、`vpc_id`、`cross_domain`、`vpc_type`、`ccn_id`。Update 方法使用 `ModifyPrivateNatGatewayAttribute` 接口，该接口不支持修改标签，因此 tags 变更需 ForceNew。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 `tencentcloud_vpc_private_nat_gateway` 资源 schema 中新增 `tags` 参数（TypeMap, Optional），支持标签键值对配置。
+- Create 方法将 tags map 转换为 `[]*vpc.Tag` 并设置到 `CreatePrivateNatGatewayRequest.Tags`。
+- Read 方法将 `PrivateNatGateway.TagSet` 转换为 map 并 set 到 state。
+- 保持向后兼容，新增字段为 Optional，不影响已有配置。
+
+**Non-Goals:**
+- 不支持通过 Update 方法动态修改标签（标签变更需重建资源）。
+- 不修改 `ModifyPrivateNatGatewayAttribute` 接口调用逻辑。
+- 不修改 `DescribeVpcPrivateNatGatewayById` 服务层方法（该方法已返回完整的 `PrivateNatGateway` 对象，包含 `TagSet`）。
+
+## Decisions
+
+### 1. tags schema 类型选择 TypeMap
+
+采用 `schema.TypeMap`（key 为 string, value 为 string），与同仓库中 `resource_tc_nat_gateway.go` 的 tags 实现保持一致。
+
+**理由**: TypeMap 使用简单，符合腾讯云标签键值对的使用习惯，与 vpc 服务的其他资源（如 `tencentcloud_nat_gateway`）保持风格统一。
+
+### 2. tags 转换为 `[]*vpc.Tag` 的实现
+
+Create 方法中遍历 `d.GetOk("tags")` 返回的 map，构建 `[]*vpc.Tag` 列表，每个元素设置 `Key` 和 `Value`。
+
+**理由**: 云 API `CreatePrivateNatGatewayRequest.Tags` 的类型是 `[]*Tag`，需要从 Terraform 的 map 类型转换。
+
+### 3. TagSet 转换为 map 的实现
+
+Read 方法中遍历 `privateNatGateway.TagSet`，将每个 `Tag` 的 `Key` 和 `Value` 写入 map，然后 `d.Set("tags", tagsMap)`。
+
+**理由**: 将云 API 的 `[]*Tag` 列表转换为 Terraform 的 map 格式存储到 state。
+
+### 4. tags 加入 immutableArgs
+
+由于 `ModifyPrivateNatGatewayAttribute` 接口不支持修改标签，将 `tags` 加入 Update 方法的 `immutableArgs` 数组。当 tags 发生变更时，返回错误提示用户需重建资源。
+
+**理由**: 与现有 `vpc_id`、`cross_domain`、`vpc_type`、`ccn_id` 的处理方式一致，这些字段同样不支持通过 Update 修改。
+
+## Risks / Trade-offs
+
+- **[tags 变更需重建资源]** → 与 vpc 服务其他资源一致，用户需通过 `terraform taint` 或删除重建来变更标签。在 immutableArgs 中明确报错提示。
+- **[空 TagSet 处理]** → Read 方法中当 `TagSet` 为 nil 或空时，不执行 `d.Set("tags", ...)`，避免设置空 map 覆盖用户配置。参考现有代码中其他字段的 nil 检查模式。

--- a/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/proposal.md
+++ b/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`tencentcloud_vpc_private_nat_gateway` 资源当前不支持标签（Tags）参数。云 API 的 `CreatePrivateNatGateway` 接口已支持通过 `Tags` 字段传入标签键值对，`DescribePrivateNatGateways` 接口的 `PrivateNatGatewaySet.TagSet` 也已返回标签数据。用户无法在 Terraform 中为私网 NAT 网关配置和管理标签，导致无法使用标签进行资源分组、成本归集和权限管理。
+
+## What Changes
+
+- 在 `tencentcloud_vpc_private_nat_gateway` 资源的 schema 中新增 `tags` 参数（TypeMap，Optional），用于配置私网 NAT 网关的标签键值对。
+- 在资源 Create 方法中，将 schema 中的 `tags` 映射转换为云 API 的 `[]*Tag` 列表，设置到 `CreatePrivateNatGatewayRequest.Tags`。
+- 在资源 Read 方法中，将云 API 返回的 `PrivateNatGateway.TagSet`（`[]*Tag`）转换为 map 并 set 到 schema 的 `tags` 字段。
+- 由于 `tags` 参数在 Create 时传入，Update 方法中将其加入 `immutableArgs`，标签变更需重建资源。
+
+## Capabilities
+
+### New Capabilities
+- `vpc-private-nat-gateway-tags`: 为 `tencentcloud_vpc_private_nat_gateway` 资源新增 tags 参数，支持在创建私网 NAT 网关时配置标签，并支持在 Read 时回显标签。
+
+### Modified Capabilities
+<!-- 无 -->
+
+## Impact
+
+- **代码文件**: `tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.go` — 新增 schema 字段、修改 Create/Read/Update 方法。
+- **测试文件**: `tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway_test.go` — 补充 tags 参数的单元测试用例。
+- **文档文件**: `tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.md` — 更新示例和文档。
+- **云 API 依赖**: 依赖 `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312` 中已有的 `Tag` 结构和 `CreatePrivateNatGatewayRequest.Tags` / `PrivateNatGateway.TagSet` 字段，无需更新 vendor。
+- **向后兼容**: 新增 Optional 字段，不影响已有配置和 state。

--- a/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/specs/vpc-private-nat-gateway-tags/spec.md
+++ b/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/specs/vpc-private-nat-gateway-tags/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Tags 参数定义
+
+`tencentcloud_vpc_private_nat_gateway` 资源 SHALL 新增 `tags` 参数，类型为 `schema.TypeMap`，`Optional: true`，用于配置私网 NAT 网关的标签键值对。Key 和 Value 均为字符串类型。
+
+#### Scenario: 用户在 Terraform 配置中指定 tags
+
+- **WHEN** 用户在 `tencentcloud_vpc_private_nat_gateway` 资源配置中设置 `tags = { "key1" = "value1", "key2" = "value2" }`
+- **THEN** 资源 schema SHALL 接受该配置，并在 plan 阶段显示 tags 参数
+
+#### Scenario: 用户未配置 tags
+
+- **WHEN** 用户在 `tencentcloud_vpc_private_nat_gateway` 资源配置中未设置 tags 参数
+- **THEN** 资源 SHALL 正常创建，tags 参数为空
+
+### Requirement: Create 方法处理 tags
+
+资源 Create 方法 SHALL 将 schema 中的 `tags` map 转换为 `[]*vpc.Tag` 列表，并设置到 `CreatePrivateNatGatewayRequest.Tags` 字段。每个 Tag 元素的 `Key` 和 `Value` 从 map 的键值对获取。
+
+#### Scenario: 创建资源时传入标签
+
+- **WHEN** 用户创建 `tencentcloud_vpc_private_nat_gateway` 资源并配置了 tags
+- **THEN** Create 方法 SHALL 将 tags map 转换为 `[]*vpc.Tag` 列表，并设置到 `CreatePrivateNatGatewayRequest.Tags`
+
+#### Scenario: 创建资源时未传入标签
+
+- **WHEN** 用户创建 `tencentcloud_vpc_private_nat_gateway` 资源且未配置 tags
+- **THEN** Create 方法 SHALL 不设置 `CreatePrivateNatGatewayRequest.Tags` 字段
+
+### Requirement: Read 方法回显 tags
+
+资源 Read 方法 SHALL 将云 API 返回的 `PrivateNatGateway.TagSet`（`[]*vpc.Tag`）转换为 map，并 set 到 schema 的 `tags` 字段。
+
+#### Scenario: 读取资源时云 API 返回标签
+
+- **WHEN** Read 方法调用 `DescribePrivateNatGateways` 返回的 `PrivateNatGateway.TagSet` 包含标签数据
+- **THEN** Read 方法 SHALL 将 TagSet 转换为 map 并 `d.Set("tags", tagsMap)`
+
+#### Scenario: 读取资源时云 API 未返回标签
+
+- **WHEN** Read 方法调用 `DescribePrivateNatGateways` 返回的 `PrivateNatGateway.TagSet` 为 nil 或空
+- **THEN** Read 方法 SHALL 不执行 `d.Set("tags", ...)`，保留 state 中已有的值
+
+### Requirement: Update 方法禁止修改 tags
+
+资源 Update 方法 SHALL 将 `tags` 加入 `immutableArgs` 数组。当 tags 发生变更时，返回错误提示参数不可变更。
+
+#### Scenario: 用户尝试修改 tags
+
+- **WHEN** 用户修改 `tencentcloud_vpc_private_nat_gateway` 资源的 tags 参数并执行 `terraform apply`
+- **THEN** Update 方法 SHALL 返回错误 `argument 'tags' cannot be changed`

--- a/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/tasks.md
+++ b/openspec/changes/archive/2026-08-13-add-vpc-private-nat-gateway-tags/tasks.md
@@ -1,0 +1,17 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.go` 的 `ResourceTencentCloudVpcPrivateNatGateway()` schema map 中新增 `tags` 参数，类型为 `schema.TypeMap`，`Optional: true`，Description 为 "Tag description of the instance."
+
+## 2. CRUD 函数修改
+
+- [x] 2.1 修改 `resourceTencentCloudVpcPrivateNatGatewayCreate` 函数：在创建请求构建部分，使用 `d.GetOk("tags")` 获取 tags map，遍历 map 构建 `[]*vpc.Tag` 列表（每个 Tag 设置 Key 和 Value），并赋值到 `request.Tags`
+- [x] 2.2 修改 `resourceTencentCloudVpcPrivateNatGatewayRead` 函数：在读取并 set 字段的部分，判断 `privateNatGateway.TagSet` 不为 nil 且长度大于 0 时，遍历 TagSet 构建 `map[string]string`，并执行 `d.Set("tags", tagsMap)`
+- [x] 2.3 修改 `resourceTencentCloudVpcPrivateNatGatewayUpdate` 函数：在 `immutableArgs` 数组中添加 `"tags"`，使 tags 变更时报错提示不可修改
+
+## 3. 测试用例补充
+
+- [x] 3.1 在 `tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway_test.go` 中补充 tags 参数的单元测试用例，使用 gomonkey 对云 API 进行 mock 处理，测试 Create 方法中 tags map 到 `[]*vpc.Tag` 的转换逻辑
+
+## 4. 文档更新
+
+- [x] 4.1 更新 `tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.md` 文件，在 Example Usage 中补充 tags 参数的使用示例

--- a/openspec/specs/vpc-private-nat-gateway-tags/spec.md
+++ b/openspec/specs/vpc-private-nat-gateway-tags/spec.md
@@ -1,0 +1,57 @@
+# vpc-private-nat-gateway-tags Specification
+
+## Purpose
+Defines the tagging requirements for the `tencentcloud_vpc_private_nat_gateway` resource, covering schema definition, Create/Read method handling, and Update method immutability of the `tags` parameter.
+
+## Requirements
+
+### Requirement: Tags 参数定义
+
+`tencentcloud_vpc_private_nat_gateway` 资源 SHALL 新增 `tags` 参数，类型为 `schema.TypeMap`，`Optional: true`，用于配置私网 NAT 网关的标签键值对。Key 和 Value 均为字符串类型。
+
+#### Scenario: 用户在 Terraform 配置中指定 tags
+
+- **WHEN** 用户在 `tencentcloud_vpc_private_nat_gateway` 资源配置中设置 `tags = { "key1" = "value1", "key2" = "value2" }`
+- **THEN** 资源 schema SHALL 接受该配置，并在 plan 阶段显示 tags 参数
+
+#### Scenario: 用户未配置 tags
+
+- **WHEN** 用户在 `tencentcloud_vpc_private_nat_gateway` 资源配置中未设置 tags 参数
+- **THEN** 资源 SHALL 正常创建，tags 参数为空
+
+### Requirement: Create 方法处理 tags
+
+资源 Create 方法 SHALL 将 schema 中的 `tags` map 转换为 `[]*vpc.Tag` 列表，并设置到 `CreatePrivateNatGatewayRequest.Tags` 字段。每个 Tag 元素的 `Key` 和 `Value` 从 map 的键值对获取。
+
+#### Scenario: 创建资源时传入标签
+
+- **WHEN** 用户创建 `tencentcloud_vpc_private_nat_gateway` 资源并配置了 tags
+- **THEN** Create 方法 SHALL 将 tags map 转换为 `[]*vpc.Tag` 列表，并设置到 `CreatePrivateNatGatewayRequest.Tags`
+
+#### Scenario: 创建资源时未传入标签
+
+- **WHEN** 用户创建 `tencentcloud_vpc_private_nat_gateway` 资源且未配置 tags
+- **THEN** Create 方法 SHALL 不设置 `CreatePrivateNatGatewayRequest.Tags` 字段
+
+### Requirement: Read 方法回显 tags
+
+资源 Read 方法 SHALL 将云 API 返回的 `PrivateNatGateway.TagSet`（`[]*vpc.Tag`）转换为 map，并 set 到 schema 的 `tags` 字段。
+
+#### Scenario: 读取资源时云 API 返回标签
+
+- **WHEN** Read 方法调用 `DescribePrivateNatGateways` 返回的 `PrivateNatGateway.TagSet` 包含标签数据
+- **THEN** Read 方法 SHALL 将 TagSet 转换为 map 并 `d.Set("tags", tagsMap)`
+
+#### Scenario: 读取资源时云 API 未返回标签
+
+- **WHEN** Read 方法调用 `DescribePrivateNatGateways` 返回的 `PrivateNatGateway.TagSet` 为 nil 或空
+- **THEN** Read 方法 SHALL 不执行 `d.Set("tags", ...)`，保留 state 中已有的值
+
+### Requirement: Update 方法禁止修改 tags
+
+资源 Update 方法 SHALL 将 `tags` 加入 `immutableArgs` 数组。当 tags 发生变更时，返回错误提示参数不可变更。
+
+#### Scenario: 用户尝试修改 tags
+
+- **WHEN** 用户修改 `tencentcloud_vpc_private_nat_gateway` 资源的 tags 参数并执行 `terraform apply`
+- **THEN** Update 方法 SHALL 返回错误 `argument 'tags' cannot be changed`

--- a/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.go
+++ b/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.go
@@ -61,6 +61,13 @@ func ResourceTencentCloudVpcPrivateNatGateway() *schema.Resource {
 				Type:        schema.TypeMap,
 				Description: "Tag description of the instance.",
 			},
+
+			// computed
+			"nat_gateway_id": {
+				Computed:    true,
+				Type:        schema.TypeString,
+				Description: "Private network NAT gateway instance ID.",
+			},
 		},
 	}
 }
@@ -173,9 +180,13 @@ func resourceTencentCloudVpcPrivateNatGatewayRead(d *schema.ResourceData, meta i
 	}
 
 	if privateNatGateway == nil {
+		log.Printf("[WARN]%s resource `tencentcloud_vpc_private_nat_gateway` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
-		log.Printf("[WARN]%s resource `VpcPrivateNatGateway` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		return nil
+	}
+
+	if privateNatGateway.NatGatewayId != nil {
+		_ = d.Set("nat_gateway_id", privateNatGateway.NatGatewayId)
 	}
 
 	if privateNatGateway.NatGatewayName != nil {
@@ -220,15 +231,9 @@ func resourceTencentCloudVpcPrivateNatGatewayUpdate(d *schema.ResourceData, meta
 
 	logId := tccommon.GetLogId(tccommon.ContextNil)
 	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
-
-	request := vpc.NewModifyPrivateNatGatewayAttributeRequest()
-
 	instanceId := d.Id()
 
-	request.NatGatewayId = &instanceId
-
 	immutableArgs := []string{"vpc_id", "cross_domain", "vpc_type", "ccn_id", "tags"}
-
 	for _, v := range immutableArgs {
 		if d.HasChange(v) {
 			return fmt.Errorf("argument `%s` cannot be changed", v)
@@ -236,42 +241,51 @@ func resourceTencentCloudVpcPrivateNatGatewayUpdate(d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("nat_gateway_name") {
+		request := vpc.NewModifyPrivateNatGatewayAttributeRequest()
 		if v, ok := d.GetOk("nat_gateway_name"); ok {
 			request.NatGatewayName = helper.String(v.(string))
 		}
+
+		request.NatGatewayId = &instanceId
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseVpcClient().ModifyPrivateNatGatewayAttribute(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s update vpc privateNatGateway failed, reason:%+v", logId, err)
+			return err
+		}
+
+		service := VpcService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+		err = resource.Retry(5*tccommon.ReadRetryTimeout, func() *resource.RetryError {
+			privateNatGateway, errRet := service.DescribeVpcPrivateNatGatewayById(ctx, instanceId)
+			if errRet != nil {
+				return tccommon.RetryError(errRet)
+			}
+
+			if privateNatGateway.Status == nil {
+				return resource.RetryableError(fmt.Errorf("waiting for instance update"))
+			}
+
+			if *privateNatGateway.Status != "AVAILABLE" {
+				return resource.RetryableError(fmt.Errorf("waiting for instance update"))
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
 	}
 
-	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseVpcClient().ModifyPrivateNatGatewayAttribute(request)
-		if e != nil {
-			return tccommon.RetryError(e)
-		} else {
-			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
-		}
-		return nil
-	})
-	if err != nil {
-		log.Printf("[CRITAL]%s update vpc privateNatGateway failed, reason:%+v", logId, err)
-		return err
-	}
-
-	service := VpcService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
-	err = resource.Retry(5*tccommon.ReadRetryTimeout, func() *resource.RetryError {
-		privateNatGateway, errRet := service.DescribeVpcPrivateNatGatewayById(ctx, instanceId)
-		if errRet != nil {
-			return tccommon.RetryError(errRet)
-		}
-		if privateNatGateway.Status == nil {
-			return resource.RetryableError(fmt.Errorf("waiting for instance update"))
-		}
-		if *privateNatGateway.Status != "AVAILABLE" {
-			return resource.RetryableError(fmt.Errorf("waiting for instance update"))
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
 	return resourceTencentCloudVpcPrivateNatGatewayRead(d, meta)
 }
 

--- a/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.go
+++ b/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.go
@@ -55,6 +55,12 @@ func ResourceTencentCloudVpcPrivateNatGateway() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Cloud Connect Network type The Cloud Connect Network instance ID required to be bound to the private network NAT gateway.",
 			},
+
+			"tags": {
+				Optional:    true,
+				Type:        schema.TypeMap,
+				Description: "Tag description of the instance.",
+			},
 		},
 	}
 }
@@ -89,6 +95,16 @@ func resourceTencentCloudVpcPrivateNatGatewayCreate(d *schema.ResourceData, meta
 
 	if v, ok := d.GetOk("ccn_id"); ok {
 		request.CcnId = helper.String(v.(string))
+	}
+
+	if tags := helper.GetTags(d, "tags"); len(tags) > 0 {
+		for tagKey, tagValue := range tags {
+			tag := vpc.Tag{
+				Key:   helper.String(tagKey),
+				Value: helper.String(tagValue),
+			}
+			request.Tags = append(request.Tags, &tag)
+		}
 	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
@@ -182,6 +198,19 @@ func resourceTencentCloudVpcPrivateNatGatewayRead(d *schema.ResourceData, meta i
 		_ = d.Set("ccn_id", privateNatGateway.CcnId)
 	}
 
+	if privateNatGateway.TagSet != nil && len(privateNatGateway.TagSet) > 0 {
+		tagsMap := make(map[string]string)
+		for _, tag := range privateNatGateway.TagSet {
+			if tag.Key != nil {
+				tagsMap[*tag.Key] = ""
+				if tag.Value != nil {
+					tagsMap[*tag.Key] = *tag.Value
+				}
+			}
+		}
+		_ = d.Set("tags", tagsMap)
+	}
+
 	return nil
 }
 
@@ -198,7 +227,7 @@ func resourceTencentCloudVpcPrivateNatGatewayUpdate(d *schema.ResourceData, meta
 
 	request.NatGatewayId = &instanceId
 
-	immutableArgs := []string{"vpc_id", "cross_domain", "vpc_type", "ccn_id"}
+	immutableArgs := []string{"vpc_id", "cross_domain", "vpc_type", "ccn_id", "tags"}
 
 	for _, v := range immutableArgs {
 		if d.HasChange(v) {

--- a/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.md
+++ b/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.md
@@ -9,6 +9,19 @@ resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
 }
 ```
 
+Create a private nat gateway with tags.
+
+```hcl
+resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
+	nat_gateway_name = "xxx"
+	vpc_id           = "xxx"
+	tags = {
+		"key1" = "value1"
+		"key2" = "value2"
+	}
+}
+```
+
 Import
 
 vpc private_nat_gateway can be imported using the id, e.g.

--- a/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.md
+++ b/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway.md
@@ -1,31 +1,21 @@
-Provides a resource to create a vpc private nat gateway
+Provides a resource to create a VPC private nat gateway
 
 Example Usage
 
 ```hcl
-resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
-	nat_gateway_name = "xxx"
-	vpc_id = "xxx"
-}
-```
-
-Create a private nat gateway with tags.
-
-```hcl
-resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
-	nat_gateway_name = "xxx"
-	vpc_id           = "xxx"
-	tags = {
-		"key1" = "value1"
-		"key2" = "value2"
-	}
+resource "tencentcloud_vpc_private_nat_gateway" "example" {
+  nat_gateway_name = "tf-example"
+  vpc_id           = "vpc-i5yyodl9"
+  tags = {
+    createBy = "Terraform"
+  }
 }
 ```
 
 Import
 
-vpc private_nat_gateway can be imported using the id, e.g.
+VPC private nat gateway can be imported using the id, e.g.
 
 ```
-terraform import tencentcloud_vpc_private_nat_gateway.private_nat_gateway private_nat_gateway_id
+terraform import tencentcloud_vpc_private_nat_gateway.example intranat-ljdy849x
 ```

--- a/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway_test.go
+++ b/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway_test.go
@@ -92,7 +92,6 @@ func newMockMetaForVpcPrivateNatGateway() *mockMetaForVpcPrivateNatGateway {
 }
 
 func ptrStrPNG(s string) *string    { return &s }
-func ptrBoolPNG(v bool) *bool       { return &v }
 func ptrUint64PNG(v uint64) *uint64 { return &v }
 
 // TestVpcPrivateNatGateway_Create_WithTags verifies that when tags is set,

--- a/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway_test.go
+++ b/tencentcloud/services/vpc/resource_tc_vpc_private_nat_gateway_test.go
@@ -1,10 +1,19 @@
 package vpc_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	vpcsdk "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312"
+
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	svcvpc "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/vpc"
 )
 
 func TestAccTencentCloudVpcPrivateNatGatewayResource_basic(t *testing.T) {
@@ -65,3 +74,252 @@ resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
   vpc_id = tencentcloud_vpc.foo.id
 }
 `
+
+// --- gomonkey mock unit tests for tags parameter ---
+
+type mockMetaForVpcPrivateNatGateway struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForVpcPrivateNatGateway) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForVpcPrivateNatGateway{}
+
+func newMockMetaForVpcPrivateNatGateway() *mockMetaForVpcPrivateNatGateway {
+	return &mockMetaForVpcPrivateNatGateway{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrPNG(s string) *string    { return &s }
+func ptrBoolPNG(v bool) *bool       { return &v }
+func ptrUint64PNG(v uint64) *uint64 { return &v }
+
+// TestVpcPrivateNatGateway_Create_WithTags verifies that when tags is set,
+// the CreatePrivateNatGateway request carries the correct Tags value.
+func TestVpcPrivateNatGateway_Create_WithTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	vpcClient := &vpcsdk.Client{}
+	patches.ApplyMethodReturn(newMockMetaForVpcPrivateNatGateway().client, "UseVpcClient", vpcClient)
+
+	var capturedRequest *vpcsdk.CreatePrivateNatGatewayRequest
+	patches.ApplyMethodFunc(vpcClient, "CreatePrivateNatGateway", func(request *vpcsdk.CreatePrivateNatGatewayRequest) (*vpcsdk.CreatePrivateNatGatewayResponse, error) {
+		capturedRequest = request
+		resp := vpcsdk.NewCreatePrivateNatGatewayResponse()
+		resp.Response = &vpcsdk.CreatePrivateNatGatewayResponseParams{
+			PrivateNatGatewaySet: []*vpcsdk.PrivateNatGateway{
+				{
+					NatGatewayId:   ptrStrPNG("intranat-abcdefgh"),
+					NatGatewayName: ptrStrPNG("tf-test-private-nat-gateway"),
+					VpcId:          ptrStrPNG("vpc-xxxxxxxx"),
+					Status:         ptrStrPNG("AVAILABLE"),
+					TagSet: []*vpcsdk.Tag{
+						{Key: ptrStrPNG("key1"), Value: ptrStrPNG("value1")},
+						{Key: ptrStrPNG("key2"), Value: ptrStrPNG("value2")},
+					},
+				},
+			},
+			TotalCount: ptrUint64PNG(1),
+			RequestId:  ptrStrPNG("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeVpcPrivateNatGatewayById for the read-back after create
+	patches.ApplyMethodFunc(&svcvpc.VpcService{}, "DescribeVpcPrivateNatGatewayById", func(_ context.Context, _ string) (*vpcsdk.PrivateNatGateway, error) {
+		return &vpcsdk.PrivateNatGateway{
+			NatGatewayId:   ptrStrPNG("intranat-abcdefgh"),
+			NatGatewayName: ptrStrPNG("tf-test-private-nat-gateway"),
+			VpcId:          ptrStrPNG("vpc-xxxxxxxx"),
+			Status:         ptrStrPNG("AVAILABLE"),
+			TagSet: []*vpcsdk.Tag{
+				{Key: ptrStrPNG("key1"), Value: ptrStrPNG("value1")},
+				{Key: ptrStrPNG("key2"), Value: ptrStrPNG("value2")},
+			},
+		}, nil
+	})
+
+	meta := newMockMetaForVpcPrivateNatGateway()
+	res := svcvpc.ResourceTencentCloudVpcPrivateNatGateway()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"nat_gateway_name": "tf-test-private-nat-gateway",
+		"vpc_id":           "vpc-xxxxxxxx",
+		"tags": map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "intranat-abcdefgh", d.Id())
+
+	// Verify Tags were set on the create request
+	assert.NotNil(t, capturedRequest.Tags)
+	assert.Len(t, capturedRequest.Tags, 2)
+
+	tagMap := make(map[string]string)
+	for _, tag := range capturedRequest.Tags {
+		if tag.Key != nil {
+			tagMap[*tag.Key] = ""
+			if tag.Value != nil {
+				tagMap[*tag.Key] = *tag.Value
+			}
+		}
+	}
+	assert.Equal(t, "value1", tagMap["key1"])
+	assert.Equal(t, "value2", tagMap["key2"])
+
+	// Verify tags are read back into state
+	tags := d.Get("tags").(map[string]interface{})
+	assert.Equal(t, "value1", tags["key1"])
+	assert.Equal(t, "value2", tags["key2"])
+}
+
+// TestVpcPrivateNatGateway_Create_WithoutTags verifies that when tags is not set,
+// the CreatePrivateNatGateway request does not carry Tags.
+func TestVpcPrivateNatGateway_Create_WithoutTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	vpcClient := &vpcsdk.Client{}
+	patches.ApplyMethodReturn(newMockMetaForVpcPrivateNatGateway().client, "UseVpcClient", vpcClient)
+
+	var capturedRequest *vpcsdk.CreatePrivateNatGatewayRequest
+	patches.ApplyMethodFunc(vpcClient, "CreatePrivateNatGateway", func(request *vpcsdk.CreatePrivateNatGatewayRequest) (*vpcsdk.CreatePrivateNatGatewayResponse, error) {
+		capturedRequest = request
+		resp := vpcsdk.NewCreatePrivateNatGatewayResponse()
+		resp.Response = &vpcsdk.CreatePrivateNatGatewayResponseParams{
+			PrivateNatGatewaySet: []*vpcsdk.PrivateNatGateway{
+				{
+					NatGatewayId:   ptrStrPNG("intranat-no-tags"),
+					NatGatewayName: ptrStrPNG("tf-test-private-nat-gateway"),
+					VpcId:          ptrStrPNG("vpc-xxxxxxxx"),
+					Status:         ptrStrPNG("AVAILABLE"),
+				},
+			},
+			TotalCount: ptrUint64PNG(1),
+			RequestId:  ptrStrPNG("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeVpcPrivateNatGatewayById for the read-back after create
+	patches.ApplyMethodFunc(&svcvpc.VpcService{}, "DescribeVpcPrivateNatGatewayById", func(_ context.Context, _ string) (*vpcsdk.PrivateNatGateway, error) {
+		return &vpcsdk.PrivateNatGateway{
+			NatGatewayId:   ptrStrPNG("intranat-no-tags"),
+			NatGatewayName: ptrStrPNG("tf-test-private-nat-gateway"),
+			VpcId:          ptrStrPNG("vpc-xxxxxxxx"),
+			Status:         ptrStrPNG("AVAILABLE"),
+		}, nil
+	})
+
+	meta := newMockMetaForVpcPrivateNatGateway()
+	res := svcvpc.ResourceTencentCloudVpcPrivateNatGateway()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"nat_gateway_name": "tf-test-private-nat-gateway",
+		"vpc_id":           "vpc-xxxxxxxx",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "intranat-no-tags", d.Id())
+
+	// Verify Tags were not set on the create request
+	assert.Empty(t, capturedRequest.Tags)
+}
+
+// TestVpcPrivateNatGateway_Read_WithTags verifies that Read converts TagSet to map.
+func TestVpcPrivateNatGateway_Read_WithTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyMethodFunc(&svcvpc.VpcService{}, "DescribeVpcPrivateNatGatewayById", func(_ context.Context, _ string) (*vpcsdk.PrivateNatGateway, error) {
+		return &vpcsdk.PrivateNatGateway{
+			NatGatewayId:   ptrStrPNG("intranat-abcdefgh"),
+			NatGatewayName: ptrStrPNG("tf-test-private-nat-gateway"),
+			VpcId:          ptrStrPNG("vpc-xxxxxxxx"),
+			Status:         ptrStrPNG("AVAILABLE"),
+			TagSet: []*vpcsdk.Tag{
+				{Key: ptrStrPNG("env"), Value: ptrStrPNG("prod")},
+				{Key: ptrStrPNG("owner"), Value: ptrStrPNG("devops")},
+			},
+		}, nil
+	})
+
+	meta := newMockMetaForVpcPrivateNatGateway()
+	res := svcvpc.ResourceTencentCloudVpcPrivateNatGateway()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+	d.SetId("intranat-abcdefgh")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	tags := d.Get("tags").(map[string]interface{})
+	assert.Equal(t, "prod", tags["env"])
+	assert.Equal(t, "devops", tags["owner"])
+}
+
+// TestVpcPrivateNatGateway_Read_WithoutTags verifies that Read does not set tags
+// when TagSet is nil or empty.
+func TestVpcPrivateNatGateway_Read_WithoutTags(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyMethodFunc(&svcvpc.VpcService{}, "DescribeVpcPrivateNatGatewayById", func(_ context.Context, _ string) (*vpcsdk.PrivateNatGateway, error) {
+		return &vpcsdk.PrivateNatGateway{
+			NatGatewayId:   ptrStrPNG("intranat-abcdefgh"),
+			NatGatewayName: ptrStrPNG("tf-test-private-nat-gateway"),
+			VpcId:          ptrStrPNG("vpc-xxxxxxxx"),
+			Status:         ptrStrPNG("AVAILABLE"),
+		}, nil
+	})
+
+	meta := newMockMetaForVpcPrivateNatGateway()
+	res := svcvpc.ResourceTencentCloudVpcPrivateNatGateway()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+	d.SetId("intranat-abcdefgh")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	tags := d.Get("tags")
+	tagsMap, ok := tags.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Empty(t, tagsMap)
+}
+
+// TestVpcPrivateNatGateway_Update_TagsImmutable verifies that changing tags
+// in Update returns an error because tags is immutable.
+func TestVpcPrivateNatGateway_Update_TagsImmutable(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaForVpcPrivateNatGateway()
+	res := svcvpc.ResourceTencentCloudVpcPrivateNatGateway()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"nat_gateway_name": "tf-test-private-nat-gateway",
+		"tags": map[string]interface{}{
+			"key1": "value1",
+		},
+	})
+	d.SetId("intranat-abcdefgh")
+
+	err := res.Update(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tags")
+	assert.Contains(t, err.Error(), "cannot be changed")
+}
+
+// TestVpcPrivateNatGateway_Schema_Tags validates the tags schema definition.
+func TestVpcPrivateNatGateway_Schema_Tags(t *testing.T) {
+	res := svcvpc.ResourceTencentCloudVpcPrivateNatGateway()
+	assert.Contains(t, res.Schema, "tags")
+
+	tagsSchema := res.Schema["tags"]
+	assert.Equal(t, schema.TypeMap, tagsSchema.Type)
+	assert.True(t, tagsSchema.Optional)
+	assert.False(t, tagsSchema.Required)
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.156"
+	params["RequestClient"] = "SDK_GO_1.3.157"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312/client.go
@@ -3548,13 +3548,7 @@ func NewCreateCdcNetPlanesResponse() (response *CreateCdcNetPlanesResponse) {
 // 创建虚拟连接，用于支持 CDC 多租户模式
 //
 // 可能返回的错误码:
-//  INTERNALERROR_MODULEERROR = "InternalError.ModuleError"
-//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
-//  INVALIDPARAMETERVALUE_RESOURCENOTFOUND = "InvalidParameterValue.ResourceNotFound"
-//  LIMITEXCEEDED = "LimitExceeded"
-//  MISSINGPARAMETER = "MissingParameter"
-//  MISSINGPARAMETER_MULTIMISSINGPARAMETER = "MissingParameter.MultiMissingParameter"
-//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION_SERVICEUNSUPPORTEDREGION = "UnsupportedOperation.ServiceUnsupportedRegion"
 func (c *Client) CreateCdcNetPlanes(request *CreateCdcNetPlanesRequest) (response *CreateCdcNetPlanesResponse, err error) {
     return c.CreateCdcNetPlanesWithContext(context.Background(), request)
 }
@@ -3563,13 +3557,7 @@ func (c *Client) CreateCdcNetPlanes(request *CreateCdcNetPlanesRequest) (respons
 // 创建虚拟连接，用于支持 CDC 多租户模式
 //
 // 可能返回的错误码:
-//  INTERNALERROR_MODULEERROR = "InternalError.ModuleError"
-//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
-//  INVALIDPARAMETERVALUE_RESOURCENOTFOUND = "InvalidParameterValue.ResourceNotFound"
-//  LIMITEXCEEDED = "LimitExceeded"
-//  MISSINGPARAMETER = "MissingParameter"
-//  MISSINGPARAMETER_MULTIMISSINGPARAMETER = "MissingParameter.MultiMissingParameter"
-//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION_SERVICEUNSUPPORTEDREGION = "UnsupportedOperation.ServiceUnsupportedRegion"
 func (c *Client) CreateCdcNetPlanesWithContext(ctx context.Context, request *CreateCdcNetPlanesRequest) (response *CreateCdcNetPlanesResponse, err error) {
     if request == nil {
         request = NewCreateCdcNetPlanesRequest()
@@ -4096,6 +4084,7 @@ func NewCreateFlowLogResponse() (response *CreateFlowLogResponse) {
 //  UNSUPPORTEDOPERATION_FLOWLOGINSTANCEEXISTED = "UnsupportedOperation.FlowLogInstanceExisted"
 //  UNSUPPORTEDOPERATION_FLOWLOGSNOTSUPPORTKOINSTANCEENI = "UnsupportedOperation.FlowLogsNotSupportKoInstanceEni"
 //  UNSUPPORTEDOPERATION_FLOWLOGSNOTSUPPORTNULLINSTANCEENI = "UnsupportedOperation.FlowLogsNotSupportNullInstanceEni"
+//  UNSUPPORTEDOPERATION_NATGATEWAYDNATANDFLOWLOGCONFLICT = "UnsupportedOperation.NatGatewayDnatAndFlowLogConflict"
 //  UNSUPPORTEDOPERATION_ONLYSUPPORTPROFESSIONKAFKA = "UnsupportedOperation.OnlySupportProfessionKafka"
 //  UNSUPPORTEDOPERATION_TAGALLOCATE = "UnsupportedOperation.TagAllocate"
 //  UNSUPPORTEDOPERATION_TAGFREE = "UnsupportedOperation.TagFree"
@@ -4141,6 +4130,7 @@ func (c *Client) CreateFlowLog(request *CreateFlowLogRequest) (response *CreateF
 //  UNSUPPORTEDOPERATION_FLOWLOGINSTANCEEXISTED = "UnsupportedOperation.FlowLogInstanceExisted"
 //  UNSUPPORTEDOPERATION_FLOWLOGSNOTSUPPORTKOINSTANCEENI = "UnsupportedOperation.FlowLogsNotSupportKoInstanceEni"
 //  UNSUPPORTEDOPERATION_FLOWLOGSNOTSUPPORTNULLINSTANCEENI = "UnsupportedOperation.FlowLogsNotSupportNullInstanceEni"
+//  UNSUPPORTEDOPERATION_NATGATEWAYDNATANDFLOWLOGCONFLICT = "UnsupportedOperation.NatGatewayDnatAndFlowLogConflict"
 //  UNSUPPORTEDOPERATION_ONLYSUPPORTPROFESSIONKAFKA = "UnsupportedOperation.OnlySupportProfessionKafka"
 //  UNSUPPORTEDOPERATION_TAGALLOCATE = "UnsupportedOperation.TagAllocate"
 //  UNSUPPORTEDOPERATION_TAGFREE = "UnsupportedOperation.TagFree"
@@ -4259,7 +4249,9 @@ func NewCreateHaVipResponse() (response *CreateHaVipResponse) {
 //  RESOURCEINSUFFICIENT = "ResourceInsufficient"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+//  UNSUPPORTEDOPERATION_NOTPUTVPCSNATIPADDRESS = "UnsupportedOperation.NotPutVpcSnatIpAddress"
 //  UNSUPPORTEDOPERATION_SUBNETNOTEXISTS = "UnsupportedOperation.SubnetNotExists"
+//  UNSUPPORTEDOPERATION_TRAFFICPROTECTIONNOTSUPPORTIPV6 = "UnsupportedOperation.TrafficProtectionNotSupportIPv6"
 func (c *Client) CreateHaVip(request *CreateHaVipRequest) (response *CreateHaVipResponse, err error) {
     return c.CreateHaVipWithContext(context.Background(), request)
 }
@@ -4281,7 +4273,9 @@ func (c *Client) CreateHaVip(request *CreateHaVipRequest) (response *CreateHaVip
 //  RESOURCEINSUFFICIENT = "ResourceInsufficient"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+//  UNSUPPORTEDOPERATION_NOTPUTVPCSNATIPADDRESS = "UnsupportedOperation.NotPutVpcSnatIpAddress"
 //  UNSUPPORTEDOPERATION_SUBNETNOTEXISTS = "UnsupportedOperation.SubnetNotExists"
+//  UNSUPPORTEDOPERATION_TRAFFICPROTECTIONNOTSUPPORTIPV6 = "UnsupportedOperation.TrafficProtectionNotSupportIPv6"
 func (c *Client) CreateHaVipWithContext(ctx context.Context, request *CreateHaVipRequest) (response *CreateHaVipResponse, err error) {
     if request == nil {
         request = NewCreateHaVipRequest()
@@ -4747,6 +4741,7 @@ func NewCreateNatGatewayDestinationIpPortTranslationNatRuleResponse() (response 
 //  LIMITEXCEEDED = "LimitExceeded"
 //  LIMITEXCEEDED_NATGATEWAYDNATLIMITEXCEEDED = "LimitExceeded.NatGatewayDnatLimitExceeded"
 //  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION_NATGATEWAYDNATANDFLOWLOGCONFLICT = "UnsupportedOperation.NatGatewayDnatAndFlowLogConflict"
 //  UNSUPPORTEDOPERATION_NATGATEWAYEIPNOTEXISTS = "UnsupportedOperation.NatGatewayEipNotExists"
 func (c *Client) CreateNatGatewayDestinationIpPortTranslationNatRule(request *CreateNatGatewayDestinationIpPortTranslationNatRuleRequest) (response *CreateNatGatewayDestinationIpPortTranslationNatRuleResponse, err error) {
     return c.CreateNatGatewayDestinationIpPortTranslationNatRuleWithContext(context.Background(), request)
@@ -4765,6 +4760,7 @@ func (c *Client) CreateNatGatewayDestinationIpPortTranslationNatRule(request *Cr
 //  LIMITEXCEEDED = "LimitExceeded"
 //  LIMITEXCEEDED_NATGATEWAYDNATLIMITEXCEEDED = "LimitExceeded.NatGatewayDnatLimitExceeded"
 //  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION_NATGATEWAYDNATANDFLOWLOGCONFLICT = "UnsupportedOperation.NatGatewayDnatAndFlowLogConflict"
 //  UNSUPPORTEDOPERATION_NATGATEWAYEIPNOTEXISTS = "UnsupportedOperation.NatGatewayEipNotExists"
 func (c *Client) CreateNatGatewayDestinationIpPortTranslationNatRuleWithContext(ctx context.Context, request *CreateNatGatewayDestinationIpPortTranslationNatRuleRequest) (response *CreateNatGatewayDestinationIpPortTranslationNatRuleResponse, err error) {
     if request == nil {
@@ -7125,6 +7121,70 @@ func (c *Client) CreateTrafficMirrorWithContext(ctx context.Context, request *Cr
     return
 }
 
+func NewCreateTrafficMirrorFilterRulesRequest() (request *CreateTrafficMirrorFilterRulesRequest) {
+    request = &CreateTrafficMirrorFilterRulesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("vpc", APIVersion, "CreateTrafficMirrorFilterRules")
+    
+    
+    return
+}
+
+func NewCreateTrafficMirrorFilterRulesResponse() (response *CreateTrafficMirrorFilterRulesResponse) {
+    response = &CreateTrafficMirrorFilterRulesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateTrafficMirrorFilterRules
+// 创建流量镜像五元组过滤规则。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_LIMITEXCEEDED = "InvalidParameterValue.LimitExceeded"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  LIMITEXCEEDED_ACTIONLIMITED = "LimitExceeded.ActionLimited"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) CreateTrafficMirrorFilterRules(request *CreateTrafficMirrorFilterRulesRequest) (response *CreateTrafficMirrorFilterRulesResponse, err error) {
+    return c.CreateTrafficMirrorFilterRulesWithContext(context.Background(), request)
+}
+
+// CreateTrafficMirrorFilterRules
+// 创建流量镜像五元组过滤规则。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_LIMITEXCEEDED = "InvalidParameterValue.LimitExceeded"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  LIMITEXCEEDED_ACTIONLIMITED = "LimitExceeded.ActionLimited"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) CreateTrafficMirrorFilterRulesWithContext(ctx context.Context, request *CreateTrafficMirrorFilterRulesRequest) (response *CreateTrafficMirrorFilterRulesResponse, err error) {
+    if request == nil {
+        request = NewCreateTrafficMirrorFilterRulesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "vpc", APIVersion, "CreateTrafficMirrorFilterRules")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateTrafficMirrorFilterRules require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateTrafficMirrorFilterRulesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateTrafficPackagesRequest() (request *CreateTrafficPackagesRequest) {
     request = &CreateTrafficPackagesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -7688,6 +7748,8 @@ func NewCreateVpnConnectionResponse() (response *CreateVpnConnectionResponse) {
 //  UNSUPPORTEDOPERATION_TAGNOTPERMIT = "UnsupportedOperation.TagNotPermit"
 //  UNSUPPORTEDOPERATION_TAGSYSTEMRESERVEDTAGKEY = "UnsupportedOperation.TagSystemReservedTagKey"
 //  UNSUPPORTEDOPERATION_VPNCONNCIDRNOTSUPPORTEDHEALTHCHECK = "UnsupportedOperation.VpnConnCidrNotSupportedHealthCheck"
+//  UNSUPPORTEDOPERATION_VPNCONNDESTCIDRCONFLICTWITHPRIVATENET = "UnsupportedOperation.VpnConnDestCidrConflictWithPrivateNet"
+//  UNSUPPORTEDOPERATION_VPNCONNROUTETYPEMIXED = "UnsupportedOperation.VpnConnRouteTypeMixed"
 //  UNSUPPORTEDOPERATION_VPNUNSUPPORTEDBGP = "UnsupportedOperation.VpnUnsupportedBgp"
 //  UNSUPPORTEDOPERATION_VPNUNSUPPORTEDBGPASNEQUAL = "UnsupportedOperation.VpnUnsupportedBgpAsnEqual"
 //  UNSUPPORTEDOPERATION_VPNUNSUPPORTEDNOTEXISTBGPASN = "UnsupportedOperation.VpnUnsupportedNotExistBgpAsn"
@@ -7743,6 +7805,8 @@ func (c *Client) CreateVpnConnection(request *CreateVpnConnectionRequest) (respo
 //  UNSUPPORTEDOPERATION_TAGNOTPERMIT = "UnsupportedOperation.TagNotPermit"
 //  UNSUPPORTEDOPERATION_TAGSYSTEMRESERVEDTAGKEY = "UnsupportedOperation.TagSystemReservedTagKey"
 //  UNSUPPORTEDOPERATION_VPNCONNCIDRNOTSUPPORTEDHEALTHCHECK = "UnsupportedOperation.VpnConnCidrNotSupportedHealthCheck"
+//  UNSUPPORTEDOPERATION_VPNCONNDESTCIDRCONFLICTWITHPRIVATENET = "UnsupportedOperation.VpnConnDestCidrConflictWithPrivateNet"
+//  UNSUPPORTEDOPERATION_VPNCONNROUTETYPEMIXED = "UnsupportedOperation.VpnConnRouteTypeMixed"
 //  UNSUPPORTEDOPERATION_VPNUNSUPPORTEDBGP = "UnsupportedOperation.VpnUnsupportedBgp"
 //  UNSUPPORTEDOPERATION_VPNUNSUPPORTEDBGPASNEQUAL = "UnsupportedOperation.VpnUnsupportedBgpAsnEqual"
 //  UNSUPPORTEDOPERATION_VPNUNSUPPORTEDNOTEXISTBGPASN = "UnsupportedOperation.VpnUnsupportedNotExistBgpAsn"
@@ -7819,6 +7883,7 @@ func NewCreateVpnGatewayResponse() (response *CreateVpnGatewayResponse) {
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNAUTHORIZEDOPERATION_NOREALNAMEAUTHENTICATION = "UnauthorizedOperation.NoRealNameAuthentication"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+//  UNSUPPORTEDOPERATION_BILLINGFAILED = "UnsupportedOperation.BillingFailed"
 //  UNSUPPORTEDOPERATION_INSUFFICIENTFUNDS = "UnsupportedOperation.InsufficientFunds"
 //  UNSUPPORTEDOPERATION_NOTSUPPORTCREATEIPV6VPNGATEWAY = "UnsupportedOperation.NotSupportCreateIpv6VpnGateway"
 //  UNSUPPORTEDOPERATION_PRIVATEBGPVPNGATEWAY = "UnsupportedOperation.PrivateBgpVpnGateway"
@@ -7873,6 +7938,7 @@ func (c *Client) CreateVpnGateway(request *CreateVpnGatewayRequest) (response *C
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNAUTHORIZEDOPERATION_NOREALNAMEAUTHENTICATION = "UnauthorizedOperation.NoRealNameAuthentication"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+//  UNSUPPORTEDOPERATION_BILLINGFAILED = "UnsupportedOperation.BillingFailed"
 //  UNSUPPORTEDOPERATION_INSUFFICIENTFUNDS = "UnsupportedOperation.InsufficientFunds"
 //  UNSUPPORTEDOPERATION_NOTSUPPORTCREATEIPV6VPNGATEWAY = "UnsupportedOperation.NotSupportCreateIpv6VpnGateway"
 //  UNSUPPORTEDOPERATION_PRIVATEBGPVPNGATEWAY = "UnsupportedOperation.PrivateBgpVpnGateway"
@@ -8628,14 +8694,7 @@ func NewDeleteCdcLDCXListResponse() (response *DeleteCdcLDCXListResponse) {
 // 删除 IDC通道
 //
 // 可能返回的错误码:
-//  INVALIDPARAMETER = "InvalidParameter"
-//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
-//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
-//  RESOURCENOTFOUND = "ResourceNotFound"
-//  UNSUPPORTEDOPERATION_CCNROUTETABLENOTEXIST = "UnsupportedOperation.CcnRouteTableNotExist"
-//  UNSUPPORTEDOPERATION_DELDEFAULTROUTE = "UnsupportedOperation.DelDefaultRoute"
-//  UNSUPPORTEDOPERATION_NOTSUPPORTDELETEDEFAULTCCNROUTETABLE = "UnsupportedOperation.NotSupportDeleteDefaultCcnRouteTable"
-//  UNSUPPORTEDOPERATION_ROUTETABLECANNOTDELETE = "UnsupportedOperation.RouteTableCanNotDelete"
+//  UNSUPPORTEDOPERATION_SERVICEUNSUPPORTEDREGION = "UnsupportedOperation.ServiceUnsupportedRegion"
 func (c *Client) DeleteCdcLDCXList(request *DeleteCdcLDCXListRequest) (response *DeleteCdcLDCXListResponse, err error) {
     return c.DeleteCdcLDCXListWithContext(context.Background(), request)
 }
@@ -8644,14 +8703,7 @@ func (c *Client) DeleteCdcLDCXList(request *DeleteCdcLDCXListRequest) (response 
 // 删除 IDC通道
 //
 // 可能返回的错误码:
-//  INVALIDPARAMETER = "InvalidParameter"
-//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
-//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
-//  RESOURCENOTFOUND = "ResourceNotFound"
-//  UNSUPPORTEDOPERATION_CCNROUTETABLENOTEXIST = "UnsupportedOperation.CcnRouteTableNotExist"
-//  UNSUPPORTEDOPERATION_DELDEFAULTROUTE = "UnsupportedOperation.DelDefaultRoute"
-//  UNSUPPORTEDOPERATION_NOTSUPPORTDELETEDEFAULTCCNROUTETABLE = "UnsupportedOperation.NotSupportDeleteDefaultCcnRouteTable"
-//  UNSUPPORTEDOPERATION_ROUTETABLECANNOTDELETE = "UnsupportedOperation.RouteTableCanNotDelete"
+//  UNSUPPORTEDOPERATION_SERVICEUNSUPPORTEDREGION = "UnsupportedOperation.ServiceUnsupportedRegion"
 func (c *Client) DeleteCdcLDCXListWithContext(ctx context.Context, request *DeleteCdcLDCXListRequest) (response *DeleteCdcLDCXListResponse, err error) {
     if request == nil {
         request = NewDeleteCdcLDCXListRequest()
@@ -9421,6 +9473,8 @@ func NewDeleteNatGatewayResponse() (response *DeleteNatGatewayResponse) {
 //  UNSUPPORTEDOPERATION_NATGATEWAYHAVEHIGHTRAFFIC = "UnsupportedOperation.NatGatewayHaveHighTraffic"
 //  UNSUPPORTEDOPERATION_NATGATEWAYHAVEROUTE = "UnsupportedOperation.NatGatewayHaveRoute"
 //  UNSUPPORTEDOPERATION_NATGATEWAYHAVEROUTEANDHIGHTRAFFIC = "UnsupportedOperation.NatGatewayHaveRouteAndHighTraffic"
+//  UNSUPPORTEDOPERATION_NATGATEWAYHAVETRAFFICMIRROR = "UnsupportedOperation.NatGatewayHaveTrafficMirror"
+//  UNSUPPORTEDOPERATION_TRAFFICVALIDATIONFAILED = "UnsupportedOperation.TrafficValidationFailed"
 func (c *Client) DeleteNatGateway(request *DeleteNatGatewayRequest) (response *DeleteNatGatewayResponse, err error) {
     return c.DeleteNatGatewayWithContext(context.Background(), request)
 }
@@ -9440,6 +9494,8 @@ func (c *Client) DeleteNatGateway(request *DeleteNatGatewayRequest) (response *D
 //  UNSUPPORTEDOPERATION_NATGATEWAYHAVEHIGHTRAFFIC = "UnsupportedOperation.NatGatewayHaveHighTraffic"
 //  UNSUPPORTEDOPERATION_NATGATEWAYHAVEROUTE = "UnsupportedOperation.NatGatewayHaveRoute"
 //  UNSUPPORTEDOPERATION_NATGATEWAYHAVEROUTEANDHIGHTRAFFIC = "UnsupportedOperation.NatGatewayHaveRouteAndHighTraffic"
+//  UNSUPPORTEDOPERATION_NATGATEWAYHAVETRAFFICMIRROR = "UnsupportedOperation.NatGatewayHaveTrafficMirror"
+//  UNSUPPORTEDOPERATION_TRAFFICVALIDATIONFAILED = "UnsupportedOperation.TrafficValidationFailed"
 func (c *Client) DeleteNatGatewayWithContext(ctx context.Context, request *DeleteNatGatewayRequest) (response *DeleteNatGatewayResponse, err error) {
     if request == nil {
         request = NewDeleteNatGatewayRequest()
@@ -11027,6 +11083,70 @@ func (c *Client) DeleteTrafficMirrorWithContext(ctx context.Context, request *De
     return
 }
 
+func NewDeleteTrafficMirrorFilterRulesRequest() (request *DeleteTrafficMirrorFilterRulesRequest) {
+    request = &DeleteTrafficMirrorFilterRulesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("vpc", APIVersion, "DeleteTrafficMirrorFilterRules")
+    
+    
+    return
+}
+
+func NewDeleteTrafficMirrorFilterRulesResponse() (response *DeleteTrafficMirrorFilterRulesResponse) {
+    response = &DeleteTrafficMirrorFilterRulesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteTrafficMirrorFilterRules
+// 删除流量镜像五元组过滤规则。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_LIMITEXCEEDED = "InvalidParameterValue.LimitExceeded"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  LIMITEXCEEDED_ACTIONLIMITED = "LimitExceeded.ActionLimited"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) DeleteTrafficMirrorFilterRules(request *DeleteTrafficMirrorFilterRulesRequest) (response *DeleteTrafficMirrorFilterRulesResponse, err error) {
+    return c.DeleteTrafficMirrorFilterRulesWithContext(context.Background(), request)
+}
+
+// DeleteTrafficMirrorFilterRules
+// 删除流量镜像五元组过滤规则。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_LIMITEXCEEDED = "InvalidParameterValue.LimitExceeded"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  LIMITEXCEEDED_ACTIONLIMITED = "LimitExceeded.ActionLimited"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) DeleteTrafficMirrorFilterRulesWithContext(ctx context.Context, request *DeleteTrafficMirrorFilterRulesRequest) (response *DeleteTrafficMirrorFilterRulesResponse, err error) {
+    if request == nil {
+        request = NewDeleteTrafficMirrorFilterRulesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "vpc", APIVersion, "DeleteTrafficMirrorFilterRules")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteTrafficMirrorFilterRules require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteTrafficMirrorFilterRulesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteTrafficPackagesRequest() (request *DeleteTrafficPackagesRequest) {
     request = &DeleteTrafficPackagesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -12100,6 +12220,7 @@ func NewDescribeAddressesResponse() (response *DescribeAddressesResponse) {
 //  INVALIDPARAMETERVALUE_NETWORKINTERFACEIDMALFORMED = "InvalidParameterValue.NetworkInterfaceIdMalformed"
 //  INVALIDPARAMETERVALUE_RESOURCEIDMALFORMED = "InvalidParameterValue.ResourceIdMalformed"
 //  LIMITEXCEEDED_NUMBEROFFILTERS = "LimitExceeded.NumberOfFilters"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) DescribeAddresses(request *DescribeAddressesRequest) (response *DescribeAddressesResponse, err error) {
     return c.DescribeAddressesWithContext(context.Background(), request)
@@ -12119,6 +12240,7 @@ func (c *Client) DescribeAddresses(request *DescribeAddressesRequest) (response 
 //  INVALIDPARAMETERVALUE_NETWORKINTERFACEIDMALFORMED = "InvalidParameterValue.NetworkInterfaceIdMalformed"
 //  INVALIDPARAMETERVALUE_RESOURCEIDMALFORMED = "InvalidParameterValue.ResourceIdMalformed"
 //  LIMITEXCEEDED_NUMBEROFFILTERS = "LimitExceeded.NumberOfFilters"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 func (c *Client) DescribeAddressesWithContext(ctx context.Context, request *DescribeAddressesRequest) (response *DescribeAddressesResponse, err error) {
     if request == nil {
@@ -17835,6 +17957,70 @@ func (c *Client) DescribeTenantCcnsWithContext(ctx context.Context, request *Des
     return
 }
 
+func NewDescribeTrafficMirrorFilterRulesRequest() (request *DescribeTrafficMirrorFilterRulesRequest) {
+    request = &DescribeTrafficMirrorFilterRulesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("vpc", APIVersion, "DescribeTrafficMirrorFilterRules")
+    
+    
+    return
+}
+
+func NewDescribeTrafficMirrorFilterRulesResponse() (response *DescribeTrafficMirrorFilterRulesResponse) {
+    response = &DescribeTrafficMirrorFilterRulesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTrafficMirrorFilterRules
+// 查询流量镜像五元组过滤规则。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_LIMITEXCEEDED = "InvalidParameterValue.LimitExceeded"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  LIMITEXCEEDED_ACTIONLIMITED = "LimitExceeded.ActionLimited"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) DescribeTrafficMirrorFilterRules(request *DescribeTrafficMirrorFilterRulesRequest) (response *DescribeTrafficMirrorFilterRulesResponse, err error) {
+    return c.DescribeTrafficMirrorFilterRulesWithContext(context.Background(), request)
+}
+
+// DescribeTrafficMirrorFilterRules
+// 查询流量镜像五元组过滤规则。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_LIMITEXCEEDED = "InvalidParameterValue.LimitExceeded"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  LIMITEXCEEDED_ACTIONLIMITED = "LimitExceeded.ActionLimited"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) DescribeTrafficMirrorFilterRulesWithContext(ctx context.Context, request *DescribeTrafficMirrorFilterRulesRequest) (response *DescribeTrafficMirrorFilterRulesResponse, err error) {
+    if request == nil {
+        request = NewDescribeTrafficMirrorFilterRulesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "vpc", APIVersion, "DescribeTrafficMirrorFilterRules")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTrafficMirrorFilterRules require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTrafficMirrorFilterRulesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeTrafficMirrorsRequest() (request *DescribeTrafficMirrorsRequest) {
     request = &DescribeTrafficMirrorsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -21976,12 +22162,18 @@ func NewModifyAddressAttributeResponse() (response *ModifyAddressAttributeRespon
 // 可能返回的错误码:
 //  INVALIDADDRESSID_BLOCKED = "InvalidAddressId.Blocked"
 //  INVALIDADDRESSID_NOTFOUND = "InvalidAddressId.NotFound"
+//  INVALIDPARAMETER_CONFLICT = "InvalidParameter.Conflict"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_ADDRESSALREADYHASPASSTHROUGH = "InvalidParameterValue.AddressAlreadyHasPassThrough"
 //  INVALIDPARAMETERVALUE_ADDRESSIDMALFORMED = "InvalidParameterValue.AddressIdMalformed"
 //  INVALIDPARAMETERVALUE_ADDRESSNOTFOUND = "InvalidParameterValue.AddressNotFound"
+//  INVALIDPARAMETERVALUE_INSTANCEDOESNOTSUPPORTEIPVISIBLEONENI = "InvalidParameterValue.InstanceDoesNotSupportEipVisibleOnEni"
+//  INVALIDPARAMETERVALUE_INSTANCEVPCDOESNOTSUPPORTEIPVISIBLEONENI = "InvalidParameterValue.InstanceVpcDoesNotSupportEipVisibleOnEni"
+//  INVALIDPARAMETERVALUE_PRIVATEIPADDRESSDOESNOTSUPPORTEIPVISIBLEONENI = "InvalidParameterValue.PrivateIpAddressDoesNotSupportEipVisibleOnEni"
 //  INVALIDPARAMETERVALUE_RESOURCENOTEXISTED = "InvalidParameterValue.ResourceNotExisted"
 //  INVALIDPARAMETERVALUE_TOOLONG = "InvalidParameterValue.TooLong"
 //  OPERATIONDENIED_MUTEXTASKRUNNING = "OperationDenied.MutexTaskRunning"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
 //  UNSUPPORTEDOPERATION_ADDRESSSTATUSNOTPERMIT = "UnsupportedOperation.AddressStatusNotPermit"
 //  UNSUPPORTEDOPERATION_INCORRECTADDRESSRESOURCETYPE = "UnsupportedOperation.IncorrectAddressResourceType"
 //  UNSUPPORTEDOPERATION_MODIFYADDRESSATTRIBUTE = "UnsupportedOperation.ModifyAddressAttribute"
@@ -21995,12 +22187,18 @@ func (c *Client) ModifyAddressAttribute(request *ModifyAddressAttributeRequest) 
 // 可能返回的错误码:
 //  INVALIDADDRESSID_BLOCKED = "InvalidAddressId.Blocked"
 //  INVALIDADDRESSID_NOTFOUND = "InvalidAddressId.NotFound"
+//  INVALIDPARAMETER_CONFLICT = "InvalidParameter.Conflict"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_ADDRESSALREADYHASPASSTHROUGH = "InvalidParameterValue.AddressAlreadyHasPassThrough"
 //  INVALIDPARAMETERVALUE_ADDRESSIDMALFORMED = "InvalidParameterValue.AddressIdMalformed"
 //  INVALIDPARAMETERVALUE_ADDRESSNOTFOUND = "InvalidParameterValue.AddressNotFound"
+//  INVALIDPARAMETERVALUE_INSTANCEDOESNOTSUPPORTEIPVISIBLEONENI = "InvalidParameterValue.InstanceDoesNotSupportEipVisibleOnEni"
+//  INVALIDPARAMETERVALUE_INSTANCEVPCDOESNOTSUPPORTEIPVISIBLEONENI = "InvalidParameterValue.InstanceVpcDoesNotSupportEipVisibleOnEni"
+//  INVALIDPARAMETERVALUE_PRIVATEIPADDRESSDOESNOTSUPPORTEIPVISIBLEONENI = "InvalidParameterValue.PrivateIpAddressDoesNotSupportEipVisibleOnEni"
 //  INVALIDPARAMETERVALUE_RESOURCENOTEXISTED = "InvalidParameterValue.ResourceNotExisted"
 //  INVALIDPARAMETERVALUE_TOOLONG = "InvalidParameterValue.TooLong"
 //  OPERATIONDENIED_MUTEXTASKRUNNING = "OperationDenied.MutexTaskRunning"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
 //  UNSUPPORTEDOPERATION_ADDRESSSTATUSNOTPERMIT = "UnsupportedOperation.AddressStatusNotPermit"
 //  UNSUPPORTEDOPERATION_INCORRECTADDRESSRESOURCETYPE = "UnsupportedOperation.IncorrectAddressResourceType"
 //  UNSUPPORTEDOPERATION_MODIFYADDRESSATTRIBUTE = "UnsupportedOperation.ModifyAddressAttribute"
@@ -22313,6 +22511,7 @@ func NewModifyAddressesBandwidthResponse() (response *ModifyAddressesBandwidthRe
 //  INVALIDPARAMETERVALUE_RESOURCENOTSUPPORT = "InvalidParameterValue.ResourceNotSupport"
 //  OPERATIONDENIED_ADDRESSINARREARS = "OperationDenied.AddressInArrears"
 //  OPERATIONDENIED_MUTEXTASKRUNNING = "OperationDenied.MutexTaskRunning"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
 //  UNSUPPORTEDOPERATION_ACTIONNOTFOUND = "UnsupportedOperation.ActionNotFound"
 //  UNSUPPORTEDOPERATION_ADDRESSSTATUSNOTPERMIT = "UnsupportedOperation.AddressStatusNotPermit"
 //  UNSUPPORTEDOPERATION_INSTANCESTATENOTSUPPORTED = "UnsupportedOperation.InstanceStateNotSupported"
@@ -22344,6 +22543,7 @@ func (c *Client) ModifyAddressesBandwidth(request *ModifyAddressesBandwidthReque
 //  INVALIDPARAMETERVALUE_RESOURCENOTSUPPORT = "InvalidParameterValue.ResourceNotSupport"
 //  OPERATIONDENIED_ADDRESSINARREARS = "OperationDenied.AddressInArrears"
 //  OPERATIONDENIED_MUTEXTASKRUNNING = "OperationDenied.MutexTaskRunning"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
 //  UNSUPPORTEDOPERATION_ACTIONNOTFOUND = "UnsupportedOperation.ActionNotFound"
 //  UNSUPPORTEDOPERATION_ADDRESSSTATUSNOTPERMIT = "UnsupportedOperation.AddressStatusNotPermit"
 //  UNSUPPORTEDOPERATION_INSTANCESTATENOTSUPPORTED = "UnsupportedOperation.InstanceStateNotSupported"
@@ -23250,6 +23450,7 @@ func NewModifyDirectConnectGatewayAttributeResponse() (response *ModifyDirectCon
 //  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
 //  INVALIDPARAMETERVALUE_TOOLONG = "InvalidParameterValue.TooLong"
 //  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCEUNAVAILABLE_DCGIPV6NEEDVPCCREATEIPV6CIDR = "ResourceUnavailable.DcgIpv6NeedVpcCreateIPv6Cidr"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 //  UNSUPPORTEDOPERATION_APPIDMISMATCH = "UnsupportedOperation.AppIdMismatch"
 //  UNSUPPORTEDOPERATION_DIRECTCONNECTGATEWAYISUPDATINGCOMMUNITY = "UnsupportedOperation.DirectConnectGatewayIsUpdatingCommunity"
@@ -23265,6 +23466,7 @@ func (c *Client) ModifyDirectConnectGatewayAttribute(request *ModifyDirectConnec
 //  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
 //  INVALIDPARAMETERVALUE_TOOLONG = "InvalidParameterValue.TooLong"
 //  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCEUNAVAILABLE_DCGIPV6NEEDVPCCREATEIPV6CIDR = "ResourceUnavailable.DcgIpv6NeedVpcCreateIPv6Cidr"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
 //  UNSUPPORTEDOPERATION_APPIDMISMATCH = "UnsupportedOperation.AppIdMismatch"
 //  UNSUPPORTEDOPERATION_DIRECTCONNECTGATEWAYISUPDATINGCOMMUNITY = "UnsupportedOperation.DirectConnectGatewayIsUpdatingCommunity"
@@ -24207,6 +24409,66 @@ func (c *Client) ModifyLocalGatewayWithContext(ctx context.Context, request *Mod
     request.SetContext(ctx)
     
     response = NewModifyLocalGatewayResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyNatGatewayAdvancedAttributeRequest() (request *ModifyNatGatewayAdvancedAttributeRequest) {
+    request = &ModifyNatGatewayAdvancedAttributeRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("vpc", APIVersion, "ModifyNatGatewayAdvancedAttribute")
+    
+    
+    return
+}
+
+func NewModifyNatGatewayAdvancedAttributeResponse() (response *ModifyNatGatewayAdvancedAttributeResponse) {
+    response = &ModifyNatGatewayAdvancedAttributeResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyNatGatewayAdvancedAttribute
+// 本接口（ModifyNatGatewayAdvancedAttribute）用于修改NAT网关的高级属性。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  INVALIDPARAMETERVALUE_RANGE = "InvalidParameterValue.Range"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) ModifyNatGatewayAdvancedAttribute(request *ModifyNatGatewayAdvancedAttributeRequest) (response *ModifyNatGatewayAdvancedAttributeResponse, err error) {
+    return c.ModifyNatGatewayAdvancedAttributeWithContext(context.Background(), request)
+}
+
+// ModifyNatGatewayAdvancedAttribute
+// 本接口（ModifyNatGatewayAdvancedAttribute）用于修改NAT网关的高级属性。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  INVALIDPARAMETERVALUE_RANGE = "InvalidParameterValue.Range"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) ModifyNatGatewayAdvancedAttributeWithContext(ctx context.Context, request *ModifyNatGatewayAdvancedAttributeRequest) (response *ModifyNatGatewayAdvancedAttributeResponse, err error) {
+    if request == nil {
+        request = NewModifyNatGatewayAdvancedAttributeRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "vpc", APIVersion, "ModifyNatGatewayAdvancedAttribute")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyNatGatewayAdvancedAttribute require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyNatGatewayAdvancedAttributeResponse()
     err = c.Send(request, response)
     return
 }
@@ -25927,6 +26189,70 @@ func (c *Client) ModifyTrafficMirrorAttributeWithContext(ctx context.Context, re
     return
 }
 
+func NewModifyTrafficMirrorFilterRulesRequest() (request *ModifyTrafficMirrorFilterRulesRequest) {
+    request = &ModifyTrafficMirrorFilterRulesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("vpc", APIVersion, "ModifyTrafficMirrorFilterRules")
+    
+    
+    return
+}
+
+func NewModifyTrafficMirrorFilterRulesResponse() (response *ModifyTrafficMirrorFilterRulesResponse) {
+    response = &ModifyTrafficMirrorFilterRulesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyTrafficMirrorFilterRules
+// 修改流量镜像五元组过滤规则。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_LIMITEXCEEDED = "InvalidParameterValue.LimitExceeded"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  LIMITEXCEEDED_ACTIONLIMITED = "LimitExceeded.ActionLimited"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) ModifyTrafficMirrorFilterRules(request *ModifyTrafficMirrorFilterRulesRequest) (response *ModifyTrafficMirrorFilterRulesResponse, err error) {
+    return c.ModifyTrafficMirrorFilterRulesWithContext(context.Background(), request)
+}
+
+// ModifyTrafficMirrorFilterRules
+// 修改流量镜像五元组过滤规则。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_LIMITEXCEEDED = "InvalidParameterValue.LimitExceeded"
+//  INVALIDPARAMETERVALUE_MALFORMED = "InvalidParameterValue.Malformed"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  LIMITEXCEEDED_ACTIONLIMITED = "LimitExceeded.ActionLimited"
+//  MISSINGPARAMETER = "MissingParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) ModifyTrafficMirrorFilterRulesWithContext(ctx context.Context, request *ModifyTrafficMirrorFilterRulesRequest) (response *ModifyTrafficMirrorFilterRulesResponse, err error) {
+    if request == nil {
+        request = NewModifyTrafficMirrorFilterRulesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "vpc", APIVersion, "ModifyTrafficMirrorFilterRules")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyTrafficMirrorFilterRules require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyTrafficMirrorFilterRulesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyVpcAttributeRequest() (request *ModifyVpcAttributeRequest) {
     request = &ModifyVpcAttributeRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -26592,6 +26918,7 @@ func NewModifyVpnGatewaySslServerResponse() (response *ModifyVpnGatewaySslServer
 //  LIMITEXCEEDED_SSLVPNCLIENTLIMITEXCEEDED = "LimitExceeded.SslVpnClientLimitExceeded"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+//  UNSUPPORTEDOPERATION_PARAMETERSSLVPNPROTOCOL = "UnsupportedOperation.ParameterSslVpnProtocol"
 //  UNSUPPORTEDOPERATION_VERSIONNOTSUPPORTED = "UnsupportedOperation.VersionNotSupported"
 func (c *Client) ModifyVpnGatewaySslServer(request *ModifyVpnGatewaySslServerRequest) (response *ModifyVpnGatewaySslServerResponse, err error) {
     return c.ModifyVpnGatewaySslServerWithContext(context.Background(), request)
@@ -26607,6 +26934,7 @@ func (c *Client) ModifyVpnGatewaySslServer(request *ModifyVpnGatewaySslServerReq
 //  LIMITEXCEEDED_SSLVPNCLIENTLIMITEXCEEDED = "LimitExceeded.SslVpnClientLimitExceeded"
 //  RESOURCENOTFOUND = "ResourceNotFound"
 //  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+//  UNSUPPORTEDOPERATION_PARAMETERSSLVPNPROTOCOL = "UnsupportedOperation.ParameterSslVpnProtocol"
 //  UNSUPPORTEDOPERATION_VERSIONNOTSUPPORTED = "UnsupportedOperation.VersionNotSupported"
 func (c *Client) ModifyVpnGatewaySslServerWithContext(ctx context.Context, request *ModifyVpnGatewaySslServerRequest) (response *ModifyVpnGatewaySslServerResponse, err error) {
     if request == nil {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312/errors.go
@@ -158,6 +158,9 @@ const (
 	// 接入网段前缀必须是10，172，192开头。
 	INVALIDPARAMETERVALUE_ACCESSSUBNETPREFIX = "InvalidParameterValue.AccessSubnetPrefix"
 
+	// 指定的EIP已开启直通开关，无法再次开启
+	INVALIDPARAMETERVALUE_ADDRESSALREADYHASPASSTHROUGH = "InvalidParameterValue.AddressAlreadyHasPassThrough"
+
 	// 被攻击的IP地址。
 	INVALIDPARAMETERVALUE_ADDRESSATTACKED = "InvalidParameterValue.AddressAttacked"
 
@@ -812,6 +815,9 @@ const (
 	// 资源不可用。
 	RESOURCEUNAVAILABLE = "ResourceUnavailable"
 
+	// 专线网关所在VPC未创建IPv6 CIDR，专线网关无法开启IPv6功能
+	RESOURCEUNAVAILABLE_DCGIPV6NEEDVPCCREATEIPV6CIDR = "ResourceUnavailable.DcgIpv6NeedVpcCreateIPv6Cidr"
+
 	// 获取CDC IDC VIP失败.
 	RESOURCEUNAVAILABLE_FAILEDGETCDCIDCVIP = "ResourceUnavailable.FailedGetCdcIdcVip"
 
@@ -889,6 +895,9 @@ const (
 
 	// 该带宽包不支持此操作。
 	UNSUPPORTEDOPERATION_BANDWIDTHPACKAGEIDNOTSUPPORTED = "UnsupportedOperation.BandwidthPackageIdNotSupported"
+
+	// 抱歉，您的操作暂时无法完成，请稍后重试或联系客服。
+	UNSUPPORTEDOPERATION_BILLINGFAILED = "UnsupportedOperation.BillingFailed"
 
 	// 绑定了防火墙，请先到防火墙页面解绑。
 	UNSUPPORTEDOPERATION_BINDCLOUDFIREWALL = "UnsupportedOperation.BindCloudFirewall"
@@ -1175,6 +1184,9 @@ const (
 	// 资源互斥操作任务正在执行。
 	UNSUPPORTEDOPERATION_MUTEXOPERATIONTASKRUNNING = "UnsupportedOperation.MutexOperationTaskRunning"
 
+	// 传统型NAT网关暂不支持同时创建DNAT规则和开通流日志功能。
+	UNSUPPORTEDOPERATION_NATGATEWAYDNATANDFLOWLOGCONFLICT = "UnsupportedOperation.NatGatewayDnatAndFlowLogConflict"
+
 	// NAT网关的公网IP不存在。
 	UNSUPPORTEDOPERATION_NATGATEWAYEIPNOTEXISTS = "UnsupportedOperation.NatGatewayEipNotExists"
 
@@ -1189,6 +1201,9 @@ const (
 
 	// NAT网关存在路由和最近流量“出/入带宽”峰值取大超过检测带宽阈值。
 	UNSUPPORTEDOPERATION_NATGATEWAYHAVEROUTEANDHIGHTRAFFIC = "UnsupportedOperation.NatGatewayHaveRouteAndHighTraffic"
+
+	// NAT实例正在使用流量镜像
+	UNSUPPORTEDOPERATION_NATGATEWAYHAVETRAFFICMIRROR = "UnsupportedOperation.NatGatewayHaveTrafficMirror"
 
 	// NAT实例当前负载较高，请稍后重试
 	UNSUPPORTEDOPERATION_NATGATEWAYISBUSY = "UnsupportedOperation.NatGatewayIsBusy"
@@ -1256,6 +1271,9 @@ const (
 	// 当前云联网为非后付费类型，无法进行此操作。
 	UNSUPPORTEDOPERATION_NOTPOSTPAIDCCNOPERATION = "UnsupportedOperation.NotPostpaidCcnOperation"
 
+	// 该VPC没有投放Snat子网地址池
+	UNSUPPORTEDOPERATION_NOTPUTVPCSNATIPADDRESS = "UnsupportedOperation.NotPutVpcSnatIpAddress"
+
 	// 当前云联网不支持同时关联EDGE实例和跨境实例
 	UNSUPPORTEDOPERATION_NOTSUPPORTATTACHEDGEANDCROSSBORDERINSTANCE = "UnsupportedOperation.NotSupportAttachEdgeAndCrossBorderInstance"
 
@@ -1312,6 +1330,9 @@ const (
 
 	// 仅支持专业版Ckafka。
 	UNSUPPORTEDOPERATION_ONLYSUPPORTPROFESSIONKAFKA = "UnsupportedOperation.OnlySupportProfessionKafka"
+
+	// 参数 `SslVpnProtocol` 不支持修改。
+	UNSUPPORTEDOPERATION_PARAMETERSSLVPNPROTOCOL = "UnsupportedOperation.ParameterSslVpnProtocol"
 
 	// 预付费云联网只支持带宽计量类型
 	UNSUPPORTEDOPERATION_PREPAIDCCNONLYSUPPORTBANDWIDTHMETERING = "UnsupportedOperation.PrepaidCcnOnlySupportBandwidthMetering"
@@ -1400,6 +1421,9 @@ const (
 	// SSL客户端状态不可用，不支持下载
 	UNSUPPORTEDOPERATION_SSLCLIENTCERTDISABLEUNSUPPORTEDDOWNLOADSSLCLIENTCERT = "UnsupportedOperation.SSLClientCertDisableUnsupportedDownloadSSLClientCert"
 
+	// 服务在当前地域不支持。
+	UNSUPPORTEDOPERATION_SERVICEUNSUPPORTEDREGION = "UnsupportedOperation.ServiceUnsupportedRegion"
+
 	// 安全组展开后的规则已达到上限。
 	UNSUPPORTEDOPERATION_SGNUMEXCEEDLIMIT = "UnsupportedOperation.SgNumExceedLimit"
 
@@ -1463,8 +1487,14 @@ const (
 	// 流量镜像源、目的不可同端。
 	UNSUPPORTEDOPERATION_TRAFFICMIRRORNOTSUPPORTSAMESRCTARGET = "UnsupportedOperation.TrafficMirrorNotSupportSameSrcTarget"
 
+	// 流量保护不支持IPv6。
+	UNSUPPORTEDOPERATION_TRAFFICPROTECTIONNOTSUPPORTIPV6 = "UnsupportedOperation.TrafficProtectionNotSupportIPv6"
+
 	// 流量调度策略分配带宽和地域间带宽不一致，不支持关闭流量调度策略功能。
 	UNSUPPORTEDOPERATION_TRAFFICQOSPOLICYBANDWIDTH = "UnsupportedOperation.TrafficQosPolicyBandwidth"
+
+	// 资源业务带宽超过防误操作检测阈值。
+	UNSUPPORTEDOPERATION_TRAFFICVALIDATIONFAILED = "UnsupportedOperation.TrafficValidationFailed"
 
 	// 账号ID不存在。
 	UNSUPPORTEDOPERATION_UINNOTFOUND = "UnsupportedOperation.UinNotFound"
@@ -1526,8 +1556,14 @@ const (
 	// VPN SPD通道不支持配置健康检查
 	UNSUPPORTEDOPERATION_VPNCONNCIDRNOTSUPPORTEDHEALTHCHECK = "UnsupportedOperation.VpnConnCidrNotSupportedHealthCheck"
 
+	// 私网VPN通道目的网段与私网VPN网关的私网网段冲突，请修改后重试。
+	UNSUPPORTEDOPERATION_VPNCONNDESTCIDRCONFLICTWITHPRIVATENET = "UnsupportedOperation.VpnConnDestCidrConflictWithPrivateNet"
+
 	// 当前通道为非可用状态，不支持该操作。
 	UNSUPPORTEDOPERATION_VPNCONNINVALIDSTATE = "UnsupportedOperation.VpnConnInvalidState"
+
+	// VPN网关下的通道不支持动态路由与非动态路由混用，请检查后重试。
+	UNSUPPORTEDOPERATION_VPNCONNROUTETYPEMIXED = "UnsupportedOperation.VpnConnRouteTypeMixed"
 
 	// SPD本端网段冲突，请检查后重试。
 	UNSUPPORTEDOPERATION_VPNCONNSPDOVERLAP = "UnsupportedOperation.VpnConnSPDOverlap"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312/models.go
@@ -2846,26 +2846,22 @@ type CcnFlowLock struct {
 }
 
 type CcnInstance struct {
-	// 关联实例ID。
+	// <p>关联实例ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 关联实例ID所属大区，例如：ap-guangzhou。
+	// <p>关联实例ID所属大区，例如：ap-guangzhou。</p>
 	InstanceRegion *string `json:"InstanceRegion,omitnil,omitempty" name:"InstanceRegion"`
 
-	// 关联实例类型，可选值：
-	// <li>`VPC`：私有网络</li>
-	// <li>`DIRECTCONNECT`：专线网关</li>
-	// <li>`BMVPC`：黑石私有网络</li>
-	// <li>`VPNGW`：VPNGW类型</li>
+	// <p>关联实例类型，可选值：</p><li><code>VPC</code>：私有网络</li><li><code>DIRECTCONNECT</code>：专线网关</li><li><code>BMVPC</code>：黑石私有网络</li><li><code>VPNGW</code>：VPNGW类型</li>
 	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
 
-	// 备注
+	// <p>备注</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
-	// 实例关联的路由表ID。
+	// <p>实例关联的路由表ID。</p>
 	RouteTableId *string `json:"RouteTableId,omitnil,omitempty" name:"RouteTableId"`
 
-	// 实例付费方式
+	// <p>实例付费方式</p><p>枚举值：</p><ul><li>PayByCcnOwner： CCN所在账号付费</li><li>PayByInstanceOwner： 关联实例所在账号付费</li></ul>
 	OrderType *string `json:"OrderType,omitnil,omitempty" name:"OrderType"`
 }
 
@@ -2928,29 +2924,35 @@ type CcnPolicyBasedRoutingNextHop struct {
 }
 
 type CcnPolicyBasedRoutingRule struct {
-	// 策略路由下一跳ID
+	// <p>策略路由下一跳ID</p>
 	PolicyBasedRoutingNextHopId *string `json:"PolicyBasedRoutingNextHopId,omitnil,omitempty" name:"PolicyBasedRoutingNextHopId"`
 
-	// 实例类型[VPC,DIRECTCONNECT,VPNGW]
+	// <p>实例类型[VPC,DIRECTCONNECT,VPNGW]</p>
 	InstanceType *string `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
 
-	// 实例ID
+	// <p>实例ID</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 源地址CIDR
+	// <p>源地址CIDR</p>
 	SourceCidrBlock *string `json:"SourceCidrBlock,omitnil,omitempty" name:"SourceCidrBlock"`
 
-	// 目的地址CIDR
+	// <p>目的地址CIDR</p>
 	DestinationCidrBlock *string `json:"DestinationCidrBlock,omitnil,omitempty" name:"DestinationCidrBlock"`
 
-	// 优先级
+	// <p>优先级</p>
 	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
 
-	// 描述
+	// <p>描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
-	// 策略路由匹配策略ID
+	// <p>策略路由匹配策略ID</p>
 	PolicyBasedRoutingRuleId *string `json:"PolicyBasedRoutingRuleId,omitnil,omitempty" name:"PolicyBasedRoutingRuleId"`
+
+	// <p>目的端实例ID</p><p>枚举值：</p><ul><li>VPC： 私有网络</li></ul>
+	DestinationInstanceType *string `json:"DestinationInstanceType,omitnil,omitempty" name:"DestinationInstanceType"`
+
+	// <p>目的端实例ID</p>
+	DestinationInstanceId *string `json:"DestinationInstanceId,omitnil,omitempty" name:"DestinationInstanceId"`
 }
 
 type CcnRegionBandwidthLimit struct {
@@ -4151,6 +4153,9 @@ type CreateBandwidthPackageRequestParams struct {
 
 	// 网络出口，默认值：center_egress1，其它可选值：center_egress2、center_egress3。
 	Egress *string `json:"Egress,omitnil,omitempty" name:"Egress"`
+
+	// 仅用于申请特殊可用区带宽包，如：TEZ/EZ边缘可用区，CDZ专属可用区。具体可选可用区信息，请参考[DescribeDesignatedZones](https://cloud.tencent.com/document/product/215/128830)接口查询结果。
+	DesignatedZone *string `json:"DesignatedZone,omitnil,omitempty" name:"DesignatedZone"`
 }
 
 type CreateBandwidthPackageRequest struct {
@@ -4194,6 +4199,9 @@ type CreateBandwidthPackageRequest struct {
 
 	// 网络出口，默认值：center_egress1，其它可选值：center_egress2、center_egress3。
 	Egress *string `json:"Egress,omitnil,omitempty" name:"Egress"`
+
+	// 仅用于申请特殊可用区带宽包，如：TEZ/EZ边缘可用区，CDZ专属可用区。具体可选可用区信息，请参考[DescribeDesignatedZones](https://cloud.tencent.com/document/product/215/128830)接口查询结果。
+	DesignatedZone *string `json:"DesignatedZone,omitnil,omitempty" name:"DesignatedZone"`
 }
 
 func (r *CreateBandwidthPackageRequest) ToJsonString() string {
@@ -4217,6 +4225,7 @@ func (r *CreateBandwidthPackageRequest) FromJsonString(s string) error {
 	delete(f, "Protocol")
 	delete(f, "TimeSpan")
 	delete(f, "Egress")
+	delete(f, "DesignatedZone")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateBandwidthPackageRequest has unknown keys!", "")
 	}
@@ -7867,6 +7876,83 @@ func (r *CreateSubnetsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type CreateTrafficMirrorFilterRulesRequestParams struct {
+	// 流量镜像实例唯一ID。
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
+}
+
+type CreateTrafficMirrorFilterRulesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 流量镜像实例唯一ID。
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
+}
+
+func (r *CreateTrafficMirrorFilterRulesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateTrafficMirrorFilterRulesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TrafficMirrorId")
+	delete(f, "IngressFilterRules")
+	delete(f, "EgressFilterRules")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateTrafficMirrorFilterRulesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateTrafficMirrorFilterRulesResponseParams struct {
+	// 流量镜像实例唯一ID。
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateTrafficMirrorFilterRulesResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateTrafficMirrorFilterRulesResponseParams `json:"Response"`
+}
+
+func (r *CreateTrafficMirrorFilterRulesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateTrafficMirrorFilterRulesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CreateTrafficMirrorRequestParams struct {
 	// VPC实例ID。
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
@@ -7883,7 +7969,7 @@ type CreateTrafficMirrorRequestParams struct {
 	// 流量镜像采集方向，支持EGRESS/INGRESS/ALL（vpc），ALL（公网IP）。
 	Direction *string `json:"Direction,omitnil,omitempty" name:"Direction"`
 
-	// 流量镜像的采集对象。
+	// 流量镜像的采集对象 (最多支持20个采集对象)。
 	CollectorSrcs []*string `json:"CollectorSrcs,omitnil,omitempty" name:"CollectorSrcs"`
 
 	// 流量镜像过滤的natgw实例。
@@ -7903,6 +7989,12 @@ type CreateTrafficMirrorRequestParams struct {
 
 	// 指定绑定的标签列表，例如：[{"Key": "city", "Value": "shanghai"}]。
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
 }
 
 type CreateTrafficMirrorRequest struct {
@@ -7923,7 +8015,7 @@ type CreateTrafficMirrorRequest struct {
 	// 流量镜像采集方向，支持EGRESS/INGRESS/ALL（vpc），ALL（公网IP）。
 	Direction *string `json:"Direction,omitnil,omitempty" name:"Direction"`
 
-	// 流量镜像的采集对象。
+	// 流量镜像的采集对象 (最多支持20个采集对象)。
 	CollectorSrcs []*string `json:"CollectorSrcs,omitnil,omitempty" name:"CollectorSrcs"`
 
 	// 流量镜像过滤的natgw实例。
@@ -7943,6 +8035,12 @@ type CreateTrafficMirrorRequest struct {
 
 	// 指定绑定的标签列表，例如：[{"Key": "city", "Value": "shanghai"}]。
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
 }
 
 func (r *CreateTrafficMirrorRequest) ToJsonString() string {
@@ -7969,6 +8067,8 @@ func (r *CreateTrafficMirrorRequest) FromJsonString(s string) error {
 	delete(f, "SubnetId")
 	delete(f, "Type")
 	delete(f, "Tags")
+	delete(f, "IngressFilterRules")
+	delete(f, "EgressFilterRules")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateTrafficMirrorRequest has unknown keys!", "")
 	}
@@ -8610,139 +8710,142 @@ func (r *CreateVpcResponse) FromJsonString(s string) error {
 }
 
 type CreateVpnConnRoute struct {
-	// 目的端IDC网段
+	// <p>目的端IDC网段</p>
 	DestinationCidrBlock *string `json:"DestinationCidrBlock,omitnil,omitempty" name:"DestinationCidrBlock"`
 
-	// 优先级；可选值0，100。
+	// <p>优先级；可选值0，100。</p>
 	Priority *uint64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>路由备注；可选值</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 }
 
 // Predefined struct for user
 type CreateVpnConnectionRequestParams struct {
-	// VPN网关实例ID。
+	// <p>VPN网关实例ID。</p>
 	VpnGatewayId *string `json:"VpnGatewayId,omitnil,omitempty" name:"VpnGatewayId"`
 
-	// 对端网关ID。例如：cgw-2wqq41m9，可通过[DescribeCustomerGateways](https://cloud.tencent.com/document/product/215/17516)接口查询对端网关。
+	// <p>对端网关ID。例如：cgw-2wqq41m9，可通过<a href="https://cloud.tencent.com/document/product/215/17516">DescribeCustomerGateways</a>接口查询对端网关。</p>
 	CustomerGatewayId *string `json:"CustomerGatewayId,omitnil,omitempty" name:"CustomerGatewayId"`
 
-	// 通道名称，可任意命名，但不得超过60个字符。
+	// <p>通道名称，可任意命名，但不得超过60个字符。</p>
 	VpnConnectionName *string `json:"VpnConnectionName,omitnil,omitempty" name:"VpnConnectionName"`
 
-	// 预共享密钥。
+	// <p>预共享密钥。</p>
 	PreShareKey *string `json:"PreShareKey,omitnil,omitempty" name:"PreShareKey"`
 
-	// VPC实例ID。可通过[DescribeVpcs](https://cloud.tencent.com/document/product/215/15778)接口返回值中的VpcId获取。
-	// CCN VPN 形的通道 可以不传VPCID
+	// <p>VPC实例ID。VPC类型网关可通过<a href="https://cloud.tencent.com/document/product/215/15778">DescribeVpcs</a>接口返回值中的VpcId获取，CCN类型网关传空值即可。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// SPD策略组，例如：{"10.0.0.5/24":["172.123.10.5/16"]}，10.0.0.5/24是vpc内网段172.123.10.5/16是IDC网段。用户指定VPC内哪些网段可以和您IDC中哪些网段通信。
+	// <p>SPD策略组，例如：{&quot;10.0.0.5/24&quot;:[&quot;172.123.10.5/16&quot;]}，10.0.0.5/24是vpc内网段172.123.10.5/16是IDC网段。用户指定VPC内哪些网段可以和您IDC中哪些网段通信。</p>
 	SecurityPolicyDatabases []*SecurityPolicyDatabase `json:"SecurityPolicyDatabases,omitnil,omitempty" name:"SecurityPolicyDatabases"`
 
-	// IKE配置（Internet Key Exchange，因特网密钥交换），IKE具有一套自我保护机制，用户配置网络安全协议
+	// <p>IKE配置（Internet Key Exchange，因特网密钥交换），IKE具有一套自我保护机制，用户配置网络安全协议</p>
 	IKEOptionsSpecification *IKEOptionsSpecification `json:"IKEOptionsSpecification,omitnil,omitempty" name:"IKEOptionsSpecification"`
 
-	// IPSec配置，腾讯云提供IPSec安全会话设置
+	// <p>IPSec配置，腾讯云提供IPSec安全会话设置</p>
 	IPSECOptionsSpecification *IPSECOptionsSpecification `json:"IPSECOptionsSpecification,omitnil,omitempty" name:"IPSECOptionsSpecification"`
 
-	// 指定绑定的标签列表，例如：[{"Key": "city", "Value": "shanghai"}]
+	// <p>指定绑定的标签列表，例如：[{&quot;Key&quot;: &quot;city&quot;, &quot;Value&quot;: &quot;shanghai&quot;}]</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 是否支持隧道内健康检查，默认为False。
+	// <p>是否支持隧道内健康检查，默认为False。</p>
 	EnableHealthCheck *bool `json:"EnableHealthCheck,omitnil,omitempty" name:"EnableHealthCheck"`
 
-	// 健康检查本端地址，默认值为随机在169.254.128.0/17分配一个IP。
+	// <p>健康检查本端地址，默认值为随机在169.254.128.0/17分配一个IP。</p>
 	HealthCheckLocalIp *string `json:"HealthCheckLocalIp,omitnil,omitempty" name:"HealthCheckLocalIp"`
 
-	// 健康检查对端地址，默认值为随机在169.254.128.0/17分配一个IP。
+	// <p>健康检查对端地址，默认值为随机在169.254.128.0/17分配一个IP。</p>
 	HealthCheckRemoteIp *string `json:"HealthCheckRemoteIp,omitnil,omitempty" name:"HealthCheckRemoteIp"`
 
-	// 通道类型, 例如:["STATIC", "StaticRoute", "Policy"]
+	// <p>通道类型, 例如:[&quot;STATIC&quot;, &quot;StaticRoute&quot;, &quot;Policy&quot;, &quot;Bgp&quot;]</p><p>枚举值：</p><ul><li>StaticRoute： 目的路由类型</li><li>Policy： SPD策略类型</li><li>Bgp： BGP类型</li></ul><p>默认值：STATIC</p>
 	RouteType *string `json:"RouteType,omitnil,omitempty" name:"RouteType"`
 
-	// 协商类型，默认为active（主动协商）。可选值：active（主动协商），passive（被动协商），flowTrigger（流量协商）
+	// <p>协商类型，默认为active（主动协商）。可选值：active（主动协商），passive（被动协商），flowTrigger（流量协商）</p>
 	NegotiationType *string `json:"NegotiationType,omitnil,omitempty" name:"NegotiationType"`
 
-	// DPD探测开关。默认为0，表示关闭DPD探测。可选值：0（关闭），1（开启）
+	// <p>DPD探测开关。默认为0，表示关闭DPD探测。可选值：0（关闭），1（开启）</p>
 	DpdEnable *int64 `json:"DpdEnable,omitnil,omitempty" name:"DpdEnable"`
 
-	// DPD超时时间。即探测确认对端不存在需要的时间。dpdEnable为1（开启）时有效。默认30，单位为秒
+	// <p>DPD超时时间。即探测确认对端不存在需要的时间。dpdEnable为1（开启）时有效。默认30，单位为秒</p>
 	DpdTimeout *string `json:"DpdTimeout,omitnil,omitempty" name:"DpdTimeout"`
 
-	// DPD超时后的动作。默认为clear。dpdEnable为1（开启）时有效。可取值为clear（断开）和restart（重试）
+	// <p>DPD超时后的动作。</p><p>入参限制：dpdEnable为1（开启）时有效。</p><p>枚举值：</p><ul><li>clear： 断开</li><li>restart： 重试</li></ul><p>默认值：restart</p>
 	DpdAction *string `json:"DpdAction,omitnil,omitempty" name:"DpdAction"`
 
-	// 创建通道路由信息。
+	// <p>创建通道路由信息。</p>
+	//
+	// Deprecated: Route is deprecated.
 	Route *CreateVpnConnRoute `json:"Route,omitnil,omitempty" name:"Route"`
 
-	// BGP配置。
+	// <p>BGP配置。</p>
 	BgpConfig *BgpConfig `json:"BgpConfig,omitnil,omitempty" name:"BgpConfig"`
 
-	// 健康检查NQA配置。
+	// <p>健康检查NQA配置。</p>
 	HealthCheckConfig *HealthCheckConfig `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
 }
 
 type CreateVpnConnectionRequest struct {
 	*tchttp.BaseRequest
 	
-	// VPN网关实例ID。
+	// <p>VPN网关实例ID。</p>
 	VpnGatewayId *string `json:"VpnGatewayId,omitnil,omitempty" name:"VpnGatewayId"`
 
-	// 对端网关ID。例如：cgw-2wqq41m9，可通过[DescribeCustomerGateways](https://cloud.tencent.com/document/product/215/17516)接口查询对端网关。
+	// <p>对端网关ID。例如：cgw-2wqq41m9，可通过<a href="https://cloud.tencent.com/document/product/215/17516">DescribeCustomerGateways</a>接口查询对端网关。</p>
 	CustomerGatewayId *string `json:"CustomerGatewayId,omitnil,omitempty" name:"CustomerGatewayId"`
 
-	// 通道名称，可任意命名，但不得超过60个字符。
+	// <p>通道名称，可任意命名，但不得超过60个字符。</p>
 	VpnConnectionName *string `json:"VpnConnectionName,omitnil,omitempty" name:"VpnConnectionName"`
 
-	// 预共享密钥。
+	// <p>预共享密钥。</p>
 	PreShareKey *string `json:"PreShareKey,omitnil,omitempty" name:"PreShareKey"`
 
-	// VPC实例ID。可通过[DescribeVpcs](https://cloud.tencent.com/document/product/215/15778)接口返回值中的VpcId获取。
-	// CCN VPN 形的通道 可以不传VPCID
+	// <p>VPC实例ID。VPC类型网关可通过<a href="https://cloud.tencent.com/document/product/215/15778">DescribeVpcs</a>接口返回值中的VpcId获取，CCN类型网关传空值即可。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// SPD策略组，例如：{"10.0.0.5/24":["172.123.10.5/16"]}，10.0.0.5/24是vpc内网段172.123.10.5/16是IDC网段。用户指定VPC内哪些网段可以和您IDC中哪些网段通信。
+	// <p>SPD策略组，例如：{&quot;10.0.0.5/24&quot;:[&quot;172.123.10.5/16&quot;]}，10.0.0.5/24是vpc内网段172.123.10.5/16是IDC网段。用户指定VPC内哪些网段可以和您IDC中哪些网段通信。</p>
 	SecurityPolicyDatabases []*SecurityPolicyDatabase `json:"SecurityPolicyDatabases,omitnil,omitempty" name:"SecurityPolicyDatabases"`
 
-	// IKE配置（Internet Key Exchange，因特网密钥交换），IKE具有一套自我保护机制，用户配置网络安全协议
+	// <p>IKE配置（Internet Key Exchange，因特网密钥交换），IKE具有一套自我保护机制，用户配置网络安全协议</p>
 	IKEOptionsSpecification *IKEOptionsSpecification `json:"IKEOptionsSpecification,omitnil,omitempty" name:"IKEOptionsSpecification"`
 
-	// IPSec配置，腾讯云提供IPSec安全会话设置
+	// <p>IPSec配置，腾讯云提供IPSec安全会话设置</p>
 	IPSECOptionsSpecification *IPSECOptionsSpecification `json:"IPSECOptionsSpecification,omitnil,omitempty" name:"IPSECOptionsSpecification"`
 
-	// 指定绑定的标签列表，例如：[{"Key": "city", "Value": "shanghai"}]
+	// <p>指定绑定的标签列表，例如：[{&quot;Key&quot;: &quot;city&quot;, &quot;Value&quot;: &quot;shanghai&quot;}]</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 是否支持隧道内健康检查，默认为False。
+	// <p>是否支持隧道内健康检查，默认为False。</p>
 	EnableHealthCheck *bool `json:"EnableHealthCheck,omitnil,omitempty" name:"EnableHealthCheck"`
 
-	// 健康检查本端地址，默认值为随机在169.254.128.0/17分配一个IP。
+	// <p>健康检查本端地址，默认值为随机在169.254.128.0/17分配一个IP。</p>
 	HealthCheckLocalIp *string `json:"HealthCheckLocalIp,omitnil,omitempty" name:"HealthCheckLocalIp"`
 
-	// 健康检查对端地址，默认值为随机在169.254.128.0/17分配一个IP。
+	// <p>健康检查对端地址，默认值为随机在169.254.128.0/17分配一个IP。</p>
 	HealthCheckRemoteIp *string `json:"HealthCheckRemoteIp,omitnil,omitempty" name:"HealthCheckRemoteIp"`
 
-	// 通道类型, 例如:["STATIC", "StaticRoute", "Policy"]
+	// <p>通道类型, 例如:[&quot;STATIC&quot;, &quot;StaticRoute&quot;, &quot;Policy&quot;, &quot;Bgp&quot;]</p><p>枚举值：</p><ul><li>StaticRoute： 目的路由类型</li><li>Policy： SPD策略类型</li><li>Bgp： BGP类型</li></ul><p>默认值：STATIC</p>
 	RouteType *string `json:"RouteType,omitnil,omitempty" name:"RouteType"`
 
-	// 协商类型，默认为active（主动协商）。可选值：active（主动协商），passive（被动协商），flowTrigger（流量协商）
+	// <p>协商类型，默认为active（主动协商）。可选值：active（主动协商），passive（被动协商），flowTrigger（流量协商）</p>
 	NegotiationType *string `json:"NegotiationType,omitnil,omitempty" name:"NegotiationType"`
 
-	// DPD探测开关。默认为0，表示关闭DPD探测。可选值：0（关闭），1（开启）
+	// <p>DPD探测开关。默认为0，表示关闭DPD探测。可选值：0（关闭），1（开启）</p>
 	DpdEnable *int64 `json:"DpdEnable,omitnil,omitempty" name:"DpdEnable"`
 
-	// DPD超时时间。即探测确认对端不存在需要的时间。dpdEnable为1（开启）时有效。默认30，单位为秒
+	// <p>DPD超时时间。即探测确认对端不存在需要的时间。dpdEnable为1（开启）时有效。默认30，单位为秒</p>
 	DpdTimeout *string `json:"DpdTimeout,omitnil,omitempty" name:"DpdTimeout"`
 
-	// DPD超时后的动作。默认为clear。dpdEnable为1（开启）时有效。可取值为clear（断开）和restart（重试）
+	// <p>DPD超时后的动作。</p><p>入参限制：dpdEnable为1（开启）时有效。</p><p>枚举值：</p><ul><li>clear： 断开</li><li>restart： 重试</li></ul><p>默认值：restart</p>
 	DpdAction *string `json:"DpdAction,omitnil,omitempty" name:"DpdAction"`
 
-	// 创建通道路由信息。
+	// <p>创建通道路由信息。</p>
 	Route *CreateVpnConnRoute `json:"Route,omitnil,omitempty" name:"Route"`
 
-	// BGP配置。
+	// <p>BGP配置。</p>
 	BgpConfig *BgpConfig `json:"BgpConfig,omitnil,omitempty" name:"BgpConfig"`
 
-	// 健康检查NQA配置。
+	// <p>健康检查NQA配置。</p>
 	HealthCheckConfig *HealthCheckConfig `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
 }
 
@@ -8786,7 +8889,7 @@ func (r *CreateVpnConnectionRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateVpnConnectionResponseParams struct {
-	// 通道实例对象。
+	// <p>通道实例对象。</p>
 	VpnConnection *VpnConnection `json:"VpnConnection,omitnil,omitempty" name:"VpnConnection"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -8811,74 +8914,74 @@ func (r *CreateVpnConnectionResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateVpnGatewayRequestParams struct {
-	// VPC实例ID。可通过[DescribeVpcs](https://cloud.tencent.com/document/product/215/15778)接口返回值中的VpcId获取。
+	// <p>VPC实例ID。可通过<a href="https://cloud.tencent.com/document/product/215/15778">DescribeVpcs</a>。接口返回值中的VpcId获取</p><p>入参限制：当Type为CCN/SSL_CCN 类型时传 &quot;&quot;，IPSEC/SSL 类型必须传对应VPC实例ID。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// VPN网关名称，最大长度不能超过60个字节。
+	// <p>VPN网关名称，最大长度不能超过60个字节。</p>
 	VpnGatewayName *string `json:"VpnGatewayName,omitnil,omitempty" name:"VpnGatewayName"`
 
-	// 公网带宽设置。可选带宽规格：5, 10, 20, 50, 100, 200, 500, 1000, 3000；单位：Mbps。
+	// <p>公网带宽设置。可选带宽规格：5, 10, 20, 50, 100, 200, 500, 1000, 3000；单位：Mbps。</p>
 	InternetMaxBandwidthOut *uint64 `json:"InternetMaxBandwidthOut,omitnil,omitempty" name:"InternetMaxBandwidthOut"`
 
-	// VPN网关计费模式，PREPAID：表示预付费，即包年包月，POSTPAID_BY_HOUR：表示后付费，即按量计费。默认：POSTPAID_BY_HOUR，如果指定预付费模式，参数InstanceChargePrepaid必填。
+	// <p>VPN网关计费模式，PREPAID：表示预付费，即包年包月，POSTPAID_BY_HOUR：表示后付费，即按量计费。默认：POSTPAID_BY_HOUR，如果指定预付费模式，参数InstanceChargePrepaid必填。</p>
 	InstanceChargeType *string `json:"InstanceChargeType,omitnil,omitempty" name:"InstanceChargeType"`
 
-	// 预付费模式，即包年包月相关参数设置。通过该参数可以指定包年包月实例的购买时长、是否设置自动续费等属性。若指定实例的付费模式为预付费则该参数必传。
+	// <p>预付费模式，即包年包月相关参数设置。通过该参数可以指定包年包月实例的购买时长、是否设置自动续费等属性。若指定实例的付费模式为预付费则该参数必传。</p>
 	InstanceChargePrepaid *InstanceChargePrepaid `json:"InstanceChargePrepaid,omitnil,omitempty" name:"InstanceChargePrepaid"`
 
-	// 可用区，如：ap-guangzhou-2。
+	// <p>可用区，如：ap-guangzhou-2。</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// VPN网关类型，默认为IPSEC。值“IPSEC”为VPC型IPSEC VPN网关，值“SSL”为VPC型SSL VPN网关，值“CCN”为云联网型IPSEC VPN网关，值“SSL_CCN”为云联网型SSL VPN网关。
+	// <p>VPN网关类型，默认为IPSEC。值“IPSEC”为VPC型IPSEC VPN网关，值“SSL”为VPC型SSL VPN网关，值“CCN”为云联网型IPSEC VPN网关，值“SSL_CCN”为云联网型SSL VPN网关。</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 指定绑定的标签列表，例如：[{"Key": "city", "Value": "shanghai"}]。
+	// <p>指定绑定的标签列表，例如：[{&quot;Key&quot;: &quot;city&quot;, &quot;Value&quot;: &quot;shanghai&quot;}]。</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// CDC实例ID。
+	// <p>CDC实例ID。</p>
 	CdcId *string `json:"CdcId,omitnil,omitempty" name:"CdcId"`
 
-	// SSL VPN连接数设置，可选规格：5, 10, 20, 50, 100, 200, 500, 1000；单位：个。仅 SSL / SSL_CCN 类型需要选这个参数。
+	// <p>SSL VPN连接数设置，可选规格：5, 10, 20, 50, 100, 200, 500, 1000；</p><p>单位：个</p><p>默认值：5</p><p>仅 SSL / SSL_CCN 类型需要填这个参数。</p>
 	MaxConnection *uint64 `json:"MaxConnection,omitnil,omitempty" name:"MaxConnection"`
 
-	// BGP ASN。
+	// <p>BGP ASN。</p>
 	BgpAsn *uint64 `json:"BgpAsn,omitnil,omitempty" name:"BgpAsn"`
 }
 
 type CreateVpnGatewayRequest struct {
 	*tchttp.BaseRequest
 	
-	// VPC实例ID。可通过[DescribeVpcs](https://cloud.tencent.com/document/product/215/15778)接口返回值中的VpcId获取。
+	// <p>VPC实例ID。可通过<a href="https://cloud.tencent.com/document/product/215/15778">DescribeVpcs</a>。接口返回值中的VpcId获取</p><p>入参限制：当Type为CCN/SSL_CCN 类型时传 &quot;&quot;，IPSEC/SSL 类型必须传对应VPC实例ID。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// VPN网关名称，最大长度不能超过60个字节。
+	// <p>VPN网关名称，最大长度不能超过60个字节。</p>
 	VpnGatewayName *string `json:"VpnGatewayName,omitnil,omitempty" name:"VpnGatewayName"`
 
-	// 公网带宽设置。可选带宽规格：5, 10, 20, 50, 100, 200, 500, 1000, 3000；单位：Mbps。
+	// <p>公网带宽设置。可选带宽规格：5, 10, 20, 50, 100, 200, 500, 1000, 3000；单位：Mbps。</p>
 	InternetMaxBandwidthOut *uint64 `json:"InternetMaxBandwidthOut,omitnil,omitempty" name:"InternetMaxBandwidthOut"`
 
-	// VPN网关计费模式，PREPAID：表示预付费，即包年包月，POSTPAID_BY_HOUR：表示后付费，即按量计费。默认：POSTPAID_BY_HOUR，如果指定预付费模式，参数InstanceChargePrepaid必填。
+	// <p>VPN网关计费模式，PREPAID：表示预付费，即包年包月，POSTPAID_BY_HOUR：表示后付费，即按量计费。默认：POSTPAID_BY_HOUR，如果指定预付费模式，参数InstanceChargePrepaid必填。</p>
 	InstanceChargeType *string `json:"InstanceChargeType,omitnil,omitempty" name:"InstanceChargeType"`
 
-	// 预付费模式，即包年包月相关参数设置。通过该参数可以指定包年包月实例的购买时长、是否设置自动续费等属性。若指定实例的付费模式为预付费则该参数必传。
+	// <p>预付费模式，即包年包月相关参数设置。通过该参数可以指定包年包月实例的购买时长、是否设置自动续费等属性。若指定实例的付费模式为预付费则该参数必传。</p>
 	InstanceChargePrepaid *InstanceChargePrepaid `json:"InstanceChargePrepaid,omitnil,omitempty" name:"InstanceChargePrepaid"`
 
-	// 可用区，如：ap-guangzhou-2。
+	// <p>可用区，如：ap-guangzhou-2。</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// VPN网关类型，默认为IPSEC。值“IPSEC”为VPC型IPSEC VPN网关，值“SSL”为VPC型SSL VPN网关，值“CCN”为云联网型IPSEC VPN网关，值“SSL_CCN”为云联网型SSL VPN网关。
+	// <p>VPN网关类型，默认为IPSEC。值“IPSEC”为VPC型IPSEC VPN网关，值“SSL”为VPC型SSL VPN网关，值“CCN”为云联网型IPSEC VPN网关，值“SSL_CCN”为云联网型SSL VPN网关。</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 指定绑定的标签列表，例如：[{"Key": "city", "Value": "shanghai"}]。
+	// <p>指定绑定的标签列表，例如：[{&quot;Key&quot;: &quot;city&quot;, &quot;Value&quot;: &quot;shanghai&quot;}]。</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// CDC实例ID。
+	// <p>CDC实例ID。</p>
 	CdcId *string `json:"CdcId,omitnil,omitempty" name:"CdcId"`
 
-	// SSL VPN连接数设置，可选规格：5, 10, 20, 50, 100, 200, 500, 1000；单位：个。仅 SSL / SSL_CCN 类型需要选这个参数。
+	// <p>SSL VPN连接数设置，可选规格：5, 10, 20, 50, 100, 200, 500, 1000；</p><p>单位：个</p><p>默认值：5</p><p>仅 SSL / SSL_CCN 类型需要填这个参数。</p>
 	MaxConnection *uint64 `json:"MaxConnection,omitnil,omitempty" name:"MaxConnection"`
 
-	// BGP ASN。
+	// <p>BGP ASN。</p>
 	BgpAsn *uint64 `json:"BgpAsn,omitnil,omitempty" name:"BgpAsn"`
 }
 
@@ -8913,7 +9016,7 @@ func (r *CreateVpnGatewayRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateVpnGatewayResponseParams struct {
-	// VPN网关对象
+	// <p>VPN网关对象</p>
 	VpnGateway *VpnGateway `json:"VpnGateway,omitnil,omitempty" name:"VpnGateway"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -12096,6 +12199,74 @@ func (r *DeleteTemplateMemberResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DeleteTrafficMirrorFilterRulesRequestParams struct {
+	// 流量镜像实例唯一ID。
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像入站过滤唯一ID列表。
+	IngressFilterRuleIds []*string `json:"IngressFilterRuleIds,omitnil,omitempty" name:"IngressFilterRuleIds"`
+
+	// 流量镜像出站过滤唯一ID列表。
+	EgressFilterRuleIds []*string `json:"EgressFilterRuleIds,omitnil,omitempty" name:"EgressFilterRuleIds"`
+}
+
+type DeleteTrafficMirrorFilterRulesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 流量镜像实例唯一ID。
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像入站过滤唯一ID列表。
+	IngressFilterRuleIds []*string `json:"IngressFilterRuleIds,omitnil,omitempty" name:"IngressFilterRuleIds"`
+
+	// 流量镜像出站过滤唯一ID列表。
+	EgressFilterRuleIds []*string `json:"EgressFilterRuleIds,omitnil,omitempty" name:"EgressFilterRuleIds"`
+}
+
+func (r *DeleteTrafficMirrorFilterRulesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteTrafficMirrorFilterRulesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TrafficMirrorId")
+	delete(f, "IngressFilterRuleIds")
+	delete(f, "EgressFilterRuleIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteTrafficMirrorFilterRulesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteTrafficMirrorFilterRulesResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteTrafficMirrorFilterRulesResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteTrafficMirrorFilterRulesResponseParams `json:"Response"`
+}
+
+func (r *DeleteTrafficMirrorFilterRulesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteTrafficMirrorFilterRulesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DeleteTrafficMirrorRequestParams struct {
 	// 流量镜像实例ID
 	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
@@ -13322,64 +13493,32 @@ func (r *DescribeAddressTemplatesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeAddressesRequestParams struct {
-	// 标识 EIP 的唯一 ID 列表。EIP 唯一 ID 形如：`eip-11112222`。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取AddressId。参数不支持同时指定`AddressIds`和`Filters.address-id`。
+	// <p>标识 EIP 的唯一 ID 列表。EIP 唯一 ID 形如：<code>eip-11112222</code>。可以使用<a href="https://cloud.tencent.com/document/product/215/16702">DescribeAddresses</a>接口获取AddressId。参数不支持同时指定<code>AddressIds</code>和<code>Filters.address-id</code>。</p><p>说明：当指定该参数进行查询时，接口返回的结果数量上限由 &nbsp;Limit&nbsp; 参数决定（默认 20 条）。响应中的 &nbsp;TotalCount&nbsp; 字段表示符合条件的记录总数。当 &nbsp;TotalCount&nbsp; 超出 &nbsp;Limit&nbsp; 限制时，接口仅返回当前页的数据，您需要结合 &nbsp;Offset&nbsp; 参数进行分页遍历，以获取完整的查询结果。</p>
 	AddressIds []*string `json:"AddressIds,omitnil,omitempty" name:"AddressIds"`
 
-	// 每次请求的`Filters`的上限为10，`Filter.Values`的上限为100。详细的过滤条件如下：
-	// <li> address-id - String - 是否必填：否 - （过滤条件）按照 EIP 的唯一 ID 过滤。EIP 唯一 ID 形如：eip-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-id。</li>
-	// <li> address-name - String - 是否必填：否 - （过滤条件）按照 EIP 名称过滤。不支持模糊过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-name。注意：当指定 address-name 参数时，仅支持按第一个传入的 address-name 参数执行查询操作。</li>
-	// <li> address-ip - String - 是否必填：否 - （过滤条件）按照 EIP 的 IP 地址过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-ip。</li>
-	// <li> address-status - String - 是否必填：否 - （过滤条件）按照 EIP 的状态过滤。状态包含：'CREATING'：创建中，'BINDING'：绑定中，'BIND'：已绑，'UNBINDING'：解绑中，'UNBIND'：未绑定，'OFFLINING'：下线中，'BIND_ENI'：绑定了ENI。</li>
-	// <li> instance-id - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的实例 ID 过滤。实例 ID 形如：ins-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取instance-id。</li>
-	// <li> private-ip-address - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的内网 IP 过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取private-ip-address。注意：当指定 private-ip-address 参数时，仅支持按第一个传入的 private-ip-address 参数执行查询操作。</li>
-	// <li> network-interface-id - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的弹性网卡 ID 过滤。弹性网卡 ID 形如：eni-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取network-interface-id。</li>
-	// <li> is-arrears - String - 是否必填：否 - （过滤条件）按照 EIP 是否欠费进行过滤。（TRUE：EIP 处于欠费状态|FALSE：EIP 费用状态正常）</li>
-	// <li> instance-type - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的实例类型进行过滤。绑定的实例类型可选值：'CVM'：云服务器，'NAT'：NAT 网关，'ENI'：弹性网卡，'CLB'：负载均衡，'HAVIP'：高可用虚拟IP，'DHCPIP'：弹性内网IP，'EKS'：弹性容器服务，'VPCE'：终端节点，'WAF'：Web 应用防火墙。
-	// 注意：过滤条件仅使用 instance-type 时，系统默认返回所有EIP类型（包括EIP、AnycastEIP、HighQualityEIP、AntiDDoSEIP、ResidentialEIP）绑定的资源列表。若需查询特定EIP类型绑定的资源，或查询普通公网IP绑定的资源，请同时指定 instance-type 和 address-type 参数进行配置。</li>
-	// <li> address-type - String - 是否必填：否 - （过滤条件）按照 IP类型 进行过滤。可选值：'WanIP'：普通公网 IP, 'EIP'：弹性公网 IP，'AnycastEIP'：加速 IP，'HighQualityEIP'：精品弹性公网 IP， 'AntiDDoSEIP'：高防 IP，'ResidentialEIP'：原生 IP。默认值是'EIP'。</li>
-	// <li> address-isp - String - 是否必填：否 - （过滤条件）按照 运营商类型 进行过滤。可选值：'BGP'：常规BGP，'CMCC'：移动，'CUCC'：联通, 'CTCC'：电信</li>
-	// <li> dedicated-cluster-id - String - 是否必填：否 - （过滤条件）按照 CDC 的唯一 ID 过滤。CDC 唯一 ID 形如：cluster-11112222。</li>
-	// <li> tag-key - String - 是否必填：否 - （过滤条件）按照标签键进行过滤。</li>
-	// <li> tag-value - String - 是否必填：否 - （过滤条件）按照标签值进行过滤。</li>
-	// <li> tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。tag-key使用具体的标签键进行替换。</li>
+	// <p>每次请求的<code>Filters</code>的上限为10，<code>Filter.Values</code>的上限为100。详细的过滤条件如下：</p><li> address-id - String - 是否必填：否 - （过滤条件）按照 EIP 的唯一 ID 过滤。EIP 唯一 ID 形如：eip-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-id。</li><li> address-name - String - 是否必填：否 - （过滤条件）按照 EIP 名称过滤。不支持模糊过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-name。注意：当指定 address-name 参数时，仅支持按第一个传入的 address-name 参数执行查询操作。</li><li> address-ip - String - 是否必填：否 - （过滤条件）按照 EIP 的 IP 地址过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-ip。</li><li> address-status - String - 是否必填：否 - （过滤条件）按照 EIP 的状态过滤。状态包含：'CREATING'：创建中，'BINDING'：绑定中，'BIND'：已绑，'UNBINDING'：解绑中，'UNBIND'：未绑定，'OFFLINING'：下线中，'BIND_ENI'：绑定了ENI。</li><li> instance-id - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的实例 ID 过滤。实例 ID 形如：ins-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取instance-id。</li><li> private-ip-address - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的内网 IP 过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取private-ip-address。注意：当指定 private-ip-address 参数时，仅支持按第一个传入的 private-ip-address 参数执行查询操作。</li><li> network-interface-id - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的弹性网卡 ID 过滤。弹性网卡 ID 形如：eni-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取network-interface-id。</li><li> is-arrears - String - 是否必填：否 - （过滤条件）按照 EIP 是否欠费进行过滤。（TRUE：EIP 处于欠费状态|FALSE：EIP 费用状态正常）</li><li> instance-type - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的实例类型进行过滤。绑定的实例类型可选值：'CVM'：云服务器，'NAT'：NAT 网关，'ENI'：弹性网卡，'CLB'：负载均衡，'HAVIP'：高可用虚拟IP，'DHCPIP'：弹性内网IP，'EKS'：弹性容器服务，'VPCE'：终端节点，'WAF'：Web 应用防火墙。注意：过滤条件仅使用 instance-type 时，系统默认返回所有EIP类型（包括EIP、AnycastEIP、HighQualityEIP、AntiDDoSEIP、ResidentialEIP）绑定的资源列表。若需查询特定EIP类型绑定的资源，或查询普通公网IP绑定的资源，请同时指定 instance-type 和 address-type 参数进行配置。</li><li> address-type - String - 是否必填：否 - （过滤条件）按照 IP类型 进行过滤。可选值：'WanIP'：普通公网 IP, 'EIP'：弹性公网 IP，'AnycastEIP'：加速 IP，'HighQualityEIP'：精品弹性公网 IP， 'AntiDDoSEIP'：高防 IP，'ResidentialEIP'：原生 IP。该参数用于指定需要查询的弹性公网 IP 类型。若不传入此参数，接口默认返回 EIP、AnycastEIP、HighQualityEIP、AntiDDoSEIP、ResidentialEIP 这五种类型的资源，不包含普通公网 IP（WanIP）。如需查询普通公网 IP，请务必显式传入 &nbsp;'WanIP' 。</li><li> address-isp - String - 是否必填：否 - （过滤条件）按照 运营商类型 进行过滤。可选值：'BGP'：常规BGP，'CMCC'：移动，'CUCC'：联通, 'CTCC'：电信</li><li> dedicated-cluster-id - String - 是否必填：否 - （过滤条件）按照 CDC 的唯一 ID 过滤。CDC 唯一 ID 形如：cluster-11112222。</li><li> tag-key - String - 是否必填：否 - （过滤条件）按照标签键进行过滤。</li><li> tag-value - String - 是否必填：否 - （过滤条件）按照标签值进行过滤。</li><li> tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。tag-key使用具体的标签键进行替换。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量，默认为0。关于`Offset`的更进一步介绍请参考 API 中的相关小节。
+	// <p>偏移量，默认为0。关于<code>Offset</code>的更进一步介绍请参考 API 中的相关小节。</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。关于`Limit`的更进一步介绍请参考 API 中的相关小节。
+	// <p>返回数量，默认为20，最大值为100。关于<code>Limit</code>的更进一步介绍请参考 API 中的相关小节。</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeAddressesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 标识 EIP 的唯一 ID 列表。EIP 唯一 ID 形如：`eip-11112222`。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取AddressId。参数不支持同时指定`AddressIds`和`Filters.address-id`。
+	// <p>标识 EIP 的唯一 ID 列表。EIP 唯一 ID 形如：<code>eip-11112222</code>。可以使用<a href="https://cloud.tencent.com/document/product/215/16702">DescribeAddresses</a>接口获取AddressId。参数不支持同时指定<code>AddressIds</code>和<code>Filters.address-id</code>。</p><p>说明：当指定该参数进行查询时，接口返回的结果数量上限由 &nbsp;Limit&nbsp; 参数决定（默认 20 条）。响应中的 &nbsp;TotalCount&nbsp; 字段表示符合条件的记录总数。当 &nbsp;TotalCount&nbsp; 超出 &nbsp;Limit&nbsp; 限制时，接口仅返回当前页的数据，您需要结合 &nbsp;Offset&nbsp; 参数进行分页遍历，以获取完整的查询结果。</p>
 	AddressIds []*string `json:"AddressIds,omitnil,omitempty" name:"AddressIds"`
 
-	// 每次请求的`Filters`的上限为10，`Filter.Values`的上限为100。详细的过滤条件如下：
-	// <li> address-id - String - 是否必填：否 - （过滤条件）按照 EIP 的唯一 ID 过滤。EIP 唯一 ID 形如：eip-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-id。</li>
-	// <li> address-name - String - 是否必填：否 - （过滤条件）按照 EIP 名称过滤。不支持模糊过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-name。注意：当指定 address-name 参数时，仅支持按第一个传入的 address-name 参数执行查询操作。</li>
-	// <li> address-ip - String - 是否必填：否 - （过滤条件）按照 EIP 的 IP 地址过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-ip。</li>
-	// <li> address-status - String - 是否必填：否 - （过滤条件）按照 EIP 的状态过滤。状态包含：'CREATING'：创建中，'BINDING'：绑定中，'BIND'：已绑，'UNBINDING'：解绑中，'UNBIND'：未绑定，'OFFLINING'：下线中，'BIND_ENI'：绑定了ENI。</li>
-	// <li> instance-id - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的实例 ID 过滤。实例 ID 形如：ins-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取instance-id。</li>
-	// <li> private-ip-address - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的内网 IP 过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取private-ip-address。注意：当指定 private-ip-address 参数时，仅支持按第一个传入的 private-ip-address 参数执行查询操作。</li>
-	// <li> network-interface-id - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的弹性网卡 ID 过滤。弹性网卡 ID 形如：eni-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取network-interface-id。</li>
-	// <li> is-arrears - String - 是否必填：否 - （过滤条件）按照 EIP 是否欠费进行过滤。（TRUE：EIP 处于欠费状态|FALSE：EIP 费用状态正常）</li>
-	// <li> instance-type - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的实例类型进行过滤。绑定的实例类型可选值：'CVM'：云服务器，'NAT'：NAT 网关，'ENI'：弹性网卡，'CLB'：负载均衡，'HAVIP'：高可用虚拟IP，'DHCPIP'：弹性内网IP，'EKS'：弹性容器服务，'VPCE'：终端节点，'WAF'：Web 应用防火墙。
-	// 注意：过滤条件仅使用 instance-type 时，系统默认返回所有EIP类型（包括EIP、AnycastEIP、HighQualityEIP、AntiDDoSEIP、ResidentialEIP）绑定的资源列表。若需查询特定EIP类型绑定的资源，或查询普通公网IP绑定的资源，请同时指定 instance-type 和 address-type 参数进行配置。</li>
-	// <li> address-type - String - 是否必填：否 - （过滤条件）按照 IP类型 进行过滤。可选值：'WanIP'：普通公网 IP, 'EIP'：弹性公网 IP，'AnycastEIP'：加速 IP，'HighQualityEIP'：精品弹性公网 IP， 'AntiDDoSEIP'：高防 IP，'ResidentialEIP'：原生 IP。默认值是'EIP'。</li>
-	// <li> address-isp - String - 是否必填：否 - （过滤条件）按照 运营商类型 进行过滤。可选值：'BGP'：常规BGP，'CMCC'：移动，'CUCC'：联通, 'CTCC'：电信</li>
-	// <li> dedicated-cluster-id - String - 是否必填：否 - （过滤条件）按照 CDC 的唯一 ID 过滤。CDC 唯一 ID 形如：cluster-11112222。</li>
-	// <li> tag-key - String - 是否必填：否 - （过滤条件）按照标签键进行过滤。</li>
-	// <li> tag-value - String - 是否必填：否 - （过滤条件）按照标签值进行过滤。</li>
-	// <li> tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。tag-key使用具体的标签键进行替换。</li>
+	// <p>每次请求的<code>Filters</code>的上限为10，<code>Filter.Values</code>的上限为100。详细的过滤条件如下：</p><li> address-id - String - 是否必填：否 - （过滤条件）按照 EIP 的唯一 ID 过滤。EIP 唯一 ID 形如：eip-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-id。</li><li> address-name - String - 是否必填：否 - （过滤条件）按照 EIP 名称过滤。不支持模糊过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-name。注意：当指定 address-name 参数时，仅支持按第一个传入的 address-name 参数执行查询操作。</li><li> address-ip - String - 是否必填：否 - （过滤条件）按照 EIP 的 IP 地址过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取address-ip。</li><li> address-status - String - 是否必填：否 - （过滤条件）按照 EIP 的状态过滤。状态包含：'CREATING'：创建中，'BINDING'：绑定中，'BIND'：已绑，'UNBINDING'：解绑中，'UNBIND'：未绑定，'OFFLINING'：下线中，'BIND_ENI'：绑定了ENI。</li><li> instance-id - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的实例 ID 过滤。实例 ID 形如：ins-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取instance-id。</li><li> private-ip-address - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的内网 IP 过滤。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取private-ip-address。注意：当指定 private-ip-address 参数时，仅支持按第一个传入的 private-ip-address 参数执行查询操作。</li><li> network-interface-id - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的弹性网卡 ID 过滤。弹性网卡 ID 形如：eni-11112222。可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取network-interface-id。</li><li> is-arrears - String - 是否必填：否 - （过滤条件）按照 EIP 是否欠费进行过滤。（TRUE：EIP 处于欠费状态|FALSE：EIP 费用状态正常）</li><li> instance-type - String - 是否必填：否 - （过滤条件）按照 EIP 绑定的实例类型进行过滤。绑定的实例类型可选值：'CVM'：云服务器，'NAT'：NAT 网关，'ENI'：弹性网卡，'CLB'：负载均衡，'HAVIP'：高可用虚拟IP，'DHCPIP'：弹性内网IP，'EKS'：弹性容器服务，'VPCE'：终端节点，'WAF'：Web 应用防火墙。注意：过滤条件仅使用 instance-type 时，系统默认返回所有EIP类型（包括EIP、AnycastEIP、HighQualityEIP、AntiDDoSEIP、ResidentialEIP）绑定的资源列表。若需查询特定EIP类型绑定的资源，或查询普通公网IP绑定的资源，请同时指定 instance-type 和 address-type 参数进行配置。</li><li> address-type - String - 是否必填：否 - （过滤条件）按照 IP类型 进行过滤。可选值：'WanIP'：普通公网 IP, 'EIP'：弹性公网 IP，'AnycastEIP'：加速 IP，'HighQualityEIP'：精品弹性公网 IP， 'AntiDDoSEIP'：高防 IP，'ResidentialEIP'：原生 IP。该参数用于指定需要查询的弹性公网 IP 类型。若不传入此参数，接口默认返回 EIP、AnycastEIP、HighQualityEIP、AntiDDoSEIP、ResidentialEIP 这五种类型的资源，不包含普通公网 IP（WanIP）。如需查询普通公网 IP，请务必显式传入 &nbsp;'WanIP' 。</li><li> address-isp - String - 是否必填：否 - （过滤条件）按照 运营商类型 进行过滤。可选值：'BGP'：常规BGP，'CMCC'：移动，'CUCC'：联通, 'CTCC'：电信</li><li> dedicated-cluster-id - String - 是否必填：否 - （过滤条件）按照 CDC 的唯一 ID 过滤。CDC 唯一 ID 形如：cluster-11112222。</li><li> tag-key - String - 是否必填：否 - （过滤条件）按照标签键进行过滤。</li><li> tag-value - String - 是否必填：否 - （过滤条件）按照标签值进行过滤。</li><li> tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。tag-key使用具体的标签键进行替换。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量，默认为0。关于`Offset`的更进一步介绍请参考 API 中的相关小节。
+	// <p>偏移量，默认为0。关于<code>Offset</code>的更进一步介绍请参考 API 中的相关小节。</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。关于`Limit`的更进一步介绍请参考 API 中的相关小节。
+	// <p>返回数量，默认为20，最大值为100。关于<code>Limit</code>的更进一步介绍请参考 API 中的相关小节。</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
@@ -13407,10 +13546,10 @@ func (r *DescribeAddressesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeAddressesResponseParams struct {
-	// 符合条件的 EIP 数量。
+	// <p>符合条件的 EIP 数量。</p>
 	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// EIP 详细信息列表。
+	// <p>EIP 详细信息列表。</p>
 	AddressSet []*Address `json:"AddressSet,omitnil,omitempty" name:"AddressSet"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -17865,46 +18004,32 @@ func (r *DescribeNetworkAccountTypeResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeNetworkAclQuintupleEntriesRequestParams struct {
-	// 网络ACL实例ID。形如：acl-12345678。
+	// <p>网络ACL实例ID。形如：acl-12345678。</p>
 	NetworkAclId *string `json:"NetworkAclId,omitnil,omitempty" name:"NetworkAclId"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最小值为1，最大值为100。
+	// <p>返回数量，默认为20，最小值为1，最大值为100。</p>
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 过滤条件，参数不支持同时指定`NetworkAclId`和`Filters`。
-	// <li>protocol - String - 协议，形如：`TCP`。</li>
-	// <li>description - String - 描述。</li>
-	// <li>destination-cidr - String - 目的CIDR， 形如：'192.168.0.0/24'。</li>
-	// <li>source-cidr- String - 源CIDR， 形如：'192.168.0.0/24'。</li>
-	// <li>action - String - 动作，形如ACCEPT或DROP。</li>
-	// <li>network-acl-quintuple-entry-id - String - 五元组唯一ID，形如：'acli45-ahnu4rv5'。</li>
-	// <li>network-acl-direction - String - 方向，形如：'INGRESS'或'EGRESS'。</li>
+	// <p>过滤条件，参数不支持同时指定<code>NetworkAclId</code>和<code>Filters</code>。</p><li>protocol - String - 协议，形如：<code>TCP</code>。</li><li>description - String - 描述。</li><li>destination-cidr - String - 目的CIDR， 形如：'192.168.0.0/24'。</li><li>source-cidr- String - 源CIDR， 形如：'192.168.0.0/24'。</li><li>action - String - 动作，形如ACCEPT或DROP。</li><li>network-acl-quintuple-entry-id - String - 五元组唯一ID，形如：'acli45-ahnu4rv5'。</li><li>network-acl-direction - String - 方向，形如：'INGRESS'或'EGRESS'。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 }
 
 type DescribeNetworkAclQuintupleEntriesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 网络ACL实例ID。形如：acl-12345678。
+	// <p>网络ACL实例ID。形如：acl-12345678。</p>
 	NetworkAclId *string `json:"NetworkAclId,omitnil,omitempty" name:"NetworkAclId"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最小值为1，最大值为100。
+	// <p>返回数量，默认为20，最小值为1，最大值为100。</p>
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 过滤条件，参数不支持同时指定`NetworkAclId`和`Filters`。
-	// <li>protocol - String - 协议，形如：`TCP`。</li>
-	// <li>description - String - 描述。</li>
-	// <li>destination-cidr - String - 目的CIDR， 形如：'192.168.0.0/24'。</li>
-	// <li>source-cidr- String - 源CIDR， 形如：'192.168.0.0/24'。</li>
-	// <li>action - String - 动作，形如ACCEPT或DROP。</li>
-	// <li>network-acl-quintuple-entry-id - String - 五元组唯一ID，形如：'acli45-ahnu4rv5'。</li>
-	// <li>network-acl-direction - String - 方向，形如：'INGRESS'或'EGRESS'。</li>
+	// <p>过滤条件，参数不支持同时指定<code>NetworkAclId</code>和<code>Filters</code>。</p><li>protocol - String - 协议，形如：<code>TCP</code>。</li><li>description - String - 描述。</li><li>destination-cidr - String - 目的CIDR， 形如：'192.168.0.0/24'。</li><li>source-cidr- String - 源CIDR， 形如：'192.168.0.0/24'。</li><li>action - String - 动作，形如ACCEPT或DROP。</li><li>network-acl-quintuple-entry-id - String - 五元组唯一ID，形如：'acli45-ahnu4rv5'。</li><li>network-acl-direction - String - 方向，形如：'INGRESS'或'EGRESS'。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 }
 
@@ -17932,10 +18057,10 @@ func (r *DescribeNetworkAclQuintupleEntriesRequest) FromJsonString(s string) err
 
 // Predefined struct for user
 type DescribeNetworkAclQuintupleEntriesResponseParams struct {
-	// 网络ACL条目列表（NetworkAclTuple5Entry）
+	// <p>网络ACL条目列表（NetworkAclTuple5Entry）</p>
 	NetworkAclQuintupleSet []*NetworkAclQuintupleEntry `json:"NetworkAclQuintupleSet,omitnil,omitempty" name:"NetworkAclQuintupleSet"`
 
-	// 符合条件的实例数量。
+	// <p>符合条件的实例数量。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -17960,50 +18085,44 @@ func (r *DescribeNetworkAclQuintupleEntriesResponse) FromJsonString(s string) er
 
 // Predefined struct for user
 type DescribeNetworkAclsRequestParams struct {
-	// 过滤条件，参数不支持同时指定NetworkAclIds和Filters。
-	// <li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-12345678。</li>
-	// <li>network-acl-id - String - （过滤条件）网络ACL实例ID，形如：acl-12345678。</li>
-	// <li>network-acl-name - String - （过滤条件）网络ACL实例名称。</li>
+	// <p>过滤条件，参数不支持同时指定NetworkAclIds和Filters。</p><li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-12345678。</li><li>network-acl-id - String - （过滤条件）网络ACL实例ID，形如：acl-12345678。</li><li>network-acl-name - String - （过滤条件）网络ACL实例名称。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 网络ACL实例ID数组。形如：[acl-12345678]。每次请求的实例的上限为100。参数不支持同时指定NetworkAclIds和Filters。
+	// <p>网络ACL实例ID数组。形如：[acl-12345678]。每次请求的实例的上限为100。参数不支持同时指定NetworkAclIds和Filters。</p>
 	NetworkAclIds []*string `json:"NetworkAclIds,omitnil,omitempty" name:"NetworkAclIds"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最小值为1，最大值为100。
+	// <p>返回数量，默认为20，最小值为1，最大值为100。</p>
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 排序字段。支持：NetworkAclId,NetworkAclName,CreatedTime
+	// <p>排序字段。支持：NetworkAclId,NetworkAclName,CreatedTime,ModifyTime</p>
 	OrderField *string `json:"OrderField,omitnil,omitempty" name:"OrderField"`
 
-	// 排序方法。顺序：ASC，倒序：DESC。
+	// <p>排序方法。顺序：ASC，倒序：DESC。</p>
 	OrderDirection *string `json:"OrderDirection,omitnil,omitempty" name:"OrderDirection"`
 }
 
 type DescribeNetworkAclsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 过滤条件，参数不支持同时指定NetworkAclIds和Filters。
-	// <li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-12345678。</li>
-	// <li>network-acl-id - String - （过滤条件）网络ACL实例ID，形如：acl-12345678。</li>
-	// <li>network-acl-name - String - （过滤条件）网络ACL实例名称。</li>
+	// <p>过滤条件，参数不支持同时指定NetworkAclIds和Filters。</p><li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-12345678。</li><li>network-acl-id - String - （过滤条件）网络ACL实例ID，形如：acl-12345678。</li><li>network-acl-name - String - （过滤条件）网络ACL实例名称。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 网络ACL实例ID数组。形如：[acl-12345678]。每次请求的实例的上限为100。参数不支持同时指定NetworkAclIds和Filters。
+	// <p>网络ACL实例ID数组。形如：[acl-12345678]。每次请求的实例的上限为100。参数不支持同时指定NetworkAclIds和Filters。</p>
 	NetworkAclIds []*string `json:"NetworkAclIds,omitnil,omitempty" name:"NetworkAclIds"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最小值为1，最大值为100。
+	// <p>返回数量，默认为20，最小值为1，最大值为100。</p>
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 排序字段。支持：NetworkAclId,NetworkAclName,CreatedTime
+	// <p>排序字段。支持：NetworkAclId,NetworkAclName,CreatedTime,ModifyTime</p>
 	OrderField *string `json:"OrderField,omitnil,omitempty" name:"OrderField"`
 
-	// 排序方法。顺序：ASC，倒序：DESC。
+	// <p>排序方法。顺序：ASC，倒序：DESC。</p>
 	OrderDirection *string `json:"OrderDirection,omitnil,omitempty" name:"OrderDirection"`
 }
 
@@ -18033,10 +18152,10 @@ func (r *DescribeNetworkAclsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeNetworkAclsResponseParams struct {
-	// 实例详细信息列表。
+	// <p>实例详细信息列表。</p>
 	NetworkAclSet []*NetworkAcl `json:"NetworkAclSet,omitnil,omitempty" name:"NetworkAclSet"`
 
-	// 符合条件的实例数量。
+	// <p>符合条件的实例数量。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -18133,76 +18252,32 @@ func (r *DescribeNetworkInterfaceLimitResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeNetworkInterfacesRequestParams struct {
-	// 弹性网卡实例ID查询。形如：eni-pxir56ns。每次请求的实例的上限为100。参数不支持同时指定NetworkInterfaceIds和Filters。可通过[DescribeNetworkInterfaces](https://cloud.tencent.com/document/product/215/15817)接口获取。
+	// <p>弹性网卡实例ID查询。形如：eni-pxir56ns。每次请求的实例的上限为100。参数不支持同时指定NetworkInterfaceIds和Filters。可通过<a href="https://cloud.tencent.com/document/product/215/15817">DescribeNetworkInterfaces</a>接口获取。</p>
 	NetworkInterfaceIds []*string `json:"NetworkInterfaceIds,omitnil,omitempty" name:"NetworkInterfaceIds"`
 
-	// 过滤条件，参数不支持同时指定NetworkInterfaceIds和Filters。
-	// <li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。可通过可通过[DescribeVpcs](https://cloud.tencent.com/document/product/215/15778)接口获取。
-	// </li>
-	// <li>subnet-id - String - （过滤条件）所属子网实例ID，形如：subnet-f49l6u0z。可通过[DescribeSubnets](https://cloud.tencent.com/document/product/215/15784)接口获取。
-	// </li>
-	// <li>network-interface-id - String - （过滤条件）弹性网卡实例ID，形如：eni-5k56k7k7。可通过[DescribeNetworkInterfaces](https://cloud.tencent.com/document/product/215/15817)接口获取。
-	// </li>
-	// <li>attachment.instance-id - String - （过滤条件）绑定的云服务器实例ID，形如：ins-3nqpdn3i。可通过[DescribeInstances](https://cloud.tencent.com/document/product/213/15728)接口获取。
-	// </li>
-	// <li>groups.security-group-id - String - （过滤条件）绑定的安全组实例ID，例如：sg-f9ekbxeq。可通过[DescribeSecurityGroups](https://cloud.tencent.com/document/product/215/15808)接口获取。
-	// </li>
-	// <li>network-interface-name - String - （过滤条件）网卡实例名称。</li>
-	// <li>network-interface-description - String - （过滤条件）网卡实例描述。</li>
-	// <li>address-ip - String - （过滤条件）内网IPv4地址，单IP后缀模糊匹配，多IP精确匹配。可以与`ip-exact-match`配合做单IP的精确匹配查询。</li>
-	// <li>ip-exact-match - Boolean - （过滤条件）内网IPv4精确匹配查询，存在多值情况，只取第一个。</li>
-	// <li>tag-key - String -是否必填：否- （过滤条件）按照标签键进行过滤。使用请参考示例2</li>
-	// <li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li>
-	// <li>is-primary - Boolean - 是否必填：否 - （过滤条件）按照是否主网卡进行过滤。值为true时，仅过滤主网卡；值为false时，仅过滤辅助网卡；此过滤参数未提供时，同时过滤主网卡和辅助网卡。</li>
-	// <li>eni-type - String -是否必填：否- （过滤条件）按照网卡类型进行过滤。“0”-辅助网卡，“1”-主网卡，“2”：中继网卡。</li>
-	// <li>eni-qos - String -是否必填：否- （过滤条件）按照网卡服务质量进行过滤。PT（云金）、AU（云银）、AG(云铜）、DEFAULT（默认）。</li>
-	// <li>address-ipv6 - String - 是否必填：否 -（过滤条件）内网IPv6地址过滤，支持多ipv6地址查询，如果和address-ip一起使用取交集。</li>
-	// <li>public-address-ip - String - （过滤条件）公网IPv4地址，精确匹配。</li>
-	// <li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。`GUA`(全球单播地址), `ULA`(唯一本地地址)。</li>
+	// <p>过滤条件，参数不支持同时指定NetworkInterfaceIds和Filters。</p><li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。可通过可通过[DescribeVpcs](https://cloud.tencent.com/document/product/215/15778)接口获取。</li><li>subnet-id - String - （过滤条件）所属子网实例ID，形如：subnet-f49l6u0z。可通过[DescribeSubnets](https://cloud.tencent.com/document/product/215/15784)接口获取。</li><li>network-interface-id - String - （过滤条件）弹性网卡实例ID，形如：eni-5k56k7k7。可通过[DescribeNetworkInterfaces](https://cloud.tencent.com/document/product/215/15817)接口获取。</li><li>attachment.instance-id - String - （过滤条件）绑定的云服务器实例ID，形如：ins-3nqpdn3i。可通过[DescribeInstances](https://cloud.tencent.com/document/product/213/15728)接口获取。</li><li>groups.security-group-id - String - （过滤条件）绑定的安全组实例ID，例如：sg-f9ekbxeq。可通过[DescribeSecurityGroups](https://cloud.tencent.com/document/product/215/15808)接口获取。</li><li>network-interface-name - String - （过滤条件）网卡实例名称。</li><li>network-interface-description - String - （过滤条件）网卡实例描述。</li><li>address-ip - String - （过滤条件）内网IPv4地址，单IP后缀模糊匹配，多IP精确匹配。可以与<code>ip-exact-match</code>配合做单IP的精确匹配查询。</li><li>ip-exact-match - Boolean - （过滤条件）内网IPv4精确匹配查询，存在多值情况，只取第一个。</li><li>tag-key - String -是否必填：否- （过滤条件）按照标签键进行过滤。使用请参考示例2</li><li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li><li>is-primary - Boolean - 是否必填：否 - （过滤条件）按照是否主网卡进行过滤。值为true时，仅过滤主网卡；值为false时，仅过滤辅助网卡；此过滤参数未提供时，同时过滤主网卡和辅助网卡。</li><li>eni-type - String -是否必填：否- （过滤条件）按照网卡类型进行过滤。“0”-辅助网卡，“1”-主网卡，“2”：中继网卡。</li><li>eni-qos - String -是否必填：否- （过滤条件）按照网卡服务质量进行过滤。PT（云金）、AU（云银）、AG(云铜）、DEFAULT（默认）。</li><li>address-ipv6 - String - 是否必填：否 -（过滤条件）内网IPv6地址过滤，支持多ipv6地址查询，如果和address-ip一起使用取交集。</li><li>public-address-ip - String - （过滤条件）公网IPv4地址，精确匹配。</li><li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。<code>GUA</code>(全球单播地址), <code>ULA</code>(唯一本地地址)。</li><li>termination-protection - String - 删除保护。取值: true; false。</li><li>traffic-protection - String - 流量保护。取值: true; false。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。
+	// <p>返回数量，默认为20，最大值为100。</p>
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeNetworkInterfacesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 弹性网卡实例ID查询。形如：eni-pxir56ns。每次请求的实例的上限为100。参数不支持同时指定NetworkInterfaceIds和Filters。可通过[DescribeNetworkInterfaces](https://cloud.tencent.com/document/product/215/15817)接口获取。
+	// <p>弹性网卡实例ID查询。形如：eni-pxir56ns。每次请求的实例的上限为100。参数不支持同时指定NetworkInterfaceIds和Filters。可通过<a href="https://cloud.tencent.com/document/product/215/15817">DescribeNetworkInterfaces</a>接口获取。</p>
 	NetworkInterfaceIds []*string `json:"NetworkInterfaceIds,omitnil,omitempty" name:"NetworkInterfaceIds"`
 
-	// 过滤条件，参数不支持同时指定NetworkInterfaceIds和Filters。
-	// <li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。可通过可通过[DescribeVpcs](https://cloud.tencent.com/document/product/215/15778)接口获取。
-	// </li>
-	// <li>subnet-id - String - （过滤条件）所属子网实例ID，形如：subnet-f49l6u0z。可通过[DescribeSubnets](https://cloud.tencent.com/document/product/215/15784)接口获取。
-	// </li>
-	// <li>network-interface-id - String - （过滤条件）弹性网卡实例ID，形如：eni-5k56k7k7。可通过[DescribeNetworkInterfaces](https://cloud.tencent.com/document/product/215/15817)接口获取。
-	// </li>
-	// <li>attachment.instance-id - String - （过滤条件）绑定的云服务器实例ID，形如：ins-3nqpdn3i。可通过[DescribeInstances](https://cloud.tencent.com/document/product/213/15728)接口获取。
-	// </li>
-	// <li>groups.security-group-id - String - （过滤条件）绑定的安全组实例ID，例如：sg-f9ekbxeq。可通过[DescribeSecurityGroups](https://cloud.tencent.com/document/product/215/15808)接口获取。
-	// </li>
-	// <li>network-interface-name - String - （过滤条件）网卡实例名称。</li>
-	// <li>network-interface-description - String - （过滤条件）网卡实例描述。</li>
-	// <li>address-ip - String - （过滤条件）内网IPv4地址，单IP后缀模糊匹配，多IP精确匹配。可以与`ip-exact-match`配合做单IP的精确匹配查询。</li>
-	// <li>ip-exact-match - Boolean - （过滤条件）内网IPv4精确匹配查询，存在多值情况，只取第一个。</li>
-	// <li>tag-key - String -是否必填：否- （过滤条件）按照标签键进行过滤。使用请参考示例2</li>
-	// <li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li>
-	// <li>is-primary - Boolean - 是否必填：否 - （过滤条件）按照是否主网卡进行过滤。值为true时，仅过滤主网卡；值为false时，仅过滤辅助网卡；此过滤参数未提供时，同时过滤主网卡和辅助网卡。</li>
-	// <li>eni-type - String -是否必填：否- （过滤条件）按照网卡类型进行过滤。“0”-辅助网卡，“1”-主网卡，“2”：中继网卡。</li>
-	// <li>eni-qos - String -是否必填：否- （过滤条件）按照网卡服务质量进行过滤。PT（云金）、AU（云银）、AG(云铜）、DEFAULT（默认）。</li>
-	// <li>address-ipv6 - String - 是否必填：否 -（过滤条件）内网IPv6地址过滤，支持多ipv6地址查询，如果和address-ip一起使用取交集。</li>
-	// <li>public-address-ip - String - （过滤条件）公网IPv4地址，精确匹配。</li>
-	// <li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。`GUA`(全球单播地址), `ULA`(唯一本地地址)。</li>
+	// <p>过滤条件，参数不支持同时指定NetworkInterfaceIds和Filters。</p><li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。可通过可通过[DescribeVpcs](https://cloud.tencent.com/document/product/215/15778)接口获取。</li><li>subnet-id - String - （过滤条件）所属子网实例ID，形如：subnet-f49l6u0z。可通过[DescribeSubnets](https://cloud.tencent.com/document/product/215/15784)接口获取。</li><li>network-interface-id - String - （过滤条件）弹性网卡实例ID，形如：eni-5k56k7k7。可通过[DescribeNetworkInterfaces](https://cloud.tencent.com/document/product/215/15817)接口获取。</li><li>attachment.instance-id - String - （过滤条件）绑定的云服务器实例ID，形如：ins-3nqpdn3i。可通过[DescribeInstances](https://cloud.tencent.com/document/product/213/15728)接口获取。</li><li>groups.security-group-id - String - （过滤条件）绑定的安全组实例ID，例如：sg-f9ekbxeq。可通过[DescribeSecurityGroups](https://cloud.tencent.com/document/product/215/15808)接口获取。</li><li>network-interface-name - String - （过滤条件）网卡实例名称。</li><li>network-interface-description - String - （过滤条件）网卡实例描述。</li><li>address-ip - String - （过滤条件）内网IPv4地址，单IP后缀模糊匹配，多IP精确匹配。可以与<code>ip-exact-match</code>配合做单IP的精确匹配查询。</li><li>ip-exact-match - Boolean - （过滤条件）内网IPv4精确匹配查询，存在多值情况，只取第一个。</li><li>tag-key - String -是否必填：否- （过滤条件）按照标签键进行过滤。使用请参考示例2</li><li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li><li>is-primary - Boolean - 是否必填：否 - （过滤条件）按照是否主网卡进行过滤。值为true时，仅过滤主网卡；值为false时，仅过滤辅助网卡；此过滤参数未提供时，同时过滤主网卡和辅助网卡。</li><li>eni-type - String -是否必填：否- （过滤条件）按照网卡类型进行过滤。“0”-辅助网卡，“1”-主网卡，“2”：中继网卡。</li><li>eni-qos - String -是否必填：否- （过滤条件）按照网卡服务质量进行过滤。PT（云金）、AU（云银）、AG(云铜）、DEFAULT（默认）。</li><li>address-ipv6 - String - 是否必填：否 -（过滤条件）内网IPv6地址过滤，支持多ipv6地址查询，如果和address-ip一起使用取交集。</li><li>public-address-ip - String - （过滤条件）公网IPv4地址，精确匹配。</li><li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。<code>GUA</code>(全球单播地址), <code>ULA</code>(唯一本地地址)。</li><li>termination-protection - String - 删除保护。取值: true; false。</li><li>traffic-protection - String - 流量保护。取值: true; false。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。
+	// <p>返回数量，默认为20，最大值为100。</p>
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
@@ -18230,10 +18305,10 @@ func (r *DescribeNetworkInterfacesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeNetworkInterfacesResponseParams struct {
-	// 实例详细信息列表。
+	// <p>实例详细信息列表。</p>
 	NetworkInterfaceSet []*NetworkInterface `json:"NetworkInterfaceSet,omitnil,omitempty" name:"NetworkInterfaceSet"`
 
-	// 符合条件的实例数量。
+	// <p>符合条件的实例数量。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -18834,54 +18909,32 @@ func (r *DescribeProductQuotaResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeReserveIpAddressesRequestParams struct {
-	// 内网保留IP唯一ID 列表
+	// <p>内网保留IP唯一ID 列表</p>
 	ReserveIpIds []*string `json:"ReserveIpIds,omitnil,omitempty" name:"ReserveIpIds"`
 
-	// 过滤条件，参数不支持同时指定ReserveIpIds和Filters。
-	// 
-	// reserve-ip-id  - String - （过滤条件）内网保留 IP唯一 ID，形如：rsvip-pvqgv9vi。
-	// vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。
-	// subnet-id - String - （过滤条件）所属子网实例ID，形如：subnet-f49l6u0z。
-	// address-ip - String - （过滤条件）内网保留 IP 地址，形如：192.168.0.10。
-	// ip-type - String - （过滤条件）业务类型 ipType，0。
-	// name - String - （过滤条件）名称。
-	// state - String - （过滤条件）状态，可选值：Bind， UnBind。
-	// resource-id - String - （过滤条件）绑定的实例资源，形如：eni-059qmnif。
-	// tag-key - String -（过滤条件）按照标签键进行过滤。
-	// tag:tag-key - String - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。
+	// <p>过滤条件，参数不支持同时指定ReserveIpIds和Filters。</p><p>reserve-ip-id  - String - （过滤条件）内网保留 IP唯一 ID，形如：rsvip-pvqgv9vi。<br>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。<br>subnet-id - String - （过滤条件）所属子网实例ID，形如：subnet-f49l6u0z。<br>reserve-address-ip - String - （过滤条件）内网保留 IP 地址，形如：192.168.0.10。<br>ip-type - String - （过滤条件）业务类型 ipType，0。<br>name - String - （过滤条件）名称。<br>state - String - （过滤条件）状态，可选值：Bind， UnBind。<br>resource-id - String - （过滤条件）绑定的实例资源，形如：eni-059qmnif。<br>tag-key - String -（过滤条件）按照标签键进行过滤。<br>tag:tag-key - String - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量。
+	// <p>偏移量。</p>
 	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 请求对象个数。
+	// <p>请求对象个数。</p>
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeReserveIpAddressesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 内网保留IP唯一ID 列表
+	// <p>内网保留IP唯一ID 列表</p>
 	ReserveIpIds []*string `json:"ReserveIpIds,omitnil,omitempty" name:"ReserveIpIds"`
 
-	// 过滤条件，参数不支持同时指定ReserveIpIds和Filters。
-	// 
-	// reserve-ip-id  - String - （过滤条件）内网保留 IP唯一 ID，形如：rsvip-pvqgv9vi。
-	// vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。
-	// subnet-id - String - （过滤条件）所属子网实例ID，形如：subnet-f49l6u0z。
-	// address-ip - String - （过滤条件）内网保留 IP 地址，形如：192.168.0.10。
-	// ip-type - String - （过滤条件）业务类型 ipType，0。
-	// name - String - （过滤条件）名称。
-	// state - String - （过滤条件）状态，可选值：Bind， UnBind。
-	// resource-id - String - （过滤条件）绑定的实例资源，形如：eni-059qmnif。
-	// tag-key - String -（过滤条件）按照标签键进行过滤。
-	// tag:tag-key - String - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。
+	// <p>过滤条件，参数不支持同时指定ReserveIpIds和Filters。</p><p>reserve-ip-id  - String - （过滤条件）内网保留 IP唯一 ID，形如：rsvip-pvqgv9vi。<br>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。<br>subnet-id - String - （过滤条件）所属子网实例ID，形如：subnet-f49l6u0z。<br>reserve-address-ip - String - （过滤条件）内网保留 IP 地址，形如：192.168.0.10。<br>ip-type - String - （过滤条件）业务类型 ipType，0。<br>name - String - （过滤条件）名称。<br>state - String - （过滤条件）状态，可选值：Bind， UnBind。<br>resource-id - String - （过滤条件）绑定的实例资源，形如：eni-059qmnif。<br>tag-key - String -（过滤条件）按照标签键进行过滤。<br>tag:tag-key - String - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量。
+	// <p>偏移量。</p>
 	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 请求对象个数。
+	// <p>请求对象个数。</p>
 	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
@@ -18909,10 +18962,10 @@ func (r *DescribeReserveIpAddressesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeReserveIpAddressesResponseParams struct {
-	// 内网保留 IP返回信息。
+	// <p>内网保留 IP返回信息。</p>
 	ReserveIpAddressSet []*ReserveIpAddressInfo `json:"ReserveIpAddressSet,omitnil,omitempty" name:"ReserveIpAddressSet"`
 
-	// 返回内网保留IP的个数。
+	// <p>返回内网保留IP的个数。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -19494,82 +19547,38 @@ func (r *DescribeRouteTableSelectionPoliciesResponse) FromJsonString(s string) e
 
 // Predefined struct for user
 type DescribeRouteTablesRequestParams struct {
-	// 过滤条件，参数不支持同时指定RouteTableIds和Filters。
-	// <li>route-table-id - String - （过滤条件）路由表实例ID。</li>
-	// <li>route-table-name - String - （过滤条件）路由表名称。</li>
-	// <li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。</li>
-	// <li>association.main - String - （过滤条件）是否主路由表。</li>
-	// <li>tag-key - String -是否必填：否 - （过滤条件）按照标签键进行过滤。</li>
-	// <li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li>
-	// <li>visible - String - （过滤条件）是否可见。</li>
-	// <li>next-hop-type - String - 是否必填：否 - （过滤条件）按下一跳类型进行过滤。使用next-hop-type进行过滤时，必须同时携带route-table-id与vpc-id。
-	// 目前我们支持的类型有：
-	// LOCAL: 本地路由
-	// CVM：公网网关类型的云服务器；
-	// VPN：VPN网关；
-	// DIRECTCONNECT：专线网关；
-	// PEERCONNECTION：对等连接；
-	// HAVIP：高可用虚拟IP；
-	// NAT：NAT网关; 
-	// NORMAL_CVM：普通云服务器；
-	// EIP：云服务器的公网IP；
-	// CCN：云联网；
-	// LOCAL_GATEWAY：本地网关。
-	// GWLB_ENDPOINT：网关负载均衡终端节点。
-	// </li>
+	// <p>过滤条件，参数不支持同时指定RouteTableIds和Filters。</p><li>route-table-id - String - （过滤条件）路由表实例ID。</li><li>route-table-name - String - （过滤条件）路由表名称。</li><li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。</li><li>association.main - String - （过滤条件）是否主路由表。</li><li>tag-key - String -是否必填：否 - （过滤条件）按照标签键进行过滤。</li><li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li><li>visible - String - （过滤条件）是否可见。</li><li>next-hop-type - String - 是否必填：否 - （过滤条件）按下一跳类型进行过滤。使用next-hop-type进行过滤时，必须同时携带route-table-id与vpc-id。目前我们支持的类型有：LOCAL: 本地路由CVM：公网网关类型的云服务器；VPN：VPN网关；DIRECTCONNECT：专线网关；PEERCONNECTION：对等连接；HAVIP：高可用虚拟IP；NAT：NAT网关; NORMAL_CVM：普通云服务器；EIP：云服务器的公网IP；CCN：云联网；LOCAL_GATEWAY：本地网关。GWLB_ENDPOINT：网关负载均衡终端节点。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 路由表实例ID，例如：rtb-azd4dt1c。
+	// <p>路由表实例ID，例如：rtb-azd4dt1c。</p>
 	RouteTableIds []*string `json:"RouteTableIds,omitnil,omitempty" name:"RouteTableIds"`
 
-	// 偏移量。
+	// <p>偏移量。</p>
 	Offset *string `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。
+	// <p>返回数量，默认为20，最大值为100。</p>
 	Limit *string `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否需要获取路由策略信息，默认获取，当控制台不需要拉取路由策略信息时，改为False。
+	// <p>是否需要获取路由策略信息，默认获取，当控制台不需要拉取路由策略信息时，改为False。</p>
 	NeedRouterInfo *bool `json:"NeedRouterInfo,omitnil,omitempty" name:"NeedRouterInfo"`
 }
 
 type DescribeRouteTablesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 过滤条件，参数不支持同时指定RouteTableIds和Filters。
-	// <li>route-table-id - String - （过滤条件）路由表实例ID。</li>
-	// <li>route-table-name - String - （过滤条件）路由表名称。</li>
-	// <li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。</li>
-	// <li>association.main - String - （过滤条件）是否主路由表。</li>
-	// <li>tag-key - String -是否必填：否 - （过滤条件）按照标签键进行过滤。</li>
-	// <li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li>
-	// <li>visible - String - （过滤条件）是否可见。</li>
-	// <li>next-hop-type - String - 是否必填：否 - （过滤条件）按下一跳类型进行过滤。使用next-hop-type进行过滤时，必须同时携带route-table-id与vpc-id。
-	// 目前我们支持的类型有：
-	// LOCAL: 本地路由
-	// CVM：公网网关类型的云服务器；
-	// VPN：VPN网关；
-	// DIRECTCONNECT：专线网关；
-	// PEERCONNECTION：对等连接；
-	// HAVIP：高可用虚拟IP；
-	// NAT：NAT网关; 
-	// NORMAL_CVM：普通云服务器；
-	// EIP：云服务器的公网IP；
-	// CCN：云联网；
-	// LOCAL_GATEWAY：本地网关。
-	// GWLB_ENDPOINT：网关负载均衡终端节点。
-	// </li>
+	// <p>过滤条件，参数不支持同时指定RouteTableIds和Filters。</p><li>route-table-id - String - （过滤条件）路由表实例ID。</li><li>route-table-name - String - （过滤条件）路由表名称。</li><li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。</li><li>association.main - String - （过滤条件）是否主路由表。</li><li>tag-key - String -是否必填：否 - （过滤条件）按照标签键进行过滤。</li><li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li><li>visible - String - （过滤条件）是否可见。</li><li>next-hop-type - String - 是否必填：否 - （过滤条件）按下一跳类型进行过滤。使用next-hop-type进行过滤时，必须同时携带route-table-id与vpc-id。目前我们支持的类型有：LOCAL: 本地路由CVM：公网网关类型的云服务器；VPN：VPN网关；DIRECTCONNECT：专线网关；PEERCONNECTION：对等连接；HAVIP：高可用虚拟IP；NAT：NAT网关; NORMAL_CVM：普通云服务器；EIP：云服务器的公网IP；CCN：云联网；LOCAL_GATEWAY：本地网关。GWLB_ENDPOINT：网关负载均衡终端节点。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 路由表实例ID，例如：rtb-azd4dt1c。
+	// <p>路由表实例ID，例如：rtb-azd4dt1c。</p>
 	RouteTableIds []*string `json:"RouteTableIds,omitnil,omitempty" name:"RouteTableIds"`
 
-	// 偏移量。
+	// <p>偏移量。</p>
 	Offset *string `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。
+	// <p>返回数量，默认为20，最大值为100。</p>
 	Limit *string `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 是否需要获取路由策略信息，默认获取，当控制台不需要拉取路由策略信息时，改为False。
+	// <p>是否需要获取路由策略信息，默认获取，当控制台不需要拉取路由策略信息时，改为False。</p>
 	NeedRouterInfo *bool `json:"NeedRouterInfo,omitnil,omitempty" name:"NeedRouterInfo"`
 }
 
@@ -19598,10 +19607,10 @@ func (r *DescribeRouteTablesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeRouteTablesResponseParams struct {
-	// 符合条件的实例数量。
+	// <p>符合条件的实例数量。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 路由表对象。
+	// <p>路由表对象。</p>
 	RouteTableSet []*RouteTable `json:"RouteTableSet,omitnil,omitempty" name:"RouteTableSet"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -20984,14 +20993,14 @@ func (r *DescribeSpecificTrafficPackageUsedDetailsResponse) FromJsonString(s str
 
 // Predefined struct for user
 type DescribeSubnetResourceDashboardRequestParams struct {
-	// Subnet实例ID，例如：subnet-f1xjkw1b。
+	// <p>Subnet实例ID，例如：subnet-f1xjkw1b。</p>
 	SubnetIds []*string `json:"SubnetIds,omitnil,omitempty" name:"SubnetIds"`
 }
 
 type DescribeSubnetResourceDashboardRequest struct {
 	*tchttp.BaseRequest
 	
-	// Subnet实例ID，例如：subnet-f1xjkw1b。
+	// <p>Subnet实例ID，例如：subnet-f1xjkw1b。</p>
 	SubnetIds []*string `json:"SubnetIds,omitnil,omitempty" name:"SubnetIds"`
 }
 
@@ -21016,7 +21025,7 @@ func (r *DescribeSubnetResourceDashboardRequest) FromJsonString(s string) error 
 
 // Predefined struct for user
 type DescribeSubnetResourceDashboardResponseParams struct {
-	// 资源统计结果。
+	// <p>资源统计结果。</p>
 	ResourceStatisticsSet []*ResourceStatistics `json:"ResourceStatisticsSet,omitnil,omitempty" name:"ResourceStatisticsSet"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -21041,72 +21050,44 @@ func (r *DescribeSubnetResourceDashboardResponse) FromJsonString(s string) error
 
 // Predefined struct for user
 type DescribeSubnetsRequestParams struct {
-	// 子网实例ID查询。形如：subnet-pxir56ns。每次请求的实例的上限为100（该参数指定的子网是否返回，需要结合分页拉取参数Limit和Offset）。参数不支持同时指定SubnetIds和Filters。
+	// <p>子网实例ID查询。形如：subnet-pxir56ns。每次请求的实例的上限为100（该参数指定的子网是否返回，需要结合分页拉取参数Limit和Offset）。参数不支持同时指定SubnetIds和Filters。</p>
 	SubnetIds []*string `json:"SubnetIds,omitnil,omitempty" name:"SubnetIds"`
 
-	// 过滤条件，参数不支持同时指定SubnetIds和Filters。
-	// <li>subnet-id - String - （过滤条件）Subnet实例名称。</li>
-	// <li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。</li>
-	// <li>cidr-block - String - （过滤条件）子网网段，形如: 192.168.1.0 。</li>
-	// <li>is-default - Boolean - （过滤条件）是否是默认子网。</li>
-	// <li>is-remote-vpc-snat - Boolean - （过滤条件）是否为VPC SNAT地址池子网。</li>
-	// <li>subnet-name - String - （过滤条件）子网名称。</li>
-	// <li>zone - String - （过滤条件）可用区。</li>
-	// <li>tag-key - String -是否必填：否- （过滤条件）按照标签键进行过滤。</li>
-	// <li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li>
-	// <li>cdc-id - String - 是否必填：否 - （过滤条件）按照cdc信息进行过滤。过滤出来制定cdc下的子网。</li>
-	// <li>is-cdc-subnet - String - 是否必填：否 - （过滤条件）按照是否是cdc子网进行过滤。取值：“0”-非cdc子网，“1”--cdc子网</li>
-	// <li>ipv6-cidr-block - String - （过滤条件）IPv6子网网段，形如: 2402:4e00:1717:8700::/64 。</li>
-	// <li>isp-type  - String - （过滤条件）运营商类型，形如: BGP 。</li>
-	// <li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。`GUA`(全球单播地址), `ULA`(唯一本地地址)。</li>
+	// <p>过滤条件，参数不支持同时指定SubnetIds和Filters。</p><li>subnet-id - String - （过滤条件）Subnet实例名称。</li><li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。</li><li>cidr-block - String - （过滤条件）子网网段，形如: 192.168.1.0 。</li><li>is-default - Boolean - （过滤条件）是否是默认子网。</li><li>is-remote-vpc-snat - Boolean - （过滤条件）是否为VPC SNAT地址池子网。</li><li>subnet-name - String - （过滤条件）子网名称。</li><li>zone - String - （过滤条件）可用区。</li><li>tag-key - String -是否必填：否- （过滤条件）按照标签键进行过滤。</li><li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li><li>cdc-id - String - 是否必填：否 - （过滤条件）按照cdc信息进行过滤。过滤出来制定cdc下的子网。</li><li>is-cdc-subnet - String - 是否必填：否 - （过滤条件）按照是否是cdc子网进行过滤。取值：“0”-非cdc子网，“1”--cdc子网</li><li>ipv6-cidr-block - String - （过滤条件）IPv6子网网段，形如: 2402:4e00:1717:8700::/64 。</li><li>isp-type  - String - （过滤条件）运营商类型，形如: BGP 。</li><li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。<code>GUA</code>(全球单播地址), <code>ULA</code>(唯一本地地址)。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *string `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。
+	// <p>返回数量，默认为20，最大值为100。</p>
 	Limit *string `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 每次调用返回的最大结果数。如果查询返回的时候有NextToken返回，您可以使用NextToken值获取更多页结果， 当NextToke返回空或者返回的结果数量小于MaxResults时，表示没有更多数据了。允许的最大页面大小为 100。
+	// <p>每次调用返回的最大结果数。如果查询返回的时候有NextToken返回，您可以使用NextToken值获取更多页结果， 当NextToke返回空或者返回的结果数量小于MaxResults时，表示没有更多数据了。允许的最大页面大小为 100。</p>
 	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 如果NextToken返回非空字符串 ，表示还有更多可用结果。 NextToken是每个页面唯一的分页令牌。使用返回的令牌再次调用以检索下一页。需要保持所有其他参数不变。每个分页令牌在 24 小时后过期。
+	// <p>如果NextToken返回非空字符串 ，表示还有更多可用结果。 NextToken是每个页面唯一的分页令牌。使用返回的令牌再次调用以检索下一页。需要保持所有其他参数不变。每个分页令牌在 24 小时后过期。</p>
 	NextToken *string `json:"NextToken,omitnil,omitempty" name:"NextToken"`
 }
 
 type DescribeSubnetsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 子网实例ID查询。形如：subnet-pxir56ns。每次请求的实例的上限为100（该参数指定的子网是否返回，需要结合分页拉取参数Limit和Offset）。参数不支持同时指定SubnetIds和Filters。
+	// <p>子网实例ID查询。形如：subnet-pxir56ns。每次请求的实例的上限为100（该参数指定的子网是否返回，需要结合分页拉取参数Limit和Offset）。参数不支持同时指定SubnetIds和Filters。</p>
 	SubnetIds []*string `json:"SubnetIds,omitnil,omitempty" name:"SubnetIds"`
 
-	// 过滤条件，参数不支持同时指定SubnetIds和Filters。
-	// <li>subnet-id - String - （过滤条件）Subnet实例名称。</li>
-	// <li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。</li>
-	// <li>cidr-block - String - （过滤条件）子网网段，形如: 192.168.1.0 。</li>
-	// <li>is-default - Boolean - （过滤条件）是否是默认子网。</li>
-	// <li>is-remote-vpc-snat - Boolean - （过滤条件）是否为VPC SNAT地址池子网。</li>
-	// <li>subnet-name - String - （过滤条件）子网名称。</li>
-	// <li>zone - String - （过滤条件）可用区。</li>
-	// <li>tag-key - String -是否必填：否- （过滤条件）按照标签键进行过滤。</li>
-	// <li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li>
-	// <li>cdc-id - String - 是否必填：否 - （过滤条件）按照cdc信息进行过滤。过滤出来制定cdc下的子网。</li>
-	// <li>is-cdc-subnet - String - 是否必填：否 - （过滤条件）按照是否是cdc子网进行过滤。取值：“0”-非cdc子网，“1”--cdc子网</li>
-	// <li>ipv6-cidr-block - String - （过滤条件）IPv6子网网段，形如: 2402:4e00:1717:8700::/64 。</li>
-	// <li>isp-type  - String - （过滤条件）运营商类型，形如: BGP 。</li>
-	// <li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。`GUA`(全球单播地址), `ULA`(唯一本地地址)。</li>
+	// <p>过滤条件，参数不支持同时指定SubnetIds和Filters。</p><li>subnet-id - String - （过滤条件）Subnet实例名称。</li><li>vpc-id - String - （过滤条件）VPC实例ID，形如：vpc-f49l6u0z。</li><li>cidr-block - String - （过滤条件）子网网段，形如: 192.168.1.0 。</li><li>is-default - Boolean - （过滤条件）是否是默认子网。</li><li>is-remote-vpc-snat - Boolean - （过滤条件）是否为VPC SNAT地址池子网。</li><li>subnet-name - String - （过滤条件）子网名称。</li><li>zone - String - （过滤条件）可用区。</li><li>tag-key - String -是否必填：否- （过滤条件）按照标签键进行过滤。</li><li>tag:tag-key - String - 是否必填：否 - （过滤条件）按照标签键值对进行过滤。 tag-key使用具体的标签键进行替换。使用请参考示例2。</li><li>cdc-id - String - 是否必填：否 - （过滤条件）按照cdc信息进行过滤。过滤出来制定cdc下的子网。</li><li>is-cdc-subnet - String - 是否必填：否 - （过滤条件）按照是否是cdc子网进行过滤。取值：“0”-非cdc子网，“1”--cdc子网</li><li>ipv6-cidr-block - String - （过滤条件）IPv6子网网段，形如: 2402:4e00:1717:8700::/64 。</li><li>isp-type  - String - （过滤条件）运营商类型，形如: BGP 。</li><li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。<code>GUA</code>(全球单播地址), <code>ULA</code>(唯一本地地址)。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *string `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。
+	// <p>返回数量，默认为20，最大值为100。</p>
 	Limit *string `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 每次调用返回的最大结果数。如果查询返回的时候有NextToken返回，您可以使用NextToken值获取更多页结果， 当NextToke返回空或者返回的结果数量小于MaxResults时，表示没有更多数据了。允许的最大页面大小为 100。
+	// <p>每次调用返回的最大结果数。如果查询返回的时候有NextToken返回，您可以使用NextToken值获取更多页结果， 当NextToke返回空或者返回的结果数量小于MaxResults时，表示没有更多数据了。允许的最大页面大小为 100。</p>
 	MaxResults *uint64 `json:"MaxResults,omitnil,omitempty" name:"MaxResults"`
 
-	// 如果NextToken返回非空字符串 ，表示还有更多可用结果。 NextToken是每个页面唯一的分页令牌。使用返回的令牌再次调用以检索下一页。需要保持所有其他参数不变。每个分页令牌在 24 小时后过期。
+	// <p>如果NextToken返回非空字符串 ，表示还有更多可用结果。 NextToken是每个页面唯一的分页令牌。使用返回的令牌再次调用以检索下一页。需要保持所有其他参数不变。每个分页令牌在 24 小时后过期。</p>
 	NextToken *string `json:"NextToken,omitnil,omitempty" name:"NextToken"`
 }
 
@@ -21136,13 +21117,13 @@ func (r *DescribeSubnetsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeSubnetsResponseParams struct {
-	// 符合条件的实例数量。
+	// <p>符合条件的实例数量。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 子网对象。
+	// <p>子网对象。</p>
 	SubnetSet []*Subnet `json:"SubnetSet,omitnil,omitempty" name:"SubnetSet"`
 
-	// 如果NextToken返回非空字符串 ，表示还有更多可用结果。 NextToken是每个页面唯一的分页令牌。使用返回的令牌再次调用以检索下一页。需要保持所有其他参数不变。每个分页令牌在 24 小时后过期。
+	// <p>如果NextToken返回非空字符串 ，表示还有更多可用结果。 NextToken是每个页面唯一的分页令牌。使用返回的令牌再次调用以检索下一页。需要保持所有其他参数不变。每个分页令牌在 24 小时后过期。</p>
 	NextToken *string `json:"NextToken,omitnil,omitempty" name:"NextToken"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -21365,6 +21346,106 @@ func (r *DescribeTenantCcnsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeTrafficMirrorFilterRulesRequestParams struct {
+	// 流量镜像唯一ID
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像出站、入站过滤唯一ID列表。
+	TrafficMirrorFilterRuleIds []*string `json:"TrafficMirrorFilterRuleIds,omitnil,omitempty" name:"TrafficMirrorFilterRuleIds"`
+
+	// <li>traffic-mirror-filter-rule-id - String - （过滤条件） 流量镜像过滤规则，形如：tmfi-qfhrb7yj。 </li>
+	// <li>action - String - （过滤条件）策略， 支持类型： ACCEPT， DROP。 </li>
+	// <li>description - String - （过滤条件）描述。 </li>
+	// <li>direction - String - （过滤条件）方向, 支持类型：INGRESS， EGRESS。</li>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 偏移量。
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 请求对象个数。
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeTrafficMirrorFilterRulesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 流量镜像唯一ID
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像出站、入站过滤唯一ID列表。
+	TrafficMirrorFilterRuleIds []*string `json:"TrafficMirrorFilterRuleIds,omitnil,omitempty" name:"TrafficMirrorFilterRuleIds"`
+
+	// <li>traffic-mirror-filter-rule-id - String - （过滤条件） 流量镜像过滤规则，形如：tmfi-qfhrb7yj。 </li>
+	// <li>action - String - （过滤条件）策略， 支持类型： ACCEPT， DROP。 </li>
+	// <li>description - String - （过滤条件）描述。 </li>
+	// <li>direction - String - （过滤条件）方向, 支持类型：INGRESS， EGRESS。</li>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// 偏移量。
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 请求对象个数。
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *DescribeTrafficMirrorFilterRulesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTrafficMirrorFilterRulesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TrafficMirrorId")
+	delete(f, "TrafficMirrorFilterRuleIds")
+	delete(f, "Filters")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTrafficMirrorFilterRulesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTrafficMirrorFilterRulesResponseParams struct {
+	// 流量镜像实例唯一ID。
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
+
+	// 符合条件的实例数量。分页查询的时候，如果IngressFilterRules的长度加上IngressFilterRules的长度，小于limit的时候表示已经查询完毕。
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTrafficMirrorFilterRulesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTrafficMirrorFilterRulesResponseParams `json:"Response"`
+}
+
+func (r *DescribeTrafficMirrorFilterRulesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTrafficMirrorFilterRulesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeTrafficMirrorsRequestParams struct {
 	// 流量镜像实例ID集合
 	TrafficMirrorIds []*string `json:"TrafficMirrorIds,omitnil,omitempty" name:"TrafficMirrorIds"`
@@ -21429,6 +21510,9 @@ func (r *DescribeTrafficMirrorsRequest) FromJsonString(s string) error {
 type DescribeTrafficMirrorsResponseParams struct {
 	// 流量镜像实例信息
 	TrafficMirrorSet []*TrafficMirror `json:"TrafficMirrorSet,omitnil,omitempty" name:"TrafficMirrorSet"`
+
+	// 符合条件的对象数
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -22423,14 +22507,14 @@ func (r *DescribeVpcPrivateIpAddressesResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeVpcResourceDashboardRequestParams struct {
-	// Vpc实例ID，例如：vpc-f1xjkw1b。
+	// <p>Vpc实例ID，例如：vpc-f1xjkw1b。</p>
 	VpcIds []*string `json:"VpcIds,omitnil,omitempty" name:"VpcIds"`
 }
 
 type DescribeVpcResourceDashboardRequest struct {
 	*tchttp.BaseRequest
 	
-	// Vpc实例ID，例如：vpc-f1xjkw1b。
+	// <p>Vpc实例ID，例如：vpc-f1xjkw1b。</p>
 	VpcIds []*string `json:"VpcIds,omitnil,omitempty" name:"VpcIds"`
 }
 
@@ -22455,7 +22539,7 @@ func (r *DescribeVpcResourceDashboardRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeVpcResourceDashboardResponseParams struct {
-	// 资源对象列表。
+	// <p>资源对象列表。</p>
 	ResourceDashboardSet []*ResourceDashboard `json:"ResourceDashboardSet,omitnil,omitempty" name:"ResourceDashboardSet"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -22543,54 +22627,32 @@ func (r *DescribeVpcTaskResultResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeVpcsRequestParams struct {
-	// VPC实例ID。形如：vpc-f49l6u0z。每次请求的实例的上限为100。参数不支持同时指定VpcIds和Filters。
+	// <p>VPC实例ID。形如：vpc-f49l6u0z。每次请求的实例的上限为100。参数不支持同时指定VpcIds和Filters。</p>
 	VpcIds []*string `json:"VpcIds,omitnil,omitempty" name:"VpcIds"`
 
-	// 过滤条件，不支持同时指定VpcIds和Filters参数。
-	// 支持的过滤条件如下：
-	// <li>vpc-name：VPC实例名称，支持模糊查询。</li>
-	// <li>is-default ：是否默认VPC。</li>
-	// <li>vpc-id ：VPC实例ID，例如：vpc-f49l6u0z。</li>
-	// <li>cidr-block：VPC的CIDR。</li>
-	// <li>tag-key ：按照标签键进行过滤，非必填参数。</li>
-	// <li>tag:tag-key：按照标签键值对进行过滤，非必填参数。 其中 tag-key 请使用具体的标签键进行替换，可参考示例2。</li>
-	//   **说明：**若同一个过滤条件（Filter）存在多个Values，则同一Filter下Values间的关系为逻辑或（OR）关系；若存在多个过滤条件（Filter），Filter之间的关系为逻辑与（AND）关系。
-	// <li>ipv6-cidr-block - String - （过滤条件）IPv6子网网段，形如: 2402:4e00:1717:8700::/64 。</li>
-	// <li>isp-type  - String - （过滤条件）运营商类型，形如: BGP 取值范围：'BGP'-默认, 'CMCC'-中国移动, 'CTCC'-中国电信, 'CUCC'-中国联通。</li>
-	// <li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。`GUA`(全球单播地址), `ULA`(唯一本地地址)。</li>
+	// <p>过滤条件，不支持同时指定VpcIds和Filters参数。<br>支持的过滤条件如下：</p><li>vpc-name：VPC实例名称，支持模糊查询。</li><li>is-default ：是否默认VPC。</li><li>vpc-id ：VPC实例ID，例如：vpc-f49l6u0z。</li><li>cidr-block：VPC的CIDR。</li><li>tag-key ：按照标签键进行过滤，非必填参数。</li><li>tag:tag-key：按照标签键值对进行过滤，非必填参数。 其中 tag-key 请使用具体的标签键进行替换，可参考示例2。</li>  **说明：**若同一个过滤条件（Filter）存在多个Values，则同一Filter下Values间的关系为逻辑或（OR）关系；若存在多个过滤条件（Filter），Filter之间的关系为逻辑与（AND）关系。<li>ipv6-cidr-block - String - （过滤条件）IPv6子网网段，形如: 2402:4e00:1717:8700::/64 。</li><li>isp-type  - String - （过滤条件）运营商类型，形如: BGP 取值范围：'BGP'-默认, 'CMCC'-中国移动, 'CTCC'-中国电信, 'CUCC'-中国联通。</li><li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。<code>GUA</code>(全球单播地址), <code>ULA</code>(唯一本地地址)。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *string `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。
+	// <p>返回数量，默认为20，最大值为100。</p>
 	Limit *string `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
 type DescribeVpcsRequest struct {
 	*tchttp.BaseRequest
 	
-	// VPC实例ID。形如：vpc-f49l6u0z。每次请求的实例的上限为100。参数不支持同时指定VpcIds和Filters。
+	// <p>VPC实例ID。形如：vpc-f49l6u0z。每次请求的实例的上限为100。参数不支持同时指定VpcIds和Filters。</p>
 	VpcIds []*string `json:"VpcIds,omitnil,omitempty" name:"VpcIds"`
 
-	// 过滤条件，不支持同时指定VpcIds和Filters参数。
-	// 支持的过滤条件如下：
-	// <li>vpc-name：VPC实例名称，支持模糊查询。</li>
-	// <li>is-default ：是否默认VPC。</li>
-	// <li>vpc-id ：VPC实例ID，例如：vpc-f49l6u0z。</li>
-	// <li>cidr-block：VPC的CIDR。</li>
-	// <li>tag-key ：按照标签键进行过滤，非必填参数。</li>
-	// <li>tag:tag-key：按照标签键值对进行过滤，非必填参数。 其中 tag-key 请使用具体的标签键进行替换，可参考示例2。</li>
-	//   **说明：**若同一个过滤条件（Filter）存在多个Values，则同一Filter下Values间的关系为逻辑或（OR）关系；若存在多个过滤条件（Filter），Filter之间的关系为逻辑与（AND）关系。
-	// <li>ipv6-cidr-block - String - （过滤条件）IPv6子网网段，形如: 2402:4e00:1717:8700::/64 。</li>
-	// <li>isp-type  - String - （过滤条件）运营商类型，形如: BGP 取值范围：'BGP'-默认, 'CMCC'-中国移动, 'CTCC'-中国电信, 'CUCC'-中国联通。</li>
-	// <li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。`GUA`(全球单播地址), `ULA`(唯一本地地址)。</li>
+	// <p>过滤条件，不支持同时指定VpcIds和Filters参数。<br>支持的过滤条件如下：</p><li>vpc-name：VPC实例名称，支持模糊查询。</li><li>is-default ：是否默认VPC。</li><li>vpc-id ：VPC实例ID，例如：vpc-f49l6u0z。</li><li>cidr-block：VPC的CIDR。</li><li>tag-key ：按照标签键进行过滤，非必填参数。</li><li>tag:tag-key：按照标签键值对进行过滤，非必填参数。 其中 tag-key 请使用具体的标签键进行替换，可参考示例2。</li>  **说明：**若同一个过滤条件（Filter）存在多个Values，则同一Filter下Values间的关系为逻辑或（OR）关系；若存在多个过滤条件（Filter），Filter之间的关系为逻辑与（AND）关系。<li>ipv6-cidr-block - String - （过滤条件）IPv6子网网段，形如: 2402:4e00:1717:8700::/64 。</li><li>isp-type  - String - （过滤条件）运营商类型，形如: BGP 取值范围：'BGP'-默认, 'CMCC'-中国移动, 'CTCC'-中国电信, 'CUCC'-中国联通。</li><li>address-type - String - （过滤条件）IPv6 Cidr 的类型，精确匹配。<code>GUA</code>(全球单播地址), <code>ULA</code>(唯一本地地址)。</li>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 
-	// 偏移量，默认为0。
+	// <p>偏移量，默认为0。</p>
 	Offset *string `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 返回数量，默认为20，最大值为100。
+	// <p>返回数量，默认为20，最大值为100。</p>
 	Limit *string `json:"Limit,omitnil,omitempty" name:"Limit"`
 }
 
@@ -22618,10 +22680,10 @@ func (r *DescribeVpcsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeVpcsResponseParams struct {
-	// 符合条件的对象数。
+	// <p>符合条件的对象数。</p>
 	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// VPC对象。
+	// <p>VPC对象。</p>
 	VpcSet []*Vpc `json:"VpcSet,omitnil,omitempty" name:"VpcSet"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -25592,13 +25654,13 @@ type HaVip struct {
 	// `HAVIP`的飘移范围。
 	HaVipAssociationSet []*HaVipAssociation `json:"HaVipAssociationSet,omitnil,omitempty" name:"HaVipAssociationSet"`
 
-	// 是否开启`HAVIP`的飘移范围校验。
+	// 是否开启`HAVIP`的漂移范围校验。
 	CheckAssociate *bool `json:"CheckAssociate,omitnil,omitempty" name:"CheckAssociate"`
 
 	// CDC实例ID。
 	CdcId *string `json:"CdcId,omitnil,omitempty" name:"CdcId"`
 
-	// HAVIP 刷新时间。该参数只作为出参数。以下场景会触发 FlushTime 被刷新：1）子机发出免费 ARP 触发 HAVIP 漂移；2）手动HAVIP解绑网卡; 没有更新时默认值：0000-00-00 00:00:00
+	// HAVIP 刷新时间。该参数只作为出参数。以下场景会触发FlushedTime 被刷新：1）子机发出免费 ARP 触发 HAVIP 漂移；2）手动HAVIP解绑网卡; 没有更新时默认值：0000-00-00 00:00:00
 	FlushedTime *string `json:"FlushedTime,omitnil,omitempty" name:"FlushedTime"`
 
 	// 标签键值对。	
@@ -25806,63 +25868,63 @@ type HighPriorityRouteTable struct {
 }
 
 type IKEOptionsSpecification struct {
-	// 加密算法，可选值：'3DES-CBC', 'AES-CBC-128', 'AES-CBC-192', 'AES-CBC-256', 'DES-CBC'，'SM4', 默认为3DES-CBC
+	// <p>加密算法，可选值：&#39;3DES-CBC&#39;, &#39;AES-CBC-128&#39;, &#39;AES-CBC-192&#39;, &#39;AES-CBC-256&#39;, &#39;DES-CBC&#39;, &#39;SM4&#39;,  &#39;AES128GCM128&#39;, &#39;AES192GCM128&#39;, &#39;AES256GCM128&#39;</p><p>默认值：3DES-CBC</p><p>仅4.0VPN网关支持 &#39;AES128GCM128&#39;, &#39;AES192GCM128&#39;, &#39;AES256GCM128&#39;</p>
 	PropoEncryAlgorithm *string `json:"PropoEncryAlgorithm,omitnil,omitempty" name:"PropoEncryAlgorithm"`
 
-	// 认证算法：可选值：'MD5'，'SHA'，'SHA-256'，'SHA-512'， 默认为SHA。
+	// <p>认证算法：可选值：&#39;MD5&#39;，&#39;SHA&#39;，&#39;SHA-256&#39;，&#39;SHA-512&#39;， 默认为SHA。</p>
 	PropoAuthenAlgorithm *string `json:"PropoAuthenAlgorithm,omitnil,omitempty" name:"PropoAuthenAlgorithm"`
 
-	// 协商模式：可选值：'AGGRESSIVE'， 'MAIN'，默认为MAIN。
+	// <p>协商模式：可选值：&#39;AGGRESSIVE&#39;， &#39;MAIN&#39;，默认为MAIN。</p>
 	ExchangeMode *string `json:"ExchangeMode,omitnil,omitempty" name:"ExchangeMode"`
 
-	// 本端标识类型：可选值：'ADDRESS', 'FQDN'，默认为ADDRESS
+	// <p>本端标识类型：可选值：&#39;ADDRESS&#39;, &#39;FQDN&#39;，默认为ADDRESS</p>
 	LocalIdentity *string `json:"LocalIdentity,omitnil,omitempty" name:"LocalIdentity"`
 
-	// 对端标识类型：可选值：'ADDRESS', 'FQDN'，默认为ADDRESS
+	// <p>对端标识类型：可选值：&#39;ADDRESS&#39;, &#39;FQDN&#39;，默认为ADDRESS</p>
 	RemoteIdentity *string `json:"RemoteIdentity,omitnil,omitempty" name:"RemoteIdentity"`
 
-	// 本端标识，当LocalIdentity选为ADDRESS时，LocalAddress必填。localAddress默认为vpn网关公网IP
+	// <p>本端标识，当LocalIdentity选为ADDRESS时，LocalAddress必填。localAddress默认为vpn网关公网IP</p>
 	LocalAddress *string `json:"LocalAddress,omitnil,omitempty" name:"LocalAddress"`
 
-	// 对端标识，当RemoteIdentity选为ADDRESS时，RemoteAddress必填
+	// <p>对端标识，当RemoteIdentity选为ADDRESS时，RemoteAddress必填</p>
 	RemoteAddress *string `json:"RemoteAddress,omitnil,omitempty" name:"RemoteAddress"`
 
-	// 本端标识，当LocalIdentity选为FQDN时，LocalFqdnName必填
+	// <p>本端标识，当LocalIdentity选为FQDN时，LocalFqdnName必填</p>
 	LocalFqdnName *string `json:"LocalFqdnName,omitnil,omitempty" name:"LocalFqdnName"`
 
-	// 对端标识，当remoteIdentity选为FQDN时，RemoteFqdnName必填
+	// <p>对端标识，当remoteIdentity选为FQDN时，RemoteFqdnName必填</p>
 	RemoteFqdnName *string `json:"RemoteFqdnName,omitnil,omitempty" name:"RemoteFqdnName"`
 
-	// DH group，指定IKE交换密钥时使用的DH组，可选值：'GROUP1', 'GROUP2', 'GROUP5', 'GROUP14', 'GROUP24'，默认是GROUP1。
+	// <p>DH group，指定IKE交换密钥时使用的DH组，可选值：&#39;GROUP1&#39;, &#39;GROUP2&#39;, &#39;GROUP5&#39;, &#39;GROUP14&#39;, &#39;GROUP15&#39;, &#39;GROUP16&#39;, &#39;GROUP19&#39;, &#39;GROUP20&#39;, &#39;GROUP21&#39;, &#39;GROUP24&#39;，默认是GROUP1。</p>
 	DhGroupName *string `json:"DhGroupName,omitnil,omitempty" name:"DhGroupName"`
 
-	// IKE SA Lifetime，单位：秒，设置IKE SA的生存周期，取值范围：60-604800
+	// <p>IKE SA Lifetime，单位：秒，设置IKE SA的生存周期</p><p>取值范围：[60, 604800]</p><p>默认值：86400</p>
 	IKESaLifetimeSeconds *uint64 `json:"IKESaLifetimeSeconds,omitnil,omitempty" name:"IKESaLifetimeSeconds"`
 
-	// IKE版本
+	// <p>IKE版本</p><p>枚举值：</p><ul><li>IKEV1： IKEV1版本</li><li>IKEV2： IKEV2版本</li></ul><p>默认值：IKEV1</p>
 	IKEVersion *string `json:"IKEVersion,omitnil,omitempty" name:"IKEVersion"`
 }
 
 type IPSECOptionsSpecification struct {
-	// 加密算法，可选值：'3DES-CBC', 'AES-CBC-128', 'AES-CBC-192', 'AES-CBC-256', 'DES-CBC', 'SM4', 'NULL'， 默认为AES-CBC-128
+	// <p>加密算法，可选值：&#39;3DES-CBC&#39;, &#39;AES-CBC-128&#39;, &#39;AES-CBC-192&#39;, &#39;AES-CBC-256&#39;, &#39;DES-CBC&#39;, &#39;SM4&#39;, &#39;NULL&#39;, &#39;AES128GCM128&#39;, &#39;AES192GCM128&#39;, &#39;AES256GCM128&#39;</p><p>默认值：AES-CBC-128</p><p>仅4.0VPN网关支持 &#39;AES128GCM128&#39;, &#39;AES192GCM128&#39;, &#39;AES256GCM128&#39;</p>
 	EncryptAlgorithm *string `json:"EncryptAlgorithm,omitnil,omitempty" name:"EncryptAlgorithm"`
 
-	// 认证算法：可选值：'MD5', 'SHA1'，'SHA-256' 默认为
+	// <p>认证算法：可选值：&#39;MD5&#39;, &#39;SHA1&#39;, &#39;SHA-256&#39;, &#39;SHA-512&#39;, &#39;SHA-384&#39;, &#39;SM3&#39;</p><p>默认值：SHA1</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	//
 	// Deprecated: IntegrityAlgorith is deprecated.
 	IntegrityAlgorith *string `json:"IntegrityAlgorith,omitnil,omitempty" name:"IntegrityAlgorith"`
 
-	// IPsec SA lifetime(s)：单位秒，取值范围：180-604800
+	// <p>IPsec SA lifetime(s)</p><p>取值范围：[180, 604800]</p><p>单位：秒</p><p>默认值：14400</p>
 	IPSECSaLifetimeSeconds *uint64 `json:"IPSECSaLifetimeSeconds,omitnil,omitempty" name:"IPSECSaLifetimeSeconds"`
 
-	// PFS：可选值：'NULL', 'DH-GROUP1', 'DH-GROUP2', 'DH-GROUP5', 'DH-GROUP14', 'DH-GROUP24'，默认为NULL
+	// <p>PFS：可选值：&#39;NULL&#39;, &#39;DH-GROUP1&#39;, &#39;DH-GROUP2&#39;, &#39;DH-GROUP5&#39;, &#39;DH-GROUP14&#39;, &#39;DH-GROUP15&#39;,&#39;DH-GROUP16&#39;,&#39;DH-GROUP19&#39;,&#39;DH-GROUP20&#39;,&#39;DH-GROUP21&#39;,&#39;DH-GROUP24&#39;，默认为NULL</p>
 	PfsDhGroup *string `json:"PfsDhGroup,omitnil,omitempty" name:"PfsDhGroup"`
 
-	// IPsec SA lifetime(KB)：单位KB，取值范围：2560-604800
+	// <p>IPsec SA lifetime(KB)</p><p>取值范围：[2560, 4294967295]</p><p>单位：KB</p><p>默认值：4096000000</p>
 	IPSECSaLifetimeTraffic *uint64 `json:"IPSECSaLifetimeTraffic,omitnil,omitempty" name:"IPSECSaLifetimeTraffic"`
 
-	// 认证算法：可选值：'MD5', 'SHA1'，'SHA-256' 默认为
+	// <p>认证算法：可选值：&#39;MD5&#39;, &#39;SHA1&#39;，&#39;SHA-256&#39; 默认为</p>
 	IntegrityAlgorithm *string `json:"IntegrityAlgorithm,omitnil,omitempty" name:"IntegrityAlgorithm"`
 }
 
@@ -27347,18 +27409,18 @@ func (r *ModifyAddressTemplateGroupAttributeResponse) FromJsonString(s string) e
 
 // Predefined struct for user
 type ModifyAddressesBandwidthRequestParams struct {
-	// EIP唯一标识ID列表，形如'eip-xxxx'，可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取AddressId。
+	// <p>EIP唯一标识ID列表，形如&#39;eip-xxxx&#39;，可以使用<a href="https://cloud.tencent.com/document/product/215/16702">DescribeAddresses</a>接口获取AddressId。</p>
 	AddressIds []*string `json:"AddressIds,omitnil,omitempty" name:"AddressIds"`
 
-	// 调整带宽目标值，可调整的带宽上限值参考产品文档[带宽上限](https://cloud.tencent.com/document/product/1199/48333)。
+	// <p>调整带宽目标值，可调整的带宽上限值参考产品文档<a href="https://cloud.tencent.com/document/product/1199/48333">带宽上限</a>。</p>
 	InternetMaxBandwidthOut *int64 `json:"InternetMaxBandwidthOut,omitnil,omitempty" name:"InternetMaxBandwidthOut"`
 
-	// 包月带宽起始时间(已废弃，输入无效)
+	// <p>包月带宽起始时间(已废弃，输入无效)</p>
 	//
 	// Deprecated: StartTime is deprecated.
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 包月带宽结束时间(已废弃，输入无效)
+	// <p>包月带宽结束时间(已废弃，输入无效)</p>
 	//
 	// Deprecated: EndTime is deprecated.
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
@@ -27367,16 +27429,16 @@ type ModifyAddressesBandwidthRequestParams struct {
 type ModifyAddressesBandwidthRequest struct {
 	*tchttp.BaseRequest
 	
-	// EIP唯一标识ID列表，形如'eip-xxxx'，可以使用[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取AddressId。
+	// <p>EIP唯一标识ID列表，形如&#39;eip-xxxx&#39;，可以使用<a href="https://cloud.tencent.com/document/product/215/16702">DescribeAddresses</a>接口获取AddressId。</p>
 	AddressIds []*string `json:"AddressIds,omitnil,omitempty" name:"AddressIds"`
 
-	// 调整带宽目标值，可调整的带宽上限值参考产品文档[带宽上限](https://cloud.tencent.com/document/product/1199/48333)。
+	// <p>调整带宽目标值，可调整的带宽上限值参考产品文档<a href="https://cloud.tencent.com/document/product/1199/48333">带宽上限</a>。</p>
 	InternetMaxBandwidthOut *int64 `json:"InternetMaxBandwidthOut,omitnil,omitempty" name:"InternetMaxBandwidthOut"`
 
-	// 包月带宽起始时间(已废弃，输入无效)
+	// <p>包月带宽起始时间(已废弃，输入无效)</p>
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 包月带宽结束时间(已废弃，输入无效)
+	// <p>包月带宽结束时间(已废弃，输入无效)</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 }
 
@@ -27404,7 +27466,7 @@ func (r *ModifyAddressesBandwidthRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyAddressesBandwidthResponseParams struct {
-	// 异步任务TaskId。可以使用[DescribeTaskResult](https://cloud.tencent.com/document/api/215/36271)接口查询任务状态。
+	// <p>异步任务TaskId。可以使用<a href="https://cloud.tencent.com/document/api/215/36271">DescribeTaskResult</a>接口查询任务状态。</p>
 	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -29472,6 +29534,81 @@ func (r *ModifyLocalGatewayResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ModifyNatGatewayAdvancedAttributeRequestParams struct {
+	// NAT网关的ID，形如：`nat-df45454`。
+	NatGatewayId *string `json:"NatGatewayId,omitnil,omitempty" name:"NatGatewayId"`
+
+	// UDP映射空闲时间，单位：秒。含义为UDP流空闲多少秒以后从NAT映射中释放。取值范围为：3-7200，默认为180。
+	UDPMappingTimeout *uint64 `json:"UDPMappingTimeout,omitnil,omitempty" name:"UDPMappingTimeout"`
+
+	// TCP已建立的连接空闲超时时间，单位：秒。含义为TCP已建立的连接空闲多少秒以后从NAT映射中释放。取值范围为：40-10800，默认为10800。
+	TCPEstablishedConnectionTimeout *uint64 `json:"TCPEstablishedConnectionTimeout,omitnil,omitempty" name:"TCPEstablishedConnectionTimeout"`
+
+	// TCP TIME_WAIT超时时间，单位：秒。含义为完全关闭的TCP连接在到期后保留在NAT映射中的秒数。取值范围为：10-600，默认为120。
+	TCPTimeWaitTimeout *uint64 `json:"TCPTimeWaitTimeout,omitnil,omitempty" name:"TCPTimeWaitTimeout"`
+}
+
+type ModifyNatGatewayAdvancedAttributeRequest struct {
+	*tchttp.BaseRequest
+	
+	// NAT网关的ID，形如：`nat-df45454`。
+	NatGatewayId *string `json:"NatGatewayId,omitnil,omitempty" name:"NatGatewayId"`
+
+	// UDP映射空闲时间，单位：秒。含义为UDP流空闲多少秒以后从NAT映射中释放。取值范围为：3-7200，默认为180。
+	UDPMappingTimeout *uint64 `json:"UDPMappingTimeout,omitnil,omitempty" name:"UDPMappingTimeout"`
+
+	// TCP已建立的连接空闲超时时间，单位：秒。含义为TCP已建立的连接空闲多少秒以后从NAT映射中释放。取值范围为：40-10800，默认为10800。
+	TCPEstablishedConnectionTimeout *uint64 `json:"TCPEstablishedConnectionTimeout,omitnil,omitempty" name:"TCPEstablishedConnectionTimeout"`
+
+	// TCP TIME_WAIT超时时间，单位：秒。含义为完全关闭的TCP连接在到期后保留在NAT映射中的秒数。取值范围为：10-600，默认为120。
+	TCPTimeWaitTimeout *uint64 `json:"TCPTimeWaitTimeout,omitnil,omitempty" name:"TCPTimeWaitTimeout"`
+}
+
+func (r *ModifyNatGatewayAdvancedAttributeRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyNatGatewayAdvancedAttributeRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NatGatewayId")
+	delete(f, "UDPMappingTimeout")
+	delete(f, "TCPEstablishedConnectionTimeout")
+	delete(f, "TCPTimeWaitTimeout")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyNatGatewayAdvancedAttributeRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyNatGatewayAdvancedAttributeResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyNatGatewayAdvancedAttributeResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyNatGatewayAdvancedAttributeResponseParams `json:"Response"`
+}
+
+func (r *ModifyNatGatewayAdvancedAttributeResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyNatGatewayAdvancedAttributeResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyNatGatewayAttributeRequestParams struct {
 	// NAT网关的ID，形如：`nat-df45454`。
 	NatGatewayId *string `json:"NatGatewayId,omitnil,omitempty" name:"NatGatewayId"`
@@ -31321,6 +31458,74 @@ func (r *ModifyTrafficMirrorAttributeResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ModifyTrafficMirrorFilterRulesRequestParams struct {
+	// 流量镜像实例唯一ID。
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
+}
+
+type ModifyTrafficMirrorFilterRulesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 流量镜像实例唯一ID。
+	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
+}
+
+func (r *ModifyTrafficMirrorFilterRulesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyTrafficMirrorFilterRulesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TrafficMirrorId")
+	delete(f, "IngressFilterRules")
+	delete(f, "EgressFilterRules")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyTrafficMirrorFilterRulesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyTrafficMirrorFilterRulesResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyTrafficMirrorFilterRulesResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyTrafficMirrorFilterRulesResponseParams `json:"Response"`
+}
+
+func (r *ModifyTrafficMirrorFilterRulesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyTrafficMirrorFilterRulesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyVpcAttributeRequestParams struct {
 	// VPC实例ID。形如：vpc-f49l6u0z。
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
@@ -31738,104 +31943,104 @@ func (r *ModifyVpcPeeringConnectionResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyVpnConnectionAttributeRequestParams struct {
-	// VPN通道实例ID。形如：vpnx-f49l6u0z。
+	// <p>VPN通道实例ID。形如：vpnx-f49l6u0z。</p>
 	VpnConnectionId *string `json:"VpnConnectionId,omitnil,omitempty" name:"VpnConnectionId"`
 
-	// VPN通道名称，可任意命名，但不得超过60个字符。
+	// <p>VPN通道名称，可任意命名，但不得超过60个字符。</p>
 	VpnConnectionName *string `json:"VpnConnectionName,omitnil,omitempty" name:"VpnConnectionName"`
 
-	// 预共享密钥。
+	// <p>预共享密钥。</p>
 	PreShareKey *string `json:"PreShareKey,omitnil,omitempty" name:"PreShareKey"`
 
-	// SPD策略组，例如：{"10.0.0.5/24":["172.123.10.5/16"]}，10.0.0.5/24是vpc内网段，172.123.10.5/16是IDC网段。用户指定VPC内哪些网段可以和您IDC中哪些网段通信。
+	// <p>SPD策略组，例如：{&quot;10.0.0.5/24&quot;:[&quot;172.123.10.5/16&quot;]}，10.0.0.5/24是vpc内网段，172.123.10.5/16是IDC网段。用户指定VPC内哪些网段可以和您IDC中哪些网段通信。</p>
 	SecurityPolicyDatabases []*SecurityPolicyDatabase `json:"SecurityPolicyDatabases,omitnil,omitempty" name:"SecurityPolicyDatabases"`
 
-	// IKE配置（Internet Key Exchange，因特网密钥交换），IKE具有一套自我保护机制，用户配置网络安全协议。
+	// <p>IKE配置（Internet Key Exchange，因特网密钥交换），IKE具有一套自我保护机制，用户配置网络安全协议。</p>
 	IKEOptionsSpecification *IKEOptionsSpecification `json:"IKEOptionsSpecification,omitnil,omitempty" name:"IKEOptionsSpecification"`
 
-	// IPSec配置，腾讯云提供IPSec安全会话设置。
+	// <p>IPSec配置，腾讯云提供IPSec安全会话设置。</p>
 	IPSECOptionsSpecification *IPSECOptionsSpecification `json:"IPSECOptionsSpecification,omitnil,omitempty" name:"IPSECOptionsSpecification"`
 
-	// 是否启用通道健康检查，默认为False。
+	// <p>是否启用通道健康检查，默认为False。</p>
 	EnableHealthCheck *bool `json:"EnableHealthCheck,omitnil,omitempty" name:"EnableHealthCheck"`
 
-	// 本端通道探测IP。
+	// <p>本端通道探测IP。</p>
 	HealthCheckLocalIp *string `json:"HealthCheckLocalIp,omitnil,omitempty" name:"HealthCheckLocalIp"`
 
-	// 对端通道探测IP。
+	// <p>对端通道探测IP。</p>
 	HealthCheckRemoteIp *string `json:"HealthCheckRemoteIp,omitnil,omitempty" name:"HealthCheckRemoteIp"`
 
-	// 协商类型，默认为active（主动协商）。可选值：active（主动协商），passive（被动协商），flowTrigger（流量协商）
+	// <p>协商类型，默认为active（主动协商）。可选值：active（主动协商），passive（被动协商），flowTrigger（流量协商）</p>
 	NegotiationType *string `json:"NegotiationType,omitnil,omitempty" name:"NegotiationType"`
 
-	// DPD探测开关。默认为0，表示关闭DPD探测。可选值：0（关闭），1（开启）
+	// <p>DPD探测开关。默认为0，表示关闭DPD探测。可选值：0（关闭），1（开启）</p>
 	DpdEnable *int64 `json:"DpdEnable,omitnil,omitempty" name:"DpdEnable"`
 
-	// DPD超时时间。即探测确认对端不存在需要的时间。dpdEnable为1（开启）时有效。默认30，单位为秒
+	// <p>DPD超时时间。即探测确认对端不存在需要的时间。dpdEnable为1（开启）时有效。默认30，单位为秒</p>
 	DpdTimeout *string `json:"DpdTimeout,omitnil,omitempty" name:"DpdTimeout"`
 
-	// DPD超时后的动作。默认为clear。dpdEnable为1（开启）时有效。可取值为clear（断开）和restart（重试）
+	// <p>DPD超时后的动作。默认为clear。dpdEnable为1（开启）时有效。可取值为clear（断开）和restart（重试）</p><p>默认值：restart</p>
 	DpdAction *string `json:"DpdAction,omitnil,omitempty" name:"DpdAction"`
 
-	// 对端网关ID，4.0及以上网关下的通道支持更新。
+	// <p>对端网关ID，4.0及以上网关下的通道支持更新。</p>
 	CustomerGatewayId *string `json:"CustomerGatewayId,omitnil,omitempty" name:"CustomerGatewayId"`
 
-	// 健康检查配置
+	// <p>健康检查配置</p>
 	HealthCheckConfig *HealthCheckConfig `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
 
-	// BGP隧道配置
+	// <p>BGP隧道配置</p>
 	BgpConfig *BgpConfig `json:"BgpConfig,omitnil,omitempty" name:"BgpConfig"`
 }
 
 type ModifyVpnConnectionAttributeRequest struct {
 	*tchttp.BaseRequest
 	
-	// VPN通道实例ID。形如：vpnx-f49l6u0z。
+	// <p>VPN通道实例ID。形如：vpnx-f49l6u0z。</p>
 	VpnConnectionId *string `json:"VpnConnectionId,omitnil,omitempty" name:"VpnConnectionId"`
 
-	// VPN通道名称，可任意命名，但不得超过60个字符。
+	// <p>VPN通道名称，可任意命名，但不得超过60个字符。</p>
 	VpnConnectionName *string `json:"VpnConnectionName,omitnil,omitempty" name:"VpnConnectionName"`
 
-	// 预共享密钥。
+	// <p>预共享密钥。</p>
 	PreShareKey *string `json:"PreShareKey,omitnil,omitempty" name:"PreShareKey"`
 
-	// SPD策略组，例如：{"10.0.0.5/24":["172.123.10.5/16"]}，10.0.0.5/24是vpc内网段，172.123.10.5/16是IDC网段。用户指定VPC内哪些网段可以和您IDC中哪些网段通信。
+	// <p>SPD策略组，例如：{&quot;10.0.0.5/24&quot;:[&quot;172.123.10.5/16&quot;]}，10.0.0.5/24是vpc内网段，172.123.10.5/16是IDC网段。用户指定VPC内哪些网段可以和您IDC中哪些网段通信。</p>
 	SecurityPolicyDatabases []*SecurityPolicyDatabase `json:"SecurityPolicyDatabases,omitnil,omitempty" name:"SecurityPolicyDatabases"`
 
-	// IKE配置（Internet Key Exchange，因特网密钥交换），IKE具有一套自我保护机制，用户配置网络安全协议。
+	// <p>IKE配置（Internet Key Exchange，因特网密钥交换），IKE具有一套自我保护机制，用户配置网络安全协议。</p>
 	IKEOptionsSpecification *IKEOptionsSpecification `json:"IKEOptionsSpecification,omitnil,omitempty" name:"IKEOptionsSpecification"`
 
-	// IPSec配置，腾讯云提供IPSec安全会话设置。
+	// <p>IPSec配置，腾讯云提供IPSec安全会话设置。</p>
 	IPSECOptionsSpecification *IPSECOptionsSpecification `json:"IPSECOptionsSpecification,omitnil,omitempty" name:"IPSECOptionsSpecification"`
 
-	// 是否启用通道健康检查，默认为False。
+	// <p>是否启用通道健康检查，默认为False。</p>
 	EnableHealthCheck *bool `json:"EnableHealthCheck,omitnil,omitempty" name:"EnableHealthCheck"`
 
-	// 本端通道探测IP。
+	// <p>本端通道探测IP。</p>
 	HealthCheckLocalIp *string `json:"HealthCheckLocalIp,omitnil,omitempty" name:"HealthCheckLocalIp"`
 
-	// 对端通道探测IP。
+	// <p>对端通道探测IP。</p>
 	HealthCheckRemoteIp *string `json:"HealthCheckRemoteIp,omitnil,omitempty" name:"HealthCheckRemoteIp"`
 
-	// 协商类型，默认为active（主动协商）。可选值：active（主动协商），passive（被动协商），flowTrigger（流量协商）
+	// <p>协商类型，默认为active（主动协商）。可选值：active（主动协商），passive（被动协商），flowTrigger（流量协商）</p>
 	NegotiationType *string `json:"NegotiationType,omitnil,omitempty" name:"NegotiationType"`
 
-	// DPD探测开关。默认为0，表示关闭DPD探测。可选值：0（关闭），1（开启）
+	// <p>DPD探测开关。默认为0，表示关闭DPD探测。可选值：0（关闭），1（开启）</p>
 	DpdEnable *int64 `json:"DpdEnable,omitnil,omitempty" name:"DpdEnable"`
 
-	// DPD超时时间。即探测确认对端不存在需要的时间。dpdEnable为1（开启）时有效。默认30，单位为秒
+	// <p>DPD超时时间。即探测确认对端不存在需要的时间。dpdEnable为1（开启）时有效。默认30，单位为秒</p>
 	DpdTimeout *string `json:"DpdTimeout,omitnil,omitempty" name:"DpdTimeout"`
 
-	// DPD超时后的动作。默认为clear。dpdEnable为1（开启）时有效。可取值为clear（断开）和restart（重试）
+	// <p>DPD超时后的动作。默认为clear。dpdEnable为1（开启）时有效。可取值为clear（断开）和restart（重试）</p><p>默认值：restart</p>
 	DpdAction *string `json:"DpdAction,omitnil,omitempty" name:"DpdAction"`
 
-	// 对端网关ID，4.0及以上网关下的通道支持更新。
+	// <p>对端网关ID，4.0及以上网关下的通道支持更新。</p>
 	CustomerGatewayId *string `json:"CustomerGatewayId,omitnil,omitempty" name:"CustomerGatewayId"`
 
-	// 健康检查配置
+	// <p>健康检查配置</p>
 	HealthCheckConfig *HealthCheckConfig `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
 
-	// BGP隧道配置
+	// <p>BGP隧道配置</p>
 	BgpConfig *BgpConfig `json:"BgpConfig,omitnil,omitempty" name:"BgpConfig"`
 }
 
@@ -32567,31 +32772,31 @@ type NetDetectState struct {
 }
 
 type NetworkAcl struct {
-	// `VPC`实例`ID`。
+	// <p><code>VPC</code>实例<code>ID</code>。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// 网络ACL实例`ID`。
+	// <p>网络ACL实例<code>ID</code>。</p>
 	NetworkAclId *string `json:"NetworkAclId,omitnil,omitempty" name:"NetworkAclId"`
 
-	// 网络ACL名称，最大长度为60。
+	// <p>网络ACL名称，最大长度为60。</p>
 	NetworkAclName *string `json:"NetworkAclName,omitnil,omitempty" name:"NetworkAclName"`
 
-	// 创建时间。
+	// <p>创建时间。</p>
 	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
-	// 网络ACL关联的子网数组。
+	// <p>网络ACL关联的子网数组。</p>
 	SubnetSet []*Subnet `json:"SubnetSet,omitnil,omitempty" name:"SubnetSet"`
 
-	// 该参数仅对三元组ACL有效，网络ACl入站规则。
+	// <p>该参数仅对三元组ACL有效，网络ACl入站规则。</p>
 	IngressEntries []*NetworkAclEntry `json:"IngressEntries,omitnil,omitempty" name:"IngressEntries"`
 
-	// 该参数仅对三元组ACL有效，网络ACL出站规则。
+	// <p>该参数仅对三元组ACL有效，网络ACL出站规则。</p>
 	EgressEntries []*NetworkAclEntry `json:"EgressEntries,omitnil,omitempty" name:"EgressEntries"`
 
-	// 网络ACL类型。三元组：'TRIPLE'   五元组：'QUINTUPLE'
+	// <p>网络ACL类型。三元组：&#39;TRIPLE&#39;   五元组：&#39;QUINTUPLE&#39;</p>
 	NetworkAclType *string `json:"NetworkAclType,omitnil,omitempty" name:"NetworkAclType"`
 
-	// 标签键值对
+	// <p>标签键值对</p>
 	TagSet []*Tag `json:"TagSet,omitnil,omitempty" name:"TagSet"`
 }
 
@@ -33459,7 +33664,7 @@ func (r *ReleaseIp6AddressesBandwidthResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type RemoveBandwidthPackageResourcesRequestParams struct {
-	// 资源唯一ID，当前支持EIP资源和LB资源，形如'eip-xxxx', 'lb-xxxx'。EIP资源列表可通过[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取，LB资源列表可通过[DescribeLoadBalancers](https://cloud.tencent.com/document/api/214/30685)接口获取。
+	// 资源唯一ID，当前支持EIP资源和LB资源，形如'eip-xxxx', 'lb-xxxx'。<li>EIP资源列表：可通过[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取。高防EIP、Anycast EIP、精品BGP EIP默认不支持从共享带宽包中移除，其中高防EIP和精品BGP IP可以迁移到其他同线路类型的共享带宽包中。</li><li>LB资源列表：可通过[DescribeLoadBalancers](https://cloud.tencent.com/document/api/214/30685)接口获取。</li>
 	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 带宽包唯一标识ID，形如'bwp-xxxx'，可以使用[DescribeBandwidthPackages](https://cloud.tencent.com/document/product/215/19209)接口查询BandwidthPackageId。
@@ -33480,7 +33685,7 @@ type RemoveBandwidthPackageResourcesRequestParams struct {
 type RemoveBandwidthPackageResourcesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 资源唯一ID，当前支持EIP资源和LB资源，形如'eip-xxxx', 'lb-xxxx'。EIP资源列表可通过[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取，LB资源列表可通过[DescribeLoadBalancers](https://cloud.tencent.com/document/api/214/30685)接口获取。
+	// 资源唯一ID，当前支持EIP资源和LB资源，形如'eip-xxxx', 'lb-xxxx'。<li>EIP资源列表：可通过[DescribeAddresses](https://cloud.tencent.com/document/product/215/16702)接口获取。高防EIP、Anycast EIP、精品BGP EIP默认不支持从共享带宽包中移除，其中高防EIP和精品BGP IP可以迁移到其他同线路类型的共享带宽包中。</li><li>LB资源列表：可通过[DescribeLoadBalancers](https://cloud.tencent.com/document/api/214/30685)接口获取。</li>
 	ResourceIds []*string `json:"ResourceIds,omitnil,omitempty" name:"ResourceIds"`
 
 	// 带宽包唯一标识ID，形如'bwp-xxxx'，可以使用[DescribeBandwidthPackages](https://cloud.tencent.com/document/product/215/19209)接口查询BandwidthPackageId。
@@ -34966,6 +35171,12 @@ type ResetTrafficMirrorFilterRequestParams struct {
 
 	// 流量镜像需要过滤的五元组规则
 	CollectorNormalFilters []*TrafficMirrorFilter `json:"CollectorNormalFilters,omitnil,omitempty" name:"CollectorNormalFilters"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
 }
 
 type ResetTrafficMirrorFilterRequest struct {
@@ -34979,6 +35190,12 @@ type ResetTrafficMirrorFilterRequest struct {
 
 	// 流量镜像需要过滤的五元组规则
 	CollectorNormalFilters []*TrafficMirrorFilter `json:"CollectorNormalFilters,omitnil,omitempty" name:"CollectorNormalFilters"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
 }
 
 func (r *ResetTrafficMirrorFilterRequest) ToJsonString() string {
@@ -34996,6 +35213,8 @@ func (r *ResetTrafficMirrorFilterRequest) FromJsonString(s string) error {
 	delete(f, "TrafficMirrorId")
 	delete(f, "NatId")
 	delete(f, "CollectorNormalFilters")
+	delete(f, "IngressFilterRules")
+	delete(f, "EgressFilterRules")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ResetTrafficMirrorFilterRequest has unknown keys!", "")
 	}
@@ -35768,31 +35987,31 @@ type RouteSelectionPolicy struct {
 }
 
 type RouteTable struct {
-	// VPC实例ID。
+	// <p>VPC实例ID。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// 路由表实例ID，例如：rtb-azd4dt1c。
+	// <p>路由表实例ID，例如：rtb-azd4dt1c。</p>
 	RouteTableId *string `json:"RouteTableId,omitnil,omitempty" name:"RouteTableId"`
 
-	// 路由表名称。
+	// <p>路由表名称。</p>
 	RouteTableName *string `json:"RouteTableName,omitnil,omitempty" name:"RouteTableName"`
 
-	// 路由表关联关系。
+	// <p>路由表关联关系。</p>
 	AssociationSet []*RouteTableAssociation `json:"AssociationSet,omitnil,omitempty" name:"AssociationSet"`
 
-	// IPv4路由策略集合。
+	// <p>IPv4路由策略集合。</p>
 	RouteSet []*Route `json:"RouteSet,omitnil,omitempty" name:"RouteSet"`
 
-	// 是否默认路由表。
+	// <p>是否默认路由表。</p>
 	Main *bool `json:"Main,omitnil,omitempty" name:"Main"`
 
-	// 创建时间。
+	// <p>创建时间。</p>
 	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
-	// 标签键值对。
+	// <p>标签键值对。</p>
 	TagSet []*Tag `json:"TagSet,omitnil,omitempty" name:"TagSet"`
 
-	// local路由是否发布云联网。
+	// <p>local路由是否发布云联网。</p>
 	LocalCidrForCcn []*CidrForCcn `json:"LocalCidrForCcn,omitnil,omitempty" name:"LocalCidrForCcn"`
 }
 
@@ -36482,55 +36701,55 @@ func (r *StopTrafficMirrorResponse) FromJsonString(s string) error {
 }
 
 type Subnet struct {
-	// `VPC`实例`ID`。
+	// <p><code>VPC</code>实例<code>ID</code>。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// 子网实例`ID`，例如：subnet-bthucmmy。
+	// <p>子网实例<code>ID</code>，例如：subnet-bthucmmy。</p>
 	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
-	// 子网名称。
+	// <p>子网名称。</p>
 	SubnetName *string `json:"SubnetName,omitnil,omitempty" name:"SubnetName"`
 
-	// 子网的 `IPv4` `CIDR`。
+	// <p>子网的 <code>IPv4</code> <code>CIDR</code>。</p>
 	CidrBlock *string `json:"CidrBlock,omitnil,omitempty" name:"CidrBlock"`
 
-	// 是否默认子网。
+	// <p>是否默认子网。</p>
 	IsDefault *bool `json:"IsDefault,omitnil,omitempty" name:"IsDefault"`
 
-	// 是否开启广播。
+	// <p>是否开启广播。</p>
 	EnableBroadcast *bool `json:"EnableBroadcast,omitnil,omitempty" name:"EnableBroadcast"`
 
-	// 可用区。
+	// <p>可用区。</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// 路由表实例ID，例如：rtb-l2h8d7c2。
+	// <p>路由表实例ID，例如：rtb-l2h8d7c2。</p>
 	RouteTableId *string `json:"RouteTableId,omitnil,omitempty" name:"RouteTableId"`
 
-	// 创建时间。
+	// <p>创建时间。</p>
 	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
-	// 可用`IPv4`数。
+	// <p>可用<code>IPv4</code>数。</p>
 	AvailableIpAddressCount *uint64 `json:"AvailableIpAddressCount,omitnil,omitempty" name:"AvailableIpAddressCount"`
 
-	// 子网的 `IPv6` `CIDR`。
+	// <p>子网的 <code>IPv6</code> <code>CIDR</code>。</p>
 	Ipv6CidrBlock *string `json:"Ipv6CidrBlock,omitnil,omitempty" name:"Ipv6CidrBlock"`
 
-	// 关联`ACL`ID
+	// <p>关联<code>ACL</code>ID</p>
 	NetworkAclId *string `json:"NetworkAclId,omitnil,omitempty" name:"NetworkAclId"`
 
-	// 是否为 `SNAT` 地址池子网。
+	// <p>是否为 <code>SNAT</code> 地址池子网。</p>
 	IsRemoteVpcSnat *bool `json:"IsRemoteVpcSnat,omitnil,omitempty" name:"IsRemoteVpcSnat"`
 
-	// 子网`IPv4`总数。
+	// <p>子网<code>IPv4</code>总数。</p>
 	TotalIpAddressCount *uint64 `json:"TotalIpAddressCount,omitnil,omitempty" name:"TotalIpAddressCount"`
 
-	// 标签键值对。
+	// <p>标签键值对。</p>
 	TagSet []*Tag `json:"TagSet,omitnil,omitempty" name:"TagSet"`
 
-	// CDC实例ID。
+	// <p>CDC实例ID。</p>
 	CdcId *string `json:"CdcId,omitnil,omitempty" name:"CdcId"`
 
-	// 是否是CDC所属子网。0:否 1:是
+	// <p>是否是CDC所属子网。0:否 1:是</p>
 	IsCdcSubnet *int64 `json:"IsCdcSubnet,omitnil,omitempty" name:"IsCdcSubnet"`
 }
 
@@ -36631,6 +36850,12 @@ type TrafficMirror struct {
 
 	// 流量镜接收目标资源信息，当接收目标为ENI和CLB时返回。
 	TargetInfo []*TrafficMirrorTargetResourceInfo `json:"TargetInfo,omitnil,omitempty" name:"TargetInfo"`
+
+	// 流量镜像入站过滤规则。
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// 流量镜像出站过滤规则。
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
 }
 
 type TrafficMirrorFilter struct {
@@ -36648,6 +36873,21 @@ type TrafficMirrorFilter struct {
 
 	// 过滤规则的目的端口，默认值1-65535
 	DstPort *string `json:"DstPort,omitnil,omitempty" name:"DstPort"`
+
+	// 流量镜像过滤规则唯一ID。
+	TrafficMirrorFilterRuleId *string `json:"TrafficMirrorFilterRuleId,omitnil,omitempty" name:"TrafficMirrorFilterRuleId"`
+
+	// 流量镜像过滤规则优先级。
+	Priority *uint64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// 流量镜像过滤规则策略，支持类型："ACCEPT", "DROP"。
+	Action *string `json:"Action,omitnil,omitempty" name:"Action"`
+
+	// 流量镜像过滤规则描述。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// 创建时间。
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 }
 
 type TrafficMirrorTarget struct {
@@ -36705,23 +36945,41 @@ type TrafficPackage struct {
 }
 
 type TrafficQosPolicySet struct {
-	// CCN实例ID。形如：ccn-f49l6u0z。
+	// <p>CCN实例ID。形如：ccn-f49l6u0z。</p>
 	CcnId *string `json:"CcnId,omitnil,omitempty" name:"CcnId"`
 
-	// qos id。
+	// <p>qos id。</p>
 	QosId *uint64 `json:"QosId,omitnil,omitempty" name:"QosId"`
 
-	// 描述。
+	// <p>描述。</p>
 	QosPolicyDescription *string `json:"QosPolicyDescription,omitnil,omitempty" name:"QosPolicyDescription"`
 
-	// 名称。
+	// <p>名称。</p>
 	QosPolicyName *string `json:"QosPolicyName,omitnil,omitempty" name:"QosPolicyName"`
 
-	// 带宽。
+	// <p>带宽。</p>
 	Bandwidth *uint64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
 
-	// 流量调度策略ID。
+	// <p>流量调度策略ID。</p>
 	QosPolicyId *string `json:"QosPolicyId,omitnil,omitempty" name:"QosPolicyId"`
+
+	// <p>服务等级信息</p>
+	QosLevel *string `json:"QosLevel,omitnil,omitempty" name:"QosLevel"`
+
+	// <p>服务等级信息</p>
+	ServiceLevel *string `json:"ServiceLevel,omitnil,omitempty" name:"ServiceLevel"`
+
+	// <p>带宽ID</p><p>参数格式：fcr-xxx</p>
+	RegionFlowControlId *string `json:"RegionFlowControlId,omitnil,omitempty" name:"RegionFlowControlId"`
+
+	// <p>源地域</p><p>参数格式：ap-xxx</p>
+	LocalRegion *string `json:"LocalRegion,omitnil,omitempty" name:"LocalRegion"`
+
+	// <p>目的地域</p><p>参数格式：ap-xxx</p>
+	RemoteRegion *string `json:"RemoteRegion,omitnil,omitempty" name:"RemoteRegion"`
+
+	// <p>流量匹配策略ID</p>
+	TrafficMatchPolicyId *string `json:"TrafficMatchPolicyId,omitnil,omitempty" name:"TrafficMatchPolicyId"`
 }
 
 // Predefined struct for user
@@ -37231,39 +37489,51 @@ func (r *UnlockCcnsResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateTrafficMirrorAllFilterRequestParams struct {
-	// 流量镜像实例ID
+	// <p>流量镜像实例ID</p>
 	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
 
-	// 流量镜像采集方向
+	// <p>流量镜像采集方向</p>
 	Direction *string `json:"Direction,omitnil,omitempty" name:"Direction"`
 
-	// 流量镜像采集对象
+	// <p>流量镜像采集对象</p>
 	CollectorSrcs []*string `json:"CollectorSrcs,omitnil,omitempty" name:"CollectorSrcs"`
 
-	// 流量镜像需要过滤的natgw实例
+	// <p>流量镜像需要过滤的natgw实例</p>
 	NatId *string `json:"NatId,omitnil,omitempty" name:"NatId"`
 
-	// 流量镜像需要过滤的五元组规则
+	// <p>流量镜像需要过滤的五元组规则</p>
 	CollectorNormalFilters []*TrafficMirrorFilter `json:"CollectorNormalFilters,omitnil,omitempty" name:"CollectorNormalFilters"`
+
+	// <p>流量镜像入站过滤规则。</p>
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// <p>流量镜像出站过滤规则。</p>
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
 }
 
 type UpdateTrafficMirrorAllFilterRequest struct {
 	*tchttp.BaseRequest
 	
-	// 流量镜像实例ID
+	// <p>流量镜像实例ID</p>
 	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
 
-	// 流量镜像采集方向
+	// <p>流量镜像采集方向</p>
 	Direction *string `json:"Direction,omitnil,omitempty" name:"Direction"`
 
-	// 流量镜像采集对象
+	// <p>流量镜像采集对象</p>
 	CollectorSrcs []*string `json:"CollectorSrcs,omitnil,omitempty" name:"CollectorSrcs"`
 
-	// 流量镜像需要过滤的natgw实例
+	// <p>流量镜像需要过滤的natgw实例</p>
 	NatId *string `json:"NatId,omitnil,omitempty" name:"NatId"`
 
-	// 流量镜像需要过滤的五元组规则
+	// <p>流量镜像需要过滤的五元组规则</p>
 	CollectorNormalFilters []*TrafficMirrorFilter `json:"CollectorNormalFilters,omitnil,omitempty" name:"CollectorNormalFilters"`
+
+	// <p>流量镜像入站过滤规则。</p>
+	IngressFilterRules []*TrafficMirrorFilter `json:"IngressFilterRules,omitnil,omitempty" name:"IngressFilterRules"`
+
+	// <p>流量镜像出站过滤规则。</p>
+	EgressFilterRules []*TrafficMirrorFilter `json:"EgressFilterRules,omitnil,omitempty" name:"EgressFilterRules"`
 }
 
 func (r *UpdateTrafficMirrorAllFilterRequest) ToJsonString() string {
@@ -37283,6 +37553,8 @@ func (r *UpdateTrafficMirrorAllFilterRequest) FromJsonString(s string) error {
 	delete(f, "CollectorSrcs")
 	delete(f, "NatId")
 	delete(f, "CollectorNormalFilters")
+	delete(f, "IngressFilterRules")
+	delete(f, "EgressFilterRules")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateTrafficMirrorAllFilterRequest has unknown keys!", "")
 	}
@@ -37316,7 +37588,15 @@ type UpdateTrafficMirrorDirectionRequestParams struct {
 	// 流量镜像实例ID
 	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
 
-	// 流量镜像采集方向
+	// 流量镜像采集方向。取值范围：
+	// 
+	// - EGRESS - 出方向采集
+	// 
+	// - INGRESS - 入方向采集
+	// 
+	// - ALL - 出入双向采集
+	// 
+	// - NO-DIRECTION - 不区分采集方向（新模式）。切换为该模式后将不再支持按方向采集，需通过 CreateTrafficMirrorFilterRules 接口创建带方向的过滤规则，过滤规则支持设置优先级和单独编辑。
 	Direction *string `json:"Direction,omitnil,omitempty" name:"Direction"`
 }
 
@@ -37326,7 +37606,15 @@ type UpdateTrafficMirrorDirectionRequest struct {
 	// 流量镜像实例ID
 	TrafficMirrorId *string `json:"TrafficMirrorId,omitnil,omitempty" name:"TrafficMirrorId"`
 
-	// 流量镜像采集方向
+	// 流量镜像采集方向。取值范围：
+	// 
+	// - EGRESS - 出方向采集
+	// 
+	// - INGRESS - 入方向采集
+	// 
+	// - ALL - 出入双向采集
+	// 
+	// - NO-DIRECTION - 不区分采集方向（新模式）。切换为该模式后将不再支持按方向采集，需通过 CreateTrafficMirrorFilterRules 接口创建带方向的过滤规则，过滤规则支持设置优先级和单独编辑。
 	Direction *string `json:"Direction,omitnil,omitempty" name:"Direction"`
 }
 
@@ -37482,52 +37770,52 @@ type UsedDetail struct {
 }
 
 type Vpc struct {
-	// `VPC`名称。
+	// <p><code>VPC</code>名称。</p>
 	VpcName *string `json:"VpcName,omitnil,omitempty" name:"VpcName"`
 
-	// `VPC`实例`ID`，例如：vpc-azd4dt1c。
+	// <p><code>VPC</code>实例<code>ID</code>，例如：vpc-azd4dt1c。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// `VPC`的`IPv4` `CIDR`。
+	// <p><code>VPC</code>的<code>IPv4</code> <code>CIDR</code>。</p>
 	CidrBlock *string `json:"CidrBlock,omitnil,omitempty" name:"CidrBlock"`
 
-	// 是否默认`VPC`。
+	// <p>是否默认<code>VPC</code>。</p>
 	IsDefault *bool `json:"IsDefault,omitnil,omitempty" name:"IsDefault"`
 
-	// 是否开启组播。
+	// <p>是否开启组播。</p>
 	EnableMulticast *bool `json:"EnableMulticast,omitnil,omitempty" name:"EnableMulticast"`
 
-	// 创建时间。
+	// <p>创建时间。</p>
 	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
-	// `DNS`列表。
+	// <p><code>DNS</code>列表。</p>
 	DnsServerSet []*string `json:"DnsServerSet,omitnil,omitempty" name:"DnsServerSet"`
 
-	// `DHCP`域名选项值。
+	// <p><code>DHCP</code>域名选项值。</p>
 	DomainName *string `json:"DomainName,omitnil,omitempty" name:"DomainName"`
 
-	// `DHCP`选项集`ID`。
+	// <p><code>DHCP</code>选项集<code>ID</code>。</p>
 	DhcpOptionsId *string `json:"DhcpOptionsId,omitnil,omitempty" name:"DhcpOptionsId"`
 
-	// 是否开启`DHCP`。
+	// <p>是否开启<code>DHCP</code>。</p>
 	EnableDhcp *bool `json:"EnableDhcp,omitnil,omitempty" name:"EnableDhcp"`
 
-	// `VPC`的`IPv6` `CIDR`。
+	// <p><code>VPC</code>的<code>IPv6</code> <code>CIDR</code>。</p>
 	Ipv6CidrBlock *string `json:"Ipv6CidrBlock,omitnil,omitempty" name:"Ipv6CidrBlock"`
 
-	// 标签键值对
+	// <p>标签键值对</p>
 	TagSet []*Tag `json:"TagSet,omitnil,omitempty" name:"TagSet"`
 
-	// 辅助CIDR
+	// <p>辅助CIDR</p>
 	AssistantCidrSet []*AssistantCidr `json:"AssistantCidrSet,omitnil,omitempty" name:"AssistantCidrSet"`
 
-	// vpc关联云联网时路由发布策略， true：开启cidr路由发布，false：开启subnet子网路由发布。创建vpc时默认为子网路由发布，当选择cidr路由发布时,请通过工单加入白名单
+	// <p>vpc关联云联网时路由发布策略， true：开启cidr路由发布，false：开启subnet子网路由发布。创建vpc时默认为子网路由发布，当选择cidr路由发布时,请通过工单加入白名单</p>
 	EnableRouteVpcPublish *bool `json:"EnableRouteVpcPublish,omitnil,omitempty" name:"EnableRouteVpcPublish"`
 
-	// 返回多运营商IPv6 Cidr Block
+	// <p>返回多运营商IPv6 Cidr Block</p>
 	Ipv6CidrBlockSet []*ISPIPv6CidrBlock `json:"Ipv6CidrBlockSet,omitnil,omitempty" name:"Ipv6CidrBlockSet"`
 
-	// vpc关联云联网时IPv6类型路由发布策略， true：开启cidr路由发布，false：开启subnet子网路由发布。创建vpc时默认为子网路由发布，当选择cidr路由发布时，请通过工单加入白名单。
+	// <p>vpc关联云联网时IPv6类型路由发布策略， true：开启cidr路由发布，false：开启subnet子网路由发布。创建vpc时默认为子网路由发布，当选择cidr路由发布时，请通过工单加入白名单。</p>
 	EnableRouteVpcPublishIpv6 *bool `json:"EnableRouteVpcPublishIpv6,omitnil,omitempty" name:"EnableRouteVpcPublishIpv6"`
 }
 
@@ -37673,68 +37961,71 @@ type VpnConnection struct {
 }
 
 type VpnGateway struct {
-	// 网关实例ID。
+	// <p>网关实例ID。</p>
 	VpnGatewayId *string `json:"VpnGatewayId,omitnil,omitempty" name:"VpnGatewayId"`
 
-	// VPC实例ID。
+	// <p>VPC实例ID。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// 网关实例名称。
+	// <p>网关实例名称。</p>
 	VpnGatewayName *string `json:"VpnGatewayName,omitnil,omitempty" name:"VpnGatewayName"`
 
-	// 网关实例类型：'IPSEC', 'SSL','CCN','SSL_CCN'。
+	// <p>网关实例类型</p><p>枚举值：</p><ul><li>IPSEC： IPSEC VPC类型VPN</li><li>SSL： SSL VPC类型VPN</li><li>CCN： IPSEC CCN类型VPN</li><li>SSL_CCN： SSL CCN类型VPN</li></ul><p>默认值：IPSEC</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 网关实例状态， 'PENDING'：生产中，'PENDING_ERROR'：生产失败，'DELETING'：删除中，'DELETING_ERROR'：删除失败，'AVAILABLE'：运行中。
+	// <p>网关实例状态。</p><p>枚举值：</p><ul><li>PENDING： 生产中</li><li>PENDING_ERROR： 生产失败</li><li>DELETING： 删除中</li><li>DELETING_ERROR： 生产失败</li><li>AVAILABLE： 运行中</li></ul>
 	State *string `json:"State,omitnil,omitempty" name:"State"`
 
-	// 网关公网IP。
+	// <p>网关公网IP。</p>
 	PublicIpAddress *string `json:"PublicIpAddress,omitnil,omitempty" name:"PublicIpAddress"`
 
-	// 网关续费类型：'NOTIFY_AND_MANUAL_RENEW'：手动续费，'NOTIFY_AND_AUTO_RENEW'：自动续费，'NOT_NOTIFY_AND_NOT_RENEW'：到期不续费。
+	// <p>网关续费类型：&#39;NOTIFY_AND_MANUAL_RENEW&#39;：手动续费，&#39;NOTIFY_AND_AUTO_RENEW&#39;：自动续费，&#39;NOT_NOTIFY_AND_NOT_RENEW&#39;：到期不续费。</p>
 	RenewFlag *string `json:"RenewFlag,omitnil,omitempty" name:"RenewFlag"`
 
-	// 网关付费类型：POSTPAID_BY_HOUR：按量计费，PREPAID：包年包月预付费。
+	// <p>网关付费类型：POSTPAID_BY_HOUR：按量计费，PREPAID：包年包月预付费。</p>
 	InstanceChargeType *string `json:"InstanceChargeType,omitnil,omitempty" name:"InstanceChargeType"`
 
-	// 网关出带宽，单位：Mbps。
+	// <p>网关出带宽</p><p>单位：Mbps</p>
 	InternetMaxBandwidthOut *uint64 `json:"InternetMaxBandwidthOut,omitnil,omitempty" name:"InternetMaxBandwidthOut"`
 
-	// 创建时间。
+	// <p>创建时间。</p>
 	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
 
-	// 预付费网关过期时间。
+	// <p>预付费网关过期时间。</p>
 	ExpiredTime *string `json:"ExpiredTime,omitnil,omitempty" name:"ExpiredTime"`
 
-	// 公网IP是否被封堵。
+	// <p>公网IP是否被封堵。</p>
 	IsAddressBlocked *bool `json:"IsAddressBlocked,omitnil,omitempty" name:"IsAddressBlocked"`
 
-	// 计费模式变更，PREPAID_TO_POSTPAID：包年包月预付费到期转按小时后付费。
+	// <p>计费模式变更，PREPAID_TO_POSTPAID：包年包月预付费到期转按小时后付费。</p>
 	NewPurchasePlan *string `json:"NewPurchasePlan,omitnil,omitempty" name:"NewPurchasePlan"`
 
-	// 网关计费状态，PROTECTIVELY_ISOLATED：被安全隔离的实例，NORMAL：正常。
+	// <p>网关计费状态，PROTECTIVELY_ISOLATED：被安全隔离的实例，NORMAL：正常。</p>
 	RestrictState *string `json:"RestrictState,omitnil,omitempty" name:"RestrictState"`
 
-	// 可用区，如：ap-guangzhou-2。
+	// <p>可用区，如：ap-guangzhou-2。</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
-	// 网关带宽配额信息。
+	// <p>网关带宽配额信息。</p>
 	VpnGatewayQuotaSet []*VpnGatewayQuota `json:"VpnGatewayQuotaSet,omitnil,omitempty" name:"VpnGatewayQuotaSet"`
 
-	// 网关实例版本信息。
+	// <p>网关实例版本信息。</p>
 	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
 
-	// Type值为CCN时，该值表示云联网实例ID。
+	// <p>Type值为CCN/SSL_CCN时，该值表示云联网实例ID。</p>
 	NetworkInstanceId *string `json:"NetworkInstanceId,omitnil,omitempty" name:"NetworkInstanceId"`
 
-	// CDC 实例ID。
+	// <p>CDC 实例ID。</p>
 	CdcId *string `json:"CdcId,omitnil,omitempty" name:"CdcId"`
 
-	// SSL-VPN 客户端连接数。
+	// <p>SSL-VPN 客户端连接数。</p>
 	MaxConnection *uint64 `json:"MaxConnection,omitnil,omitempty" name:"MaxConnection"`
 
-	// Bgp ASN
+	// <p>Bgp ASN</p>
 	BgpAsn *uint64 `json:"BgpAsn,omitnil,omitempty" name:"BgpAsn"`
+
+	// <p>标签列表</p>
+	TagSet []*Tag `json:"TagSet,omitnil,omitempty" name:"TagSet"`
 }
 
 type VpnGatewayQuota struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1470,7 +1470,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vdb/v20230616
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod v1.3.127
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vod/v20180717
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.62
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.3.157
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/waf v1.3.144

--- a/website/docs/r/vpc_private_nat_gateway.html.markdown
+++ b/website/docs/r/vpc_private_nat_gateway.html.markdown
@@ -20,6 +20,19 @@ resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
 }
 ```
 
+### Create a private nat gateway with tags.
+
+```hcl
+resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
+  nat_gateway_name = "xxx"
+  vpc_id           = "xxx"
+  tags = {
+    "key1" = "value1"
+    "key2" = "value2"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -27,6 +40,7 @@ The following arguments are supported:
 * `nat_gateway_name` - (Required, String) Private network gateway name.
 * `ccn_id` - (Optional, String) Cloud Connect Network type The Cloud Connect Network instance ID required to be bound to the private network NAT gateway.
 * `cross_domain` - (Optional, Bool) Cross-domain parameters. Cross-domain binding of VPCs is supported only when the value is True.
+* `tags` - (Optional, Map) Tag description of the instance.
 * `vpc_id` - (Optional, String) Private Cloud instance ID. This parameter is required when creating a VPC type private network NAT gateway or a private network NAT gateway of private network gateway.
 * `vpc_type` - (Optional, Bool) VPC type private network NAT gateway. Only when the value is True will a VPC type private network NAT gateway be created.
 

--- a/website/docs/r/vpc_private_nat_gateway.html.markdown
+++ b/website/docs/r/vpc_private_nat_gateway.html.markdown
@@ -4,31 +4,21 @@ layout: "tencentcloud"
 page_title: "TencentCloud: tencentcloud_vpc_private_nat_gateway"
 sidebar_current: "docs-tencentcloud-resource-vpc_private_nat_gateway"
 description: |-
-  Provides a resource to create a vpc private nat gateway
+  Provides a resource to create a VPC private nat gateway
 ---
 
 # tencentcloud_vpc_private_nat_gateway
 
-Provides a resource to create a vpc private nat gateway
+Provides a resource to create a VPC private nat gateway
 
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
-  nat_gateway_name = "xxx"
-  vpc_id           = "xxx"
-}
-```
-
-### Create a private nat gateway with tags.
-
-```hcl
-resource "tencentcloud_vpc_private_nat_gateway" "private_nat_gateway" {
-  nat_gateway_name = "xxx"
-  vpc_id           = "xxx"
+resource "tencentcloud_vpc_private_nat_gateway" "example" {
+  nat_gateway_name = "tf-example"
+  vpc_id           = "vpc-i5yyodl9"
   tags = {
-    "key1" = "value1"
-    "key2" = "value2"
+    createBy = "Terraform"
   }
 }
 ```
@@ -49,14 +39,14 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-
+* `nat_gateway_id` - Private network NAT gateway instance ID.
 
 
 ## Import
 
-vpc private_nat_gateway can be imported using the id, e.g.
+VPC private nat gateway can be imported using the id, e.g.
 
 ```
-terraform import tencentcloud_vpc_private_nat_gateway.private_nat_gateway private_nat_gateway_id
+terraform import tencentcloud_vpc_private_nat_gateway.example intranat-ljdy849x
 ```
 


### PR DESCRIPTION
Add tags parameter to tencentcloud_vpc_private_nat_gateway resource. The tags parameter is a TypeMap and Optional field, which allows users to configure tags for the private NAT gateway during creation. The Create method maps the tags to []*vpc.Tag and sets it to CreatePrivateNatGatewayRequest.Tags. The Read method converts the returned PrivateNatGateway.TagSet to a map and sets it to the schema. The Update method adds tags to immutableArgs, so changing tags requires resource recreation.