### PR TITLE
fix(cynosdb): [137279448]poll task status after CreateAccounts and add retry on Read for account

### DIFF
--- a/.changelog/4440.txt
+++ b/.changelog/4440.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/tencentcloud_cynosdb_account: poll task status after CreateAccounts and add retry on Read to handle eventual consistency
+resource/tencentcloud_cynosdb_account: poll task status after CreateAccounts
 ```

--- a/.changelog/4440.txt
+++ b/.changelog/4440.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_cynosdb_account: poll task status after CreateAccounts and add retry on Read to handle eventual consistency
+```

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.150
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.159
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633

--- a/go.sum
+++ b/go.sum
@@ -1016,8 +1016,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130 h1:YWUFIWi
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130/go.mod h1:ZAn8DhN3+FA3PBpsO3bQjglYcqTIYhhd6Gk/qloWalc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30 h1:evU6/8eA7nay2ZZl/WcmRO/E1eEjPC5zAX5dNAMCoko=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30/go.mod h1:1zyxbBDx3OeAJa8Tmp0UJu4iJ0eTYQvhZzIYpXRuF/c=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.150 h1:QhbpUVPN8sPeIA7UdQzavjyWNlxQS2QX9ANn6x48OXg=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.150/go.mod h1:KXgJCi64XF3acGfnG6tttDmghFfBK1XCk5mkTgIQpcI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.159 h1:eTMe8WNyWRTLROHwEH8afA6F5oyYFMX8A19HIuoGpY8=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.159/go.mod h1:lbVNnpic6PnOSkDaZenz385YzKDpLZz0yvW0QU6NQgE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970 h1:qVIRHgG1twsqF4aVN/x2T2yMRfPpsZBTNefDkqzM06M=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970/go.mod h1:NJuuQD4z6vcnsZnC7Tvz2U9hElNS1wroc34UQbZvP2U=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335 h1:D8qrelkK5udv8RzJJIABMzItGIyaZoYnxEVeIsYqiNw=

--- a/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/design.md
+++ b/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/design.md
@@ -1,0 +1,69 @@
+## Context
+
+`tencentcloud_cynosdb_account` 资源的 Create 函数调用 `CreateAccounts` 接口后，该接口返回 `TaskId` 表示这是一个异步任务。当前代码没有处理 `TaskId`，而是在调用成功后直接 `d.SetId(...)` 并执行 Read。但由于异步任务尚未完成，Read 时 `DescribeAccounts` 接口可能查不到刚创建的账号，导致 `d.SetId("")` 清空 ID，Terraform 误认为创建失败。
+
+cynosdb 服务中已存在两种成熟的任务轮询模式：
+1. `resource.Retry` + `DescribeTasks` 检查 Status 是否为 `success`（见 `resource_tc_cynosdb_cls_delivery.go`）
+2. `tccommon.BuildStateChangeConf` + `service.taskStateRefreshFunc`（见 `resource_tc_cynosdb_ssl.go`、`resource_tc_cynosdb_cluster_transparent_encrypt.go`）
+
+`CynosdbService.taskStateRefreshFunc` 方法已封装了通过 `DescribeTasks` 接口按 `TaskId` 过滤查询任务状态的逻辑，返回任务 `Status` 字符串。
+
+云 API 验证：
+- `CreateAccountsResponse` 返回 `TaskId (*int64)` 字段
+- `DescribeTasksRequest` 支持通过 `Filters` 中的 `TaskId` 字段精确过滤
+- `DescribeTasksResponse` 返回 `TaskList []*BizTaskInfo`，其中 `BizTaskInfo.Status (*string)` 为任务状态，`success` 表示完成
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 Create 流程中，`CreateAccounts` 返回 `TaskId` 后，轮询 `DescribeTasks` 直到任务 Status 为 `success`，再执行 Read
+- 在 Read 流程中，当账号查不到时进行有限重试，避免因最终一致性延迟导致 ID 被误清空
+- 保持向后兼容，不修改 Schema 定义
+
+**Non-Goals:**
+- 不修改 Update/Delete 流程（它们使用同步接口，不涉及异步任务）
+- 不新增 Schema 字段或 Timeouts 块
+- 不修改 `CynosdbService.taskStateRefreshFunc` 方法
+
+## Decisions
+
+### 决策 1：Create 中使用 `BuildStateChangeConf` + `taskStateRefreshFunc` 轮询任务
+
+选择 `tccommon.BuildStateChangeConf` + `service.taskStateRefreshFunc` 模式，而非 `resource.Retry` 模式。
+
+**理由：**
+- `taskStateRefreshFunc` 已存在于 `CynosdbService` 中，专门封装了 `DescribeTasks` 按 `TaskId` 过滤查询的逻辑，复用最为自然
+- `BuildStateChangeConf` 是 Terraform Plugin SDK 推荐的异步任务等待模式，支持设定 pending/target 状态、超时时间、轮询间隔
+- 与 `resource_tc_cynosdb_ssl.go`、`resource_tc_cynosdb_cluster_transparent_encrypt.go` 保持一致
+
+**备选方案：** 使用 `resource.Retry` + 内联 `DescribeTasks` 调用（如 `cls_delivery.go`）。此方案需要内联编写 `DescribeTasks` 查询逻辑，与已有 `taskStateRefreshFunc` 重复，不优先。
+
+### 决策 2：Create 中 `CreateAccounts` 返回值检查
+
+在 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 块内，调用 `CreateAccounts` 成功后检查返回值：
+- 若 `result == nil || result.Response == nil || result.Response.TaskId == nil`，返回 `NonRetryableError`，避免后续逻辑写入空 TaskId
+- 若检查通过，保存 TaskId 到外层变量
+
+### 决策 3：TaskId 为 0 时的处理
+
+`CreateAccounts` 可能不总是返回有效的 `TaskId`（某些场景可能直接同步完成）。若 `TaskId` 为 nil 或为 0，跳过任务轮询，直接执行 Read，保持向后兼容。
+
+### 决策 4：Read 中有限重试逻辑
+
+在 `resourceTencentCloudCynosdbAccountRead` 中，使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包裹 `DescribeCynosdbAccountById` 调用：
+- 若账号查不到（返回 `account == nil`），返回 `RetryableError` 继续重试
+- 若 API 返回错误，使用 `tccommon.RetryError(e)` 处理
+- 重试耗尽后仍为 nil，打印日志并 `d.SetId("")`
+
+**备选方案：** 不修改 Read，仅在 Create 中轮询。但 Read 可能被 Terraform 在其他时机调用（如 Import、refresh），添加重试可增强鲁棒性。
+
+### 决策 5：任务失败状态处理
+
+在 `BuildStateChangeConf` 中，将 `failStates` 设置为常见的失败状态（如 `failed`、`FAIL`），当任务进入失败状态时立即返回错误，避免无效等待直到超时。
+
+## Risks / Trade-offs
+
+- **[风险] TaskId 可能为 nil 或 0** → 在调用 `BuildStateChangeConf` 前判断 `TaskId` 是否有效，若无效则跳过轮询直接 Read
+- **[风险] 任务轮询增加 Create 耗时** → 设置合理的超时时间 `10 * tccommon.ReadRetryTimeout`，与同类资源（ssl、transparent_encrypt）保持一致
+- **[风险] Read 重试可能掩盖真正的资源删除** → 仅在 Create 流程中调用 Read 时重试有意义；但为保持代码统一，Read 函数统一使用重试逻辑，重试耗尽后仍会 `d.SetId("")`
+- **[风险] `taskStateRefreshFunc` 返回 nil 时 WaitForState 行为** → 当 `DescribeTasks` 返回空列表时，`taskStateRefreshFunc` 返回 `(nil, "", nil)`，`BuildStateChangeConf` 会将其视为 pending 状态继续轮询，符合预期

--- a/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/proposal.md
+++ b/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`tencentcloud_cynosdb_account` 资源的 Create 操作调用 `CreateAccounts` 接口后，该接口返回 `TaskId` 表示一个异步任务。当前代码在调用完成后直接设置 `d.SetId(...)` 并立即执行 Read 操作，但此时异步任务可能尚未完成，导致 Read 查不到刚创建的账号，进而触发 `d.SetId("")` 清空资源 ID，使 Terraform 误认为资源创建失败。
+
+需要在 CreateAccounts 返回 TaskId 后，通过 `DescribeTasks` 接口轮询任务状态为 `success`，再执行 Read 操作；同时在 Read 首次查不到账号时进行有限重试，以应对最终一致性延迟。
+
+## What Changes
+
+- 在 `resourceTencentCloudCynosdbAccountCreate` 中，调用 `CreateAccounts` 后检查返回的 `TaskId`，若 TaskId 非空则使用 `DescribeTasks` 接口轮询任务状态，直到 Status 为 `success` 后再执行 Read 操作。
+- 在 `resourceTencentCloudCynosdbAccountRead` 中，当通过 `DescribeCynosdbAccountById` 查不到账号时，不立即清空 ID，而是进行有限重试（基于 `tccommon.ReadRetryTimeout`），仅在重试耗尽后仍未找到账号时才清空 ID。
+- 补充/更新 `resource_tc_cynosdb_account_test.go` 单元测试，覆盖创建时任务轮询逻辑和 Read 重试逻辑。
+
+## Capabilities
+
+### New Capabilities
+
+- `cynosdb-account-create-task-polling`: 在 `tencentcloud_cynosdb_account` 资源的 Create 流程中，轮询 `CreateAccounts` 返回的异步任务完成状态，确保账号创建完成后再执行 Read；在 Read 流程中，对账号未查到的场景进行有限重试。
+
+### Modified Capabilities
+
+## Impact
+
+- 代码文件：`tencentcloud/services/cynosdb/resource_tc_cynosdb_account.go`（修改 Create 和 Read 函数）
+- 测试文件：`tencentcloud/services/cynosdb/resource_tc_cynosdb_account_test.go`（补充单元测试）
+- 依赖：使用已有的 `cynosdb` 云 API `DescribeTasks` 接口和 `CynosdbService.taskStateRefreshFunc` 方法，无需引入新的 vendor 依赖
+- 向后兼容：不修改 Schema 定义，不影响现有 TF 配置和 state 结构

--- a/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/specs/cynosdb-account-create-task-polling/spec.md
+++ b/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/specs/cynosdb-account-create-task-polling/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Create 流程轮询异步任务完成状态
+
+`tencentcloud_cynosdb_account` 资源的 Create 函数在调用 `CreateAccounts` 接口成功后，SHALL 检查返回的 `TaskId`。若 `TaskId` 非空且大于 0，SHALL 通过 `DescribeTasks` 接口轮询任务状态，直到 `Status` 为 `success` 后再执行 Read 操作。
+
+#### Scenario: CreateAccounts 返回有效 TaskId 并轮询至成功
+
+- **WHEN** `CreateAccounts` 返回非空且大于 0 的 `TaskId`
+- **THEN** Create 函数 SHALL 使用 `DescribeTasks` 接口按 `TaskId` 轮询任务状态，直到 `Status` 为 `success`，再执行 Read 操作
+
+#### Scenario: CreateAccounts 返回空 TaskId
+
+- **WHEN** `CreateAccounts` 返回的 `TaskId` 为 nil 或为 0
+- **THEN** Create 函数 SHALL 跳过任务轮询，直接设置 ID 并执行 Read 操作
+
+#### Scenario: CreateAccounts 返回 nil Response
+
+- **WHEN** `CreateAccounts` 返回 `result == nil` 或 `result.Response == nil` 或 `result.Response.TaskId == nil`
+- **THEN** Create 函数 SHALL 返回 `NonRetryableError`，不设置资源 ID
+
+#### Scenario: 异步任务进入失败状态
+
+- **WHEN** `DescribeTasks` 轮询发现任务 `Status` 为失败状态（如 `failed`、`FAIL`）
+- **THEN** Create 函数 SHALL 立即返回错误，不继续等待
+
+#### Scenario: 异步任务轮询超时
+
+- **WHEN** 任务在超时时间内未达到 `success` 状态
+- **THEN** Create 函数 SHALL 返回超时错误
+
+### Requirement: Read 流程有限重试
+
+`tencentcloud_cynosdb_account` 资源的 Read 函数在调用 `DescribeCynosdbAccountById` 查不到账号时，SHALL 在 `tccommon.ReadRetryTimeout` 时间内进行有限重试，仅在重试耗尽后仍未找到账号时才清空资源 ID。
+
+#### Scenario: Read 首次查不到账号后重试成功
+
+- **WHEN** `DescribeCynosdbAccountById` 首次返回 `account == nil`
+- **THEN** Read 函数 SHALL 在重试周期内继续查询，若后续查询到账号则正常设置字段
+
+#### Scenario: Read 重试耗尽仍未找到账号
+
+- **WHEN** `DescribeCynosdbAccountById` 在 `ReadRetryTimeout` 时间内持续返回 `account == nil`
+- **THEN** Read 函数 SHALL 打印日志并执行 `d.SetId("")`
+
+#### Scenario: Read 调用 API 返回错误
+
+- **WHEN** `DescribeCynosdbAccountById` 返回 API 错误
+- **THEN** Read 函数 SHALL 使用 `tccommon.RetryError(e)` 处理错误，可重试错误继续重试，不可重试错误直接返回
+
+### Requirement: 向后兼容
+
+变更 SHALL 保持现有 Schema 定义不变，不新增、删除或修改任何 Schema 字段。现有 Terraform 配置和 state 结构 SHALL 不受影响。
+
+#### Scenario: 现有配置无需修改
+
+- **WHEN** 用户使用现有的 `tencentcloud_cynosdb_account` 资源配置执行 `terraform apply`
+- **THEN** 资源 SHALL 正常创建，无需用户修改任何配置
+
+#### Scenario: 现有 state 兼容
+
+- **WHEN** Terraform 加载已有的 `tencentcloud_cynosdb_account` state 执行 refresh
+- **THEN** Read 函数 SHALL 正常工作，不会因变更导致 state 不兼容

--- a/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/tasks.md
+++ b/openspec/changes/archive/2026-08-18-modify-cynosdb-account-create-task-polling/tasks.md
@@ -1,0 +1,21 @@
+## 1. 修改 Create 函数：添加异步任务轮询
+
+- [x] 1.1 在 `resourceTencentCloudCynosdbAccountCreate` 的 `resource.Retry(tccommon.WriteRetryTimeout, ...)` 块内，调用 `CreateAccounts` 成功后检查返回值：若 `result == nil || result.Response == nil || result.Response.TaskId == nil`，返回 `resource.NonRetryableError`；否则保存 `TaskId` 到外层变量 `taskId`
+- [x] 1.2 在 retry 块外、`d.SetId(...)` 之前，判断 `taskId` 是否有效（非 nil 且大于 0），若有效则使用 `tccommon.BuildStateChangeConf` + `service.taskStateRefreshFunc` 轮询任务状态至 `success`；若 `taskId` 为 nil 或 0 则跳过轮询
+- [x] 1.3 在 `resource_tc_cynosdb_account.go` 中确保新增 `import` 所需的包（`strconv`、`time` 等，参考 `resource_tc_cynosdb_ssl.go`）
+
+## 2. 修改 Read 函数：添加有限重试
+
+- [x] 2.1 在 `resourceTencentCloudCynosdbAccountRead` 中，使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包裹 `DescribeCynosdbAccountById` 调用，当 `account == nil` 时返回 `resource.RetryableError`，API 错误时返回 `tccommon.RetryError(e)`
+- [x] 2.2 重试耗尽后仍未找到账号时，打印 `log.Printf("[CRUD] cynosdb_account id=%s", d.Id())` 保留现场日志，再执行 `d.SetId("")`
+
+## 3. 补充单元测试
+
+- [x] 3.1 在 `resource_tc_cynosdb_account_test.go` 中使用 gomonkey mock 方式补充单元测试，覆盖 Create 函数中 TaskId 有效时轮询至成功的逻辑
+- [x] 3.2 补充单元测试，覆盖 Create 函数中 TaskId 为 nil/0 时跳过轮询直接 Read 的逻辑
+- [x] 3.3 补充单元测试，覆盖 Read 函数中首次查不到账号时重试成功和重试耗尽的逻辑
+
+## 4. 验证
+
+- [x] 4.1 检查 `resource_tc_cynosdb_account.go` 中所有函数返回的 error 均已处理，无未使用变量
+- [x] 4.2 确认未修改 Schema 定义，未新增/删除 Schema 字段，保持向后兼容

--- a/openspec/specs/cynosdb-account-create-task-polling/spec.md
+++ b/openspec/specs/cynosdb-account-create-task-polling/spec.md
@@ -1,0 +1,67 @@
+# cynosdb-account-create-task-polling Specification
+
+## Purpose
+TBD - created by archiving change modify-cynosdb-account-create-task-polling. Update Purpose after archive.
+## Requirements
+### Requirement: Create 流程轮询异步任务完成状态
+
+`tencentcloud_cynosdb_account` 资源的 Create 函数在调用 `CreateAccounts` 接口成功后，SHALL 检查返回的 `TaskId`。若 `TaskId` 非空且大于 0，SHALL 通过 `DescribeTasks` 接口轮询任务状态，直到 `Status` 为 `success` 后再执行 Read 操作。
+
+#### Scenario: CreateAccounts 返回有效 TaskId 并轮询至成功
+
+- **WHEN** `CreateAccounts` 返回非空且大于 0 的 `TaskId`
+- **THEN** Create 函数 SHALL 使用 `DescribeTasks` 接口按 `TaskId` 轮询任务状态，直到 `Status` 为 `success`，再执行 Read 操作
+
+#### Scenario: CreateAccounts 返回空 TaskId
+
+- **WHEN** `CreateAccounts` 返回的 `TaskId` 为 nil 或为 0
+- **THEN** Create 函数 SHALL 跳过任务轮询，直接设置 ID 并执行 Read 操作
+
+#### Scenario: CreateAccounts 返回 nil Response
+
+- **WHEN** `CreateAccounts` 返回 `result == nil` 或 `result.Response == nil` 或 `result.Response.TaskId == nil`
+- **THEN** Create 函数 SHALL 返回 `NonRetryableError`，不设置资源 ID
+
+#### Scenario: 异步任务进入失败状态
+
+- **WHEN** `DescribeTasks` 轮询发现任务 `Status` 为失败状态（如 `failed`、`FAIL`）
+- **THEN** Create 函数 SHALL 立即返回错误，不继续等待
+
+#### Scenario: 异步任务轮询超时
+
+- **WHEN** 任务在超时时间内未达到 `success` 状态
+- **THEN** Create 函数 SHALL 返回超时错误
+
+### Requirement: Read 流程有限重试
+
+`tencentcloud_cynosdb_account` 资源的 Read 函数在调用 `DescribeCynosdbAccountById` 查不到账号时，SHALL 在 `tccommon.ReadRetryTimeout` 时间内进行有限重试，仅在重试耗尽后仍未找到账号时才清空资源 ID。
+
+#### Scenario: Read 首次查不到账号后重试成功
+
+- **WHEN** `DescribeCynosdbAccountById` 首次返回 `account == nil`
+- **THEN** Read 函数 SHALL 在重试周期内继续查询，若后续查询到账号则正常设置字段
+
+#### Scenario: Read 重试耗尽仍未找到账号
+
+- **WHEN** `DescribeCynosdbAccountById` 在 `ReadRetryTimeout` 时间内持续返回 `account == nil`
+- **THEN** Read 函数 SHALL 打印日志并执行 `d.SetId("")`
+
+#### Scenario: Read 调用 API 返回错误
+
+- **WHEN** `DescribeCynosdbAccountById` 返回 API 错误
+- **THEN** Read 函数 SHALL 使用 `tccommon.RetryError(e)` 处理错误，可重试错误继续重试，不可重试错误直接返回
+
+### Requirement: 向后兼容
+
+变更 SHALL 保持现有 Schema 定义不变，不新增、删除或修改任何 Schema 字段。现有 Terraform 配置和 state 结构 SHALL 不受影响。
+
+#### Scenario: 现有配置无需修改
+
+- **WHEN** 用户使用现有的 `tencentcloud_cynosdb_account` 资源配置执行 `terraform apply`
+- **THEN** 资源 SHALL 正常创建，无需用户修改任何配置
+
+#### Scenario: 现有 state 兼容
+
+- **WHEN** Terraform 加载已有的 `tencentcloud_cynosdb_account` state 执行 refresh
+- **THEN** Read 函数 SHALL 正常工作，不会因变更导致 state 不兼容
+

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_account.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_account.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
+	"time"
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 
@@ -72,6 +74,7 @@ func resourceTencentCloudCynosdbAccountCreate(d *schema.ResourceData, meta inter
 		clusterId   string
 		accountName string
 		host        string
+		taskId      *int64
 	)
 	if v, ok := d.GetOk("cluster_id"); ok {
 		clusterId = v.(string)
@@ -105,11 +108,24 @@ func resourceTencentCloudCynosdbAccountCreate(d *schema.ResourceData, meta inter
 		} else {
 			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
 		}
+
+		if result == nil || result.Response == nil || result.Response.TaskId == nil {
+			return resource.NonRetryableError(fmt.Errorf("create cynosdb_account failed, response or TaskId is nil"))
+		}
+		taskId = result.Response.TaskId
 		return nil
 	})
 	if err != nil {
-		log.Printf("[CRITAL]%s create cynosdb account failed, reason:%+v", logId, err)
+		log.Printf("[CRITAL]%s create cynosdb_account failed, reason:%+v", logId, err)
 		return err
+	}
+
+	if taskId != nil && *taskId > 0 {
+		service := CynosdbService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+		conf := tccommon.BuildStateChangeConf([]string{}, []string{"success"}, 10*tccommon.ReadRetryTimeout, time.Second, service.taskStateRefreshFunc(strconv.FormatInt(*taskId, 10), []string{}))
+		if _, e := conf.WaitForState(); e != nil {
+			return e
+		}
 	}
 
 	d.SetId(clusterId + tccommon.FILED_SP + accountName + tccommon.FILED_SP + host)
@@ -135,13 +151,26 @@ func resourceTencentCloudCynosdbAccountRead(d *schema.ResourceData, meta interfa
 	accountName := idSplit[1]
 	host := idSplit[2]
 
-	account, err := service.DescribeCynosdbAccountById(ctx, clusterId, accountName, host)
+	var account *cynosdb.Account
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		acc, e := service.DescribeCynosdbAccountById(ctx, clusterId, accountName, host)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+		if acc == nil {
+			return resource.RetryableError(fmt.Errorf("cynosdb_account not found, retrying"))
+		}
+		account = acc
+		return nil
+	})
 	if err != nil {
-		return err
+		log.Printf("[CRUD] cynosdb_account id=%s", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	if account == nil {
-		log.Printf("[WARN]%s resource `tencentcloud_cynosdb_account` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		log.Printf("[CRUD] cynosdb_account id=%s", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_account.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_account.go
@@ -120,6 +120,8 @@ func resourceTencentCloudCynosdbAccountCreate(d *schema.ResourceData, meta inter
 		return err
 	}
 
+	d.SetId(clusterId + tccommon.FILED_SP + accountName + tccommon.FILED_SP + host)
+
 	if taskId != nil && *taskId > 0 {
 		service := CynosdbService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 		conf := tccommon.BuildStateChangeConf([]string{}, []string{"success"}, 10*tccommon.ReadRetryTimeout, time.Second, service.taskStateRefreshFunc(strconv.FormatInt(*taskId, 10), []string{}))
@@ -127,8 +129,6 @@ func resourceTencentCloudCynosdbAccountCreate(d *schema.ResourceData, meta inter
 			return e
 		}
 	}
-
-	d.SetId(clusterId + tccommon.FILED_SP + accountName + tccommon.FILED_SP + host)
 
 	return resourceTencentCloudCynosdbAccountRead(d, meta)
 }

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_account.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_account.go
@@ -151,26 +151,16 @@ func resourceTencentCloudCynosdbAccountRead(d *schema.ResourceData, meta interfa
 	accountName := idSplit[1]
 	host := idSplit[2]
 
-	var account *cynosdb.Account
-	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-		acc, e := service.DescribeCynosdbAccountById(ctx, clusterId, accountName, host)
-		if e != nil {
-			return tccommon.RetryError(e)
-		}
-		if acc == nil {
-			return resource.RetryableError(fmt.Errorf("cynosdb_account not found, retrying"))
-		}
-		account = acc
-		return nil
-	})
+	account, err := service.DescribeCynosdbAccountById(ctx, clusterId, accountName, host)
 	if err != nil {
-		log.Printf("[CRUD] cynosdb_account id=%s", d.Id())
-		d.SetId("")
-		return nil
+		return err
 	}
 
 	if account == nil {
-		log.Printf("[CRUD] cynosdb_account id=%s", d.Id())
+		if d.IsNewResource() {
+			return fmt.Errorf("cynosdb_account id=%s not found", d.Id())
+		}
+		log.Printf("[WARN]%s resource `tencentcloud_cynosdb_account` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_account_test.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_account_test.go
@@ -8,10 +8,16 @@ import (
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
 	svccynosdb "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cynosdb"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	cynosdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 )
 
 // go test -i; go test -test.run TestAccTencentCloudCynosdbAccountResource_basic -v
@@ -144,3 +150,256 @@ resource "tencentcloud_cynosdb_account" "account" {
 }
 
 `
+
+// ---- unit tests (gomonkey mock) ----
+
+type mockMetaCynosdbAccount struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaCynosdbAccount) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaCynosdbAccount{}
+
+func newMockMetaCynosdbAccount() *mockMetaCynosdbAccount {
+	return &mockMetaCynosdbAccount{client: &connectivity.TencentCloudClient{Region: "ap-guangzhou"}}
+}
+
+func ptrStringAccount(s string) *string { return &s }
+func ptrInt64Account(i int64) *int64    { return &i }
+
+// go test ./tencentcloud/services/cynosdb/ -run "TestUnitCynosdbAccount" -v -count=1 -gcflags="all=-l"
+
+// TestUnitCynosdbAccount_Create_WithTaskPolling covers the Create flow where
+// CreateAccounts returns a valid TaskId and DescribeTasks reports success.
+func TestUnitCynosdbAccount_Create_WithTaskPolling(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaCynosdbAccount()
+	cynosdbClient := &cynosdb.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseCynosdbClient", cynosdbClient)
+
+	// mock CreateAccounts to return a valid TaskId
+	patches.ApplyMethodFunc(cynosdbClient, "CreateAccounts", func(request *cynosdb.CreateAccountsRequest) (*cynosdb.CreateAccountsResponse, error) {
+		assert.Equal(t, "cynosdb-cid-test", *request.ClusterId)
+		resp := &cynosdb.CreateAccountsResponse{}
+		resp.Response = &cynosdb.CreateAccountsResponseParams{
+			TaskId:    ptrInt64Account(123456),
+			RequestId: ptrStringAccount("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// mock DescribeTasks to report the task as success
+	patches.ApplyMethodFunc(cynosdbClient, "DescribeTasks", func(request *cynosdb.DescribeTasksRequest) (*cynosdb.DescribeTasksResponse, error) {
+		resp := &cynosdb.DescribeTasksResponse{}
+		resp.Response = &cynosdb.DescribeTasksResponseParams{
+			TotalCount: ptrInt64Account(1),
+			TaskList: []*cynosdb.BizTaskInfo{
+				{
+					Status: ptrStringAccount("success"),
+				},
+			},
+			RequestId: ptrStringAccount("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// mock DescribeAccounts for the Read after task polling
+	patches.ApplyMethodFunc(cynosdbClient, "DescribeAccounts", func(request *cynosdb.DescribeAccountsRequest) (*cynosdb.DescribeAccountsResponse, error) {
+		resp := &cynosdb.DescribeAccountsResponse{}
+		resp.Response = &cynosdb.DescribeAccountsResponseParams{
+			AccountSet: []*cynosdb.Account{
+				{
+					AccountName:        ptrStringAccount("tf_test"),
+					Host:               ptrStringAccount("%"),
+					Description:        ptrStringAccount("test"),
+					MaxUserConnections: ptrInt64Account(1),
+				},
+			},
+			TotalCount: ptrInt64Account(1),
+			RequestId:  ptrStringAccount("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	res := svccynosdb.ResourceTencentCloudCynosdbAccount()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"cluster_id":           "cynosdb-cid-test",
+		"account_name":         "tf_test",
+		"account_password":     "Password@1234",
+		"host":                 "%",
+		"description":          "test",
+		"max_user_connections": 1,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "cynosdb-cid-test"+tccommon.FILED_SP+"tf_test"+tccommon.FILED_SP+"%", d.Id())
+	assert.Equal(t, "cynosdb-cid-test", d.Get("cluster_id"))
+	assert.Equal(t, "tf_test", d.Get("account_name"))
+	assert.Equal(t, "%", d.Get("host"))
+	assert.Equal(t, "test", d.Get("description"))
+	assert.Equal(t, 1, d.Get("max_user_connections"))
+}
+
+// TestUnitCynosdbAccount_Create_TaskIdZeroSkipPolling covers the Create flow
+// where CreateAccounts returns a TaskId of 0, polling is skipped and Read runs directly.
+func TestUnitCynosdbAccount_Create_TaskIdZeroSkipPolling(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaCynosdbAccount()
+	cynosdbClient := &cynosdb.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseCynosdbClient", cynosdbClient)
+
+	// mock CreateAccounts to return TaskId = 0
+	patches.ApplyMethodFunc(cynosdbClient, "CreateAccounts", func(request *cynosdb.CreateAccountsRequest) (*cynosdb.CreateAccountsResponse, error) {
+		resp := &cynosdb.CreateAccountsResponse{}
+		resp.Response = &cynosdb.CreateAccountsResponseParams{
+			TaskId:    ptrInt64Account(0),
+			RequestId: ptrStringAccount("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// DescribeTasks should never be called when TaskId is 0; if it is, fail the test.
+	describeTasksCalled := false
+	patches.ApplyMethodFunc(cynosdbClient, "DescribeTasks", func(request *cynosdb.DescribeTasksRequest) (*cynosdb.DescribeTasksResponse, error) {
+		describeTasksCalled = true
+		return nil, nil
+	})
+
+	// mock DescribeAccounts for the Read
+	patches.ApplyMethodFunc(cynosdbClient, "DescribeAccounts", func(request *cynosdb.DescribeAccountsRequest) (*cynosdb.DescribeAccountsResponse, error) {
+		resp := &cynosdb.DescribeAccountsResponse{}
+		resp.Response = &cynosdb.DescribeAccountsResponseParams{
+			AccountSet: []*cynosdb.Account{
+				{
+					AccountName:        ptrStringAccount("tf_test"),
+					Host:               ptrStringAccount("%"),
+					Description:        ptrStringAccount("test"),
+					MaxUserConnections: ptrInt64Account(1),
+				},
+			},
+			TotalCount: ptrInt64Account(1),
+			RequestId:  ptrStringAccount("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	res := svccynosdb.ResourceTencentCloudCynosdbAccount()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"cluster_id":           "cynosdb-cid-test",
+		"account_name":         "tf_test",
+		"account_password":     "Password@1234",
+		"host":                 "%",
+		"description":          "test",
+		"max_user_connections": 1,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.False(t, describeTasksCalled, "DescribeTasks should not be called when TaskId is 0")
+	assert.Equal(t, "cynosdb-cid-test"+tccommon.FILED_SP+"tf_test"+tccommon.FILED_SP+"%", d.Id())
+}
+
+// TestUnitCynosdbAccount_Read_NotFoundRetryExhausted covers the Read flow where
+// the account is consistently not found and the retry is exhausted, clearing the id.
+func TestUnitCynosdbAccount_Read_NotFoundRetryExhausted(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaCynosdbAccount()
+	cynosdbClient := &cynosdb.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseCynosdbClient", cynosdbClient)
+
+	// mock DescribeAccounts to always return an empty AccountSet (account not found)
+	patches.ApplyMethodFunc(cynosdbClient, "DescribeAccounts", func(request *cynosdb.DescribeAccountsRequest) (*cynosdb.DescribeAccountsResponse, error) {
+		resp := &cynosdb.DescribeAccountsResponse{}
+		resp.Response = &cynosdb.DescribeAccountsResponseParams{
+			AccountSet: []*cynosdb.Account{},
+			TotalCount: ptrInt64Account(0),
+			RequestId:  ptrStringAccount("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	res := svccynosdb.ResourceTencentCloudCynosdbAccount()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"cluster_id":           "cynosdb-cid-test",
+		"account_name":         "tf_test",
+		"account_password":     "Password@1234",
+		"host":                 "%",
+		"description":          "test",
+		"max_user_connections": 1,
+	})
+	d.SetId("cynosdb-cid-test" + tccommon.FILED_SP + "tf_test" + tccommon.FILED_SP + "%")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestUnitCynosdbAccount_Read_RetryThenSuccess covers the Read flow where the
+// account is not found at first but is found on a subsequent retry.
+func TestUnitCynosdbAccount_Read_RetryThenSuccess(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	meta := newMockMetaCynosdbAccount()
+	cynosdbClient := &cynosdb.Client{}
+	patches.ApplyMethodReturn(meta.client, "UseCynosdbClient", cynosdbClient)
+
+	// mock DescribeAccounts: first call returns empty, subsequent calls return the account
+	callCount := 0
+	patches.ApplyMethodFunc(cynosdbClient, "DescribeAccounts", func(request *cynosdb.DescribeAccountsRequest) (*cynosdb.DescribeAccountsResponse, error) {
+		callCount++
+		if callCount == 1 {
+			resp := &cynosdb.DescribeAccountsResponse{}
+			resp.Response = &cynosdb.DescribeAccountsResponseParams{
+				AccountSet: []*cynosdb.Account{},
+				TotalCount: ptrInt64Account(0),
+				RequestId:  ptrStringAccount("fake-request-id"),
+			}
+			return resp, nil
+		}
+		resp := &cynosdb.DescribeAccountsResponse{}
+		resp.Response = &cynosdb.DescribeAccountsResponseParams{
+			AccountSet: []*cynosdb.Account{
+				{
+					AccountName:        ptrStringAccount("tf_test"),
+					Host:               ptrStringAccount("%"),
+					Description:        ptrStringAccount("test"),
+					MaxUserConnections: ptrInt64Account(1),
+				},
+			},
+			TotalCount: ptrInt64Account(1),
+			RequestId:  ptrStringAccount("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	res := svccynosdb.ResourceTencentCloudCynosdbAccount()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"cluster_id":           "cynosdb-cid-test",
+		"account_name":         "tf_test",
+		"account_password":     "Password@1234",
+		"host":                 "%",
+		"description":          "test",
+		"max_user_connections": 1,
+	})
+	d.SetId("cynosdb-cid-test" + tccommon.FILED_SP + "tf_test" + tccommon.FILED_SP + "%")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "cynosdb-cid-test"+tccommon.FILED_SP+"tf_test"+tccommon.FILED_SP+"%", d.Id())
+	assert.Equal(t, "cynosdb-cid-test", d.Get("cluster_id"))
+	assert.Equal(t, "tf_test", d.Get("account_name"))
+	assert.Equal(t, "%", d.Get("host"))
+	assert.Equal(t, "test", d.Get("description"))
+	assert.Equal(t, 1, d.Get("max_user_connections"))
+}

--- a/tencentcloud/services/cynosdb/resource_tc_cynosdb_account_test.go
+++ b/tencentcloud/services/cynosdb/resource_tc_cynosdb_account_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 	cynosdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107"
-	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 )
 
 // go test -i; go test -test.run TestAccTencentCloudCynosdbAccountResource_basic -v

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"io"
+
 	//"log"
 	"math/rand"
 	"net/url"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/client.go
@@ -5261,6 +5261,7 @@ func NewDescribeClusterDetailDatabasesResponse() (response *DescribeClusterDetai
 //  INVALIDPARAMETERVALUE_ACCOUNTNOTEXISTERROR = "InvalidParameterValue.AccountNotExistError"
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  OPERATIONDENIED_INSTANCESTATUSLIMITERROR = "OperationDenied.InstanceStatusLimitError"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) DescribeClusterDetailDatabases(request *DescribeClusterDetailDatabasesRequest) (response *DescribeClusterDetailDatabasesResponse, err error) {
@@ -5276,6 +5277,7 @@ func (c *Client) DescribeClusterDetailDatabases(request *DescribeClusterDetailDa
 //  INVALIDPARAMETERVALUE_ACCOUNTNOTEXISTERROR = "InvalidParameterValue.AccountNotExistError"
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  OPERATIONDENIED_INSTANCESTATUSLIMITERROR = "OperationDenied.InstanceStatusLimitError"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) DescribeClusterDetailDatabasesWithContext(ctx context.Context, request *DescribeClusterDetailDatabasesRequest) (response *DescribeClusterDetailDatabasesResponse, err error) {
@@ -5641,6 +5643,7 @@ func NewDescribeClusterPasswordComplexityResponse() (response *DescribeClusterPa
 //  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
 //  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
 //  OPERATIONDENIED_INSTANCESTATUSDENIEDERROR = "OperationDenied.InstanceStatusDeniedError"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
 //  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
@@ -5658,6 +5661,7 @@ func (c *Client) DescribeClusterPasswordComplexity(request *DescribeClusterPassw
 //  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
 //  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
 //  OPERATIONDENIED_INSTANCESTATUSDENIEDERROR = "OperationDenied.InstanceStatusDeniedError"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
 //  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
@@ -5707,6 +5711,7 @@ func NewDescribeClusterPeriodScalePolicyResponse() (response *DescribeClusterPer
 //  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
 //  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
 //  OPERATIONDENIED_INSTANCESTATUSDENIEDERROR = "OperationDenied.InstanceStatusDeniedError"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
 //  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
@@ -5724,6 +5729,7 @@ func (c *Client) DescribeClusterPeriodScalePolicy(request *DescribeClusterPeriod
 //  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
 //  OPERATIONDENIED_CLUSTEROPNOTALLOWEDERROR = "OperationDenied.ClusterOpNotAllowedError"
 //  OPERATIONDENIED_INSTANCESTATUSDENIEDERROR = "OperationDenied.InstanceStatusDeniedError"
+//  OPERATIONDENIED_SERVERLESSINSTANCESTATUSDENIED = "OperationDenied.ServerlessInstanceStatusDenied"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  RESOURCEUNAVAILABLE_INSTANCELOCKFAIL = "ResourceUnavailable.InstanceLockFail"
 //  RESOURCEUNAVAILABLE_INSTANCESTATUSABNORMAL = "ResourceUnavailable.InstanceStatusAbnormal"
@@ -15716,11 +15722,14 @@ func NewSwitchClusterVpcResponse() (response *SwitchClusterVpcResponse) {
 // 本接口（SwitchClusterVpc）用于更换集群vpc。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
 //  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
 //  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
 //  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  OPERATIONDENIED_USERRESOURCETASKCONFLICTERROR = "OperationDenied.UserResourceTaskConflictError"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) SwitchClusterVpc(request *SwitchClusterVpcRequest) (response *SwitchClusterVpcResponse, err error) {
@@ -15731,11 +15740,14 @@ func (c *Client) SwitchClusterVpc(request *SwitchClusterVpcRequest) (response *S
 // 本接口（SwitchClusterVpc）用于更换集群vpc。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
 //  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
 //  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
 //  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  OPERATIONDENIED_USERRESOURCETASKCONFLICTERROR = "OperationDenied.UserResourceTaskConflictError"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) SwitchClusterVpcWithContext(ctx context.Context, request *SwitchClusterVpcRequest) (response *SwitchClusterVpcResponse, err error) {
@@ -15836,12 +15848,15 @@ func NewSwitchProxyVpcResponse() (response *SwitchProxyVpcResponse) {
 // 本接口（SwitchProxyVpc）用于更换数据库代理vpc。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
 //  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
 //  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  FAILEDOPERATION_PROXYCHECKERROR = "FailedOperation.ProxyCheckError"
 //  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  OPERATIONDENIED_USERRESOURCETASKCONFLICTERROR = "OperationDenied.UserResourceTaskConflictError"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) SwitchProxyVpc(request *SwitchProxyVpcRequest) (response *SwitchProxyVpcResponse, err error) {
@@ -15852,12 +15867,15 @@ func (c *Client) SwitchProxyVpc(request *SwitchProxyVpcRequest) (response *Switc
 // 本接口（SwitchProxyVpc）用于更换数据库代理vpc。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
 //  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
 //  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  FAILEDOPERATION_PROXYCHECKERROR = "FailedOperation.ProxyCheckError"
 //  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  OPERATIONDENIED_USERRESOURCETASKCONFLICTERROR = "OperationDenied.UserResourceTaskConflictError"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) SwitchProxyVpcWithContext(ctx context.Context, request *SwitchProxyVpcRequest) (response *SwitchProxyVpcResponse, err error) {
@@ -15900,12 +15918,15 @@ func NewTransferClusterPrepayToPostpayResponse() (response *TransferClusterPrepa
 // 本接口（TransferClusterPrepayToPostpay）用于将预付费集群转为后付费集群
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
 //  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
 //  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  FAILEDOPERATION_PROXYCHECKERROR = "FailedOperation.ProxyCheckError"
 //  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  OPERATIONDENIED_USERRESOURCETASKCONFLICTERROR = "OperationDenied.UserResourceTaskConflictError"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) TransferClusterPrepayToPostpay(request *TransferClusterPrepayToPostpayRequest) (response *TransferClusterPrepayToPostpayResponse, err error) {
@@ -15916,12 +15937,15 @@ func (c *Client) TransferClusterPrepayToPostpay(request *TransferClusterPrepayTo
 // 本接口（TransferClusterPrepayToPostpay）用于将预付费集群转为后付费集群
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
 //  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
 //  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  FAILEDOPERATION_PROXYCHECKERROR = "FailedOperation.ProxyCheckError"
 //  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  OPERATIONDENIED_USERRESOURCETASKCONFLICTERROR = "OperationDenied.UserResourceTaskConflictError"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) TransferClusterPrepayToPostpayWithContext(ctx context.Context, request *TransferClusterPrepayToPostpayRequest) (response *TransferClusterPrepayToPostpayResponse, err error) {
@@ -15964,12 +15988,15 @@ func NewTransferClusterZoneResponse() (response *TransferClusterZoneResponse) {
 // 本接口（TransferClusterZone）用于发起跨可用区迁移。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
 //  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
 //  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  FAILEDOPERATION_PROXYCHECKERROR = "FailedOperation.ProxyCheckError"
 //  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  OPERATIONDENIED_USERRESOURCETASKCONFLICTERROR = "OperationDenied.UserResourceTaskConflictError"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) TransferClusterZone(request *TransferClusterZoneRequest) (response *TransferClusterZoneResponse, err error) {
@@ -15980,12 +16007,15 @@ func (c *Client) TransferClusterZone(request *TransferClusterZoneRequest) (respo
 // 本接口（TransferClusterZone）用于发起跨可用区迁移。
 //
 // 可能返回的错误码:
+//  FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
 //  FAILEDOPERATION_DATABASEACCESSERROR = "FailedOperation.DatabaseAccessError"
 //  FAILEDOPERATION_FLOWCREATEERROR = "FailedOperation.FlowCreateError"
 //  FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+//  FAILEDOPERATION_PROXYCHECKERROR = "FailedOperation.ProxyCheckError"
 //  INTERNALERROR_SYSTEMERROR = "InternalError.SystemError"
 //  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 //  INVALIDPARAMETERVALUE_PARAMERROR = "InvalidParameterValue.ParamError"
+//  OPERATIONDENIED_USERRESOURCETASKCONFLICTERROR = "OperationDenied.UserResourceTaskConflictError"
 //  RESOURCENOTFOUND_CLUSTERNOTFOUNDERROR = "ResourceNotFound.ClusterNotFoundError"
 //  UNAUTHORIZEDOPERATION_PERMISSIONDENIED = "UnauthorizedOperation.PermissionDenied"
 func (c *Client) TransferClusterZoneWithContext(ctx context.Context, request *TransferClusterZoneRequest) (response *TransferClusterZoneResponse, err error) {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/errors.go
@@ -35,6 +35,9 @@ const (
 	// 鉴权失败，请稍后重试。如果持续不成功，请联系客服进行处理。
 	FAILEDOPERATION_CAMSIGANDAUTHERROR = "FailedOperation.CamSigAndAuthError"
 
+	// VPC/子网校验失败：{{1}}
+	FAILEDOPERATION_CHECKVPCANDSUBNETERROR = "FailedOperation.CheckVpcAndSubnetError"
+
 	// 创建审计失败
 	FAILEDOPERATION_CREATEAUDITFAILERROR = "FailedOperation.CreateAuditFailError"
 
@@ -79,6 +82,9 @@ const (
 
 	// 操作失败，请稍后重试。如果持续不成功，请联系客服进行处理。
 	FAILEDOPERATION_OPERATIONFAILEDERROR = "FailedOperation.OperationFailedError"
+
+	// Proxy校验失败：{{1}}。
+	FAILEDOPERATION_PROXYCHECKERROR = "FailedOperation.ProxyCheckError"
 
 	// 查询资源包消耗明细失败
 	FAILEDOPERATION_QUERYSOURCEPACKAGEDETAILERROR = "FailedOperation.QuerySourcePackageDetailError"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107/models.go
@@ -2825,6 +2825,9 @@ func (r *CreateAccountsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateAccountsResponseParams struct {
+	// <p>任务 ID</p>
+	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
@@ -5202,7 +5205,7 @@ type CynosdbClusterDetail struct {
 	// <p>地域</p>
 	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// <p>可用区</p>
+	// <p>集群主可用区</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
 	// <p>物理可用区</p>
@@ -5292,7 +5295,7 @@ type CynosdbClusterDetail struct {
 	// <p>任务列表</p>
 	Tasks []*ObjectTask `json:"Tasks,omitnil,omitempty" name:"Tasks"`
 
-	// <p>主可用区</p>
+	// <p>读写实例当前所在可用区</p>
 	MasterZone *string `json:"MasterZone,omitnil,omitempty" name:"MasterZone"`
 
 	// <p>从可用区列表</p>
@@ -5366,6 +5369,9 @@ type CynosdbClusterDetail struct {
 
 	// <p>是否开启透明加密</p>
 	IsOpenTDE *bool `json:"IsOpenTDE,omitnil,omitempty" name:"IsOpenTDE"`
+
+	// <p>实例当前所在可用区</p>
+	RealZone *string `json:"RealZone,omitnil,omitempty" name:"RealZone"`
 }
 
 type CynosdbErrorLogItem struct {
@@ -5404,7 +5410,7 @@ type CynosdbInstance struct {
 	// <p>地域</p>
 	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// <p>可用区</p>
+	// <p>集群主可用区</p>
 	Zone *string `json:"Zone,omitnil,omitempty" name:"Zone"`
 
 	// <p>实例状态</p>
@@ -5525,7 +5531,7 @@ type CynosdbInstance struct {
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 
-	// <p>主可用区</p>
+	// <p>读写实例当前所在可用区</p>
 	MasterZone *string `json:"MasterZone,omitnil,omitempty" name:"MasterZone"`
 
 	// <p>备可用区</p>
@@ -5559,6 +5565,9 @@ type CynosdbInstance struct {
 
 	// <p>全球数据库唯一标识</p>
 	GdnId *string `json:"GdnId,omitnil,omitempty" name:"GdnId"`
+
+	// <p>实例当前所在可用区</p>
+	RealZone *string `json:"RealZone,omitnil,omitempty" name:"RealZone"`
 }
 
 type CynosdbInstanceDetail struct {
@@ -8868,14 +8877,14 @@ func (r *DescribeClusterDetailDatabasesResponse) FromJsonString(s string) error 
 
 // Predefined struct for user
 type DescribeClusterDetailRequestParams struct {
-	// 集群Id
+	// <p>集群Id</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 }
 
 type DescribeClusterDetailRequest struct {
 	*tchttp.BaseRequest
 	
-	// 集群Id
+	// <p>集群Id</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 }
 
@@ -8900,7 +8909,7 @@ func (r *DescribeClusterDetailRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeClusterDetailResponseParams struct {
-	// 集群详细信息
+	// <p>集群详细信息</p>
 	Detail *CynosdbClusterDetail `json:"Detail,omitnil,omitempty" name:"Detail"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1285,7 +1285,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp/v20180228
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.150
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb v1.3.159
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cynosdb/v20190107
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970


### PR DESCRIPTION
Optimize the create logic of tencentcloud_cynosdb_account: after CreateAccounts returns a TaskId, poll the task completion status via DescribeTasks until Status is success, then perform Read. Also add limited retry in Read when the account is not found on first attempt to handle eventual consistency.