### PR TITLE
fix(cfw): [137118095] `tencentcloud_cfw_edge_firewall_switch` support retry

### DIFF
--- a/.changelog/4428.txt
+++ b/.changelog/4428.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_cfw_edge_firewall_switch: support retry
+```

--- a/tencentcloud/services/cfw/resource_tc_cfw_edge_firewall_switch.go
+++ b/tencentcloud/services/cfw/resource_tc_cfw_edge_firewall_switch.go
@@ -74,8 +74,8 @@ func resourceTencentCloudCfwEdgeFirewallSwitchRead(d *schema.ResourceData, meta 
 	}
 
 	if edgeFirewallSwitch == nil {
+		log.Printf("[WARN]%s resource `tencentcloud_cfw_edge_firewall_switch` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
-		log.Printf("[WARN]%s resource `CfwEdgeFirewallSwitch` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		return nil
 	}
 
@@ -135,7 +135,7 @@ func resourceTencentCloudCfwEdgeFirewallSwitchUpdate(d *schema.ResourceData, met
 	})
 
 	if err != nil {
-		log.Printf("[CRITAL]%s update cfw edgeFirewallSwitch failed, reason:%+v", logId, err)
+		log.Printf("[CRITAL]%s update cfw edge firewall switch failed, reason:%+v", logId, err)
 		return err
 	}
 

--- a/tencentcloud/services/cfw/service_tencentcloud_cfw.go
+++ b/tencentcloud/services/cfw/service_tencentcloud_cfw.go
@@ -953,6 +953,7 @@ func (me *CfwService) DescribeCfwEdgeFirewallSwitchById(ctx context.Context, pub
 	logId := tccommon.GetLogId(ctx)
 
 	request := cfw.NewDescribeFwEdgeIpsRequest()
+	response := cfw.NewDescribeFwEdgeIpsResponse()
 	request.Filters = []*cfw.CommonFilter{
 		{
 			Name:         common.StringPtr("PublicIp"),
@@ -960,7 +961,7 @@ func (me *CfwService) DescribeCfwEdgeFirewallSwitchById(ctx context.Context, pub
 			OperatorType: common.Int64Ptr(1),
 		},
 	}
-	request.Limit = helper.Int64(10)
+	request.Limit = helper.Int64(100)
 
 	defer func() {
 		if errRet != nil {
@@ -968,15 +969,27 @@ func (me *CfwService) DescribeCfwEdgeFirewallSwitchById(ctx context.Context, pub
 		}
 	}()
 
-	ratelimit.Check(request.GetAction())
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, e := me.client.UseCfwClient().DescribeFwEdgeIps(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
 
-	response, err := me.client.UseCfwClient().DescribeFwEdgeIps(request)
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe fw edgeIps failed, Response is nil."))
+		}
+
+		response = result
+		return nil
+	})
+
 	if err != nil {
 		errRet = err
 		return
 	}
-
-	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
 
 	if len(response.Response.Data) < 1 {
 		return


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
