### PR TITLE
fix(cls): preserve extract rule key order

### DIFF
--- a/.changelog/4451.txt
+++ b/.changelog/4451.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/tencentcloud_cls_config_extra: preserve extract_rule.keys order
+```

--- a/openspec/changes/fix-cls-config-extra-ordered-keys/.openspec.yaml
+++ b/openspec/changes/fix-cls-config-extra-ordered-keys/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/fix-cls-config-extra-ordered-keys/design.md
+++ b/openspec/changes/fix-cls-config-extra-ordered-keys/design.md
@@ -1,0 +1,85 @@
+## Context
+
+CLS extraction keys are positional. For delimiter logs, each key names the
+corresponding delimited field. For full regular-expression logs, each key names
+the corresponding capture group. The TencentCloud SDK represents
+`ExtractRuleInfo.Keys` as an ordered slice, but the existing Terraform schema
+uses a set and Create/Update enumerate that set.
+
+Changing a released SDKv2 collection type also changes the resource state
+shape. Existing state therefore needs an explicit schema version and upgrader.
+The old set state has already lost the user's original HCL order, so migration
+cannot reconstruct that intent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve declared key order through Create and Update.
+- Preserve CLS API order through Read and Import.
+- Make a key-only reorder an in-place Terraform diff.
+- Upgrade version 0 JSON and legacy flatmap state without decode errors or
+  resource replacement.
+- Keep the change local to `tencentcloud_cls_config_extra` and avoid dependency
+  changes.
+
+**Non-Goals:**
+
+- Reconstruct order that was already discarded in version 0 set state.
+- Suppress the one-time corrective diff when migrated state and configuration
+  order differ.
+- Change `tencentcloud_cls_config`, CLS data sources, or any other collection
+  schema.
+- Perform or authorize changes to existing CLS resources.
+
+## Decisions
+
+### Model keys as `schema.TypeList`
+
+`TypeList` matches the positional API contract and makes a reorder observable
+to Terraform. Create and Update convert the list directly to the SDK string
+pointer slice. Read passes the API slice to `d.Set`, which encodes it in the
+same order.
+
+### Use a local version 0 schema copy
+
+The resource declares schema version 1. Its version 0 upgrader type is derived
+from a copy of the current schema where only `extract_rule.keys` is restored to
+`TypeSet`. The copy clones the `extract_rule` schema, nested resource, nested
+schema map, and `keys` leaf before mutation, so the current schema is not
+modified through shared pointers.
+
+### Let the upgrader return the decoded state map
+
+SDKv2 represents both sets and lists as arrays in JSON state. The legacy type
+decodes version 0 state and the current schema re-encodes the returned map as a
+list. The protocol-level regression test exercises this complete path instead
+of only invoking the upgrade callback.
+
+For legacy flatmap state, the set contains values keyed by hashes and has no
+declaration order to preserve. Migration retains all values. A subsequent Read
+uses CLS API order, and Terraform may plan one in-place correction if the HCL
+list differs.
+
+## Risks / Trade-offs
+
+- A migrated instance may show a one-time in-place diff because version 0 state
+  cannot recover original declaration order. Hiding that diff would preserve a
+  potentially incorrect capture mapping.
+- Downgrading after version 1 state is written is not a supported rollback.
+  Users should restore a pre-upgrade state backup if migration itself fails.
+- Cloud acceptance requires TencentCloud credentials and must run only in an
+  isolated test account.
+
+## Migration Plan
+
+1. Upgrade version 0 state through the registered legacy schema type.
+2. Refresh from CLS so state reflects the API's current key order.
+3. If configuration order differs, apply the resulting in-place update once.
+4. Verify the following plan is empty.
+
+No resource replacement or API mutation is performed by state upgrade alone.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-cls-config-extra-ordered-keys/proposal.md
+++ b/openspec/changes/fix-cls-config-extra-ordered-keys/proposal.md
@@ -1,0 +1,42 @@
+# Change: Preserve CLS ConfigExtra Extract Rule Key Order
+
+## Why
+
+`tencentcloud_cls_config_extra.extract_rule.keys` maps extracted fields to
+delimiter columns or regular-expression capture groups by position. The
+released SDKv2 resource models this attribute as `schema.TypeSet`, so the
+provider discards configuration order before Create or Update sends the keys
+to CLS. Reordering keys also cannot be represented reliably as a Terraform
+change.
+
+## What Changes
+
+- Change `extract_rule.keys` from `schema.TypeSet` to `schema.TypeList`.
+- Preserve list order in Create, Read, and Update.
+- Increment the resource schema version from 0 to 1 and register a version 0
+  state upgrader.
+- Cover ordered Create/Update/Import behavior and the real SDKv2 state upgrade
+  protocol for JSON and legacy flatmap state.
+- Document `keys` as an ordered list.
+
+## Capabilities
+
+### New Capabilities
+
+- `cls-config-extra-ordered-keys`: Defines ordered key handling and backward
+  compatible state migration for `tencentcloud_cls_config_extra`.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Resource: `tencentcloud_cls_config_extra` only.
+- Schema: `extract_rule.keys` changes from `set(string)` to `list(string)`.
+- State: existing schema version 0 instances are upgraded to version 1 without
+  resource replacement.
+- API: Create and Update send keys in configuration order; Read stores the CLS
+  API order.
+- Dependencies: no `go.mod`, `go.sum`, or vendor changes.
+- Out of scope: other CLS resources with similar collection schemas.

--- a/openspec/changes/fix-cls-config-extra-ordered-keys/specs/cls-config-extra-ordered-keys/spec.md
+++ b/openspec/changes/fix-cls-config-extra-ordered-keys/specs/cls-config-extra-ordered-keys/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: ConfigExtra extraction keys SHALL preserve positional order
+
+The `tencentcloud_cls_config_extra.extract_rule.keys` attribute SHALL be an
+ordered list of strings. Create and Update SHALL send keys to CLS in
+configuration order, and Read SHALL store keys in CLS API response order.
+
+#### Scenario: Create preserves declared key order
+
+- **WHEN** a user creates a ConfigExtra with `keys = ["first", "second"]`
+- **THEN** the Create request sends `ExtractRule.Keys` as `first`, then
+  `second`
+- **AND** the refreshed Terraform state stores `first` at index 0 and `second`
+  at index 1
+
+#### Scenario: Reordering keys updates in place
+
+- **GIVEN** an existing ConfigExtra has `keys = ["first", "second"]`
+- **WHEN** the user changes the configuration to
+  `keys = ["second", "first"]`
+- **THEN** Terraform detects a meaningful in-place change
+- **AND** the Update request sends `second`, then `first`
+- **AND** a subsequent refresh and plan converge without replacement or a
+  perpetual diff
+
+#### Scenario: Import preserves API key order
+
+- **GIVEN** CLS returns extraction keys in a defined order
+- **WHEN** the ConfigExtra is imported or refreshed
+- **THEN** Terraform state stores the keys in the same order
+
+### Requirement: Version 0 ConfigExtra state SHALL upgrade without replacement
+
+The resource SHALL declare schema version 1 and a version 0 state upgrader whose
+legacy type models `extract_rule.keys` as a set. The upgrade SHALL accept
+supported JSON and legacy flatmap state, retain all stored keys, and encode the
+result using the current list schema without error or resource replacement.
+
+#### Scenario: JSON state upgrades through the provider protocol
+
+- **GIVEN** version 0 JSON state contains extraction keys represented as an
+  array
+- **WHEN** SDKv2 executes `UpgradeResourceState`
+- **THEN** the response contains no error diagnostics
+- **AND** the upgraded msgpack decodes using the version 1 schema
+- **AND** the decoded key list contains the same values in the JSON array order
+
+#### Scenario: Legacy flatmap state upgrades through the provider protocol
+
+- **GIVEN** version 0 flatmap state contains extraction keys represented by set
+  hashes
+- **WHEN** SDKv2 executes `UpgradeResourceState`
+- **THEN** the response contains no error diagnostics
+- **AND** the upgraded msgpack decodes using the version 1 schema
+- **AND** every legacy set value is present in the decoded key list
+
+#### Scenario: Lost version 0 declaration order is not fabricated
+
+- **GIVEN** version 0 set state no longer contains the user's original HCL
+  order
+- **WHEN** the state is upgraded and refreshed
+- **THEN** the provider uses the order available from decoded state and the CLS
+  API
+- **AND** Terraform may plan one in-place correction when current configuration
+  order differs
+- **AND** the provider SHALL NOT suppress that corrective diff or replace the
+  resource

--- a/openspec/changes/fix-cls-config-extra-ordered-keys/tasks.md
+++ b/openspec/changes/fix-cls-config-extra-ordered-keys/tasks.md
@@ -1,0 +1,28 @@
+## 1. Resource Schema and State
+
+- [x] 1.1 Change `extract_rule.keys` from `schema.TypeSet` to `schema.TypeList`.
+- [x] 1.2 Preserve key order in Create and Update request expansion.
+- [x] 1.3 Set schema version 1 and register the version 0 legacy schema.
+- [x] 1.4 Ensure legacy schema construction does not mutate the current schema.
+
+## 2. Verification
+
+- [x] 2.1 Add a unit test for the ordered list schema.
+- [x] 2.2 Exercise JSON and legacy flatmap migration through
+  `GRPCProviderServer.UpgradeResourceState` and decode the resulting current
+  schema state.
+- [x] 2.3 Extend acceptance coverage for create order, reversed update order,
+  post-refresh convergence, and import state.
+- [ ] 2.4 Run the acceptance test in an isolated TencentCloud test account.
+- [x] 2.5 Rebase onto the current upstream `master` and rerun build, format,
+  lint, mux, and targeted tests.
+
+## 3. Documentation and Contribution
+
+- [x] 3.1 Update the resource example source and generated website docs to
+  document `keys` as an ordered list.
+- [x] 3.2 Record the schema, migration, compatibility, and rollback contract in
+  this OpenSpec change.
+- [x] 3.3 Create the upstream issue using the bug report template.
+- [x] 3.4 Add `.changelog/4451.txt` after the upstream PR number is assigned.
+- [x] 3.5 Open the upstream PR with the issue reference and verification status.

--- a/tencentcloud/services/cls/resource_tc_cls_config_extra.go
+++ b/tencentcloud/services/cls/resource_tc_cls_config_extra.go
@@ -15,7 +15,7 @@ import (
 )
 
 func ResourceTencentCloudClsConfigExtra() *schema.Resource {
-	return &schema.Resource{
+	configExtraResource := &schema.Resource{
 		Create: resourceTencentCloudClsConfigExtraCreate,
 		Read:   resourceTencentCloudClsConfigExtraRead,
 		Delete: resourceTencentCloudClsConfigExtraDelete,
@@ -275,10 +275,10 @@ func ResourceTencentCloudClsConfigExtra() *schema.Resource {
 							Description: "First-Line matching rule, which is valid only if log_type is multiline_log or fullregex_log.",
 						},
 						"keys": {
-							Type:        schema.TypeSet,
+							Type:        schema.TypeList,
 							Optional:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
-							Description: "Key name of each extracted field. An empty key indicates to discard the field. This parameter is valid only if log_type is delimiter_log. json_log logs use the key of JSON itself.",
+							Description: "Ordered key names for fields extracted from delimiter or full regex logs. An empty key indicates to discard the field. JSON logs use the keys from the JSON object itself.",
 						},
 						"filter_key_regex": {
 							Type:        schema.TypeList,
@@ -357,6 +357,45 @@ func ResourceTencentCloudClsConfigExtra() *schema.Resource {
 			},
 		},
 	}
+
+	legacyResource := &schema.Resource{Schema: clsConfigExtraV0Schema(configExtraResource.Schema)}
+	configExtraResource.SchemaVersion = 1
+	configExtraResource.StateUpgraders = []schema.StateUpgrader{
+		{
+			Version: 0,
+			Type:    legacyResource.CoreConfigSchema().ImpliedType(),
+			// Sets and lists have the same JSON representation. The legacy type
+			// decodes the set state before it is encoded using the current schema.
+			Upgrade: func(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+				return rawState, nil
+			},
+		},
+	}
+
+	return configExtraResource
+}
+
+func clsConfigExtraV0Schema(current map[string]*schema.Schema) map[string]*schema.Schema {
+	legacy := make(map[string]*schema.Schema, len(current))
+	for name, value := range current {
+		legacy[name] = value
+	}
+
+	extractRule := *legacy["extract_rule"]
+	extractRuleResource := *extractRule.Elem.(*schema.Resource)
+	extractRuleSchema := make(map[string]*schema.Schema, len(extractRuleResource.Schema))
+	for name, value := range extractRuleResource.Schema {
+		extractRuleSchema[name] = value
+	}
+
+	keys := *extractRuleSchema["keys"]
+	keys.Type = schema.TypeSet
+	extractRuleSchema["keys"] = &keys
+	extractRuleResource.Schema = extractRuleSchema
+	extractRule.Elem = &extractRuleResource
+	legacy["extract_rule"] = &extractRule
+
+	return legacy
 }
 
 func resourceTencentCloudClsConfigExtraCreate(d *schema.ResourceData, meta interface{}) error {
@@ -553,10 +592,7 @@ func resourceTencentCloudClsConfigExtraCreate(d *schema.ResourceData, meta inter
 			extractRule.BeginRegex = helper.String(v.(string))
 		}
 		if v, ok := dMap["keys"]; ok {
-			keys := v.(*schema.Set).List()
-			for _, key := range keys {
-				extractRule.Keys = append(extractRule.Keys, helper.String(key.(string)))
-			}
+			extractRule.Keys = helper.InterfacesStringsPoint(v.([]interface{}))
 		}
 		if v, ok := dMap["filter_key_regex"]; ok {
 			keyRegexs := make([]*cls.KeyRegexInfo, 0, 10)
@@ -1127,10 +1163,7 @@ func resourceTencentCloudClsConfigExtraUpdate(d *schema.ResourceData, meta inter
 				extractRule.BeginRegex = helper.String(v.(string))
 			}
 			if v, ok := dMap["keys"]; ok {
-				keys := v.(*schema.Set).List()
-				for _, key := range keys {
-					extractRule.Keys = append(extractRule.Keys, helper.String(key.(string)))
-				}
+				extractRule.Keys = helper.InterfacesStringsPoint(v.([]interface{}))
 			}
 			if v, ok := dMap["filter_key_regex"]; ok {
 				keyRegexs := make([]*cls.KeyRegexInfo, 0, 10)

--- a/tencentcloud/services/cls/resource_tc_cls_config_extra.md
+++ b/tencentcloud/services/cls/resource_tc_cls_config_extra.md
@@ -43,7 +43,7 @@ resource "tencentcloud_cls_config_extra" "extra" {
   name        = "helloworld-test"
   topic_id    = tencentcloud_cls_topic.topic.id
   type        = "container_file"
-  log_type    = "json_log"
+  log_type    = "fullregex_log"
   config_flag = "label_k8s"
   logset_id   = tencentcloud_cls_logset.logset.id
   logset_name = tencentcloud_cls_logset.logset.logset_name
@@ -59,6 +59,10 @@ resource "tencentcloud_cls_config_extra" "extra" {
       name      = "nginx"
       namespace = "default"
     }
+  }
+  extract_rule {
+    log_regex = "^(first) (second)$"
+    keys      = ["first", "second"]
   }
   group_id = tencentcloud_cls_machine_group.group.id
 }

--- a/tencentcloud/services/cls/resource_tc_cls_config_extra_test.go
+++ b/tencentcloud/services/cls/resource_tc_cls_config_extra_test.go
@@ -1,6 +1,7 @@
 package cls_test
 
 import (
+	"strings"
 	"testing"
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
@@ -19,6 +20,15 @@ func TestAccTencentCloudClsConfigExtra_basic(t *testing.T) {
 				Config: testAccClsConfigExtra,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tencentcloud_cls_config_extra.extra", "name", "helloworld"),
+					resource.TestCheckResourceAttr("tencentcloud_cls_config_extra.extra", "extract_rule.0.keys.0", "first"),
+					resource.TestCheckResourceAttr("tencentcloud_cls_config_extra.extra", "extract_rule.0.keys.1", "second"),
+				),
+			},
+			{
+				Config: strings.Replace(testAccClsConfigExtra, `keys      = ["first", "second"]`, `keys      = ["second", "first"]`, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tencentcloud_cls_config_extra.extra", "extract_rule.0.keys.0", "second"),
+					resource.TestCheckResourceAttr("tencentcloud_cls_config_extra.extra", "extract_rule.0.keys.1", "first"),
 				),
 			},
 			{
@@ -71,7 +81,7 @@ resource "tencentcloud_cls_config_extra" "extra" {
   name        = "helloworld"
   topic_id    = tencentcloud_cls_topic.topic.id
   type        = "container_file"
-  log_type    = "json_log"
+  log_type    = "fullregex_log"
   config_flag = "label_k8s"
   logset_id   = tencentcloud_cls_logset.logset.id
   logset_name = tencentcloud_cls_logset.logset.logset_name
@@ -87,6 +97,10 @@ resource "tencentcloud_cls_config_extra" "extra" {
       name      = "nginx"
       namespace = "default"
     }
+  }
+  extract_rule {
+    log_regex = "^(first) (second)$"
+    keys      = ["first", "second"]
   }
   group_id = tencentcloud_cls_machine_group.group.id
 }

--- a/tencentcloud/services/cls/resource_tc_cls_config_extra_unit_test.go
+++ b/tencentcloud/services/cls/resource_tc_cls_config_extra_unit_test.go
@@ -1,0 +1,179 @@
+package cls
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestClsConfigExtraExtractRuleKeysPreserveOrder(t *testing.T) {
+	resource := ResourceTencentCloudClsConfigExtra()
+	data := schema.TestResourceDataRaw(t, resource.Schema, map[string]interface{}{
+		"extract_rule": []interface{}{
+			map[string]interface{}{
+				"keys": []interface{}{"first", "second"},
+			},
+		},
+	})
+
+	extractRules := data.Get("extract_rule").([]interface{})
+	keysValue := extractRules[0].(map[string]interface{})["keys"]
+	keys, ok := keysValue.([]interface{})
+	if !ok {
+		t.Fatalf("extract_rule.keys must preserve order as a list, got %T", keysValue)
+	}
+
+	want := []interface{}{"first", "second"}
+	if !reflect.DeepEqual(keys, want) {
+		t.Fatalf("extract_rule.keys = %#v, want %#v", keys, want)
+	}
+}
+
+func TestClsConfigExtraStateUpgradeV0(t *testing.T) {
+	resourceDef := ResourceTencentCloudClsConfigExtra()
+	if resourceDef.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1", resourceDef.SchemaVersion)
+	}
+	if len(resourceDef.StateUpgraders) != 1 {
+		t.Fatalf("StateUpgraders length = %d, want 1", len(resourceDef.StateUpgraders))
+	}
+
+	upgrader := resourceDef.StateUpgraders[0]
+	legacyKeysType := upgrader.Type.AttributeType("extract_rule").ElementType().AttributeType("keys")
+	if !legacyKeysType.IsSetType() {
+		t.Fatalf("legacy extract_rule.keys type = %s, want set", legacyKeysType.FriendlyName())
+	}
+
+	currentType := resourceDef.CoreConfigSchema().ImpliedType()
+	currentKeysType := currentType.AttributeType("extract_rule").ElementType().AttributeType("keys")
+	if !currentKeysType.IsListType() {
+		t.Fatalf("current extract_rule.keys type = %s, want list", currentKeysType.FriendlyName())
+	}
+
+	server := schema.NewGRPCProviderServer(&schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"tencentcloud_cls_config_extra": resourceDef,
+		},
+	})
+	firstKey := fmt.Sprintf("extract_rule.0.keys.%d", schema.HashString("first"))
+	secondKey := fmt.Sprintf("extract_rule.0.keys.%d", schema.HashString("second"))
+
+	tests := []struct {
+		name     string
+		rawState *tfprotov5.RawState
+		ordered  bool
+	}{
+		{
+			name: "JSON state",
+			rawState: &tfprotov5.RawState{
+				JSON: []byte(`{"id":"config-extra-id","extract_rule":[{"keys":["first","second"]}]}`),
+			},
+			ordered: true,
+		},
+		{
+			name: "legacy flatmap state",
+			rawState: &tfprotov5.RawState{
+				Flatmap: map[string]string{
+					"id":                    "config-extra-id",
+					"extract_rule.#":        "1",
+					"extract_rule.0.keys.#": "2",
+					firstKey:                "first",
+					secondKey:               "second",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := server.UpgradeResourceState(t.Context(), &tfprotov5.UpgradeResourceStateRequest{
+				TypeName: "tencentcloud_cls_config_extra",
+				Version:  0,
+				RawState: test.rawState,
+			})
+			if err != nil {
+				t.Fatalf("UpgradeResourceState returned error: %v", err)
+			}
+			if len(response.Diagnostics) != 0 {
+				t.Fatalf("UpgradeResourceState returned diagnostics: %#v", response.Diagnostics)
+			}
+			if response.UpgradedState == nil || len(response.UpgradedState.MsgPack) == 0 {
+				t.Fatal("UpgradeResourceState returned empty state")
+			}
+
+			keys := clsConfigExtraUpgradedKeys(t, server, response.UpgradedState)
+			if test.ordered {
+				want := []string{"first", "second"}
+				if !reflect.DeepEqual(keys, want) {
+					t.Fatalf("upgraded keys = %#v, want %#v", keys, want)
+				}
+				return
+			}
+
+			if len(keys) != 2 {
+				t.Fatalf("upgraded keys = %#v, want two values", keys)
+			}
+			got := map[string]bool{keys[0]: true, keys[1]: true}
+			if !got["first"] || !got["second"] {
+				t.Fatalf("upgraded keys = %#v, want first and second", keys)
+			}
+		})
+	}
+
+	if err := resourceDef.InternalValidate(nil, true); err != nil {
+		t.Fatalf("resource validation failed: %v", err)
+	}
+}
+
+func clsConfigExtraUpgradedKeys(t *testing.T, server *schema.GRPCProviderServer, state *tfprotov5.DynamicValue) []string {
+	t.Helper()
+
+	schemaResponse, err := server.GetProviderSchema(context.Background(), &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema returned error: %v", err)
+	}
+	if len(schemaResponse.Diagnostics) != 0 {
+		t.Fatalf("GetProviderSchema returned diagnostics: %#v", schemaResponse.Diagnostics)
+	}
+	resourceSchema := schemaResponse.ResourceSchemas["tencentcloud_cls_config_extra"]
+	if resourceSchema == nil {
+		t.Fatal("GetProviderSchema did not return tencentcloud_cls_config_extra")
+	}
+
+	value, err := state.Unmarshal(resourceSchema.ValueType())
+	if err != nil {
+		t.Fatalf("cannot decode upgraded state: %v", err)
+	}
+	var attributes map[string]tftypes.Value
+	if err := value.As(&attributes); err != nil {
+		t.Fatalf("cannot decode state attributes: %v", err)
+	}
+	var extractRules []tftypes.Value
+	if err := attributes["extract_rule"].As(&extractRules); err != nil {
+		t.Fatalf("cannot decode extract_rule: %v", err)
+	}
+	if len(extractRules) != 1 {
+		t.Fatalf("extract_rule length = %d, want 1", len(extractRules))
+	}
+	var extractRule map[string]tftypes.Value
+	if err := extractRules[0].As(&extractRule); err != nil {
+		t.Fatalf("cannot decode extract_rule element: %v", err)
+	}
+	var keyValues []tftypes.Value
+	if err := extractRule["keys"].As(&keyValues); err != nil {
+		t.Fatalf("cannot decode keys: %v", err)
+	}
+
+	keys := make([]string, len(keyValues))
+	for i, keyValue := range keyValues {
+		if err := keyValue.As(&keys[i]); err != nil {
+			t.Fatalf("cannot decode key %d: %v", i, err)
+		}
+	}
+	return keys
+}

--- a/website/docs/r/cls_config_extra.html.markdown
+++ b/website/docs/r/cls_config_extra.html.markdown
@@ -54,7 +54,7 @@ resource "tencentcloud_cls_config_extra" "extra" {
   name        = "helloworld-test"
   topic_id    = tencentcloud_cls_topic.topic.id
   type        = "container_file"
-  log_type    = "json_log"
+  log_type    = "fullregex_log"
   config_flag = "label_k8s"
   logset_id   = tencentcloud_cls_logset.logset.id
   logset_name = tencentcloud_cls_logset.logset.logset_name
@@ -70,6 +70,10 @@ resource "tencentcloud_cls_config_extra" "extra" {
       name      = "nginx"
       namespace = "default"
     }
+  }
+  extract_rule {
+    log_regex = "^(first) (second)$"
+    keys      = ["first", "second"]
   }
   group_id = tencentcloud_cls_machine_group.group.id
 }
@@ -128,7 +132,7 @@ The `extract_rule` object supports the following:
 * `begin_regex` - (Optional, String) First-Line matching rule, which is valid only if log_type is multiline_log or fullregex_log.
 * `delimiter` - (Optional, String) Delimiter for delimited log, which is valid only if log_type is delimiter_log.
 * `filter_key_regex` - (Optional, List) Log keys to be filtered and the corresponding regex.
-* `keys` - (Optional, Set) Key name of each extracted field. An empty key indicates to discard the field. This parameter is valid only if log_type is delimiter_log. json_log logs use the key of JSON itself.
+* `keys` - (Optional, List) Ordered key names for fields extracted from delimiter or full regex logs. An empty key indicates to discard the field. JSON logs use the keys from the JSON object itself.
 * `log_regex` - (Optional, String) Full log matching rule, which is valid only if log_type is fullregex_log.
 * `time_format` - (Optional, String) Time field format. For more information, please see the output parameters of the time format description of the strftime function in C language.
 * `time_key` - (Optional, String) Time field key name. time_key and time_format must appear in pair.


### PR DESCRIPTION
## What

Change `tencentcloud_cls_config_extra.extract_rule.keys` from `TypeSet` to `TypeList` and preserve its order across Create, Read, Update, and Import.

Set the resource schema version to 1 and add a version 0 state upgrader with regression coverage for JSON and legacy flatmap state. Update the acceptance tests, documentation, changelog, and OpenSpec change record.

## Why

CLS maps delimiter fields and regex capture groups to keys by position. `TypeSet` discards declaration order and treats reordered keys as equivalent, so the provider can send incorrect mappings and miss positional updates.

Fixes #4450.

## Type of change

- [x] Modification to an existing resource / data source
- [x] Bug fix

## Checklist

- [x] `make build` succeeds locally
- [x] `make fmtcheck` passes
- [x] `make golangci-lint-local` passes with golangci-lint v2.4.0 (0 issues)
- [x] `make tfproviderlint-local` passes with tfproviderlint v0.31.0
- [x] `make check-mux` passes
- [x] No provider registration or mux changes were needed
- [x] Acceptance tests updated; not run locally because no isolated TencentCloud test account was used
- [x] Website docs updated under `website/docs/r/`
- [x] No `go.mod` change
- [x] Changelog entry added under `.changelog/4451.txt`

## Notes for reviewers

Version 0 state cannot recover the original HCL order. Migration preserves the order encoded in state; refresh uses CLS API order. A configuration whose order differs may produce one in-place corrective update.
