### PR TITLE
fix(as): [137200640] `tencentcloud_as_scaling_group` support new fields

### DIFF
--- a/.changelog/4432.txt
+++ b/.changelog/4432.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloudtencentcloud_as_scaling_group: support new fields
+```

--- a/tencentcloud/services/as/resource_tc_as_scaling_group.go
+++ b/tencentcloud/services/as/resource_tc_as_scaling_group.go
@@ -213,8 +213,33 @@ func ResourceTencentCloudAsScalingGroup() *schema.Resource {
 				Optional:    true,
 				Description: "Tags of a scaling group.",
 			},
+			"multi_zone_subnet_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: tccommon.ValidateAllowedStringValue([]string{MultiZoneSubnetPolicyPriority,
+					MultiZoneSubnetPolicyEquality}),
+				Description: "Multi zone or subnet strategy, Valid values: `PRIORITY` and `EQUALITY`.",
+			},
+			"instance_allocation_policy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Description: "Instance allocation strategy, with values including `LAUNCH_CONFIGURATION` and `SPOT_MIXED`, defaults to `LAUNCH_CONFIGURATION`.\n`LAUNCH_CONFIGURATION`: Represents the traditional startup configuration mode;\n`SPOT_MIXED`: Representing the bidding mixed mode. At present, only hybrid mode is supported when the startup configuration is set to pay by volume mode. In hybrid mode, the scaling group will expand according to the set pay by volume or bidding models. When using hybrid mode, the billing type of the associated startup configuration cannot be modified.",
+			},
+			"concurrent_scale_out_for_desired_capacity": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "The concurrent expansion function that matches the expected number cannot be set when `instance_allocation_policy` is in bidding `SPOT_MIXED` mode, nor can it be set when `scaling_mode` is in expansion priority boot mode(`WAKE_UP_STOPPED_SCALING`). At present, only two matching expected expansion activities are supported concurrently, and other types of activities such as specified quantity expansion and contraction are not supported. The default value is False, indicating that it is not turned on.",
+			},
 
 			// computed value
+			"auto_scaling_group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of a scaling group.",
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -229,13 +254,6 @@ func ResourceTencentCloudAsScalingGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The time when the AS group was created.",
-			},
-			"multi_zone_subnet_policy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: tccommon.ValidateAllowedStringValue([]string{MultiZoneSubnetPolicyPriority,
-					MultiZoneSubnetPolicyEquality}),
-				Description: "Multi zone or subnet strategy, Valid values: PRIORITY and EQUALITY.",
 			},
 		},
 	}
@@ -376,6 +394,14 @@ func resourceTencentCloudAsScalingGroupCreate(d *schema.ResourceData, meta inter
 		}
 	}
 
+	if v, ok := d.GetOk("instance_allocation_policy"); ok {
+		request.InstanceAllocationPolicy = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOkExists("concurrent_scale_out_for_desired_capacity"); ok {
+		request.ConcurrentScaleOutForDesiredCapacity = helper.Bool(v.(bool))
+	}
+
 	var id string
 	if err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		ratelimit.Check(request.GetAction())
@@ -508,6 +534,18 @@ func resourceTencentCloudAsScalingGroupRead(d *schema.ResourceData, meta interfa
 		_ = d.Set("forward_balancer_ids", forwardLoadBalancers)
 	}
 
+	if scalingGroup.InstanceAllocationPolicy != nil {
+		_ = d.Set("instance_allocation_policy", scalingGroup.InstanceAllocationPolicy)
+	}
+
+	if scalingGroup.ConcurrentScaleOutForDesiredCapacity != nil {
+		_ = d.Set("concurrent_scale_out_for_desired_capacity", scalingGroup.ConcurrentScaleOutForDesiredCapacity)
+	}
+
+	if scalingGroup.AutoScalingGroupId != nil {
+		_ = d.Set("auto_scaling_group_id", scalingGroup.AutoScalingGroupId)
+	}
+
 	tcClient := meta.(tccommon.ProviderMeta).GetAPIV3Conn()
 	tagService := svctag.NewTagService(tcClient)
 	tags, err := tagService.DescribeResourceTags(ctx, "as", "auto-scaling-group", tcClient.Region, d.Id())
@@ -637,32 +675,48 @@ func resourceTencentCloudAsScalingGroupUpdate(d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("health_check_type") || d.HasChange("lb_health_check_grace_period") {
+		updateAttrs = append(updateAttrs, "health_check_type", "lb_health_check_grace_period")
 		request.HealthCheckType = helper.String(d.Get("health_check_type").(string))
 		if v, ok := d.GetOkExists("lb_health_check_grace_period"); ok {
 			request.LoadBalancerHealthCheckGracePeriod = helper.IntUint64(v.(int))
 		}
 	}
 
-	if err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-		ratelimit.Check(request.GetAction())
+	if d.HasChange("instance_allocation_policy") {
+		updateAttrs = append(updateAttrs, "instance_allocation_policy")
+		if v, ok := d.GetOk("instance_allocation_policy"); ok {
+			request.InstanceAllocationPolicy = helper.String(v.(string))
+		}
+	}
 
-		response, err := client.UseAsClient().ModifyAutoScalingGroup(request)
-		if err != nil {
-			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
-				logId, request.GetAction(), request.ToJsonString(), err.Error())
-			return tccommon.RetryError(err)
+	if d.HasChange("concurrent_scale_out_for_desired_capacity") {
+		updateAttrs = append(updateAttrs, "concurrent_scale_out_for_desired_capacity")
+		if v, ok := d.GetOkExists("concurrent_scale_out_for_desired_capacity"); ok {
+			request.ConcurrentScaleOutForDesiredCapacity = helper.Bool(v.(bool))
 		}
 
-		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
-			logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+	}
 
-		return nil
-	}); err != nil {
-		return err
+	if len(updateAttrs) > 0 {
+		if err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			ratelimit.Check(request.GetAction())
+			response, err := client.UseAsClient().ModifyAutoScalingGroup(request)
+			if err != nil {
+				log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+					logId, request.GetAction(), request.ToJsonString(), err.Error())
+				return tccommon.RetryError(err)
+			}
+
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 
 	updateAttrs = updateAttrs[:0]
-
 	balancerRequest := as.NewModifyLoadBalancersRequest()
 	balancerRequest.AutoScalingGroupId = &scalingGroupId
 	if d.HasChange("load_balancer_ids") {
@@ -771,7 +825,7 @@ func resourceTencentCloudAsScalingGroupDelete(d *schema.ResourceData, meta inter
 		}
 	}
 
-	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		if errRet := asService.DeleteScalingGroup(ctx, scalingGroupId); errRet != nil {
 			if sdkErr, ok := errRet.(*sdkErrors.TencentCloudSDKError); ok {
 				if sdkErr.Code == AsScalingGroupNotFound {

--- a/tencentcloud/services/as/resource_tc_as_scaling_group.md
+++ b/tencentcloud/services/as/resource_tc_as_scaling_group.md
@@ -117,8 +117,8 @@ resource "tencentcloud_as_scaling_group" "example" {
 
 Import
 
-AutoScaling Groups can be imported using the id, e.g.
+Auto scaling Group can be imported using the id, e.g.
 
 ```
-$ terraform import tencentcloud_as_scaling_group.example asg-n32ymck2
+terraform import tencentcloud_as_scaling_group.example asg-n32ymck2
 ```

--- a/website/docs/r/as_scaling_group.html.markdown
+++ b/website/docs/r/as_scaling_group.html.markdown
@@ -135,14 +135,18 @@ The following arguments are supported:
 * `min_size` - (Required, Int) Minimum number of CVM instances. Valid value ranges: (0~2000).
 * `scaling_group_name` - (Required, String) Name of a scaling group.
 * `vpc_id` - (Required, String) ID of VPC network.
+* `concurrent_scale_out_for_desired_capacity` - (Optional, Bool) The concurrent expansion function that matches the expected number cannot be set when `instance_allocation_policy` is in bidding `SPOT_MIXED` mode, nor can it be set when `scaling_mode` is in expansion priority boot mode(`WAKE_UP_STOPPED_SCALING`). At present, only two matching expected expansion activities are supported concurrently, and other types of activities such as specified quantity expansion and contraction are not supported. The default value is False, indicating that it is not turned on.
 * `default_cooldown` - (Optional, Int) Default cooldown time in second, and default value is `300`.
 * `desired_capacity_sync_with_max_min_size` - (Optional, Bool) The expected number of instances is synchronized with the maximum and minimum values. The default value is `False`. This parameter is effective only in the scenario where the expected number is not passed in when modifying the scaling group interface. True: When modifying the maximum or minimum value, if there is a conflict with the current expected number, the expected number is adjusted synchronously. For example, when modifying, if the minimum value 2 is passed in and the current expected number is 1, the expected number is adjusted synchronously to 2; False: When modifying the maximum or minimum value, if there is a conflict with the current expected number, an error message is displayed indicating that the modification is not allowed.
 * `desired_capacity` - (Optional, Int) Desired volume of CVM instances, which is between `max_size` and `min_size`.
 * `forward_balancer_ids` - (Optional, Set) List of application load balancers, which can't be specified with `load_balancer_ids` together.
 * `health_check_type` - (Optional, String) Health check type of instances in a scaling group.<br><li>CVM: confirm whether an instance is healthy based on the network status. If the pinged instance is unreachable, the instance will be considered unhealthy. For more information, see [Instance Health Check](https://intl.cloud.tencent.com/document/product/377/8553?from_cn_redirect=1)<br><li>CLB: confirm whether an instance is healthy based on the CLB health check status. For more information, see [Health Check Overview](https://intl.cloud.tencent.com/document/product/214/6097?from_cn_redirect=1).<br>If the parameter is set to `CLB`, the scaling group will check both the network status and the CLB health check status. If the network check indicates unhealthy, the `HealthStatus` field will return `UNHEALTHY`. If the CLB health check indicates unhealthy, the `HealthStatus` field will return `CLB_UNHEALTHY`. If both checks indicate unhealthy, the `HealthStatus` field will return `UNHEALTHY|CLB_UNHEALTHY`. Default value: `CLB`.
+* `instance_allocation_policy` - (Optional, String) Instance allocation strategy, with values including `LAUNCH_CONFIGURATION` and `SPOT_MIXED`, defaults to `LAUNCH_CONFIGURATION`.
+`LAUNCH_CONFIGURATION`: Represents the traditional startup configuration mode;
+`SPOT_MIXED`: Representing the bidding mixed mode. At present, only hybrid mode is supported when the startup configuration is set to pay by volume mode. In hybrid mode, the scaling group will expand according to the set pay by volume or bidding models. When using hybrid mode, the billing type of the associated startup configuration cannot be modified.
 * `lb_health_check_grace_period` - (Optional, Int) Grace period of the CLB health check during which the `IN_SERVICE` instances added will not be marked as `CLB_UNHEALTHY`.<br>Valid range: 0-7200, in seconds. Default value: `0`.
 * `load_balancer_ids` - (Optional, List: [`String`]) ID list of traditional load balancers.
-* `multi_zone_subnet_policy` - (Optional, String) Multi zone or subnet strategy, Valid values: PRIORITY and EQUALITY.
+* `multi_zone_subnet_policy` - (Optional, String) Multi zone or subnet strategy, Valid values: `PRIORITY` and `EQUALITY`.
 * `priority_scale_in_unhealthy` - (Optional, Bool) Whether to enable priority for unhealthy instances during scale-in operations. If set to `true`, unhealthy instances will be removed first when scaling in.
 * `project_id` - (Optional, Int) Specifies to which project the scaling group belongs.
 * `replace_load_balancer_unhealthy` - (Optional, Bool) Enable unhealthy instance replacement. If set to `true`, AS will replace instances that are found unhealthy in the CLB health check.
@@ -172,6 +176,7 @@ The `target_attribute` object of `forward_balancer_ids` supports the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
+* `auto_scaling_group_id` - ID of a scaling group.
 * `create_time` - The time when the AS group was created.
 * `instance_count` - Instance number of a scaling group.
 * `status` - Current status of a scaling group.
@@ -179,9 +184,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-AutoScaling Groups can be imported using the id, e.g.
+Auto scaling Group can be imported using the id, e.g.
 
 ```
-$ terraform import tencentcloud_as_scaling_group.example asg-n32ymck2
+terraform import tencentcloud_as_scaling_group.example asg-n32ymck2
 ```
 


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
