### PR TITLE
feat(ccn): [137305064]add order_type param to ccn_instances_accept_attach

### DIFF
--- a/.changelog/4449.txt
+++ b/.changelog/4449.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_ccn_instances_accept_attach: support `order_type` parameter to specify billing account for accepted CCN attachment instances
+```

--- a/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/design.md
+++ b/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The `tencentcloud_ccn_instances_accept_attach` resource is located at `tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.go`. It wraps the VPC `AcceptAttachCcnInstances` API to accept cross-region CCN attachment instances.
+
+**Current state:**
+- The resource schema has a top-level `ccn_id` field and an `instances` block (TypeList, ForceNew).
+- The `instances` block contains sub-fields: `instance_id`, `instance_region`, `instance_type`, `description`, and `route_table_id`.
+- The Create function builds `vpc.CcnInstance` structs from the schema and appends them to `request.Instances`.
+- The resource has no Update operation; `instances` is `ForceNew`, so any change triggers recreation.
+- The Read function is a no-op (the API has no direct query endpoint for this resource).
+- The Delete function is a no-op.
+
+**SDK analysis:**
+The `CcnInstance` struct in `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312/models.go` already includes an `OrderType *string` field with the following documentation:
+> 实例付费方式。枚举值：PayByCcnOwner（CCN所在账号付费）、PayByInstanceOwner（关联实例所在账号付费）
+
+No SDK update is required — the field is already present in the vendored SDK.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add an optional `order_type` sub-field (TypeString) to the `instances` block of the `tencentcloud_ccn_instances_accept_attach` resource schema.
+- Pass `OrderType` to the `AcceptAttachCcnInstances` API by setting `CcnInstance.OrderType` in the Create function when the user specifies it.
+- Maintain full backward compatibility — existing configurations continue to work unchanged.
+- Add unit test coverage using gomonkey mock (no terraform test suite, per project guidelines for new resources).
+
+**Non-Goals:**
+- Adding `order_type` to any other CCN resource or datasource.
+- Adding an Update operation (the resource only supports Create and Delete).
+- Adding Read support for `order_type` (the Read function is a no-op because the `AcceptAttachCcnInstances` API has no corresponding query endpoint).
+
+## Decisions
+
+### Decision 1: `order_type` as a sub-field of `instances` block
+
+**Rationale:** The cloud API path is `request.Instances.OrderType`, meaning `OrderType` is a field on the `CcnInstance` struct (each element of the `Instances` array), not a top-level field on `AcceptAttachCcnInstancesRequest`. Therefore, in the Terraform schema, `order_type` must be a sub-field within the `instances` block, consistent with the existing `instance_id`, `instance_region`, `instance_type`, `description`, and `route_table_id` fields.
+
+### Decision 2: `order_type` is Optional and inherits ForceNew from parent block
+
+**Rationale:** The `instances` block is `ForceNew: true` at the block level. Individual sub-fields within a `ForceNew` TypeList block do not need their own `ForceNew` flag — any change to any sub-field triggers recreation of the entire resource. The `order_type` field is Optional (TypeString) so users can omit it when they want the API default behavior.
+
+### Decision 3: Only set `OrderType` when the value is non-empty
+
+**Rationale:** Consistent with the existing pattern for `route_table_id` in the Create function, `OrderType` should only be set on the `CcnInstance` struct when the user provides a non-empty value. This avoids overriding API defaults with an empty string.
+
+### Decision 4: No validation of enum values
+
+**Rationale:** The API accepts `PayByCcnOwner` and `PayByInstanceOwner`. Rather than adding provider-side `ValidateFunc` validation (which could become stale if the API adds new values), we rely on the API to reject invalid values. This is consistent with the existing `instance_type` field which also has no `ValidateFunc`.
+
+## Risks / Trade-offs
+
+- **[Risk] Read function does not refresh `order_type`**: The Read function is a no-op, so `order_type` will not be refreshed from the cloud after creation.
+  - **Mitigation:** This is consistent with the existing behavior of all fields in this resource. Terraform preserves the configured value in state. No additional handling needed.
+- **[Risk] No Update support**: Users cannot change `order_type` without recreating the resource.
+  - **Mitigation:** This is an inherent limitation of the `AcceptAttachCcnInstances` API, which only has a Create endpoint. The `instances` block is already `ForceNew`, so this behavior is consistent.

--- a/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/proposal.md
+++ b/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `tencentcloud_ccn_instances_accept_attach` resource allows users to accept cross-region CCN attachment instances, but it does not expose the `OrderType` parameter that controls which account pays for the instances. The Tencent Cloud VPC SDK's `CcnInstance` struct already supports the `OrderType` field (`PayByCcnOwner` or `PayByInstanceOwner`), but the Terraform provider does not pass it through. Users who need to specify the billing account for accepted CCN attachments are forced to use the console or API directly.
+
+## What Changes
+
+- Add an optional `order_type` sub-field to the `instances` block of the `tencentcloud_ccn_instances_accept_attach` resource schema. Since `instances` is `ForceNew`, `order_type` inherits the same immutability behavior.
+- Pass `OrderType` to the `AcceptAttachCcnInstances` API request by setting `CcnInstance.OrderType` for each instance in the Create function.
+- The `OrderType` field maps to the cloud API path `request.Instances.OrderType` (a field on the `CcnInstance` struct, not the top-level request).
+
+## Capabilities
+
+### New Capabilities
+- `ccn-instances-accept-attach-order-type`: Add the `order_type` optional sub-field to the `instances` block of the `tencentcloud_ccn_instances_accept_attach` resource, allowing users to specify the billing account (`PayByCcnOwner` or `PayByInstanceOwner`) for accepted CCN attachment instances.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.go` — add `order_type` schema field under `instances` block, wire through Create function
+  - `tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach_test.go` — add unit test coverage using gomonkey mock
+  - `tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.md` — update documentation with `order_type` usage example
+- **SDK dependency:** No SDK update needed — the `CcnInstance` struct in `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312` already includes the `OrderType *string` field.
+- **Backward compatibility:** fully backward compatible — the new parameter is Optional; existing configurations continue to work unchanged.
+- **API constraints:** `OrderType` is only part of the `AcceptAttachCcnInstances` Create request (via the `CcnInstance` struct). Since the resource has no Update operation and `instances` is `ForceNew`, `order_type` is immutable after creation.

--- a/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/specs/ccn-instances-accept-attach-order-type/spec.md
+++ b/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/specs/ccn-instances-accept-attach-order-type/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Order type on CCN instances accept attach
+The `tencentcloud_ccn_instances_accept_attach` resource SHALL support an optional `order_type` parameter (TypeString) as a sub-field of the `instances` block. When specified, the provider SHALL pass the value to the `AcceptAttachCcnInstances` API by setting `CcnInstance.OrderType` for each instance in the request. Valid values are `PayByCcnOwner` (CCN owner pays) and `PayByInstanceOwner` (instance owner pays). When the user does not specify `order_type`, the provider SHALL NOT set `OrderType` on the `CcnInstance` struct, allowing the API to apply its default behavior.
+
+#### Scenario: Create CCN instances accept attach with order_type specified
+- **WHEN** a user specifies `order_type = "PayByCcnOwner"` within an `instances` block in the `tencentcloud_ccn_instances_accept_attach` resource configuration
+- **THEN** the provider SHALL set `CcnInstance.OrderType = "PayByCcnOwner"` for that instance in the `AcceptAttachCcnInstances` API request
+
+#### Scenario: Create CCN instances accept attach without order_type
+- **WHEN** a user does NOT specify `order_type` within an `instances` block in the `tencentcloud_ccn_instances_accept_attach` resource configuration
+- **THEN** the provider SHALL NOT set `OrderType` on the `CcnInstance` struct for that instance in the `AcceptAttachCcnInstances` API request
+
+#### Scenario: Order type is immutable after creation
+- **WHEN** a user changes `order_type` within an `instances` block after the resource has been created
+- **THEN** the provider SHALL trigger recreation of the resource (ForceNew behavior inherited from the `instances` block)
+
+#### Scenario: Order type with empty value is ignored
+- **WHEN** a user specifies `order_type = ""` within an `instances` block in the `tencentcloud_ccn_instances_accept_attach` resource configuration
+- **THEN** the provider SHALL NOT set `OrderType` on the `CcnInstance` struct for that instance in the `AcceptAttachCcnInstances` API request

--- a/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/tasks.md
+++ b/openspec/changes/archive/2026-08-20-add-ccn-instances-accept-attach-order-type/tasks.md
@@ -1,0 +1,18 @@
+## 1. Schema Changes
+
+- [x] 1.1 Add `order_type` sub-field (TypeString, Optional, Description: "Instance billing method. Valid values: `PayByCcnOwner` (CCN owner pays), `PayByInstanceOwner` (instance owner pays).") to the `instances` block schema in `ResourceTencentCloudCcnInstancesAcceptAttach()` in `tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.go`
+
+## 2. Create Function Changes
+
+- [x] 2.1 In `resourceTencentCloudCcnInstancesAcceptAttachCreate`, read `order_type` from the `dMap` for each instance in the `instances` list
+- [x] 2.2 Set `CcnInstance.OrderType` via `helper.String(v.(string))` only when `order_type` is non-empty (consistent with the existing `route_table_id` pattern)
+
+## 3. Unit Tests
+
+- [x] 3.1 Create `tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach_test.go` with unit tests using gomonkey mock for the `AcceptAttachCcnInstances` API
+- [x] 3.2 Add test case: Create CCN instances accept attach with `order_type` specified, verify `CcnInstance.OrderType` is set in the request
+- [x] 3.3 Add test case: Create CCN instances accept attach without `order_type`, verify `CcnInstance.OrderType` is NOT set in the request
+
+## 4. Documentation
+
+- [x] 4.1 Update `tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.md` to add `order_type` field in the example usage within the `instances` block

--- a/openspec/specs/ccn-instances-accept-attach-order-type/spec.md
+++ b/openspec/specs/ccn-instances-accept-attach-order-type/spec.md
@@ -1,0 +1,23 @@
+# ccn-instances-accept-attach-order-type Specification
+
+## Purpose
+Add the `order_type` optional sub-field to the `instances` block of the `tencentcloud_ccn_instances_accept_attach` resource, allowing users to specify the billing account (`PayByCcnOwner` or `PayByInstanceOwner`) for accepted CCN attachment instances.
+## Requirements
+### Requirement: Order type on CCN instances accept attach
+The `tencentcloud_ccn_instances_accept_attach` resource SHALL support an optional `order_type` parameter (TypeString) as a sub-field of the `instances` block. When specified, the provider SHALL pass the value to the `AcceptAttachCcnInstances` API by setting `CcnInstance.OrderType` for each instance in the request. Valid values are `PayByCcnOwner` (CCN owner pays) and `PayByInstanceOwner` (instance owner pays). When the user does not specify `order_type`, the provider SHALL NOT set `OrderType` on the `CcnInstance` struct, allowing the API to apply its default behavior.
+
+#### Scenario: Create CCN instances accept attach with order_type specified
+- **WHEN** a user specifies `order_type = "PayByCcnOwner"` within an `instances` block in the `tencentcloud_ccn_instances_accept_attach` resource configuration
+- **THEN** the provider SHALL set `CcnInstance.OrderType = "PayByCcnOwner"` for that instance in the `AcceptAttachCcnInstances` API request
+
+#### Scenario: Create CCN instances accept attach without order_type
+- **WHEN** a user does NOT specify `order_type` within an `instances` block in the `tencentcloud_ccn_instances_accept_attach` resource configuration
+- **THEN** the provider SHALL NOT set `OrderType` on the `CcnInstance` struct for that instance in the `AcceptAttachCcnInstances` API request
+
+#### Scenario: Order type is immutable after creation
+- **WHEN** a user changes `order_type` within an `instances` block after the resource has been created
+- **THEN** the provider SHALL trigger recreation of the resource (ForceNew behavior inherited from the `instances` block)
+
+#### Scenario: Order type with empty value is ignored
+- **WHEN** a user specifies `order_type = ""` within an `instances` block in the `tencentcloud_ccn_instances_accept_attach` resource configuration
+- **THEN** the provider SHALL NOT set `OrderType` on the `CcnInstance` struct for that instance in the `AcceptAttachCcnInstances` API request

--- a/tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.go
+++ b/tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.go
@@ -61,6 +61,11 @@ func ResourceTencentCloudCcnInstancesAcceptAttach() *schema.Resource {
 							Optional:    true,
 							Description: "ID of the routing table associated with the instance. Note: This field may return null, indicating that no valid value can be obtained.",
 						},
+						"order_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Instance billing method. Valid values: `PayByCcnOwner` (CCN owner pays), `PayByInstanceOwner` (instance owner pays).",
+						},
 					},
 				},
 			},
@@ -103,6 +108,12 @@ func resourceTencentCloudCcnInstancesAcceptAttachCreate(d *schema.ResourceData, 
 				routeTableId := v.(string)
 				if routeTableId != "" {
 					ccnInstance.RouteTableId = helper.String(v.(string))
+				}
+			}
+			if v, ok := dMap["order_type"]; ok {
+				orderType := v.(string)
+				if orderType != "" {
+					ccnInstance.OrderType = helper.String(orderType)
 				}
 			}
 			request.Instances = append(request.Instances, &ccnInstance)

--- a/tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.md
+++ b/tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach.md
@@ -9,6 +9,7 @@ resource "tencentcloud_ccn_instances_accept_attach" "ccn_instances_accept_attach
     instance_id = "vpc-j9yhbzpn"
     instance_region = "ap-guangzhou"
     instance_type = "VPC"
+    order_type = "PayByCcnOwner"
   }
 }
 ```

--- a/tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach_test.go
+++ b/tencentcloud/services/ccn/resource_tc_ccn_instances_accept_attach_test.go
@@ -1,0 +1,179 @@
+package ccn_test
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	vpcsdk "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	svcccn "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/ccn"
+)
+
+type mockMetaForCcnInstancesAcceptAttach struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForCcnInstancesAcceptAttach) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForCcnInstancesAcceptAttach{}
+
+func newMockMetaForCcnInstancesAcceptAttach() *mockMetaForCcnInstancesAcceptAttach {
+	return &mockMetaForCcnInstancesAcceptAttach{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrCIAA(s string) *string { return &s }
+
+// TestCcnInstancesAcceptAttach_Create_WithOrderType verifies that when order_type is set,
+// the AcceptAttachCcnInstances request carries the correct OrderType value on the CcnInstance.
+func TestCcnInstancesAcceptAttach_Create_WithOrderType(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	vpcClient := &vpcsdk.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCcnInstancesAcceptAttach().client, "UseVpcClient", vpcClient)
+
+	var capturedRequest *vpcsdk.AcceptAttachCcnInstancesRequest
+	patches.ApplyMethodFunc(vpcClient, "AcceptAttachCcnInstances", func(request *vpcsdk.AcceptAttachCcnInstancesRequest) (*vpcsdk.AcceptAttachCcnInstancesResponse, error) {
+		capturedRequest = request
+		resp := vpcsdk.NewAcceptAttachCcnInstancesResponse()
+		resp.Response = &vpcsdk.AcceptAttachCcnInstancesResponseParams{
+			RequestId: ptrStrCIAA("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCcnInstancesAcceptAttach()
+	res := svcccn.ResourceTencentCloudCcnInstancesAcceptAttach()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"ccn_id": "ccn-xxxxxxxx",
+		"instances": []interface{}{
+			map[string]interface{}{
+				"instance_id":     "vpc-yyyyyyyy",
+				"instance_region": "ap-guangzhou",
+				"instance_type":   "VPC",
+				"order_type":      "PayByCcnOwner",
+				"route_table_id":  "rtb-zzzzzzzz",
+				"description":     "test",
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "ccn-xxxxxxxx", d.Id())
+
+	// Verify the request captured the OrderType
+	assert.NotNil(t, capturedRequest)
+	assert.Len(t, capturedRequest.Instances, 1)
+	assert.NotNil(t, capturedRequest.Instances[0].OrderType)
+	assert.Equal(t, "PayByCcnOwner", *capturedRequest.Instances[0].OrderType)
+}
+
+// TestCcnInstancesAcceptAttach_Create_WithoutOrderType verifies that when order_type is not set,
+// the AcceptAttachCcnInstances request does not carry OrderType on the CcnInstance.
+func TestCcnInstancesAcceptAttach_Create_WithoutOrderType(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	vpcClient := &vpcsdk.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCcnInstancesAcceptAttach().client, "UseVpcClient", vpcClient)
+
+	var capturedRequest *vpcsdk.AcceptAttachCcnInstancesRequest
+	patches.ApplyMethodFunc(vpcClient, "AcceptAttachCcnInstances", func(request *vpcsdk.AcceptAttachCcnInstancesRequest) (*vpcsdk.AcceptAttachCcnInstancesResponse, error) {
+		capturedRequest = request
+		resp := vpcsdk.NewAcceptAttachCcnInstancesResponse()
+		resp.Response = &vpcsdk.AcceptAttachCcnInstancesResponseParams{
+			RequestId: ptrStrCIAA("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCcnInstancesAcceptAttach()
+	res := svcccn.ResourceTencentCloudCcnInstancesAcceptAttach()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"ccn_id": "ccn-xxxxxxxx",
+		"instances": []interface{}{
+			map[string]interface{}{
+				"instance_id":     "vpc-yyyyyyyy",
+				"instance_region": "ap-guangzhou",
+				"instance_type":   "VPC",
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "ccn-xxxxxxxx", d.Id())
+
+	// Verify OrderType was not set on the request
+	assert.NotNil(t, capturedRequest)
+	assert.Len(t, capturedRequest.Instances, 1)
+	assert.Nil(t, capturedRequest.Instances[0].OrderType)
+}
+
+// TestCcnInstancesAcceptAttach_Create_WithEmptyOrderType verifies that when order_type is empty string,
+// the AcceptAttachCcnInstances request does not carry OrderType on the CcnInstance.
+func TestCcnInstancesAcceptAttach_Create_WithEmptyOrderType(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	vpcClient := &vpcsdk.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCcnInstancesAcceptAttach().client, "UseVpcClient", vpcClient)
+
+	var capturedRequest *vpcsdk.AcceptAttachCcnInstancesRequest
+	patches.ApplyMethodFunc(vpcClient, "AcceptAttachCcnInstances", func(request *vpcsdk.AcceptAttachCcnInstancesRequest) (*vpcsdk.AcceptAttachCcnInstancesResponse, error) {
+		capturedRequest = request
+		resp := vpcsdk.NewAcceptAttachCcnInstancesResponse()
+		resp.Response = &vpcsdk.AcceptAttachCcnInstancesResponseParams{
+			RequestId: ptrStrCIAA("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCcnInstancesAcceptAttach()
+	res := svcccn.ResourceTencentCloudCcnInstancesAcceptAttach()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"ccn_id": "ccn-xxxxxxxx",
+		"instances": []interface{}{
+			map[string]interface{}{
+				"instance_id":     "vpc-yyyyyyyy",
+				"instance_region": "ap-guangzhou",
+				"instance_type":   "VPC",
+				"order_type":      "",
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "ccn-xxxxxxxx", d.Id())
+
+	// Verify OrderType was not set on the request when empty
+	assert.NotNil(t, capturedRequest)
+	assert.Len(t, capturedRequest.Instances, 1)
+	assert.Nil(t, capturedRequest.Instances[0].OrderType)
+}
+
+// TestCcnInstancesAcceptAttach_Schema_OrderType validates the order_type schema definition.
+func TestCcnInstancesAcceptAttach_Schema_OrderType(t *testing.T) {
+	res := svcccn.ResourceTencentCloudCcnInstancesAcceptAttach()
+	assert.Contains(t, res.Schema, "instances")
+
+	instancesSchema := res.Schema["instances"]
+	assert.Equal(t, schema.TypeList, instancesSchema.Type)
+
+	elemRes, ok := instancesSchema.Elem.(*schema.Resource)
+	assert.True(t, ok)
+	assert.Contains(t, elemRes.Schema, "order_type")
+
+	orderTypeSchema := elemRes.Schema["order_type"]
+	assert.Equal(t, schema.TypeString, orderTypeSchema.Type)
+	assert.True(t, orderTypeSchema.Optional)
+	assert.False(t, orderTypeSchema.Required)
+}

--- a/website/docs/r/ccn_instances_accept_attach.html.markdown
+++ b/website/docs/r/ccn_instances_accept_attach.html.markdown
@@ -20,6 +20,7 @@ resource "tencentcloud_ccn_instances_accept_attach" "ccn_instances_accept_attach
     instance_id     = "vpc-j9yhbzpn"
     instance_region = "ap-guangzhou"
     instance_type   = "VPC"
+    order_type      = "PayByCcnOwner"
   }
 }
 ```
@@ -37,6 +38,7 @@ The `instances` object supports the following:
 * `instance_region` - (Required, String) Instance Region.
 * `description` - (Optional, String) Description.
 * `instance_type` - (Optional, String) InstanceType: `VPC`, `DIRECTCONNECT`, `BMVPC`, `VPNGW`.
+* `order_type` - (Optional, String) Instance billing method. Valid values: `PayByCcnOwner` (CCN owner pays), `PayByInstanceOwner` (instance owner pays).
 * `route_table_id` - (Optional, String) ID of the routing table associated with the instance. Note: This field may return null, indicating that no valid value can be obtained.
 
 ## Attributes Reference


### PR DESCRIPTION
Add the optional `order_type` sub-field to the `instances` block of the `tencentcloud_ccn_instances_accept_attach` resource, allowing users to specify the billing account (`PayByCcnOwner` or `PayByInstanceOwner`) for accepted CCN attachment instances. The `OrderType` value is passed through to the `AcceptAttachCcnInstances` API request on the `CcnInstance` struct. This change is fully backward compatible.