### PR TITLE
docs(teo): [137320501] update import zone config content field description

### DIFF
--- a/.changelog/4446.txt
+++ b/.changelog/4446.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_teo_import_zone_config: update content field description with detailed import requirements
+```

--- a/tencentcloud/services/teo/resource_tc_teo_import_zone_config_operation.go
+++ b/tencentcloud/services/teo/resource_tc_teo_import_zone_config_operation.go
@@ -28,7 +28,7 @@ func ResourceTencentCloudTeoImportZoneConfigOperation() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The configuration content to import. It must be in JSON format and encoded in UTF-8. You can obtain the configuration content via the tencentcloud_teo_export_zone_config data source.",
+				Description: "Configuration content to be imported. Use JSON format and encode by UTF-8. You can obtain the configuration content through the site configuration export interface (ExportZoneConfig). You can individually import \"Site Acceleration - Global Acceleration Configuration\" or \"Site Acceleration - Rule Engine\". Just pass in the corresponding fields. For specific details, see the example below. Note: AccelerationDomain (acceleration domain name configuration) and Origin (origin configuration) exported by ExportZoneConfig are temporary not supported for import through this interface. If the Content contains the above configuration content, it will cause import failure.",
 			},
 			"task_id": {
 				Type:        schema.TypeString,

--- a/website/docs/r/teo_import_zone_config_operation.html.markdown
+++ b/website/docs/r/teo_import_zone_config_operation.html.markdown
@@ -29,7 +29,7 @@ resource "tencentcloud_teo_import_zone_config_operation" "example" {
 
 The following arguments are supported:
 
-* `content` - (Required, String, ForceNew) The configuration content to import. It must be in JSON format and encoded in UTF-8. You can obtain the configuration content via the tencentcloud_teo_export_zone_config data source.
+* `content` - (Required, String, ForceNew) Configuration content to be imported. Use JSON format and encode by UTF-8. You can obtain the configuration content through the site configuration export interface (ExportZoneConfig). You can individually import "Site Acceleration - Global Acceleration Configuration" or "Site Acceleration - Rule Engine". Just pass in the corresponding fields. For specific details, see the example below. Note: AccelerationDomain (acceleration domain name configuration) and Origin (origin configuration) exported by ExportZoneConfig are temporary not supported for import through this interface. If the Content contains the above configuration content, it will cause import failure.
 * `zone_id` - (Required, String, ForceNew) Site ID.
 
 ## Attributes Reference


### PR DESCRIPTION
Update the description of the content field in the tencentcloud_teo_import_zone_config resource to provide more detailed information about the configuration content to be imported, including format requirements and unsupported fields.