### PR TITLE
docs(teo): update import zone config content description

### DIFF
--- a/.changelog/4445.txt
+++ b/.changelog/4445.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_import_zone_config_operation: update content field description
+```

--- a/tencentcloud/services/teo/resource_tc_teo_import_zone_config_operation.go
+++ b/tencentcloud/services/teo/resource_tc_teo_import_zone_config_operation.go
@@ -28,7 +28,7 @@ func ResourceTencentCloudTeoImportZoneConfigOperation() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The configuration content to import. It must be in JSON format and encoded in UTF-8. You can obtain the configuration content via the tencentcloud_teo_export_zone_config data source.",
+				Description: `The configuration content to be imported, which should be in the JSON format and be encoded in the UTF-8 mode. The configuration content can be obtained through the site configuration export API (ExportZoneConfig). You can individually import "Site Acceleration - Global Acceleration Configuration" or "Site Acceleration - Rule Engine" by passing in the corresponding fields. Refer to the example below for details.`,
 			},
 			"task_id": {
 				Type:        schema.TypeString,

--- a/website/docs/r/teo_import_zone_config_operation.html.markdown
+++ b/website/docs/r/teo_import_zone_config_operation.html.markdown
@@ -29,7 +29,7 @@ resource "tencentcloud_teo_import_zone_config_operation" "example" {
 
 The following arguments are supported:
 
-* `content` - (Required, String, ForceNew) The configuration content to import. It must be in JSON format and encoded in UTF-8. You can obtain the configuration content via the tencentcloud_teo_export_zone_config data source.
+* `content` - (Required, String, ForceNew) The configuration content to be imported, which should be in the JSON format and be encoded in the UTF-8 mode. The configuration content can be obtained through the site configuration export API (ExportZoneConfig). You can individually import "Site Acceleration - Global Acceleration Configuration" or "Site Acceleration - Rule Engine" by passing in the corresponding fields. Refer to the example below for details.
 * `zone_id` - (Required, String, ForceNew) Site ID.
 
 ## Attributes Reference


### PR DESCRIPTION
Update the description of the 'content' field in the tencentcloud_teo_import_zone_config_operation resource to provide more detailed information about the configuration content format and usage.