### PR TITLE
feat(cls): [137269841] add tencentcloud_cls_metric_subscribe resource

### DIFF
--- a/.changelog/4437.txt
+++ b/.changelog/4437.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_cls_metric_subscribe
+```

--- a/go.mod
+++ b/go.mod
@@ -45,8 +45,8 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.160
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.160
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30

--- a/go.sum
+++ b/go.sum
@@ -921,8 +921,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150 h1:2X+xqin
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150/go.mod h1:CHHOG5L7otIpZ7/vezeb8JpKH80pcD1UWiKLHsA8q5o=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40 h1:bhPBpfz0w3mdVyEolvXrtELUf+gE00O0WnAYIHZq70s=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40/go.mod h1:taTki0q8SHBIUFhjtnDA5UkiVic/WaPQzTqoXeGH3Ns=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156 h1:ZJFNFbOfG76X9KlwK7AbcdkBcwfFWig7IS9SZvatPQ8=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156/go.mod h1:oTXIO50jAekHXp0oQcgGN1znG5u4clgQu4ilsgcBRY0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.160 h1:cCcgpusJ/z+9Js/SKiEnMAqFbCdAVAO0DGngc+S04aI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.160/go.mod h1:nZH+l2W7cPVP3ZdZRVPQv+Cfkzd9Z9dWYvzqytTUP+k=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.414/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.486/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.533/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
@@ -1003,8 +1003,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.151/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157 h1:sGxZxR4mE1Qi2Qs57PwR+8aiSCZD4tbmoTdIdhD3c9g=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.160 h1:Bc6pIWV+MpyUEiloajqRh3U7tKnYPvQQg11CQ3r7SJo=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.160/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=

--- a/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/design.md
+++ b/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/design.md
@@ -1,0 +1,102 @@
+## Context
+
+CLS (日志服务) 提供指标订阅功能，可将日志主题中的指标数据采集并订阅到云监控。当前 Terraform Provider 缺少对该功能的管理，用户只能通过控制台或 API 手动操作。
+
+本次新增 `tencentcloud_cls_metric_subscribe` 资源 (RESOURCE_KIND_GENERAL)，使用 CLS API v20201016 的 `CreateMetricSubscribe`、`DescribeMetricSubscribes`、`ModifyMetricSubscribe`、`DeleteMetricSubscribe` 四个接口实现完整 CRUD。
+
+代码风格严格参考 `tencentcloud/services/igtm/resource_tc_igtm_strategy.go` 资源。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 实现 `tencentcloud_cls_metric_subscribe` 资源的完整 CRUD (Create/Read/Update/Delete)
+- 支持 import 导入 (使用复合 ID `topicId#taskId`)
+- 支持所有云 API 定义的参数: name、topic_id、namespace、metrics (嵌套)、instance_info (嵌套)、enable、task_id (computed)、status (computed)、create_time (computed)、update_time (computed)
+- 在 provider.go 和 provider.md 中注册资源
+- 生成对应的 .md 文档和单元测试文件
+
+**Non-Goals:**
+- 不实现数据源 (RESOURCE_KIND_DATASOURCE)
+- 不修改任何现有资源的 schema
+- 不涉及 website/ 目录文件的直接修改 (由 `make doc` 在收尾阶段生成)
+
+## Decisions
+
+### 1. 资源 ID 格式: 复合 ID `topicId#taskId`
+
+**理由**: Create 接口出参为 `TaskId`，但 Read (DescribeMetricSubscribes) 接口入参需要 `TopicId` + `Filters` (按 taskId 过滤)。Delete 和 Modify 接口同时需要 `TopicId` 和 `TaskId`。因此使用复合 ID `topicId#taskId` (以 `tccommon.FILED_SP` 分隔)，在 Read/Update/Delete 中拆分获取两个值。
+
+**import 说明**: 因为使用复合 ID，在 .md 文档 import 示例中需说明使用 `topicId#taskId` 格式。
+
+### 2. Schema 字段设计
+
+根据云 API 的请求/响应结构定义以下 schema:
+
+**顶层字段:**
+| 字段 | 类型 | Required | ForceNew | Computed | 说明 |
+|------|------|----------|----------|----------|------|
+| `name` | TypeString | Yes | No | No | 订阅任务名称 |
+| `topic_id` | TypeString | Yes | Yes | No | 日志主题 ID (CRUD 均需此字段，ForceNew) |
+| `namespace` | TypeString | Yes | No | No | 云产品命名空间 |
+| `metrics` | TypeList | Yes | No | No | 指标配置信息 (嵌套) |
+| `instance_info` | TypeList (MaxItems=1) | Yes | No | No | 实例配置信息 (嵌套) |
+| `enable` | TypeInt | Optional | No | No | 任务开关: 1 暂停, 2 启用 |
+| `task_id` | TypeString | Computed | No | Yes | 订阅任务 ID (创建后返回) |
+| `status` | TypeInt | Computed | No | Yes | 运行状态: 0 创建中, 1 暂停, 2 运行中, 3 异常 |
+| `create_time` | TypeInt | Computed | No | Yes | 创建时间 (秒级时间戳) |
+| `update_time` | TypeInt | Computed | No | Yes | 更新时间 (秒级时间戳) |
+
+**`metrics` 嵌套结构 (MetricConfig):**
+| 字段 | 类型 | Required | 说明 |
+|------|------|----------|------|
+| `metric_name` | TypeString | Yes | 指标名称 |
+| `periods` | TypeList(TypeInt) | Optional | 统计周期 (秒) |
+| `metric_labels` | TypeList | Optional | 自定义指标标签 (嵌套) |
+
+**`metrics.metric_labels` 嵌套结构 (MetricLabel):**
+| 字段 | 类型 | Required | 说明 |
+|------|------|----------|------|
+| `key` | TypeString | Yes | 指标标签名称 |
+| `value` | TypeString | Yes | 指标标签内容 |
+
+**`instance_info` 嵌套结构 (InstanceConfig):**
+| 字段 | 类型 | Required | 说明 |
+|------|------|----------|------|
+| `instance_dimension` | TypeList(TypeString) | Optional | 实例维度 |
+| `instances` | TypeList | Optional | 实例值列表 (嵌套) |
+
+**`instance_info.instances` 嵌套结构 (Instance):**
+| 字段 | 类型 | Required | 说明 |
+|------|------|----------|------|
+| `values` | TypeList(TypeString) | Optional | 实例信息值列表 |
+
+### 3. `topic_id` 设为 ForceNew
+
+**理由**: `topic_id` 在 Create 中是必填入参，且 Read/Update/Delete 接口均需此字段。由于 `ModifyMetricSubscribe` 中 `TopicId` 是必填但语义为"指定要修改的任务所属主题"，不支持将任务迁移到其他主题。将 `topic_id` 设为 ForceNew，变更时重建资源。
+
+### 4. Read 接口实现: 通过 DescribeMetricSubscribes + Filter 查询
+
+**理由**: 云 API 没有提供单条查询接口 `DescribeMetricSubscribe`，只有列表查询接口 `DescribeMetricSubscribes`。Read 实现时使用 `TopicId` + `Filters` (Key=taskId, Values=[taskId]) 进行过滤查询，从返回的 `Datas` 列表中取第一条匹配记录。
+
+分页参数 `Limit` 设为云 API 注释中的最大值 100，`Offset` 设为 0。
+
+### 5. Update 实现: 使用 ModifyMetricSubscribe
+
+Update 方法中，检查 `name`、`namespace`、metrics`、`instance_info`、`enable` 字段是否有变更。任一变更则调用 `ModifyMetricSubscribe` 接口 (传入 `TopicId` + `TaskId` + 变更字段)。
+
+### 6. Service 层: 新增 `DescribeClsMetricSubscribeById`
+
+在 `service_tencentcloud_cls.go` 中新增方法，封装 `DescribeMetricSubscribes` 调用逻辑 (带 `tccommon.ReadRetryTimeout` 重试)，通过 TopicId + taskId 过滤返回单条 `MetricSubscribeInfo`。
+
+### 7. 错误处理与重试
+
+- Create/Update/Delete: 使用 `tccommon.WriteRetryTimeout` 作为超时进行重试，失败时用 `tccommon.RetryError()` 包装错误
+- Read: 使用 `tccommon.ReadRetryTimeout` 作为超时进行重试
+- Create 完成后检查返回值 `TaskId` 是否为空，为空则返回 `NonRetryableError`
+- Read 中若 API 返回空列表，先打印 `log.Printf("[CRUD] cls_metric_subscribe id=%s", d.Id())` 再 `d.SetId("")`
+
+## Risks / Trade-offs
+
+- **[Read 依赖列表查询接口]** → 通过 `Filters` 按 taskId 精确过滤，且 `Limit` 设为最大值 100 降低漏数据风险；若返回空列表则清理 state (SetId(""))
+- **[嵌套结构较深]** → metrics 内含 metric_labels，instance_info 内含 instances，层级较深。严格按 igtm_strategy 风格逐层展开，保证 set/read 逻辑清晰
+- **[enable 字段在 Create 中无对应入参]** → Create 接口 (`CreateMetricSubscribeRequest`) 不包含 `enable` 参数，新建任务默认状态由云 API 决定。`enable` 字段在 schema 中设为 Optional，仅在 Update 时通过 `ModifyMetricSubscribe` 设置

--- a/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/proposal.md
+++ b/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+CLS (日志服务) 提供了指标订阅 (Metric Subscribe) 功能，允许用户将日志主题中的指标数据订阅并采集到云监控。当前 Terraform Provider 中没有 `tencentcloud_cls_metric_subscribe` 资源，用户无法通过 Terraform 管理指标订阅配置的完整生命周期 (创建、读取、更新、删除)，只能通过控制台或 API 手动操作，导致基础设施漂移且无法统一管理。
+
+## What Changes
+
+- 新增 RESOURCE_KIND_GENERAL 资源 `tencentcloud_cls_metric_subscribe`，支持完整的 CRUD 操作
+- 资源使用 CLS API v20201016 的以下接口:
+  - `CreateMetricSubscribe` — 创建指标订阅配置
+  - `DescribeMetricSubscribes` — 查询指标订阅配置 (用于 Read)
+  - `ModifyMetricSubscribe` — 修改指标订阅配置 (用于 Update)
+  - `DeleteMetricSubscribe` — 删除指标订阅配置
+- 资源使用复合 ID 格式: `topicId#taskId` (由 `tccommon.FILED_SP` 分隔)
+- 在 `tencentcloud/provider.go` 和 `tencentcloud/provider.md` 中注册新资源
+- 生成对应的单元测试文件 (使用 gomonkey mock 云 API)
+- 生成对应的 `.md` 文档
+
+## Capabilities
+
+### New Capabilities
+- `cls-metric-subscribe`: CLS 指标订阅资源配置管理，包括名称、日志主题 ID、云产品命名空间、指标配置信息、实例配置信息、任务开关等参数的增删改查
+
+### Modified Capabilities
+<!-- 无修改的已有能力 -->
+
+## Impact
+
+- **新增文件**:
+  - `tencentcloud/services/cls/resource_tc_cls_metric_subscribe.go` — 资源 CRUD 实现
+  - `tencentcloud/services/cls/resource_tc_cls_metric_subscribe.md` — 资源文档
+  - `tencentcloud/services/cls/resource_tc_cls_metric_subscribe_test.go` — 单元测试
+- **修改文件**:
+  - `tencentcloud/services/cls/service_tencentcloud_cls.go` — 新增 `DescribeClsMetricSubscribeById` 方法
+  - `tencentcloud/provider.go` — 注册 `tencentcloud_cls_metric_subscribe` 资源
+  - `tencentcloud/provider.md` — 添加资源文档条目
+- **API 依赖**: CLS API v20201016 (`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016`)
+- **兼容性**: 向后兼容，纯新增资源，不影响现有资源

--- a/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/specs/cls-metric-subscribe/spec.md
+++ b/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/specs/cls-metric-subscribe/spec.md
@@ -1,0 +1,123 @@
+## ADDED Requirements
+
+### Requirement: Resource schema definition
+
+The system SHALL provide a Terraform resource `tencentcloud_cls_metric_subscribe` with the following top-level schema fields:
+- `name` (Required, string): 订阅任务名称，长度不超过64字符
+- `topic_id` (Required, string, ForceNew): 日志主题 ID
+- `namespace` (Required, string): 云产品命名空间
+- `metrics` (Required, list): 指标配置信息列表
+- `instance_info` (Required, list, MaxItems=1): 实例配置信息
+- `enable` (Optional, int): 任务开关，1 暂停 / 2 启用
+- `task_id` (Computed, string): 订阅任务 ID
+- `status` (Computed, int): 运行状态，0 创建中 / 1 暂停 / 2 运行中 / 3 异常
+- `create_time` (Computed, int): 创建时间（秒级时间戳）
+- `update_time` (Computed, int): 更新时间（秒级时间戳）
+
+#### Scenario: Schema contains all required fields
+- **WHEN** the resource schema is defined
+- **THEN** the schema SHALL include `name`, `topic_id`, `namespace`, `metrics`, `instance_info` as Required fields and `task_id`, `status`, `create_time`, `update_time` as Computed fields
+
+#### Scenario: topic_id is ForceNew
+- **WHEN** the user changes `topic_id` on an existing resource
+- **THEN** Terraform SHALL destroy and recreate the resource rather than update in place
+
+### Requirement: Nested metrics schema
+
+The `metrics` field SHALL be a TypeList of `MetricConfig` objects with the following nested schema:
+- `metric_name` (Required, string): 指标名称
+- `periods` (Optional, list of int): 统计周期（秒）
+- `metric_labels` (Optional, list): 自定义指标标签
+
+The `metric_labels` nested list SHALL contain:
+- `key` (Required, string): 指标标签名称
+- `value` (Required, string): 指标标签内容
+
+#### Scenario: Metrics list with metric labels
+- **WHEN** the user provides a metrics block with metric_name, periods, and metric_labels
+- **THEN** the system SHALL correctly map these to the cloud API `MetricConfig` structure
+
+### Requirement: Nested instance_info schema
+
+The `instance_info` field SHALL be a TypeList with MaxItems=1 of `InstanceConfig` objects with the following nested schema:
+- `instance_dimension` (Optional, list of string): 实例维度
+- `instances` (Optional, list): 实例值列表
+
+The `instances` nested list SHALL contain:
+- `values` (Optional, list of string): 实例信息值列表
+
+#### Scenario: Instance info with dimensions and instances
+- **WHEN** the user provides an instance_info block with instance_dimension and instances
+- **THEN** the system SHALL correctly map these to the cloud API `InstanceConfig` structure
+
+### Requirement: Create operation
+
+The system SHALL implement a Create function that calls the `CreateMetricSubscribe` API with `Name`, `TopicId`, `Namespace`, `Metrics`, `InstanceInfo` parameters and sets the resource ID to the composite format `topicId#taskId` (using `tccommon.FILED_SP` as separator).
+
+#### Scenario: Successful creation
+- **WHEN** the user creates a `tencentcloud_cls_metric_subscribe` resource with all required fields
+- **THEN** the system SHALL call `CreateMetricSubscribe`, retrieve the returned `TaskId`, and set the resource ID to `topicId#taskId`
+
+#### Scenario: Create returns empty TaskId
+- **WHEN** the `CreateMetricSubscribe` API returns an empty `TaskId`
+- **THEN** the system SHALL return a `NonRetryableError` to avoid writing an empty ID into state
+
+### Requirement: Read operation
+
+The system SHALL implement a Read function that calls the `DescribeMetricSubscribes` API with `TopicId` and a `Filter` (Key=taskId, Values=[taskId]) to query the resource, then populates the state from the first matching `MetricSubscribeInfo` record.
+
+#### Scenario: Resource exists
+- **WHEN** the Read function queries the resource by topicId and taskId
+- **THEN** the system SHALL populate all schema fields from the returned `MetricSubscribeInfo` including computed fields `task_id`, `status`, `create_time`, `update_time`
+
+#### Scenario: Resource not found
+- **WHEN** the `DescribeMetricSubscribes` API returns an empty list
+- **THEN** the system SHALL log the resource ID and call `d.SetId("")` to remove the resource from state
+
+### Requirement: Update operation
+
+The system SHALL implement an Update function that calls the `ModifyMetricSubscribe` API when any of `name`, `namespace`, `metrics`, `instance_info`, `enable` fields change, passing `TopicId` and `TaskId` as required identifiers along with the changed fields.
+
+#### Scenario: Update name
+- **WHEN** the user changes the `name` field
+- **THEN** the system SHALL call `ModifyMetricSubscribe` with the new `Name` value, along with `TopicId` and `TaskId`
+
+#### Scenario: Update enable status
+- **WHEN** the user changes the `enable` field
+- **THEN** the system SHALL call `ModifyMetricSubscribe` with the new `Enable` value
+
+### Requirement: Delete operation
+
+The system SHALL implement a Delete function that calls the `DeleteMetricSubscribe` API with `TaskId` and `TopicId` parameters.
+
+#### Scenario: Successful deletion
+- **WHEN** the user destroys the resource
+- **THEN** the system SHALL call `DeleteMetricSubscribe` with `TaskId` and `TopicId` extracted from the composite resource ID
+
+### Requirement: Import support
+
+The resource SHALL support Terraform import using the composite ID format `topicId#taskId`.
+
+#### Scenario: Import by composite ID
+- **WHEN** the user runs `terraform import tencentcloud_cls_metric_subscribe.example topicId#taskId`
+- **THEN** the system SHALL parse the composite ID, call Read, and populate the resource state
+
+### Requirement: Provider registration
+
+The system SHALL register the `tencentcloud_cls_metric_subscribe` resource in `tencentcloud/provider.go` and add the corresponding entry in `tencentcloud/provider.md`.
+
+#### Scenario: Resource registered in provider
+- **WHEN** the provider is initialized
+- **THEN** the resource `tencentcloud_cls_metric_subscribe` SHALL be available for use in Terraform configurations
+
+### Requirement: Error handling and retry
+
+All CRUD operations SHALL use appropriate retry timeouts (`tccommon.WriteRetryTimeout` for Create/Update/Delete, `tccommon.ReadRetryTimeout` for Read) and wrap API errors with `tccommon.RetryError()`.
+
+#### Scenario: API transient failure during create
+- **WHEN** the `CreateMetricSubscribe` API returns a transient error
+- **THEN** the system SHALL retry within the `WriteRetryTimeout` period before failing
+
+#### Scenario: API transient failure during read
+- **WHEN** the `DescribeMetricSubscribes` API returns a transient error
+- **THEN** the system SHALL retry within the `ReadRetryTimeout` period before failing

--- a/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/tasks.md
+++ b/openspec/changes/archive/2026-08-18-add-cls-metric-subscribe-resource/tasks.md
@@ -1,0 +1,32 @@
+## 1. Service Layer
+
+- [x] 1.1 在 `tencentcloud/services/cls/service_tencentcloud_cls.go` 中新增 `DescribeClsMetricSubscribeById` 方法，封装 `DescribeMetricSubscribes` API 调用（带 `tccommon.ReadRetryTimeout` 重试），通过 TopicId + Filter(taskId) 查询单条 `MetricSubscribeInfo`
+
+## 2. Resource Schema & CRUD
+
+- [x] 2.1 创建 `tencentcloud/services/cls/resource_tc_cls_metric_subscribe.go`，定义 `ResourceTencentCloudClsMetricSubscribe()` schema，包含顶层字段 `name`、`topic_id`(ForceNew)、`namespace`、`metrics`(嵌套)、`instance_info`(嵌套)、`enable`、以及 computed 字段 `task_id`、`status`、`create_time`、`update_time`
+- [x] 2.2 定义 `metrics` 嵌套 schema（`metric_name`、`periods`、`metric_labels` 嵌套含 `key`/`value`）
+- [x] 2.3 定义 `instance_info` 嵌套 schema（`instance_dimension`、`instances` 嵌套含 `values`），MaxItems=1
+- [x] 2.4 实现 `resourceTencentCloudClsMetricSubscribeCreate`：构建 `CreateMetricSubscribeRequest`，设置 Name/TopicId/Namespace/Metrics/InstanceInfo，调用 API（WriteRetryTimeout 重试），检查返回 TaskId 非空，设置复合 ID `topicId#taskId`，调用 Read 刷新
+- [x] 2.5 实现 `resourceTencentCloudClsMetricSubscribeRead`：拆分复合 ID 获取 topicId/taskId，调用 `DescribeClsMetricSubscribeById`，判空后打印日志并 SetId("")，将返回的 MetricSubscribeInfo 字段 set 到 state（含 computed 字段）
+- [x] 2.6 实现 `resourceTencentCloudClsMetricSubscribeUpdate`：拆分复合 ID，检查 name/namespace/metrics/instance_info/enable 变更，构建 `ModifyMetricSubscribeRequest`（含 TopicId/TaskId），调用 API（WriteRetryTimeout 重试），调用 Read 刷新
+- [x] 2.7 实现 `resourceTencentCloudClsMetricSubscribeDelete`：拆分复合 ID，构建 `DeleteMetricSubscribeRequest`（含 TaskId/TopicId），调用 API（WriteRetryTimeout 重试）
+- [x] 2.8 在资源定义中注册 Importer（`schema.ImportStatePassthrough`）
+
+## 3. Provider Registration
+
+- [x] 3.1 在 `tencentcloud/provider.go` 的 resources map 中注册 `tencentcloud_cls_metric_subscribe` → `cls.ResourceTencentCloudClsMetricSubscribe()`
+- [x] 3.2 在 `tencentcloud/provider.md` 中添加 `tencentcloud_cls_metric_subscribe` 资源条目
+
+## 4. Documentation
+
+- [x] 4.1 创建 `tencentcloud/services/cls/resource_tc_cls_metric_subscribe.md`，包含一句话描述（带 CLS 产品名）、Example Usage（含 metrics 和 instance_info 嵌套块示例）、Import 部分（说明使用复合 ID `topicId#taskId`）
+
+## 5. Unit Tests
+
+- [x] 5.1 创建 `tencentcloud/services/cls/resource_tc_cls_metric_subscribe_test.go`，使用 gomonkey mock 云 API，补充 Create/Read/Update/Delete 业务逻辑的单元测试用例（不使用 terraform 测试套件）
+
+## 6. Validation
+
+- [x] 6.1 验证代码编译通过（go build 由其他流程执行，仅检查代码正确性）
+- [x] 6.2 检查所有函数返回的 error 是否已正确处理

--- a/openspec/specs/cls-metric-subscribe/spec.md
+++ b/openspec/specs/cls-metric-subscribe/spec.md
@@ -1,0 +1,126 @@
+# cls-metric-subscribe Specification
+
+## Purpose
+TBD - created by archiving change add-cls-metric-subscribe-resource. Update Purpose after archive.
+## Requirements
+### Requirement: Resource schema definition
+
+The system SHALL provide a Terraform resource `tencentcloud_cls_metric_subscribe` with the following top-level schema fields:
+- `name` (Required, string): 订阅任务名称，长度不超过64字符
+- `topic_id` (Required, string, ForceNew): 日志主题 ID
+- `namespace` (Required, string): 云产品命名空间
+- `metrics` (Required, list): 指标配置信息列表
+- `instance_info` (Required, list, MaxItems=1): 实例配置信息
+- `enable` (Optional, int): 任务开关，1 暂停 / 2 启用
+- `task_id` (Computed, string): 订阅任务 ID
+- `status` (Computed, int): 运行状态，0 创建中 / 1 暂停 / 2 运行中 / 3 异常
+- `create_time` (Computed, int): 创建时间（秒级时间戳）
+- `update_time` (Computed, int): 更新时间（秒级时间戳）
+
+#### Scenario: Schema contains all required fields
+- **WHEN** the resource schema is defined
+- **THEN** the schema SHALL include `name`, `topic_id`, `namespace`, `metrics`, `instance_info` as Required fields and `task_id`, `status`, `create_time`, `update_time` as Computed fields
+
+#### Scenario: topic_id is ForceNew
+- **WHEN** the user changes `topic_id` on an existing resource
+- **THEN** Terraform SHALL destroy and recreate the resource rather than update in place
+
+### Requirement: Nested metrics schema
+
+The `metrics` field SHALL be a TypeList of `MetricConfig` objects with the following nested schema:
+- `metric_name` (Required, string): 指标名称
+- `periods` (Optional, list of int): 统计周期（秒）
+- `metric_labels` (Optional, list): 自定义指标标签
+
+The `metric_labels` nested list SHALL contain:
+- `key` (Required, string): 指标标签名称
+- `value` (Required, string): 指标标签内容
+
+#### Scenario: Metrics list with metric labels
+- **WHEN** the user provides a metrics block with metric_name, periods, and metric_labels
+- **THEN** the system SHALL correctly map these to the cloud API `MetricConfig` structure
+
+### Requirement: Nested instance_info schema
+
+The `instance_info` field SHALL be a TypeList with MaxItems=1 of `InstanceConfig` objects with the following nested schema:
+- `instance_dimension` (Optional, list of string): 实例维度
+- `instances` (Optional, list): 实例值列表
+
+The `instances` nested list SHALL contain:
+- `values` (Optional, list of string): 实例信息值列表
+
+#### Scenario: Instance info with dimensions and instances
+- **WHEN** the user provides an instance_info block with instance_dimension and instances
+- **THEN** the system SHALL correctly map these to the cloud API `InstanceConfig` structure
+
+### Requirement: Create operation
+
+The system SHALL implement a Create function that calls the `CreateMetricSubscribe` API with `Name`, `TopicId`, `Namespace`, `Metrics`, `InstanceInfo` parameters and sets the resource ID to the composite format `topicId#taskId` (using `tccommon.FILED_SP` as separator).
+
+#### Scenario: Successful creation
+- **WHEN** the user creates a `tencentcloud_cls_metric_subscribe` resource with all required fields
+- **THEN** the system SHALL call `CreateMetricSubscribe`, retrieve the returned `TaskId`, and set the resource ID to `topicId#taskId`
+
+#### Scenario: Create returns empty TaskId
+- **WHEN** the `CreateMetricSubscribe` API returns an empty `TaskId`
+- **THEN** the system SHALL return a `NonRetryableError` to avoid writing an empty ID into state
+
+### Requirement: Read operation
+
+The system SHALL implement a Read function that calls the `DescribeMetricSubscribes` API with `TopicId` and a `Filter` (Key=taskId, Values=[taskId]) to query the resource, then populates the state from the first matching `MetricSubscribeInfo` record.
+
+#### Scenario: Resource exists
+- **WHEN** the Read function queries the resource by topicId and taskId
+- **THEN** the system SHALL populate all schema fields from the returned `MetricSubscribeInfo` including computed fields `task_id`, `status`, `create_time`, `update_time`
+
+#### Scenario: Resource not found
+- **WHEN** the `DescribeMetricSubscribes` API returns an empty list
+- **THEN** the system SHALL log the resource ID and call `d.SetId("")` to remove the resource from state
+
+### Requirement: Update operation
+
+The system SHALL implement an Update function that calls the `ModifyMetricSubscribe` API when any of `name`, `namespace`, `metrics`, `instance_info`, `enable` fields change, passing `TopicId` and `TaskId` as required identifiers along with the changed fields.
+
+#### Scenario: Update name
+- **WHEN** the user changes the `name` field
+- **THEN** the system SHALL call `ModifyMetricSubscribe` with the new `Name` value, along with `TopicId` and `TaskId`
+
+#### Scenario: Update enable status
+- **WHEN** the user changes the `enable` field
+- **THEN** the system SHALL call `ModifyMetricSubscribe` with the new `Enable` value
+
+### Requirement: Delete operation
+
+The system SHALL implement a Delete function that calls the `DeleteMetricSubscribe` API with `TaskId` and `TopicId` parameters.
+
+#### Scenario: Successful deletion
+- **WHEN** the user destroys the resource
+- **THEN** the system SHALL call `DeleteMetricSubscribe` with `TaskId` and `TopicId` extracted from the composite resource ID
+
+### Requirement: Import support
+
+The resource SHALL support Terraform import using the composite ID format `topicId#taskId`.
+
+#### Scenario: Import by composite ID
+- **WHEN** the user runs `terraform import tencentcloud_cls_metric_subscribe.example topicId#taskId`
+- **THEN** the system SHALL parse the composite ID, call Read, and populate the resource state
+
+### Requirement: Provider registration
+
+The system SHALL register the `tencentcloud_cls_metric_subscribe` resource in `tencentcloud/provider.go` and add the corresponding entry in `tencentcloud/provider.md`.
+
+#### Scenario: Resource registered in provider
+- **WHEN** the provider is initialized
+- **THEN** the resource `tencentcloud_cls_metric_subscribe` SHALL be available for use in Terraform configurations
+
+### Requirement: Error handling and retry
+
+All CRUD operations SHALL use appropriate retry timeouts (`tccommon.WriteRetryTimeout` for Create/Update/Delete, `tccommon.ReadRetryTimeout` for Read) and wrap API errors with `tccommon.RetryError()`.
+
+#### Scenario: API transient failure during create
+- **WHEN** the `CreateMetricSubscribe` API returns a transient error
+- **THEN** the system SHALL retry within the `WriteRetryTimeout` period before failing
+
+#### Scenario: API transient failure during read
+- **WHEN** the `DescribeMetricSubscribes` API returns a transient error
+- **THEN** the system SHALL retry within the `ReadRetryTimeout` period before failing

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -2115,6 +2115,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_cls_scheduled_sql":                                                        cls.ResourceTencentCloudClsScheduledSql(),
 			"tencentcloud_cls_dlc_deliver":                                                          cls.ResourceTencentCloudClsDlcDeliver(),
 			"tencentcloud_cls_console":                                                              cls.ResourceTencentCloudClsConsole(),
+			"tencentcloud_cls_metric_subscribe":                                                     cls.ResourceTencentCloudClsMetricSubscribe(),
 			"tencentcloud_lighthouse_instance":                                                      lighthouse.ResourceTencentCloudLighthouseInstance(),
 			"tencentcloud_lighthouse_firewall_template":                                             lighthouse.ResourceTencentCloudLighthouseFirewallTemplate(),
 			"tencentcloud_tem_environment":                                                          tem.ResourceTencentCloudTemEnvironment(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1526,6 +1526,7 @@ tencentcloud_cls_cloud_product_log_task_v2
 tencentcloud_cls_open_service_operation
 tencentcloud_cls_dlc_deliver
 tencentcloud_cls_console
+tencentcloud_cls_metric_subscribe
 
 Data Source
 tencentcloud_cls_shipper_tasks

--- a/tencentcloud/services/cls/resource_tc_cls_metric_subscribe.go
+++ b/tencentcloud/services/cls/resource_tc_cls_metric_subscribe.go
@@ -56,7 +56,7 @@ func ResourceTencentCloudClsMetricSubscribe() *schema.Resource {
 						},
 						"periods": {
 							Type:        schema.TypeList,
-							Optional:    true,
+							Required:    true,
 							Elem:        &schema.Schema{Type: schema.TypeInt},
 							Description: "Statistical period, unit: second(s).",
 						},
@@ -92,19 +92,19 @@ func ResourceTencentCloudClsMetricSubscribe() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"instance_dimension": {
 							Type:        schema.TypeList,
-							Optional:    true,
+							Required:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: "Instance dimension.",
 						},
 						"instances": {
 							Type:        schema.TypeList,
-							Optional:    true,
+							Required:    true,
 							Description: "Instance value list.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"values": {
 										Type:        schema.TypeList,
-										Optional:    true,
+										Required:    true,
 										Elem:        &schema.Schema{Type: schema.TypeString},
 										Description: "Instance info value list.",
 									},
@@ -118,6 +118,7 @@ func ResourceTencentCloudClsMetricSubscribe() *schema.Resource {
 			"enable": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "Task switch, 1: pause, 2: enable.",
 			},
 
@@ -132,18 +133,6 @@ func ResourceTencentCloudClsMetricSubscribe() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Subscribe task running status. 0: creating, 1: paused, 2: running, 3: abnormal.",
-			},
-
-			"create_time": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Creation time (second-level timestamp).",
-			},
-
-			"update_time": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Update time (second-level timestamp).",
 			},
 		},
 	}
@@ -234,7 +223,6 @@ func resourceTencentCloudClsMetricSubscribeCreate(d *schema.ResourceData, meta i
 			}
 
 			request.InstanceInfo = &instanceConfig
-			break
 		}
 	}
 
@@ -267,6 +255,39 @@ func resourceTencentCloudClsMetricSubscribeCreate(d *schema.ResourceData, meta i
 
 	taskId = *response.Response.TaskId
 	d.SetId(strings.Join([]string{topicId, taskId}, tccommon.FILED_SP))
+
+	//
+	if v, ok := d.GetOkExists("enable"); ok {
+		if v.(int) == 1 {
+			request := clsv20201016.NewModifyMetricSubscribeRequest()
+			request.TopicId = helper.String(topicId)
+			request.TaskId = helper.String(taskId)
+			if v, ok := d.GetOkExists("enable"); ok {
+				request.Enable = helper.IntUint64(v.(int))
+			}
+
+			reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+				result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsV20201016Client().ModifyMetricSubscribeWithContext(ctx, request)
+				if e != nil {
+					return tccommon.RetryError(e)
+				} else {
+					log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+				}
+
+				if result == nil || result.Response == nil {
+					return resource.NonRetryableError(fmt.Errorf("Modify cls metric subscribe failed, Response is nil."))
+				}
+
+				return nil
+			})
+
+			if reqErr != nil {
+				log.Printf("[CRITAL]%s update cls metric subscribe failed, reason:%+v", logId, reqErr)
+				return reqErr
+			}
+		}
+	}
+
 	return resourceTencentCloudClsMetricSubscribeRead(d, meta)
 }
 
@@ -294,7 +315,7 @@ func resourceTencentCloudClsMetricSubscribeRead(d *schema.ResourceData, meta int
 	}
 
 	if respData == nil {
-		log.Printf("[CRUD] cls_metric_subscribe id=%s", d.Id())
+		log.Printf("[CRUD] tencentcloud_cls_metric_subscribe id=%s", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -406,14 +427,6 @@ func resourceTencentCloudClsMetricSubscribeRead(d *schema.ResourceData, meta int
 		_ = d.Set("status", int(*respData.Status))
 	}
 
-	if respData.CreateTime != nil {
-		_ = d.Set("create_time", int(*respData.CreateTime))
-	}
-
-	if respData.UpdateTime != nil {
-		_ = d.Set("update_time", int(*respData.UpdateTime))
-	}
-
 	return nil
 }
 
@@ -515,11 +528,10 @@ func resourceTencentCloudClsMetricSubscribeUpdate(d *schema.ResourceData, meta i
 				}
 
 				request.InstanceInfo = &instanceConfig
-				break
 			}
 		}
 
-		if v, ok := d.GetOk("enable"); ok {
+		if v, ok := d.GetOkExists("enable"); ok {
 			request.Enable = helper.IntUint64(v.(int))
 		}
 

--- a/tencentcloud/services/cls/resource_tc_cls_metric_subscribe.go
+++ b/tencentcloud/services/cls/resource_tc_cls_metric_subscribe.go
@@ -1,0 +1,592 @@
+package cls
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	clsv20201016 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudClsMetricSubscribe() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudClsMetricSubscribeCreate,
+		Read:   resourceTencentCloudClsMetricSubscribeRead,
+		Update: resourceTencentCloudClsMetricSubscribeUpdate,
+		Delete: resourceTencentCloudClsMetricSubscribeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Subscribe task name, up to 64 characters, start with a letter, support 0-9, a-z, A-Z, _, -, Chinese characters.",
+			},
+
+			"topic_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Log topic id.",
+			},
+
+			"namespace": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Cloud product namespace.",
+			},
+
+			"metrics": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "Metric config info list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metric_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Metric name.",
+						},
+						"periods": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeInt},
+							Description: "Statistical period, unit: second(s).",
+						},
+						"metric_labels": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Custom metric labels.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Metric label name.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Metric label content.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"instance_info": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: "Instance config info.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_dimension": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "Instance dimension.",
+						},
+						"instances": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Instance value list.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"values": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "Instance info value list.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"enable": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Task switch, 1: pause, 2: enable.",
+			},
+
+			// computed
+			"task_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Subscribe task id.",
+			},
+
+			"status": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Subscribe task running status. 0: creating, 1: paused, 2: running, 3: abnormal.",
+			},
+
+			"create_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Creation time (second-level timestamp).",
+			},
+
+			"update_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Update time (second-level timestamp).",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudClsMetricSubscribeCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_cls_metric_subscribe.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId    = tccommon.GetLogId(tccommon.ContextNil)
+		ctx      = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request  = clsv20201016.NewCreateMetricSubscribeRequest()
+		response = clsv20201016.NewCreateMetricSubscribeResponse()
+		topicId  string
+		taskId   string
+	)
+
+	if v, ok := d.GetOk("topic_id"); ok {
+		request.TopicId = helper.String(v.(string))
+		topicId = v.(string)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		request.Name = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("namespace"); ok {
+		request.Namespace = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("metrics"); ok {
+		for _, item := range v.([]interface{}) {
+			metricsMap := item.(map[string]interface{})
+			metricConfig := clsv20201016.MetricConfig{}
+			if v, ok := metricsMap["metric_name"].(string); ok && v != "" {
+				metricConfig.MetricName = helper.String(v)
+			}
+
+			if v, ok := metricsMap["periods"].([]interface{}); ok && len(v) > 0 {
+				for _, period := range v {
+					metricConfig.Periods = append(metricConfig.Periods, helper.IntUint64(period.(int)))
+				}
+			}
+
+			if v, ok := metricsMap["metric_labels"].([]interface{}); ok && len(v) > 0 {
+				for _, labelItem := range v {
+					labelMap := labelItem.(map[string]interface{})
+					metricLabel := clsv20201016.MetricLabel{}
+					if v, ok := labelMap["key"].(string); ok && v != "" {
+						metricLabel.Key = helper.String(v)
+					}
+
+					if v, ok := labelMap["value"].(string); ok && v != "" {
+						metricLabel.Value = helper.String(v)
+					}
+
+					metricConfig.MetricLabels = append(metricConfig.MetricLabels, &metricLabel)
+				}
+			}
+
+			request.Metrics = append(request.Metrics, &metricConfig)
+		}
+	}
+
+	if v, ok := d.GetOk("instance_info"); ok {
+		for _, item := range v.([]interface{}) {
+			instanceInfoMap := item.(map[string]interface{})
+			instanceConfig := clsv20201016.InstanceConfig{}
+			if v, ok := instanceInfoMap["instance_dimension"].([]interface{}); ok && len(v) > 0 {
+				for _, dimension := range v {
+					instanceConfig.InstanceDimension = append(instanceConfig.InstanceDimension, helper.String(dimension.(string)))
+				}
+			}
+
+			if v, ok := instanceInfoMap["instances"].([]interface{}); ok && len(v) > 0 {
+				for _, instanceItem := range v {
+					instanceMap := instanceItem.(map[string]interface{})
+					instance := clsv20201016.Instance{}
+					if v, ok := instanceMap["values"].([]interface{}); ok && len(v) > 0 {
+						for _, value := range v {
+							instance.Values = append(instance.Values, helper.String(value.(string)))
+						}
+					}
+
+					instanceConfig.Instances = append(instanceConfig.Instances, &instance)
+				}
+			}
+
+			request.InstanceInfo = &instanceConfig
+			break
+		}
+	}
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsV20201016Client().CreateMetricSubscribeWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create cls metric subscribe failed, Response is nil."))
+		}
+
+		response = result
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s create cls metric subscribe failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	log.Printf("[CRUD] cls_metric_subscribe logId=%s, topicId=%s, taskId=%+v", logId, topicId, response.Response.TaskId)
+
+	if response.Response.TaskId == nil || *response.Response.TaskId == "" {
+		return fmt.Errorf("Create cls metric subscribe failed, TaskId is empty.")
+	}
+
+	taskId = *response.Response.TaskId
+	d.SetId(strings.Join([]string{topicId, taskId}, tccommon.FILED_SP))
+	return resourceTencentCloudClsMetricSubscribeRead(d, meta)
+}
+
+func resourceTencentCloudClsMetricSubscribeRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_cls_metric_subscribe.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service = ClsService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	topicId := idSplit[0]
+	taskId := idSplit[1]
+
+	respData, err := service.DescribeClsMetricSubscribeById(ctx, topicId, taskId)
+	if err != nil {
+		return err
+	}
+
+	if respData == nil {
+		log.Printf("[CRUD] cls_metric_subscribe id=%s", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if respData.Name != nil {
+		_ = d.Set("name", respData.Name)
+	}
+
+	if respData.TopicId != nil {
+		_ = d.Set("topic_id", respData.TopicId)
+	}
+
+	if respData.Namespace != nil {
+		_ = d.Set("namespace", respData.Namespace)
+	}
+
+	if respData.Metrics != nil && len(respData.Metrics) > 0 {
+		metricsList := make([]map[string]interface{}, 0, len(respData.Metrics))
+		for _, metricConfig := range respData.Metrics {
+			metricMap := map[string]interface{}{}
+			if metricConfig.MetricName != nil {
+				metricMap["metric_name"] = *metricConfig.MetricName
+			}
+
+			if metricConfig.Periods != nil && len(metricConfig.Periods) > 0 {
+				periodsList := make([]interface{}, 0, len(metricConfig.Periods))
+				for _, period := range metricConfig.Periods {
+					if period != nil {
+						periodsList = append(periodsList, int(*period))
+					}
+				}
+				if len(periodsList) > 0 {
+					metricMap["periods"] = periodsList
+				}
+			}
+
+			if metricConfig.MetricLabels != nil && len(metricConfig.MetricLabels) > 0 {
+				metricLabelsList := make([]map[string]interface{}, 0, len(metricConfig.MetricLabels))
+				for _, metricLabel := range metricConfig.MetricLabels {
+					metricLabelMap := map[string]interface{}{}
+					if metricLabel.Key != nil {
+						metricLabelMap["key"] = *metricLabel.Key
+					}
+
+					if metricLabel.Value != nil {
+						metricLabelMap["value"] = *metricLabel.Value
+					}
+
+					metricLabelsList = append(metricLabelsList, metricLabelMap)
+				}
+				metricMap["metric_labels"] = metricLabelsList
+			}
+
+			metricsList = append(metricsList, metricMap)
+		}
+
+		_ = d.Set("metrics", metricsList)
+	}
+
+	if respData.InstanceInfo != nil {
+		instanceInfoList := make([]map[string]interface{}, 0, 1)
+		instanceInfoMap := map[string]interface{}{}
+		if respData.InstanceInfo.InstanceDimension != nil && len(respData.InstanceInfo.InstanceDimension) > 0 {
+			instanceDimensionList := make([]interface{}, 0, len(respData.InstanceInfo.InstanceDimension))
+			for _, dimension := range respData.InstanceInfo.InstanceDimension {
+				if dimension != nil {
+					instanceDimensionList = append(instanceDimensionList, *dimension)
+				}
+			}
+			if len(instanceDimensionList) > 0 {
+				instanceInfoMap["instance_dimension"] = instanceDimensionList
+			}
+		}
+
+		if respData.InstanceInfo.Instances != nil && len(respData.InstanceInfo.Instances) > 0 {
+			instancesList := make([]map[string]interface{}, 0, len(respData.InstanceInfo.Instances))
+			for _, instance := range respData.InstanceInfo.Instances {
+				instanceMap := map[string]interface{}{}
+				if instance.Values != nil && len(instance.Values) > 0 {
+					valuesList := make([]interface{}, 0, len(instance.Values))
+					for _, value := range instance.Values {
+						if value != nil {
+							valuesList = append(valuesList, *value)
+						}
+					}
+					if len(valuesList) > 0 {
+						instanceMap["values"] = valuesList
+					}
+				}
+
+				instancesList = append(instancesList, instanceMap)
+			}
+			instanceInfoMap["instances"] = instancesList
+		}
+
+		instanceInfoList = append(instanceInfoList, instanceInfoMap)
+		_ = d.Set("instance_info", instanceInfoList)
+	}
+
+	if respData.Enable != nil {
+		_ = d.Set("enable", int(*respData.Enable))
+	}
+
+	if respData.TaskId != nil {
+		_ = d.Set("task_id", respData.TaskId)
+	}
+
+	if respData.Status != nil {
+		_ = d.Set("status", int(*respData.Status))
+	}
+
+	if respData.CreateTime != nil {
+		_ = d.Set("create_time", int(*respData.CreateTime))
+	}
+
+	if respData.UpdateTime != nil {
+		_ = d.Set("update_time", int(*respData.UpdateTime))
+	}
+
+	return nil
+}
+
+func resourceTencentCloudClsMetricSubscribeUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_cls_metric_subscribe.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId = tccommon.GetLogId(tccommon.ContextNil)
+		ctx   = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	topicId := idSplit[0]
+	taskId := idSplit[1]
+
+	needChange := false
+	mutableArgs := []string{"name", "namespace", "metrics", "instance_info", "enable"}
+	for _, v := range mutableArgs {
+		if d.HasChange(v) {
+			needChange = true
+			break
+		}
+	}
+
+	if needChange {
+		request := clsv20201016.NewModifyMetricSubscribeRequest()
+		request.TopicId = helper.String(topicId)
+		request.TaskId = helper.String(taskId)
+
+		if v, ok := d.GetOk("name"); ok {
+			request.Name = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("namespace"); ok {
+			request.Namespace = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("metrics"); ok {
+			for _, item := range v.([]interface{}) {
+				metricsMap := item.(map[string]interface{})
+				metricConfig := clsv20201016.MetricConfig{}
+				if v, ok := metricsMap["metric_name"].(string); ok && v != "" {
+					metricConfig.MetricName = helper.String(v)
+				}
+
+				if v, ok := metricsMap["periods"].([]interface{}); ok && len(v) > 0 {
+					for _, period := range v {
+						metricConfig.Periods = append(metricConfig.Periods, helper.IntUint64(period.(int)))
+					}
+				}
+
+				if v, ok := metricsMap["metric_labels"].([]interface{}); ok && len(v) > 0 {
+					for _, labelItem := range v {
+						labelMap := labelItem.(map[string]interface{})
+						metricLabel := clsv20201016.MetricLabel{}
+						if v, ok := labelMap["key"].(string); ok && v != "" {
+							metricLabel.Key = helper.String(v)
+						}
+
+						if v, ok := labelMap["value"].(string); ok && v != "" {
+							metricLabel.Value = helper.String(v)
+						}
+
+						metricConfig.MetricLabels = append(metricConfig.MetricLabels, &metricLabel)
+					}
+				}
+
+				request.Metrics = append(request.Metrics, &metricConfig)
+			}
+		}
+
+		if v, ok := d.GetOk("instance_info"); ok {
+			for _, item := range v.([]interface{}) {
+				instanceInfoMap := item.(map[string]interface{})
+				instanceConfig := clsv20201016.InstanceConfig{}
+				if v, ok := instanceInfoMap["instance_dimension"].([]interface{}); ok && len(v) > 0 {
+					for _, dimension := range v {
+						instanceConfig.InstanceDimension = append(instanceConfig.InstanceDimension, helper.String(dimension.(string)))
+					}
+				}
+
+				if v, ok := instanceInfoMap["instances"].([]interface{}); ok && len(v) > 0 {
+					for _, instanceItem := range v {
+						instanceMap := instanceItem.(map[string]interface{})
+						instance := clsv20201016.Instance{}
+						if v, ok := instanceMap["values"].([]interface{}); ok && len(v) > 0 {
+							for _, value := range v {
+								instance.Values = append(instance.Values, helper.String(value.(string)))
+							}
+						}
+
+						instanceConfig.Instances = append(instanceConfig.Instances, &instance)
+					}
+				}
+
+				request.InstanceInfo = &instanceConfig
+				break
+			}
+		}
+
+		if v, ok := d.GetOk("enable"); ok {
+			request.Enable = helper.IntUint64(v.(int))
+		}
+
+		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsV20201016Client().ModifyMetricSubscribeWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify cls metric subscribe failed, Response is nil."))
+			}
+
+			return nil
+		})
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s update cls metric subscribe failed, reason:%+v", logId, reqErr)
+			return reqErr
+		}
+	}
+
+	return resourceTencentCloudClsMetricSubscribeRead(d, meta)
+}
+
+func resourceTencentCloudClsMetricSubscribeDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_cls_metric_subscribe.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(tccommon.ContextNil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		request = clsv20201016.NewDeleteMetricSubscribeRequest()
+	)
+
+	idSplit := strings.Split(d.Id(), tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("id is broken,%s", d.Id())
+	}
+
+	topicId := idSplit[0]
+	taskId := idSplit[1]
+
+	request.TopicId = helper.String(topicId)
+	request.TaskId = helper.String(taskId)
+
+	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsV20201016Client().DeleteMetricSubscribeWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Delete cls metric subscribe failed, Response is nil."))
+		}
+
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[CRITAL]%s delete cls metric subscribe failed, reason:%+v", logId, reqErr)
+		return reqErr
+	}
+
+	return nil
+}

--- a/tencentcloud/services/cls/resource_tc_cls_metric_subscribe.md
+++ b/tencentcloud/services/cls/resource_tc_cls_metric_subscribe.md
@@ -1,0 +1,34 @@
+Provides a resource to create a CLS metric subscribe
+
+Example Usage
+
+```hcl
+resource "tencentcloud_cls_metric_subscribe" "example" {
+  name      = "tf-example-metric-subscribe"
+  topic_id  = "c9b68233-948a-4eaf-a363-d0c2ced393ae"
+  namespace = "QCE/CVM"
+  enable    = 2
+  metrics {
+    metric_name = "cpu_usage"
+    periods     = [60, 300]
+    metric_labels {
+      key   = "label_key"
+      value = "label_value"
+    }
+  }
+  instance_info {
+    instance_dimension = ["InstanceId"]
+    instances {
+      values = ["ins-xxxxxxxx"]
+    }
+  }
+}
+```
+
+Import
+
+CLS metric subscribe can be imported using the composite id, e.g. the composite id is `topicId#taskId` formatted by `topicId` and `taskId` joined with `#`:
+
+```
+terraform import tencentcloud_cls_metric_subscribe.example topicId#taskId
+```

--- a/tencentcloud/services/cls/resource_tc_cls_metric_subscribe.md
+++ b/tencentcloud/services/cls/resource_tc_cls_metric_subscribe.md
@@ -4,22 +4,48 @@ Example Usage
 
 ```hcl
 resource "tencentcloud_cls_metric_subscribe" "example" {
-  name      = "tf-example-metric-subscribe"
-  topic_id  = "c9b68233-948a-4eaf-a363-d0c2ced393ae"
-  namespace = "QCE/CVM"
+  name      = "tf-example"
+  topic_id  = "da978f4a-b205-4286-830c-86d0ca45d7f3"
+  namespace = "qce/cvm"
   enable    = 2
   metrics {
-    metric_name = "cpu_usage"
-    periods     = [60, 300]
+    metric_name = "BaseCpuUsage"
+    periods     = [10]
     metric_labels {
       key   = "label_key"
       value = "label_value"
     }
   }
+
+  metrics {
+    metric_name = "CbsVolumeFsUsage"
+    periods     = [10]
+    metric_labels {
+      key   = "label_key"
+      value = "label_value"
+    }
+  }
+
+  metrics {
+    metric_name = "MemUsed"
+    periods     = [10]
+    metric_labels {
+      key   = "label_key"
+      value = "label_value"
+    }
+  }
+
   instance_info {
-    instance_dimension = ["InstanceId"]
+    instance_dimension = [
+      "InstanceId",
+      "diskid"
+    ]
+
     instances {
-      values = ["ins-xxxxxxxx"]
+      values = [
+        "ins-ly9ibb5w",
+        "disk-781trig2"
+      ]
     }
   }
 }
@@ -30,5 +56,5 @@ Import
 CLS metric subscribe can be imported using the composite id, e.g. the composite id is `topicId#taskId` formatted by `topicId` and `taskId` joined with `#`:
 
 ```
-terraform import tencentcloud_cls_metric_subscribe.example topicId#taskId
+terraform import tencentcloud_cls_metric_subscribe.example da978f4a-b205-4286-830c-86d0ca45d7f3#bc28af29-b274-4a69-ba77-6e665db26850
 ```

--- a/tencentcloud/services/cls/resource_tc_cls_metric_subscribe_test.go
+++ b/tencentcloud/services/cls/resource_tc_cls_metric_subscribe_test.go
@@ -1,0 +1,333 @@
+package cls_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	clsv20201016 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	localcls "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cls"
+)
+
+type mockMetaForClsMetricSubscribe struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForClsMetricSubscribe) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForClsMetricSubscribe{}
+
+func newMockMetaForClsMetricSubscribe() *mockMetaForClsMetricSubscribe {
+	return &mockMetaForClsMetricSubscribe{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringMS(s string) *string { return &s }
+func ptrUint64MS(v uint64) *uint64 { return &v }
+func ptrInt64MS(v int64) *int64    { return &v }
+
+func buildMetricSubscribeInfo() *clsv20201016.MetricSubscribeInfo {
+	return &clsv20201016.MetricSubscribeInfo{
+		TaskId:    ptrStringMS("task-test-123"),
+		TopicId:   ptrStringMS("topic-test-123"),
+		Name:      ptrStringMS("tf-example-metric-subscribe"),
+		Namespace: ptrStringMS("QCE/CVM"),
+		Metrics: []*clsv20201016.MetricConfig{
+			{
+				MetricName: ptrStringMS("cpu_usage"),
+				Periods:    []*uint64{ptrUint64MS(60), ptrUint64MS(300)},
+				MetricLabels: []*clsv20201016.MetricLabel{
+					{
+						Key:   ptrStringMS("label_key"),
+						Value: ptrStringMS("label_value"),
+					},
+				},
+			},
+		},
+		InstanceInfo: &clsv20201016.InstanceConfig{
+			InstanceDimension: []*string{ptrStringMS("InstanceId")},
+			Instances: []*clsv20201016.Instance{
+				{
+					Values: []*string{ptrStringMS("ins-xxxxxxxx")},
+				},
+			},
+		},
+		Enable:     ptrUint64MS(2),
+		Status:     ptrUint64MS(2),
+		CreateTime: ptrInt64MS(1700000000),
+		UpdateTime: ptrInt64MS(1700000100),
+	}
+}
+
+func metricSubscribeRawInput() map[string]interface{} {
+	return map[string]interface{}{
+		"name":      "tf-example-metric-subscribe",
+		"topic_id":  "topic-test-123",
+		"namespace": "QCE/CVM",
+		"enable":    2,
+		"metrics": []interface{}{
+			map[string]interface{}{
+				"metric_name": "cpu_usage",
+				"periods":     []interface{}{60, 300},
+				"metric_labels": []interface{}{
+					map[string]interface{}{
+						"key":   "label_key",
+						"value": "label_value",
+					},
+				},
+			},
+		},
+		"instance_info": []interface{}{
+			map[string]interface{}{
+				"instance_dimension": []interface{}{"InstanceId"},
+				"instances": []interface{}{
+					map[string]interface{}{
+						"values": []interface{}{"ins-xxxxxxxx"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestClsMetricSubscribe_Create_Success tests the Create flow maps fields to the
+// CreateMetricSubscribe request and sets the composite id topicId#taskId.
+func TestClsMetricSubscribe_Create_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClsMetricSubscribe().client, "UseClsV20201016Client", clsClient)
+
+	var capturedRequest *clsv20201016.CreateMetricSubscribeRequest
+	patches.ApplyMethodFunc(clsClient, "CreateMetricSubscribeWithContext", func(_ context.Context, request *clsv20201016.CreateMetricSubscribeRequest) (*clsv20201016.CreateMetricSubscribeResponse, error) {
+		capturedRequest = request
+		resp := clsv20201016.NewCreateMetricSubscribeResponse()
+		resp.Response = &clsv20201016.CreateMetricSubscribeResponseParams{
+			TaskId:    ptrStringMS("task-test-123"),
+			RequestId: ptrStringMS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	info := buildMetricSubscribeInfo()
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsMetricSubscribeById", func(_ context.Context, _ string, _ string) (*clsv20201016.MetricSubscribeInfo, error) {
+		return info, nil
+	})
+
+	meta := newMockMetaForClsMetricSubscribe()
+	res := localcls.ResourceTencentCloudClsMetricSubscribe()
+	d := schema.TestResourceDataRaw(t, res.Schema, metricSubscribeRawInput())
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "topic-test-123"+tccommon.FILED_SP+"task-test-123", d.Id())
+
+	// Verify request mapping
+	assert.NotNil(t, capturedRequest)
+	assert.Equal(t, "tf-example-metric-subscribe", *capturedRequest.Name)
+	assert.Equal(t, "topic-test-123", *capturedRequest.TopicId)
+	assert.Equal(t, "QCE/CVM", *capturedRequest.Namespace)
+	assert.NotNil(t, capturedRequest.Metrics)
+	assert.Equal(t, 1, len(capturedRequest.Metrics))
+	assert.Equal(t, "cpu_usage", *capturedRequest.Metrics[0].MetricName)
+	assert.Equal(t, 2, len(capturedRequest.Metrics[0].Periods))
+	assert.Equal(t, uint64(60), *capturedRequest.Metrics[0].Periods[0])
+	assert.Equal(t, uint64(300), *capturedRequest.Metrics[0].Periods[1])
+	assert.Equal(t, 1, len(capturedRequest.Metrics[0].MetricLabels))
+	assert.Equal(t, "label_key", *capturedRequest.Metrics[0].MetricLabels[0].Key)
+	assert.Equal(t, "label_value", *capturedRequest.Metrics[0].MetricLabels[0].Value)
+	assert.NotNil(t, capturedRequest.InstanceInfo)
+	assert.Equal(t, 1, len(capturedRequest.InstanceInfo.InstanceDimension))
+	assert.Equal(t, "InstanceId", *capturedRequest.InstanceInfo.InstanceDimension[0])
+	assert.Equal(t, 1, len(capturedRequest.InstanceInfo.Instances))
+	assert.Equal(t, 1, len(capturedRequest.InstanceInfo.Instances[0].Values))
+	assert.Equal(t, "ins-xxxxxxxx", *capturedRequest.InstanceInfo.Instances[0].Values[0])
+
+	// Verify computed fields read back into state
+	assert.Equal(t, "task-test-123", d.Get("task_id"))
+	assert.Equal(t, 2, d.Get("status"))
+	assert.Equal(t, 1700000000, d.Get("create_time"))
+	assert.Equal(t, 1700000100, d.Get("update_time"))
+}
+
+// TestClsMetricSubscribe_Create_EmptyTaskId tests that an empty TaskId in the
+// response returns an error (NonRetryableError) instead of writing an empty id.
+func TestClsMetricSubscribe_Create_EmptyTaskId(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClsMetricSubscribe().client, "UseClsV20201016Client", clsClient)
+
+	patches.ApplyMethodFunc(clsClient, "CreateMetricSubscribeWithContext", func(_ context.Context, request *clsv20201016.CreateMetricSubscribeRequest) (*clsv20201016.CreateMetricSubscribeResponse, error) {
+		resp := clsv20201016.NewCreateMetricSubscribeResponse()
+		resp.Response = &clsv20201016.CreateMetricSubscribeResponseParams{
+			TaskId:    ptrStringMS(""),
+			RequestId: ptrStringMS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForClsMetricSubscribe()
+	res := localcls.ResourceTencentCloudClsMetricSubscribe()
+	d := schema.TestResourceDataRaw(t, res.Schema, metricSubscribeRawInput())
+
+	err := res.Create(d, meta)
+	assert.Error(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestClsMetricSubscribe_Read_Success tests Read populates state from the
+// DescribeClsMetricSubscribeById service method response.
+func TestClsMetricSubscribe_Read_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	info := buildMetricSubscribeInfo()
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsMetricSubscribeById", func(_ context.Context, _ string, _ string) (*clsv20201016.MetricSubscribeInfo, error) {
+		return info, nil
+	})
+
+	meta := newMockMetaForClsMetricSubscribe()
+	res := localcls.ResourceTencentCloudClsMetricSubscribe()
+	d := schema.TestResourceDataRaw(t, res.Schema, metricSubscribeRawInput())
+	d.SetId("topic-test-123" + tccommon.FILED_SP + "task-test-123")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "topic-test-123"+tccommon.FILED_SP+"task-test-123", d.Id())
+	assert.Equal(t, "tf-example-metric-subscribe", d.Get("name"))
+	assert.Equal(t, "topic-test-123", d.Get("topic_id"))
+	assert.Equal(t, "QCE/CVM", d.Get("namespace"))
+	assert.Equal(t, "task-test-123", d.Get("task_id"))
+	assert.Equal(t, 2, d.Get("status"))
+	assert.Equal(t, 1700000000, d.Get("create_time"))
+	assert.Equal(t, 1700000100, d.Get("update_time"))
+}
+
+// TestClsMetricSubscribe_Read_NotFound tests that Read clears state (SetId(""))
+// when the service method returns nil (resource not found).
+func TestClsMetricSubscribe_Read_NotFound(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsMetricSubscribeById", func(_ context.Context, _ string, _ string) (*clsv20201016.MetricSubscribeInfo, error) {
+		return nil, nil
+	})
+
+	meta := newMockMetaForClsMetricSubscribe()
+	res := localcls.ResourceTencentCloudClsMetricSubscribe()
+	d := schema.TestResourceDataRaw(t, res.Schema, metricSubscribeRawInput())
+	d.SetId("topic-test-123" + tccommon.FILED_SP + "task-test-123")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestClsMetricSubscribe_Update_Success tests the Update flow builds a
+// ModifyMetricSubscribe request with changed fields and calls Read.
+func TestClsMetricSubscribe_Update_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClsMetricSubscribe().client, "UseClsV20201016Client", clsClient)
+
+	var capturedModifyRequest *clsv20201016.ModifyMetricSubscribeRequest
+	patches.ApplyMethodFunc(clsClient, "ModifyMetricSubscribeWithContext", func(_ context.Context, request *clsv20201016.ModifyMetricSubscribeRequest) (*clsv20201016.ModifyMetricSubscribeResponse, error) {
+		capturedModifyRequest = request
+		resp := clsv20201016.NewModifyMetricSubscribeResponse()
+		resp.Response = &clsv20201016.ModifyMetricSubscribeResponseParams{
+			RequestId: ptrStringMS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	info := buildMetricSubscribeInfo()
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsMetricSubscribeById", func(_ context.Context, _ string, _ string) (*clsv20201016.MetricSubscribeInfo, error) {
+		return info, nil
+	})
+
+	meta := newMockMetaForClsMetricSubscribe()
+	res := localcls.ResourceTencentCloudClsMetricSubscribe()
+	d := schema.TestResourceDataRaw(t, res.Schema, metricSubscribeRawInput())
+	d.SetId("topic-test-123" + tccommon.FILED_SP + "task-test-123")
+
+	// Simulate a change on "name" to trigger the Modify call
+	_ = d.Set("name", "tf-example-metric-subscribe-updated")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	// Verify the modify request carried TopicId/TaskId and the updated name
+	assert.NotNil(t, capturedModifyRequest)
+	assert.Equal(t, "topic-test-123", *capturedModifyRequest.TopicId)
+	assert.Equal(t, "task-test-123", *capturedModifyRequest.TaskId)
+	assert.Equal(t, "tf-example-metric-subscribe-updated", *capturedModifyRequest.Name)
+}
+
+// TestClsMetricSubscribe_Delete_Success tests the Delete flow builds a
+// DeleteMetricSubscribe request with TaskId and TopicId from the composite id.
+func TestClsMetricSubscribe_Delete_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClsMetricSubscribe().client, "UseClsV20201016Client", clsClient)
+
+	var capturedRequest *clsv20201016.DeleteMetricSubscribeRequest
+	patches.ApplyMethodFunc(clsClient, "DeleteMetricSubscribeWithContext", func(_ context.Context, request *clsv20201016.DeleteMetricSubscribeRequest) (*clsv20201016.DeleteMetricSubscribeResponse, error) {
+		capturedRequest = request
+		resp := clsv20201016.NewDeleteMetricSubscribeResponse()
+		resp.Response = &clsv20201016.DeleteMetricSubscribeResponseParams{
+			RequestId: ptrStringMS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForClsMetricSubscribe()
+	res := localcls.ResourceTencentCloudClsMetricSubscribe()
+	d := schema.TestResourceDataRaw(t, res.Schema, metricSubscribeRawInput())
+	d.SetId("topic-test-123" + tccommon.FILED_SP + "task-test-123")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+
+	// Verify the delete request carried TaskId and TopicId from the composite id
+	assert.NotNil(t, capturedRequest)
+	assert.Equal(t, "task-test-123", *capturedRequest.TaskId)
+	assert.Equal(t, "topic-test-123", *capturedRequest.TopicId)
+}
+
+// TestClsMetricSubscribe_Schema tests key schema definitions.
+func TestClsMetricSubscribe_Schema(t *testing.T) {
+	res := localcls.ResourceTencentCloudClsMetricSubscribe()
+
+	assert.NotNil(t, res)
+
+	// ForceNew fields
+	topicIdSchema := res.Schema["topic_id"]
+	assert.True(t, topicIdSchema.ForceNew)
+	assert.True(t, topicIdSchema.Required)
+
+	// Computed fields
+	for _, field := range []string{"task_id", "status", "create_time", "update_time"} {
+		s := res.Schema[field]
+		assert.True(t, s.Computed, "field %s should be Computed", field)
+	}
+
+	// instance_info MaxItems=1
+	instanceInfoSchema := res.Schema["instance_info"]
+	assert.Equal(t, 1, instanceInfoSchema.MaxItems)
+
+	// Importer registered
+	assert.NotNil(t, res.Importer)
+}

--- a/tencentcloud/services/cls/service_tencentcloud_cls.go
+++ b/tencentcloud/services/cls/service_tencentcloud_cls.go
@@ -1946,3 +1946,56 @@ func (me *ClsService) DescribeClsConsoleById(ctx context.Context, consoleId stri
 	ret = response.Response.Consoles[0]
 	return
 }
+
+func (me *ClsService) DescribeClsMetricSubscribeById(ctx context.Context, topicId, taskId string) (ret *cls.MetricSubscribeInfo, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	var (
+		request  = cls.NewDescribeMetricSubscribesRequest()
+		response = cls.NewDescribeMetricSubscribesResponse()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	request.TopicId = helper.String(topicId)
+	request.Filters = []*cls.Filter{
+		{
+			Key:    helper.String("taskId"),
+			Values: []*string{helper.String(taskId)},
+		},
+	}
+	request.Offset = helper.Uint64(0)
+	request.Limit = helper.Uint64(100)
+
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, e := me.client.UseClsV20201016Client().DescribeMetricSubscribesWithContext(ctx, request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe cls metric subscribe failed, Response is nil."))
+		}
+
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		response = result
+		return nil
+	})
+
+	if err != nil {
+		errRet = err
+		return
+	}
+
+	if len(response.Response.Datas) == 0 {
+		return
+	}
+
+	ret = response.Response.Datas[0]
+	return
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/models.go
@@ -255,74 +255,57 @@ type AlarmInfo struct {
 }
 
 type AlarmNotice struct {
-	// 告警通知渠道组名称。
+	// <p>告警通知渠道组名称。</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 告警通知渠道组绑定的标签信息。
+	// <p>告警通知渠道组绑定的标签信息。</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 告警模板的类型。可选值：
-	// <br><li> Trigger - 告警触发</li>
-	// <br><li> Recovery - 告警恢复</li>
-	// <br><li> All - 告警触发和告警恢复</li>
+	// <p>告警模板的类型。可选值：<br><br><li> Trigger - 告警触发</li><br><br><li> Recovery - 告警恢复</li><br><br><li> All - 告警触发和告警恢复</li></p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 告警通知模板接收者信息。
+	// <p>告警通知模板接收者信息。</p>
 	NoticeReceivers []*NoticeReceiver `json:"NoticeReceivers,omitnil,omitempty" name:"NoticeReceivers"`
 
-	// 告警通知模板回调信息。
+	// <p>告警通知模板回调信息。</p>
 	WebCallbacks []*WebCallback `json:"WebCallbacks,omitnil,omitempty" name:"WebCallbacks"`
 
-	// 告警通知模板ID。
+	// <p>告警通知模板ID。</p>
 	AlarmNoticeId *string `json:"AlarmNoticeId,omitnil,omitempty" name:"AlarmNoticeId"`
 
-	// 通知规则。
+	// <p>通知规则。</p>
 	NoticeRules []*NoticeRule `json:"NoticeRules,omitnil,omitempty" name:"NoticeRules"`
 
-	// 免登录操作告警开关。
-	// 参数值： 1：关闭 2：开启（默认开启）
+	// <p>免登录操作告警开关。<br>参数值： 1：关闭 2：开启（默认开启）</p>
 	AlarmShieldStatus *uint64 `json:"AlarmShieldStatus,omitnil,omitempty" name:"AlarmShieldStatus"`
 
-	// 调用链接域名。http:// 或者 https:// 开头，不能/结尾
+	// <p>告警详情需要安全认证登录开关，未传时默认&quot;关闭&quot;</p><p>枚举值：</p><ul><li>1： 关闭（默认值）</li><li>2： 开启</li></ul>
+	SecureDetailStatus *uint64 `json:"SecureDetailStatus,omitnil,omitempty" name:"SecureDetailStatus"`
+
+	// <p>调用链接域名。http:// 或者 https:// 开头，不能/结尾</p>
 	JumpDomain *string `json:"JumpDomain,omitnil,omitempty" name:"JumpDomain"`
 
-	// 投递相关信息。
+	// <p>投递相关信息。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	AlarmNoticeDeliverConfig *AlarmNoticeDeliverConfig `json:"AlarmNoticeDeliverConfig,omitnil,omitempty" name:"AlarmNoticeDeliverConfig"`
 
-	// 创建时间。格式： YYYY-MM-DD HH:MM:SS
+	// <p>创建时间。格式： YYYY-MM-DD HH:MM:SS</p>
 	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
-	// 最近更新时间。格式： YYYY-MM-DD HH:MM:SS
+	// <p>最近更新时间。格式： YYYY-MM-DD HH:MM:SS</p>
 	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 
-	// 投递日志开关。
-	// 
-	// 参数值：
-	// 
-	// 1：关闭
-	// 
-	// 2：开启 
+	// <p>投递日志开关。</p><p>参数值：</p><p>1：关闭</p><p>2：开启</p>
 	DeliverStatus *uint64 `json:"DeliverStatus,omitnil,omitempty" name:"DeliverStatus"`
 
-	// 投递日志标识。
-	// 
-	// 参数值：
-	// 
-	// 1：未启用
-	// 
-	// 2：已启用
-	// 
-	// 3：投递异常
+	// <p>投递日志标识。</p><p>参数值：</p><p>1：未启用</p><p>2：已启用</p><p>3：投递异常</p>
 	DeliverFlag *uint64 `json:"DeliverFlag,omitnil,omitempty" name:"DeliverFlag"`
 
-	// 通知渠道组配置的告警屏蔽统计状态数量信息。
+	// <p>通知渠道组配置的告警屏蔽统计状态数量信息。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	AlarmShieldCount *AlarmShieldCount `json:"AlarmShieldCount,omitnil,omitempty" name:"AlarmShieldCount"`
 
-	// 统一设定自定义回调参数。
-	// -  true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。
-	// -  false:优先使用告警策略中单独配置的请求头及请求内容。
+	// <p>统一设定自定义回调参数。</p><ul><li>true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。</li><li>false:优先使用告警策略中单独配置的请求头及请求内容。</li></ul>
 	CallbackPrioritize *bool `json:"CallbackPrioritize,omitnil,omitempty" name:"CallbackPrioritize"`
 }
 
@@ -1984,102 +1967,80 @@ func (r *CreateAgentApplicationResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateAlarmNoticeRequestParams struct {
-	// 通知渠道组名称。最大支持255个字节。 不支持 '|'。
+	// <p>通知渠道组名称。最大支持255个字节。 不支持 &#39;|&#39;。</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 标签描述列表，通过指定该参数可以同时绑定标签到相应的通知渠道组。最大支持50个标签键值对，并且不能有重复的键值对。
+	// <p>标签描述列表，通过指定该参数可以同时绑定标签到相应的通知渠道组。最大支持50个标签键值对，并且不能有重复的键值对。</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 【简易模式】（简易模式/告警模式二选一，分别配置相应参数）
-	// 需要发送通知的告警类型。可选值：
-	// - Trigger - 告警触发
-	// - Recovery - 告警恢复
-	// - All - 告警触发和告警恢复
+	// <p>【简易模式】（简易模式/告警模式二选一，分别配置相应参数）<br>需要发送通知的告警类型。可选值：</p><ul><li>Trigger - 告警触发</li><li>Recovery - 告警恢复</li><li>All - 告警触发和告警恢复</li></ul>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 【简易模式】（简易模式/告警模式二选一，分别配置相应参数）
-	// 通知接收对象。
+	// <p>【简易模式】（简易模式/告警模式二选一，分别配置相应参数）<br>通知接收对象。</p>
 	NoticeReceivers []*NoticeReceiver `json:"NoticeReceivers,omitnil,omitempty" name:"NoticeReceivers"`
 
-	// 【简易模式】（简易模式/告警模式二选一，分别配置相应参数）
-	// 接口回调信息（包括企业微信、钉钉、飞书）。
+	// <p>【简易模式】（简易模式/告警模式二选一，分别配置相应参数）<br>接口回调信息（包括企业微信、钉钉、飞书）。</p>
 	WebCallbacks []*WebCallback `json:"WebCallbacks,omitnil,omitempty" name:"WebCallbacks"`
 
-	// 【高级模式】（简易模式/告警模式二选一，分别配置相应参数）
-	// 通知规则。
+	// <p>【高级模式】（简易模式/告警模式二选一，分别配置相应参数）<br>通知规则。</p>
 	NoticeRules []*NoticeRule `json:"NoticeRules,omitnil,omitempty" name:"NoticeRules"`
 
-	// 查询数据链接。http:// 或者 https:// 开头，不能/结尾
+	// <p>查询数据链接。http:// 或者 https:// 开头，不能/结尾</p>
 	JumpDomain *string `json:"JumpDomain,omitnil,omitempty" name:"JumpDomain"`
 
-	// 投递日志开关。可取值如下：
-	// 1：关闭（默认值）；
-	// 2：开启 
-	// 投递日志开关开启时， DeliverConfig参数必填。
+	// <p>投递日志开关。可取值如下：<br>1：关闭（默认值）；<br>2：开启<br>投递日志开关开启时， DeliverConfig参数必填。</p>
 	DeliverStatus *uint64 `json:"DeliverStatus,omitnil,omitempty" name:"DeliverStatus"`
 
-	// 投递日志配置参数。当DeliverStatus开启时，必填。
+	// <p>投递日志配置参数。当DeliverStatus开启时，必填。</p>
 	DeliverConfig *DeliverConfig `json:"DeliverConfig,omitnil,omitempty" name:"DeliverConfig"`
 
-	// 免登录操作告警开关。可取值如下：
-	// -      1：关闭
-	// -      2：开启（默认值）
+	// <p>免登录操作告警开关。可取值如下：</p><ul><li>1：关闭</li><li>2：开启（默认值）</li></ul>
 	AlarmShieldStatus *uint64 `json:"AlarmShieldStatus,omitnil,omitempty" name:"AlarmShieldStatus"`
 
-	// 统一设定自定义回调参数。
-	// -  true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。
-	// -  false:优先使用告警策略中单独配置的请求头及请求内容。
+	// <p>告警详情安全认证跳转开关，未传时默认&quot;关闭&quot;</p><p>枚举值：</p><ul><li>1： 关闭（默认值）</li><li>2： 开启</li></ul>
+	SecureDetailStatus *uint64 `json:"SecureDetailStatus,omitnil,omitempty" name:"SecureDetailStatus"`
+
+	// <p>统一设定自定义回调参数。</p><ul><li>true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。</li><li>false:优先使用告警策略中单独配置的请求头及请求内容。</li></ul>
 	CallbackPrioritize *bool `json:"CallbackPrioritize,omitnil,omitempty" name:"CallbackPrioritize"`
 }
 
 type CreateAlarmNoticeRequest struct {
 	*tchttp.BaseRequest
 	
-	// 通知渠道组名称。最大支持255个字节。 不支持 '|'。
+	// <p>通知渠道组名称。最大支持255个字节。 不支持 &#39;|&#39;。</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 标签描述列表，通过指定该参数可以同时绑定标签到相应的通知渠道组。最大支持50个标签键值对，并且不能有重复的键值对。
+	// <p>标签描述列表，通过指定该参数可以同时绑定标签到相应的通知渠道组。最大支持50个标签键值对，并且不能有重复的键值对。</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 【简易模式】（简易模式/告警模式二选一，分别配置相应参数）
-	// 需要发送通知的告警类型。可选值：
-	// - Trigger - 告警触发
-	// - Recovery - 告警恢复
-	// - All - 告警触发和告警恢复
+	// <p>【简易模式】（简易模式/告警模式二选一，分别配置相应参数）<br>需要发送通知的告警类型。可选值：</p><ul><li>Trigger - 告警触发</li><li>Recovery - 告警恢复</li><li>All - 告警触发和告警恢复</li></ul>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 【简易模式】（简易模式/告警模式二选一，分别配置相应参数）
-	// 通知接收对象。
+	// <p>【简易模式】（简易模式/告警模式二选一，分别配置相应参数）<br>通知接收对象。</p>
 	NoticeReceivers []*NoticeReceiver `json:"NoticeReceivers,omitnil,omitempty" name:"NoticeReceivers"`
 
-	// 【简易模式】（简易模式/告警模式二选一，分别配置相应参数）
-	// 接口回调信息（包括企业微信、钉钉、飞书）。
+	// <p>【简易模式】（简易模式/告警模式二选一，分别配置相应参数）<br>接口回调信息（包括企业微信、钉钉、飞书）。</p>
 	WebCallbacks []*WebCallback `json:"WebCallbacks,omitnil,omitempty" name:"WebCallbacks"`
 
-	// 【高级模式】（简易模式/告警模式二选一，分别配置相应参数）
-	// 通知规则。
+	// <p>【高级模式】（简易模式/告警模式二选一，分别配置相应参数）<br>通知规则。</p>
 	NoticeRules []*NoticeRule `json:"NoticeRules,omitnil,omitempty" name:"NoticeRules"`
 
-	// 查询数据链接。http:// 或者 https:// 开头，不能/结尾
+	// <p>查询数据链接。http:// 或者 https:// 开头，不能/结尾</p>
 	JumpDomain *string `json:"JumpDomain,omitnil,omitempty" name:"JumpDomain"`
 
-	// 投递日志开关。可取值如下：
-	// 1：关闭（默认值）；
-	// 2：开启 
-	// 投递日志开关开启时， DeliverConfig参数必填。
+	// <p>投递日志开关。可取值如下：<br>1：关闭（默认值）；<br>2：开启<br>投递日志开关开启时， DeliverConfig参数必填。</p>
 	DeliverStatus *uint64 `json:"DeliverStatus,omitnil,omitempty" name:"DeliverStatus"`
 
-	// 投递日志配置参数。当DeliverStatus开启时，必填。
+	// <p>投递日志配置参数。当DeliverStatus开启时，必填。</p>
 	DeliverConfig *DeliverConfig `json:"DeliverConfig,omitnil,omitempty" name:"DeliverConfig"`
 
-	// 免登录操作告警开关。可取值如下：
-	// -      1：关闭
-	// -      2：开启（默认值）
+	// <p>免登录操作告警开关。可取值如下：</p><ul><li>1：关闭</li><li>2：开启（默认值）</li></ul>
 	AlarmShieldStatus *uint64 `json:"AlarmShieldStatus,omitnil,omitempty" name:"AlarmShieldStatus"`
 
-	// 统一设定自定义回调参数。
-	// -  true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。
-	// -  false:优先使用告警策略中单独配置的请求头及请求内容。
+	// <p>告警详情安全认证跳转开关，未传时默认&quot;关闭&quot;</p><p>枚举值：</p><ul><li>1： 关闭（默认值）</li><li>2： 开启</li></ul>
+	SecureDetailStatus *uint64 `json:"SecureDetailStatus,omitnil,omitempty" name:"SecureDetailStatus"`
+
+	// <p>统一设定自定义回调参数。</p><ul><li>true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。</li><li>false:优先使用告警策略中单独配置的请求头及请求内容。</li></ul>
 	CallbackPrioritize *bool `json:"CallbackPrioritize,omitnil,omitempty" name:"CallbackPrioritize"`
 }
 
@@ -2105,6 +2066,7 @@ func (r *CreateAlarmNoticeRequest) FromJsonString(s string) error {
 	delete(f, "DeliverStatus")
 	delete(f, "DeliverConfig")
 	delete(f, "AlarmShieldStatus")
+	delete(f, "SecureDetailStatus")
 	delete(f, "CallbackPrioritize")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateAlarmNoticeRequest has unknown keys!", "")
@@ -2114,7 +2076,7 @@ func (r *CreateAlarmNoticeRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateAlarmNoticeResponseParams struct {
-	// 告警模板ID
+	// <p>告警模板ID</p>
 	AlarmNoticeId *string `json:"AlarmNoticeId,omitnil,omitempty" name:"AlarmNoticeId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -4703,38 +4665,26 @@ func (r *CreateKafkaRechargeResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateLogsetRequestParams struct {
-	// 日志集名字。
-	// 
-	// - 最大支持255个字符。不支持`|`字符。
+	// <p>日志集名字。</p><ul><li>最大支持255个字符。不支持<code>|</code>字符。</li></ul>
 	LogsetName *string `json:"LogsetName,omitnil,omitempty" name:"LogsetName"`
 
-	// 标签描述列表。最大支持10个标签键值对，并且不能有重复的键值对
+	// <p>标签描述列表。最大支持10个标签键值对，并且不能有重复的键值对</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 日志集ID，格式为：用户自定义部分-用户APPID。未填写该参数时将自动生成ID。
-	// 
-	// - 用户自定义部分仅支持小写字母、数字和-，且不能以-开头和结尾，长度为3至40字符。
-	// - 尾部需要使用-拼接用户APPID，APPID可在https://console.cloud.tencent.com/developer页面查询。
-	// - 如果指定该字段，需保证全地域唯一
+	// <p>日志集ID，格式为：用户自定义部分-用户APPID。未填写该参数时将自动生成ID。</p><ul><li>用户自定义部分仅支持小写字母、数字和-，且不能以-开头和结尾，长度为3至40字符。</li><li>尾部需要使用-拼接用户APPID，APPID可在https://console.cloud.tencent.com/developer页面查询。</li><li>如果指定该字段，需保证全地域唯一</li></ul>
 	LogsetId *string `json:"LogsetId,omitnil,omitempty" name:"LogsetId"`
 }
 
 type CreateLogsetRequest struct {
 	*tchttp.BaseRequest
 	
-	// 日志集名字。
-	// 
-	// - 最大支持255个字符。不支持`|`字符。
+	// <p>日志集名字。</p><ul><li>最大支持255个字符。不支持<code>|</code>字符。</li></ul>
 	LogsetName *string `json:"LogsetName,omitnil,omitempty" name:"LogsetName"`
 
-	// 标签描述列表。最大支持10个标签键值对，并且不能有重复的键值对
+	// <p>标签描述列表。最大支持10个标签键值对，并且不能有重复的键值对</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 日志集ID，格式为：用户自定义部分-用户APPID。未填写该参数时将自动生成ID。
-	// 
-	// - 用户自定义部分仅支持小写字母、数字和-，且不能以-开头和结尾，长度为3至40字符。
-	// - 尾部需要使用-拼接用户APPID，APPID可在https://console.cloud.tencent.com/developer页面查询。
-	// - 如果指定该字段，需保证全地域唯一
+	// <p>日志集ID，格式为：用户自定义部分-用户APPID。未填写该参数时将自动生成ID。</p><ul><li>用户自定义部分仅支持小写字母、数字和-，且不能以-开头和结尾，长度为3至40字符。</li><li>尾部需要使用-拼接用户APPID，APPID可在https://console.cloud.tencent.com/developer页面查询。</li><li>如果指定该字段，需保证全地域唯一</li></ul>
 	LogsetId *string `json:"LogsetId,omitnil,omitempty" name:"LogsetId"`
 }
 
@@ -4761,7 +4711,7 @@ func (r *CreateLogsetRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateLogsetResponseParams struct {
-	// 日志集ID
+	// <p>日志集ID</p>
 	LogsetId *string `json:"LogsetId,omitnil,omitempty" name:"LogsetId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -8432,7 +8382,7 @@ func (r *DeleteKafkaRechargeResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteLogRequestParams struct {
-	// <p>日志主题id</p>
+	// <p>日志主题id</p><p>仅在创建日志主题时，开启了日志修改/删除开关的主题，支持日志修改/删除。该功能暂时仅面向白名单内客户使用。</p>
 	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
 
 	// <p>检索时间范围-开始时间</p><p>单位：ms</p>
@@ -8448,7 +8398,7 @@ type DeleteLogRequestParams struct {
 type DeleteLogRequest struct {
 	*tchttp.BaseRequest
 	
-	// <p>日志主题id</p>
+	// <p>日志主题id</p><p>仅在创建日志主题时，开启了日志修改/删除开关的主题，支持日志修改/删除。该功能暂时仅面向白名单内客户使用。</p>
 	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
 
 	// <p>检索时间范围-开始时间</p><p>单位：ms</p>
@@ -17160,118 +17110,86 @@ func (r *ModifyAgentApplicationResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyAlarmNoticeRequestParams struct {
-	// 通知渠道组ID。-通过[获取通知渠道组列表](https://cloud.tencent.com/document/api/614/56462)获取通知渠道组ID
+	// <p>通知渠道组ID。-通过<a href="https://cloud.tencent.com/document/api/614/56462">获取通知渠道组列表</a>获取通知渠道组ID</p>
 	AlarmNoticeId *string `json:"AlarmNoticeId,omitnil,omitempty" name:"AlarmNoticeId"`
 
-	// 标签描述列表，通过指定该参数可以同时绑定标签到相应的通知渠道组。最大支持10个标签键值对，并且不能有重复的键值对。
+	// <p>标签描述列表，通过指定该参数可以同时绑定标签到相应的通知渠道组。最大支持10个标签键值对，并且不能有重复的键值对。</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 通知渠道组名称。
+	// <p>通知渠道组名称。</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 通知类型。可选值：
-	// <li> Trigger - 告警触发</li>
-	// <li> Recovery - 告警恢复</li>
-	// <li> All - 告警触发和告警恢复</li>
+	// <p>通知类型。可选值：</p><li> Trigger - 告警触发</li><li> Recovery - 告警恢复</li><li> All - 告警触发和告警恢复</li>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 通知接收对象。
+	// <p>通知接收对象。</p>
 	NoticeReceivers []*NoticeReceiver `json:"NoticeReceivers,omitnil,omitempty" name:"NoticeReceivers"`
 
-	// 接口回调信息（包括企业微信等）。
+	// <p>接口回调信息（包括企业微信等）。</p>
 	WebCallbacks []*WebCallback `json:"WebCallbacks,omitnil,omitempty" name:"WebCallbacks"`
 
-	// 通知规则。
-	// 
-	// 注意: 
-	// 
-	// - Type、NoticeReceivers和WebCallbacks是一组配置，NoticeRules是另一组配置，2组配置互斥。
-	// - 传其中一组数据，则另一组数据置空。
+	// <p>通知规则。</p><p>注意: </p><ul><li>Type、NoticeReceivers和WebCallbacks是一组配置，NoticeRules是另一组配置，2组配置互斥。</li><li>传其中一组数据，则另一组数据置空。</li></ul>
 	NoticeRules []*NoticeRule `json:"NoticeRules,omitnil,omitempty" name:"NoticeRules"`
 
-	// 调用链接域名。http:// 或者 https:// 开头，不能/结尾
+	// <p>调用链接域名。http:// 或者 https:// 开头，不能/结尾</p>
 	JumpDomain *string `json:"JumpDomain,omitnil,omitempty" name:"JumpDomain"`
 
-	// 投递日志开关。
-	// 
-	// 参数值：
-	// 1：关闭；
-	// 
-	// 2：开启 
+	// <p>投递日志开关。</p><p>参数值：<br>1：关闭；</p><p>2：开启</p>
 	DeliverStatus *uint64 `json:"DeliverStatus,omitnil,omitempty" name:"DeliverStatus"`
 
-	// 投递日志配置。
+	// <p>投递日志配置。</p>
 	DeliverConfig *DeliverConfig `json:"DeliverConfig,omitnil,omitempty" name:"DeliverConfig"`
 
-	// 免登录操作告警开关。
-	// 
-	// 参数值： 
-	//         1：关闭
-	//         2：开启（默认开启）
+	// <p>免登录操作告警开关。</p><p>参数值：<br>        1：关闭<br>        2：开启（默认开启）</p>
 	AlarmShieldStatus *uint64 `json:"AlarmShieldStatus,omitnil,omitempty" name:"AlarmShieldStatus"`
 
-	// 统一设定自定义回调参数。
-	// -  true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。
-	// -  false:优先使用告警策略中单独配置的请求头及请求内容。
+	// <p>告警详情安全认证跳转开关，未传时默认&quot;关闭&quot;</p><p>枚举值：</p><ul><li>1： 关闭（默认值）</li><li>2： 开启</li></ul>
+	SecureDetailStatus *uint64 `json:"SecureDetailStatus,omitnil,omitempty" name:"SecureDetailStatus"`
+
+	// <p>统一设定自定义回调参数。</p><ul><li>true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。</li><li>false:优先使用告警策略中单独配置的请求头及请求内容。</li></ul>
 	CallbackPrioritize *bool `json:"CallbackPrioritize,omitnil,omitempty" name:"CallbackPrioritize"`
 }
 
 type ModifyAlarmNoticeRequest struct {
 	*tchttp.BaseRequest
 	
-	// 通知渠道组ID。-通过[获取通知渠道组列表](https://cloud.tencent.com/document/api/614/56462)获取通知渠道组ID
+	// <p>通知渠道组ID。-通过<a href="https://cloud.tencent.com/document/api/614/56462">获取通知渠道组列表</a>获取通知渠道组ID</p>
 	AlarmNoticeId *string `json:"AlarmNoticeId,omitnil,omitempty" name:"AlarmNoticeId"`
 
-	// 标签描述列表，通过指定该参数可以同时绑定标签到相应的通知渠道组。最大支持10个标签键值对，并且不能有重复的键值对。
+	// <p>标签描述列表，通过指定该参数可以同时绑定标签到相应的通知渠道组。最大支持10个标签键值对，并且不能有重复的键值对。</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 通知渠道组名称。
+	// <p>通知渠道组名称。</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 通知类型。可选值：
-	// <li> Trigger - 告警触发</li>
-	// <li> Recovery - 告警恢复</li>
-	// <li> All - 告警触发和告警恢复</li>
+	// <p>通知类型。可选值：</p><li> Trigger - 告警触发</li><li> Recovery - 告警恢复</li><li> All - 告警触发和告警恢复</li>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 通知接收对象。
+	// <p>通知接收对象。</p>
 	NoticeReceivers []*NoticeReceiver `json:"NoticeReceivers,omitnil,omitempty" name:"NoticeReceivers"`
 
-	// 接口回调信息（包括企业微信等）。
+	// <p>接口回调信息（包括企业微信等）。</p>
 	WebCallbacks []*WebCallback `json:"WebCallbacks,omitnil,omitempty" name:"WebCallbacks"`
 
-	// 通知规则。
-	// 
-	// 注意: 
-	// 
-	// - Type、NoticeReceivers和WebCallbacks是一组配置，NoticeRules是另一组配置，2组配置互斥。
-	// - 传其中一组数据，则另一组数据置空。
+	// <p>通知规则。</p><p>注意: </p><ul><li>Type、NoticeReceivers和WebCallbacks是一组配置，NoticeRules是另一组配置，2组配置互斥。</li><li>传其中一组数据，则另一组数据置空。</li></ul>
 	NoticeRules []*NoticeRule `json:"NoticeRules,omitnil,omitempty" name:"NoticeRules"`
 
-	// 调用链接域名。http:// 或者 https:// 开头，不能/结尾
+	// <p>调用链接域名。http:// 或者 https:// 开头，不能/结尾</p>
 	JumpDomain *string `json:"JumpDomain,omitnil,omitempty" name:"JumpDomain"`
 
-	// 投递日志开关。
-	// 
-	// 参数值：
-	// 1：关闭；
-	// 
-	// 2：开启 
+	// <p>投递日志开关。</p><p>参数值：<br>1：关闭；</p><p>2：开启</p>
 	DeliverStatus *uint64 `json:"DeliverStatus,omitnil,omitempty" name:"DeliverStatus"`
 
-	// 投递日志配置。
+	// <p>投递日志配置。</p>
 	DeliverConfig *DeliverConfig `json:"DeliverConfig,omitnil,omitempty" name:"DeliverConfig"`
 
-	// 免登录操作告警开关。
-	// 
-	// 参数值： 
-	//         1：关闭
-	//         2：开启（默认开启）
+	// <p>免登录操作告警开关。</p><p>参数值：<br>        1：关闭<br>        2：开启（默认开启）</p>
 	AlarmShieldStatus *uint64 `json:"AlarmShieldStatus,omitnil,omitempty" name:"AlarmShieldStatus"`
 
-	// 统一设定自定义回调参数。
-	// -  true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。
-	// -  false:优先使用告警策略中单独配置的请求头及请求内容。
+	// <p>告警详情安全认证跳转开关，未传时默认&quot;关闭&quot;</p><p>枚举值：</p><ul><li>1： 关闭（默认值）</li><li>2： 开启</li></ul>
+	SecureDetailStatus *uint64 `json:"SecureDetailStatus,omitnil,omitempty" name:"SecureDetailStatus"`
+
+	// <p>统一设定自定义回调参数。</p><ul><li>true: 使用通知内容模板中的自定义回调参数覆盖告警策略中单独配置的请求头及请求内容。</li><li>false:优先使用告警策略中单独配置的请求头及请求内容。</li></ul>
 	CallbackPrioritize *bool `json:"CallbackPrioritize,omitnil,omitempty" name:"CallbackPrioritize"`
 }
 
@@ -17298,6 +17216,7 @@ func (r *ModifyAlarmNoticeRequest) FromJsonString(s string) error {
 	delete(f, "DeliverStatus")
 	delete(f, "DeliverConfig")
 	delete(f, "AlarmShieldStatus")
+	delete(f, "SecureDetailStatus")
 	delete(f, "CallbackPrioritize")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyAlarmNoticeRequest has unknown keys!", "")
@@ -19741,7 +19660,7 @@ func (r *ModifyKafkaRechargeResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyLogRequestParams struct {
-	// <p>日志主题id</p>
+	// <p>日志主题id</p><p>仅在创建日志主题时，开启了日志修改/删除开关的主题，支持日志修改/删除。该功能暂时仅面向白名单内客户使用。</p>
 	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
 
 	// <p>检索时间范围-开始时间</p><p>单位：ms</p>
@@ -19763,7 +19682,7 @@ type ModifyLogRequestParams struct {
 type ModifyLogRequest struct {
 	*tchttp.BaseRequest
 	
-	// <p>日志主题id</p>
+	// <p>日志主题id</p><p>仅在创建日志主题时，开启了日志修改/删除开关的主题，支持日志修改/删除。该功能暂时仅面向白名单内客户使用。</p>
 	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
 
 	// <p>检索时间范围-开始时间</p><p>单位：ms</p>

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.157"
+	params["RequestClient"] = "SDK_GO_1.3.160"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1259,10 +1259,10 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.156
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.160
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.160
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors

--- a/website/docs/r/cls_metric_subscribe.html.markdown
+++ b/website/docs/r/cls_metric_subscribe.html.markdown
@@ -1,0 +1,88 @@
+---
+subcategory: "Cloud Log Service(CLS)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_cls_metric_subscribe"
+sidebar_current: "docs-tencentcloud-resource-cls_metric_subscribe"
+description: |-
+  Provides a resource to create a CLS metric subscribe
+---
+
+# tencentcloud_cls_metric_subscribe
+
+Provides a resource to create a CLS metric subscribe
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_cls_metric_subscribe" "example" {
+  name      = "tf-example-metric-subscribe"
+  topic_id  = "c9b68233-948a-4eaf-a363-d0c2ced393ae"
+  namespace = "QCE/CVM"
+  enable    = 2
+  metrics {
+    metric_name = "cpu_usage"
+    periods     = [60, 300]
+    metric_labels {
+      key   = "label_key"
+      value = "label_value"
+    }
+  }
+  instance_info {
+    instance_dimension = ["InstanceId"]
+    instances {
+      values = ["ins-xxxxxxxx"]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_info` - (Required, List) Instance config info.
+* `metrics` - (Required, List) Metric config info list.
+* `name` - (Required, String) Subscribe task name, up to 64 characters, start with a letter, support 0-9, a-z, A-Z, _, -, Chinese characters.
+* `namespace` - (Required, String) Cloud product namespace.
+* `topic_id` - (Required, String, ForceNew) Log topic id.
+* `enable` - (Optional, Int) Task switch, 1: pause, 2: enable.
+
+The `instance_info` object supports the following:
+
+* `instance_dimension` - (Optional, List) Instance dimension.
+* `instances` - (Optional, List) Instance value list.
+
+The `instances` object of `instance_info` supports the following:
+
+* `values` - (Optional, List) Instance info value list.
+
+The `metric_labels` object of `metrics` supports the following:
+
+* `key` - (Required, String) Metric label name.
+* `value` - (Required, String) Metric label content.
+
+The `metrics` object supports the following:
+
+* `metric_name` - (Required, String) Metric name.
+* `metric_labels` - (Optional, List) Custom metric labels.
+* `periods` - (Optional, List) Statistical period, unit: second(s).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `create_time` - Creation time (second-level timestamp).
+* `status` - Subscribe task running status. 0: creating, 1: paused, 2: running, 3: abnormal.
+* `task_id` - Subscribe task id.
+* `update_time` - Update time (second-level timestamp).
+
+
+## Import
+
+CLS metric subscribe can be imported using the composite id, e.g. the composite id is `topicId#taskId` formatted by `topicId` and `taskId` joined with `#`:
+
+```
+terraform import tencentcloud_cls_metric_subscribe.example topicId#taskId
+```
+

--- a/website/docs/r/cls_metric_subscribe.html.markdown
+++ b/website/docs/r/cls_metric_subscribe.html.markdown
@@ -15,22 +15,48 @@ Provides a resource to create a CLS metric subscribe
 
 ```hcl
 resource "tencentcloud_cls_metric_subscribe" "example" {
-  name      = "tf-example-metric-subscribe"
-  topic_id  = "c9b68233-948a-4eaf-a363-d0c2ced393ae"
-  namespace = "QCE/CVM"
+  name      = "tf-example"
+  topic_id  = "da978f4a-b205-4286-830c-86d0ca45d7f3"
+  namespace = "qce/cvm"
   enable    = 2
   metrics {
-    metric_name = "cpu_usage"
-    periods     = [60, 300]
+    metric_name = "BaseCpuUsage"
+    periods     = [10]
     metric_labels {
       key   = "label_key"
       value = "label_value"
     }
   }
+
+  metrics {
+    metric_name = "CbsVolumeFsUsage"
+    periods     = [10]
+    metric_labels {
+      key   = "label_key"
+      value = "label_value"
+    }
+  }
+
+  metrics {
+    metric_name = "MemUsed"
+    periods     = [10]
+    metric_labels {
+      key   = "label_key"
+      value = "label_value"
+    }
+  }
+
   instance_info {
-    instance_dimension = ["InstanceId"]
+    instance_dimension = [
+      "InstanceId",
+      "diskid"
+    ]
+
     instances {
-      values = ["ins-xxxxxxxx"]
+      values = [
+        "ins-ly9ibb5w",
+        "disk-781trig2"
+      ]
     }
   }
 }
@@ -49,12 +75,12 @@ The following arguments are supported:
 
 The `instance_info` object supports the following:
 
-* `instance_dimension` - (Optional, List) Instance dimension.
-* `instances` - (Optional, List) Instance value list.
+* `instance_dimension` - (Required, List) Instance dimension.
+* `instances` - (Required, List) Instance value list.
 
 The `instances` object of `instance_info` supports the following:
 
-* `values` - (Optional, List) Instance info value list.
+* `values` - (Required, List) Instance info value list.
 
 The `metric_labels` object of `metrics` supports the following:
 
@@ -64,18 +90,16 @@ The `metric_labels` object of `metrics` supports the following:
 The `metrics` object supports the following:
 
 * `metric_name` - (Required, String) Metric name.
+* `periods` - (Required, List) Statistical period, unit: second(s).
 * `metric_labels` - (Optional, List) Custom metric labels.
-* `periods` - (Optional, List) Statistical period, unit: second(s).
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-* `create_time` - Creation time (second-level timestamp).
 * `status` - Subscribe task running status. 0: creating, 1: paused, 2: running, 3: abnormal.
 * `task_id` - Subscribe task id.
-* `update_time` - Update time (second-level timestamp).
 
 
 ## Import
@@ -83,6 +107,6 @@ In addition to all arguments above, the following attributes are exported:
 CLS metric subscribe can be imported using the composite id, e.g. the composite id is `topicId#taskId` formatted by `topicId` and `taskId` joined with `#`:
 
 ```
-terraform import tencentcloud_cls_metric_subscribe.example topicId#taskId
+terraform import tencentcloud_cls_metric_subscribe.example da978f4a-b205-4286-830c-86d0ca45d7f3#bc28af29-b274-4a69-ba77-6e665db26850
 ```
 

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -1794,6 +1794,9 @@
                                     <a href="/docs/providers/tencentcloud/r/cls_machine_group.html">tencentcloud_cls_machine_group</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/r/cls_metric_subscribe.html">tencentcloud_cls_metric_subscribe</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/r/cls_notice_content.html">tencentcloud_cls_notice_content</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add new resource tencentcloud_cls_metric_subscribe for CLS (Cloud Log Service) metric subscribe management. This resource supports full CRUD operations via CLS API v20201016 (CreateMetricSubscribe, DescribeMetricSubscribes, ModifyMetricSubscribe, DeleteMetricSubscribe) and uses a composite ID format topicId#taskId. Includes resource schema, service layer method, provider registration, documentation, and unit tests.