### PR TITLE
feat(clb): [137375105]add tags parameter to tencentcloud_clb_log_topic resource

### DIFF
--- a/.changelog/4453.txt
+++ b/.changelog/4453.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_clb_log_topic: support configuring tags
+```

--- a/go.mod
+++ b/go.mod
@@ -43,10 +43,10 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs v1.0.600
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.164
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.164
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.165
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30

--- a/go.sum
+++ b/go.sum
@@ -917,8 +917,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695 h1:FGwsF1
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695/go.mod h1:HAasVoWz8ed6kAg7Q/DTg+8uZXiOgW7lmJeAGGrquEQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133 h1:u69hqN3/tI7y5o9b106CFhwAwFsQXZt1QqCxwZjbQ2Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133/go.mod h1:9Ex1k11ifCKOpUVYRXn53HgXpDVuEEuJ+qJSLMBGoM0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150 h1:2X+xqinBP8zfoeyb26F3EPn8++QxB/lNMNaT7CJEJxM=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150/go.mod h1:CHHOG5L7otIpZ7/vezeb8JpKH80pcD1UWiKLHsA8q5o=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165 h1:sQRHq9cZ2TOPqTl86exaNKZ/B7RKvCEviQRvqgC8cqI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165/go.mod h1:s88/DboRoSIkZNA9/lmXt1ja4LGDG+A+4ZwbqLrCZMQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40 h1:bhPBpfz0w3mdVyEolvXrtELUf+gE00O0WnAYIHZq70s=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40/go.mod h1:taTki0q8SHBIUFhjtnDA5UkiVic/WaPQzTqoXeGH3Ns=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.164 h1:GZWaZ0zrTkS/tHqFTxv4WYgEvnBL1pUImUO01veSy58=
@@ -998,14 +998,14 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.139/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.150/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.158/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.159/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.164 h1:Br7GgAR49SXT2oisWI0uYmeM5XHM9/7vlbWmm5+0iwY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.164/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.165 h1:P/wmSC7iSHqjToaTlgkWT0O+sVIJmNm5CeQPOJdzSv0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.165/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/design.md
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The `tencentcloud_clb_log_topic` resource manages CLB (Cloud Load Balancer) log topics. It currently supports `log_set_id`, `topic_name`, `status`, and the computed `create_time` fields. The underlying cloud APIs already support tags, but the Terraform resource does not expose this capability.
+
+A key technical detail is that the Create and Read/Update operations span two different SDK packages with different tag structures:
+- **CreateTopic** (`clb/v20180317`): uses `[]*TagInfo` with fields `TagKey` / `TagValue`
+- **ModifyTopic** (`cls/v20201016`): uses `[]*Tag` with fields `Key` / `Value`
+- **DescribeTopics** (`cls/v20201016`): returns `TopicInfo.Tags` as `[]*Tag` with fields `Key` / `Value`
+
+The existing resource implementation already crosses these two SDK packages: `CreateTopic` is called via `ClbService.CreateTopic` (clb client), while `ModifyTopic` and `DescribeTopics` are called via the cls client / `ClsService.DescribeClsTopicById`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a single new `tags` parameter to `tencentcloud_clb_log_topic` that lets users configure tags on CLB log topics.
+- Ensure tags are passed on Create (via `TagInfo`), updated on Update (via `Tag`), and read back from Describe (via `Tag`).
+- Maintain full backward compatibility: the new parameter is optional.
+
+**Non-Goals:**
+- Refactoring the existing cross-package (clb/cls) structure of the resource.
+- Adding any other parameters besides `tags`.
+- Changing the existing `status`, `topic_name`, or `log_set_id` behavior.
+
+## Decisions
+
+### Decision 1: Unified `tags` schema field using `key` / `value` element fields
+
+The Terraform schema will define `tags` as a `TypeList` of objects, where each element has `key` and `value` string fields.
+
+**Rationale**: The Read (`DescribeTopics`) and Update (`ModifyTopic`) APIs both use the `Tag` structure with `Key`/`Value` fields. Only Create (`CreateTopic`) uses `TagInfo` with `TagKey`/`TagValue`. Unifying on `key`/`value` keeps the state consistent with what the Read API returns and avoids name-mismatch drift in state. The Create code path performs the mapping from schema `key`/`value` to `TagInfo.TagKey`/`TagInfo.TagValue`.
+
+**Alternative considered**: Name the element fields `tag_key`/`tag_value` to match the Create API. Rejected because Read/Update (2 of 3 operations) use `Key`/`Value`, so `key`/`value` minimizes mapping and keeps state aligned with the Describe response.
+
+### Decision 2: Tags are updatable (not ForceNew)
+
+The `tags` parameter will be `Optional` without `ForceNew`, and the Update method will call `ModifyTopic` with the new tags when `d.HasChange("tags")`.
+
+**Rationale**: The `ModifyTopic` API (`cls/v20201016`) accepts `Tags []*Tag`, confirming tags can be modified after creation without recreating the topic.
+
+### Decision 3: Create passes tags through the existing `ClbService.CreateTopic` params map
+
+The existing `CreateTopic` service method takes a `params map[string]interface{}`. Tags will be passed through this map and converted to `[]*clb.TagInfo` inside the service method, keeping the resource Create function consistent with the existing pattern (which already passes `topic_name` and `partition_count` via the params map).
+
+### Decision 4: Read maps `TopicInfo.Tags` ([]*Tag) back to the schema list
+
+The existing `resourceTencentCloudClbInstanceTopicRead` calls `ClsService.DescribeClsTopicById`, which returns a `*cls.TopicInfo`. The `TopicInfo.Tags` field (`[]*cls.Tag` with `Key`/`Value`) will be flattened into the `tags` schema list, with nil-safety checks before setting.
+
+## Risks / Trade-offs
+
+- **[Tag structure mismatch between Create and Update/Read]** → Mitigated by Decision 1: unified schema field names with explicit mapping only in the Create code path.
+- **[Existing `CreateTopic` service method uses a loosely-typed params map]** → Mitigated by passing tags as a typed `[]*clb.TagInfo` value in the map and handling it explicitly inside the service method; type assertions are guarded.
+- **[Read returns empty tags vs. nil]** → Mitigated by nil-checking `res.Tags` before flattening; an empty/nil tag list results in an empty list in state.

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/design.md
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/design.md
@@ -23,13 +23,13 @@ The existing resource implementation already crosses these two SDK packages: `Cr
 
 ## Decisions
 
-### Decision 1: Unified `tags` schema field using `key` / `value` element fields
+### Decision 1: `tags` schema field as a `TypeMap` of string key/value pairs
 
-The Terraform schema will define `tags` as a `TypeList` of objects, where each element has `key` and `value` string fields.
+The Terraform schema will define `tags` as a `TypeMap` (`Elem: &schema.Schema{Type: schema.TypeString}`), where each map key is the tag key and each map value is the tag value.
 
-**Rationale**: The Read (`DescribeTopics`) and Update (`ModifyTopic`) APIs both use the `Tag` structure with `Key`/`Value` fields. Only Create (`CreateTopic`) uses `TagInfo` with `TagKey`/`TagValue`. Unifying on `key`/`value` keeps the state consistent with what the Read API returns and avoids name-mismatch drift in state. The Create code path performs the mapping from schema `key`/`value` to `TagInfo.TagKey`/`TagInfo.TagValue`.
+**Rationale**: Tags are naturally represented as a key/value map. The Read (`DescribeTopics`) and Update (`ModifyTopic`) APIs both use the `Tag` structure with `Key`/`Value` fields, and Create (`CreateTopic`) uses `TagInfo` with `TagKey`/`TagValue`. Using a `TypeMap` keeps state aligned with the API responses and avoids the extra `TypeList` wrapper. The Create and Update code paths map the map entries to `TagInfo.TagKey`/`TagInfo.TagValue` and `Tag.Key`/`Tag.Value` respectively.
 
-**Alternative considered**: Name the element fields `tag_key`/`tag_value` to match the Create API. Rejected because Read/Update (2 of 3 operations) use `Key`/`Value`, so `key`/`value` minimizes mapping and keeps state aligned with the Describe response.
+**Alternative considered**: Use a `TypeList` of objects with `key`/`value` element fields. Rejected because a map is simpler and matches the key/value nature of tags, eliminating the redundant list wrapper.
 
 ### Decision 2: Tags are updatable (not ForceNew)
 
@@ -41,12 +41,12 @@ The `tags` parameter will be `Optional` without `ForceNew`, and the Update metho
 
 The existing `CreateTopic` service method takes a `params map[string]interface{}`. Tags will be passed through this map and converted to `[]*clb.TagInfo` inside the service method, keeping the resource Create function consistent with the existing pattern (which already passes `topic_name` and `partition_count` via the params map).
 
-### Decision 4: Read maps `TopicInfo.Tags` ([]*Tag) back to the schema list
+### Decision 4: Read maps `TopicInfo.Tags` ([]*Tag) back to the schema map
 
-The existing `resourceTencentCloudClbInstanceTopicRead` calls `ClsService.DescribeClsTopicById`, which returns a `*cls.TopicInfo`. The `TopicInfo.Tags` field (`[]*cls.Tag` with `Key`/`Value`) will be flattened into the `tags` schema list, with nil-safety checks before setting.
+The existing `resourceTencentCloudClbInstanceTopicRead` calls `ClsService.DescribeClsTopicById`, which returns a `*cls.TopicInfo`. The `TopicInfo.Tags` field (`[]*cls.Tag` with `Key`/`Value`) will be flattened into the `tags` schema map (`map[string]string`), with nil-safety checks before setting.
 
 ## Risks / Trade-offs
 
-- **[Tag structure mismatch between Create and Update/Read]** → Mitigated by Decision 1: unified schema field names with explicit mapping only in the Create code path.
-- **[Existing `CreateTopic` service method uses a loosely-typed params map]** → Mitigated by passing tags as a typed `[]*clb.TagInfo` value in the map and handling it explicitly inside the service method; type assertions are guarded.
-- **[Read returns empty tags vs. nil]** → Mitigated by nil-checking `res.Tags` before flattening; an empty/nil tag list results in an empty list in state.
+- **[Tag structure mismatch between Create and Update/Read]** → Mitigated by Decision 1: a single `TypeMap` schema field with explicit mapping to the correct SDK structures (`TagInfo` on Create, `Tag` on Update/Read).
+- **[Existing `CreateTopic` service method uses a loosely-typed params map]** → Mitigated by passing tags as a `map[string]interface{}` value in the map and handling it explicitly inside the service method; type assertions are guarded.
+- **[Read returns empty tags vs. nil]** → Mitigated by nil-checking `res.Tags` before flattening; an empty/nil tag list results in an empty map in state.

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/proposal.md
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/proposal.md
@@ -4,7 +4,7 @@ The `tencentcloud_clb_log_topic` resource currently does not support configuring
 
 ## What Changes
 
-- Add a new optional `tags` parameter (TypeList of objects with `tag_key`/`tag_value` fields for create, and `key`/`value` for read/update) to the `tencentcloud_clb_log_topic` resource schema.
+- Add a new optional `tags` parameter (TypeMap of string key/value pairs) to the `tencentcloud_clb_log_topic` resource schema.
 - Update the `Create` method to pass tags to the `CreateTopic` API (`clb/v20180317`) using the `TagInfo` structure (`TagKey`/`TagValue` fields).
 - Update the `Update` method to pass tags to the `ModifyTopic` API (`cls/v20201016`) using the `Tag` structure (`Key`/`Value` fields) when tags change.
 - Update the `Read` method to read tags from the `DescribeTopics` API response (`cls/v20201016`) `TopicInfo.Tags` (`Tag` structure with `Key`/`Value` fields) and set them into state.

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/proposal.md
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `tencentcloud_clb_log_topic` resource currently does not support configuring tags, even though the underlying cloud APIs (`CreateTopic`, `ModifyTopic`, `DescribeTopics`) all support tag parameters. Users cannot attach tags to CLB log topics through Terraform, which limits cost allocation, access control, and resource organization capabilities. This change adds tag support to achieve feature parity with the cloud API.
+
+## What Changes
+
+- Add a new optional `tags` parameter (TypeList of objects with `tag_key`/`tag_value` fields for create, and `key`/`value` for read/update) to the `tencentcloud_clb_log_topic` resource schema.
+- Update the `Create` method to pass tags to the `CreateTopic` API (`clb/v20180317`) using the `TagInfo` structure (`TagKey`/`TagValue` fields).
+- Update the `Update` method to pass tags to the `ModifyTopic` API (`cls/v20201016`) using the `Tag` structure (`Key`/`Value` fields) when tags change.
+- Update the `Read` method to read tags from the `DescribeTopics` API response (`cls/v20201016`) `TopicInfo.Tags` (`Tag` structure with `Key`/`Value` fields) and set them into state.
+
+## Capabilities
+
+### New Capabilities
+- `clb-log-topic-tags`: Adds tag support to the `tencentcloud_clb_log_topic` resource, allowing users to configure and manage tags on CLB log topics through Terraform.
+
+### Modified Capabilities
+<!-- None - no existing capability spec is being modified. -->
+
+## Impact
+
+- **Files Modified**:
+  - `tencentcloud/services/clb/resource_tc_clb_log_topic.go` - Add `tags` schema field and update CRUD logic
+  - `tencentcloud/services/clb/resource_tc_clb_log_topic_test.go` - Add test cases for the new `tags` parameter
+  - `tencentcloud/services/clb/resource_tc_clb_log_topic.md` - Update documentation with tags example
+- **APIs Involved**:
+  - `CreateTopic` (`clb/v20180317`) - Tags via `[]*TagInfo` (`TagKey`/`TagValue`)
+  - `ModifyTopic` (`cls/v20201016`) - Tags via `[]*Tag` (`Key`/`Value`)
+  - `DescribeTopics` (`cls/v20201016`) - Tags returned in `TopicInfo.Tags` (`Tag` with `Key`/`Value`)
+- **Backward Compatibility**: The new `tags` parameter is optional; existing configurations continue working without changes.

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/specs/clb-log-topic-tags/spec.md
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/specs/clb-log-topic-tags/spec.md
@@ -2,15 +2,15 @@
 
 ### Requirement: Support tags on CLB log topic
 
-The `tencentcloud_clb_log_topic` resource SHALL support an optional `tags` parameter that allows users to configure tags on a CLB log topic. Each tag element SHALL have a `key` and `value` string field.
+The `tencentcloud_clb_log_topic` resource SHALL support an optional `tags` parameter that allows users to configure tags on a CLB log topic. The `tags` parameter SHALL be a map where each key is a tag key and each value is a tag value.
 
 **Rationale**: The underlying cloud APIs (`CreateTopic`, `ModifyTopic`, `DescribeTopics`) all support tags, but the Terraform resource does not expose them. Adding tag support enables cost allocation, access control, and resource organization.
 
 #### Scenario: Create a CLB log topic with tags
 
-- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource with the `tags` parameter set to a list of `{ key, value }` objects
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource with the `tags` parameter set to a map of tag key/value pairs
 - **THEN** the resource is created successfully
-- **AND** the tags are passed to the `CreateTopic` API as `[]*TagInfo` with `TagKey`/`TagValue` mapped from the schema `key`/`value`
+- **AND** the tags are passed to the `CreateTopic` API as `[]*TagInfo` with `TagKey`/`TagValue` mapped from the map key/value
 - **AND** a subsequent `terraform plan` shows no changes
 
 #### Scenario: Create a CLB log topic without tags
@@ -22,19 +22,19 @@ The `tencentcloud_clb_log_topic` resource SHALL support an optional `tags` param
 #### Scenario: Read tags back from the DescribeTopics API
 
 - **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Tags` contains a list of `Tag` objects with `Key`/`Value`
-- **THEN** the tags are flattened into the `tags` schema list with `key`/`value` fields
+- **THEN** the tags are flattened into the `tags` schema map with tag key/value entries
 - **AND** the state reflects the tags returned by the API
 
 #### Scenario: Read when no tags are returned
 
 - **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Tags` is nil or empty
-- **THEN** the `tags` field in state is set to an empty list
+- **THEN** the `tags` field in state is set to an empty map
 - **AND** no error is returned
 
 #### Scenario: Update tags on an existing CLB log topic
 
 - **WHEN** a user updates the `tags` parameter on an existing `tencentcloud_clb_log_topic` resource
-- **THEN** the `ModifyTopic` API is called with the new tags as `[]*Tag` with `Key`/`Value` mapped from the schema `key`/`value`
+- **THEN** the `ModifyTopic` API is called with the new tags as `[]*Tag` with `Key`/`Value` mapped from the map key/value
 - **AND** the resource is not recreated
 - **AND** a subsequent read reflects the updated tags
 

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/specs/clb-log-topic-tags/spec.md
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/specs/clb-log-topic-tags/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Support tags on CLB log topic
+
+The `tencentcloud_clb_log_topic` resource SHALL support an optional `tags` parameter that allows users to configure tags on a CLB log topic. Each tag element SHALL have a `key` and `value` string field.
+
+**Rationale**: The underlying cloud APIs (`CreateTopic`, `ModifyTopic`, `DescribeTopics`) all support tags, but the Terraform resource does not expose them. Adding tag support enables cost allocation, access control, and resource organization.
+
+#### Scenario: Create a CLB log topic with tags
+
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource with the `tags` parameter set to a list of `{ key, value }` objects
+- **THEN** the resource is created successfully
+- **AND** the tags are passed to the `CreateTopic` API as `[]*TagInfo` with `TagKey`/`TagValue` mapped from the schema `key`/`value`
+- **AND** a subsequent `terraform plan` shows no changes
+
+#### Scenario: Create a CLB log topic without tags
+
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource without specifying the `tags` parameter
+- **THEN** the resource is created successfully
+- **AND** no tags are sent to the `CreateTopic` API
+
+#### Scenario: Read tags back from the DescribeTopics API
+
+- **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Tags` contains a list of `Tag` objects with `Key`/`Value`
+- **THEN** the tags are flattened into the `tags` schema list with `key`/`value` fields
+- **AND** the state reflects the tags returned by the API
+
+#### Scenario: Read when no tags are returned
+
+- **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Tags` is nil or empty
+- **THEN** the `tags` field in state is set to an empty list
+- **AND** no error is returned
+
+#### Scenario: Update tags on an existing CLB log topic
+
+- **WHEN** a user updates the `tags` parameter on an existing `tencentcloud_clb_log_topic` resource
+- **THEN** the `ModifyTopic` API is called with the new tags as `[]*Tag` with `Key`/`Value` mapped from the schema `key`/`value`
+- **AND** the resource is not recreated
+- **AND** a subsequent read reflects the updated tags
+
+#### Scenario: Tags parameter is optional and backward compatible
+
+- **WHEN** an existing `tencentcloud_clb_log_topic` configuration without the `tags` parameter is applied after the provider upgrade
+- **THEN** the resource continues to work without any changes
+- **AND** no tags are added or removed

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/tasks.md
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/tasks.md
@@ -1,0 +1,21 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `tags` schema field to `ResourceTencentCloudClbLogTopic()` in `tencentcloud/services/clb/resource_tc_clb_log_topic.go` as a `TypeList` of objects with `key` (string, required) and `value` (string, optional) element fields; `Optional`, no `ForceNew`.
+
+## 2. Service Layer
+
+- [x] 2.1 Update `ClbService.CreateTopic()` in `tencentcloud/services/clb/service_tencentcloud_clb.go` to read `tags` from the `params` map and convert it to `[]*clb.TagInfo` (mapping schema `key`→`TagKey`, `value`→`TagValue`), then set `request.Tags`.
+
+## 3. CRUD Implementation
+
+- [x] 3.1 Update `resourceTencentCloudClbInstanceTopicCreate()` to extract `tags` from schema and pass it into the `params` map passed to `ClbService.CreateTopic()`.
+- [x] 3.2 Update `resourceTencentCloudClbInstanceTopicRead()` to flatten `res.Tags` (`[]*cls.Tag` with `Key`/`Value`) into the `tags` schema list, with nil-safety checks before calling `d.Set("tags", ...)`.
+- [x] 3.3 Update `resourceTencentCloudClbInstanceTopicUpdate()` to call `cls.ModifyTopic` with `Tags` (`[]*cls.Tag` mapping schema `key`→`Key`, `value`→`Value`) when `d.HasChange("tags")`, using the existing retry pattern (`tccommon.WriteRetryTimeout` / `tccommon.RetryError`).
+
+## 4. Documentation
+
+- [x] 4.1 Update `tencentcloud/services/clb/resource_tc_clb_log_topic.md` with a `tags` example in the Example Usage section (generated `website/docs/` files are produced by `make doc` in the finalize phase).
+
+## 5. Tests
+
+- [x] 5.1 Add test cases for the `tags` parameter in `tencentcloud/services/clb/resource_tc_clb_log_topic_test.go` covering create with tags, read-back of tags, and update of tags (using the existing test suite pattern).

--- a/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/tasks.md
+++ b/openspec/changes/archive/2026-08-24-add-clb-log-topic-tags-param/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Schema Definition
 
-- [x] 1.1 Add `tags` schema field to `ResourceTencentCloudClbLogTopic()` in `tencentcloud/services/clb/resource_tc_clb_log_topic.go` as a `TypeList` of objects with `key` (string, required) and `value` (string, optional) element fields; `Optional`, no `ForceNew`.
+- [x] 1.1 Add `tags` schema field to `ResourceTencentCloudClbLogTopic()` in `tencentcloud/services/clb/resource_tc_clb_log_topic.go` as a `TypeMap` of string values (`Elem: &schema.Schema{Type: schema.TypeString}`); `Optional`, no `ForceNew`.
 
 ## 2. Service Layer
 
-- [x] 2.1 Update `ClbService.CreateTopic()` in `tencentcloud/services/clb/service_tencentcloud_clb.go` to read `tags` from the `params` map and convert it to `[]*clb.TagInfo` (mapping schema `key`→`TagKey`, `value`→`TagValue`), then set `request.Tags`.
+- [x] 2.1 Update `ClbService.CreateTopic()` in `tencentcloud/services/clb/service_tencentcloud_clb.go` to read `tags` from the `params` map (a `map[string]interface{}`) and convert it to `[]*clb.TagInfo` (mapping map key→`TagKey`, map value→`TagValue`), then set `request.Tags`.
 
 ## 3. CRUD Implementation
 
 - [x] 3.1 Update `resourceTencentCloudClbInstanceTopicCreate()` to extract `tags` from schema and pass it into the `params` map passed to `ClbService.CreateTopic()`.
-- [x] 3.2 Update `resourceTencentCloudClbInstanceTopicRead()` to flatten `res.Tags` (`[]*cls.Tag` with `Key`/`Value`) into the `tags` schema list, with nil-safety checks before calling `d.Set("tags", ...)`.
-- [x] 3.3 Update `resourceTencentCloudClbInstanceTopicUpdate()` to call `cls.ModifyTopic` with `Tags` (`[]*cls.Tag` mapping schema `key`→`Key`, `value`→`Value`) when `d.HasChange("tags")`, using the existing retry pattern (`tccommon.WriteRetryTimeout` / `tccommon.RetryError`).
+- [x] 3.2 Update `resourceTencentCloudClbInstanceTopicRead()` to flatten `res.Tags` (`[]*cls.Tag` with `Key`/`Value`) into the `tags` schema map (`map[string]string`), with nil-safety checks before calling `d.Set("tags", ...)`.
+- [x] 3.3 Update `resourceTencentCloudClbInstanceTopicUpdate()` to call `cls.ModifyTopic` with `Tags` (`[]*cls.Tag` mapping map key→`Key`, map value→`Value`) when `d.HasChange("tags")`, using the existing retry pattern (`tccommon.WriteRetryTimeout` / `tccommon.RetryError`).
 
 ## 4. Documentation
 

--- a/openspec/specs/clb-log-topic-tags/spec.md
+++ b/openspec/specs/clb-log-topic-tags/spec.md
@@ -1,0 +1,49 @@
+# clb-log-topic-tags Specification
+
+## Purpose
+TBD - created by archiving change add-clb-log-topic-tags-param. Update Purpose after archive.
+## Requirements
+### Requirement: Support tags on CLB log topic
+
+The `tencentcloud_clb_log_topic` resource SHALL support an optional `tags` parameter that allows users to configure tags on a CLB log topic. Each tag element SHALL have a `key` and `value` string field.
+
+**Rationale**: The underlying cloud APIs (`CreateTopic`, `ModifyTopic`, `DescribeTopics`) all support tags, but the Terraform resource does not expose them. Adding tag support enables cost allocation, access control, and resource organization.
+
+#### Scenario: Create a CLB log topic with tags
+
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource with the `tags` parameter set to a list of `{ key, value }` objects
+- **THEN** the resource is created successfully
+- **AND** the tags are passed to the `CreateTopic` API as `[]*TagInfo` with `TagKey`/`TagValue` mapped from the schema `key`/`value`
+- **AND** a subsequent `terraform plan` shows no changes
+
+#### Scenario: Create a CLB log topic without tags
+
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource without specifying the `tags` parameter
+- **THEN** the resource is created successfully
+- **AND** no tags are sent to the `CreateTopic` API
+
+#### Scenario: Read tags back from the DescribeTopics API
+
+- **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Tags` contains a list of `Tag` objects with `Key`/`Value`
+- **THEN** the tags are flattened into the `tags` schema list with `key`/`value` fields
+- **AND** the state reflects the tags returned by the API
+
+#### Scenario: Read when no tags are returned
+
+- **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Tags` is nil or empty
+- **THEN** the `tags` field in state is set to an empty list
+- **AND** no error is returned
+
+#### Scenario: Update tags on an existing CLB log topic
+
+- **WHEN** a user updates the `tags` parameter on an existing `tencentcloud_clb_log_topic` resource
+- **THEN** the `ModifyTopic` API is called with the new tags as `[]*Tag` with `Key`/`Value` mapped from the schema `key`/`value`
+- **AND** the resource is not recreated
+- **AND** a subsequent read reflects the updated tags
+
+#### Scenario: Tags parameter is optional and backward compatible
+
+- **WHEN** an existing `tencentcloud_clb_log_topic` configuration without the `tags` parameter is applied after the provider upgrade
+- **THEN** the resource continues to work without any changes
+- **AND** no tags are added or removed
+

--- a/openspec/specs/clb-log-topic-tags/spec.md
+++ b/openspec/specs/clb-log-topic-tags/spec.md
@@ -5,15 +5,15 @@ TBD - created by archiving change add-clb-log-topic-tags-param. Update Purpose a
 ## Requirements
 ### Requirement: Support tags on CLB log topic
 
-The `tencentcloud_clb_log_topic` resource SHALL support an optional `tags` parameter that allows users to configure tags on a CLB log topic. Each tag element SHALL have a `key` and `value` string field.
+The `tencentcloud_clb_log_topic` resource SHALL support an optional `tags` parameter that allows users to configure tags on a CLB log topic. The `tags` parameter SHALL be a map where each key is a tag key and each value is a tag value.
 
 **Rationale**: The underlying cloud APIs (`CreateTopic`, `ModifyTopic`, `DescribeTopics`) all support tags, but the Terraform resource does not expose them. Adding tag support enables cost allocation, access control, and resource organization.
 
 #### Scenario: Create a CLB log topic with tags
 
-- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource with the `tags` parameter set to a list of `{ key, value }` objects
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource with the `tags` parameter set to a map of tag key/value pairs
 - **THEN** the resource is created successfully
-- **AND** the tags are passed to the `CreateTopic` API as `[]*TagInfo` with `TagKey`/`TagValue` mapped from the schema `key`/`value`
+- **AND** the tags are passed to the `CreateTopic` API as `[]*TagInfo` with `TagKey`/`TagValue` mapped from the map key/value
 - **AND** a subsequent `terraform plan` shows no changes
 
 #### Scenario: Create a CLB log topic without tags
@@ -25,19 +25,19 @@ The `tencentcloud_clb_log_topic` resource SHALL support an optional `tags` param
 #### Scenario: Read tags back from the DescribeTopics API
 
 - **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Tags` contains a list of `Tag` objects with `Key`/`Value`
-- **THEN** the tags are flattened into the `tags` schema list with `key`/`value` fields
+- **THEN** the tags are flattened into the `tags` schema map with tag key/value entries
 - **AND** the state reflects the tags returned by the API
 
 #### Scenario: Read when no tags are returned
 
 - **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Tags` is nil or empty
-- **THEN** the `tags` field in state is set to an empty list
+- **THEN** the `tags` field in state is set to an empty map
 - **AND** no error is returned
 
 #### Scenario: Update tags on an existing CLB log topic
 
 - **WHEN** a user updates the `tags` parameter on an existing `tencentcloud_clb_log_topic` resource
-- **THEN** the `ModifyTopic` API is called with the new tags as `[]*Tag` with `Key`/`Value` mapped from the schema `key`/`value`
+- **THEN** the `ModifyTopic` API is called with the new tags as `[]*Tag` with `Key`/`Value` mapped from the map key/value
 - **AND** the resource is not recreated
 - **AND** a subsequent read reflects the updated tags
 

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic.go
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic.go
@@ -47,6 +47,25 @@ func ResourceTencentCloudClbLogTopic() *schema.Resource {
 				Computed:    true,
 				Description: "The status of log topic. true: enable; false: disable. Default is true.",
 			},
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Tags of clb log topic.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag key.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Tag value.",
+						},
+					},
+				},
+			},
 			//compute
 			"create_time": {
 				Type:        schema.TypeString,
@@ -83,10 +102,17 @@ func resourceTencentCloudClbInstanceTopicCreate(d *schema.ResourceData, meta int
 	if partitionCount, ok := d.GetOk("partition_count"); ok {
 		params["partition_count"] = partitionCount
 	}
+	if tags, ok := d.GetOk("tags"); ok {
+		params["tags"] = tags.([]interface{})
+	}
 	resp, err := clbService.CreateTopic(ctx, params)
 	if err != nil {
-		log.Printf("[CRITAL]%s create clb topic failed, reason:%+v", logId, err)
+		log.Printf("[CRITAL]%s create clb log topic failed, reason:%+v", logId, err)
 		return err
+	}
+	if resp == nil || resp.Response == nil || resp.Response.TopicId == nil {
+		log.Printf("[CRITAL]%s create clb log topic failed, response is nil, logId=%s", logId, logId)
+		return fmt.Errorf("create clb log topic failed, response is nil")
 	}
 
 	topicId := *resp.Response.TopicId
@@ -130,6 +156,7 @@ func resourceTencentCloudClbInstanceTopicRead(d *schema.ResourceData, meta inter
 		return err
 	}
 	if res == nil {
+		log.Printf("[CRUD] clb log topic id=%s", id)
 		d.SetId("")
 		return fmt.Errorf("resource `logTopic` %s does not exist", id)
 	}
@@ -137,6 +164,25 @@ func resourceTencentCloudClbInstanceTopicRead(d *schema.ResourceData, meta inter
 	_ = d.Set("topic_name", res.TopicName)
 	_ = d.Set("create_time", res.CreateTime)
 	_ = d.Set("status", res.Status)
+
+	if res.Tags != nil {
+		tagsList := make([]map[string]interface{}, 0, len(res.Tags))
+		for _, tag := range res.Tags {
+			if tag == nil {
+				continue
+			}
+			tagMap := make(map[string]interface{})
+			if tag.Key != nil {
+				tagMap["key"] = *tag.Key
+			}
+			if tag.Value != nil {
+				tagMap["value"] = *tag.Value
+			}
+			tagsList = append(tagsList, tagMap)
+		}
+		_ = d.Set("tags", tagsList)
+	}
+
 	return nil
 }
 
@@ -167,6 +213,46 @@ func resourceTencentCloudClbInstanceTopicUpdate(d *schema.ResourceData, meta int
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	if d.HasChange("tags") {
+		request := cls.NewModifyTopicRequest()
+		request.TopicId = &topicId
+		if v, ok := d.GetOk("tags"); ok {
+			tagsList := v.([]interface{})
+			if len(tagsList) > 0 {
+				clsTags := make([]*cls.Tag, 0, len(tagsList))
+				for _, tag := range tagsList {
+					tagMap, ok := tag.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					clsTag := &cls.Tag{}
+					if key, ok := tagMap["key"].(string); ok {
+						clsTag.Key = helper.String(key)
+					}
+					if value, ok := tagMap["value"].(string); ok {
+						clsTag.Value = helper.String(value)
+					}
+					clsTags = append(clsTags, clsTag)
+				}
+				request.Tags = clsTags
+			}
+		}
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().ModifyTopic(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return err
 		}
 	}
 

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic.go
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic.go
@@ -48,23 +48,10 @@ func ResourceTencentCloudClbLogTopic() *schema.Resource {
 				Description: "The status of log topic. true: enable; false: disable. Default is true.",
 			},
 			"tags": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeMap,
 				Optional:    true,
 				Description: "Tags of clb log topic.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Tag key.",
-						},
-						"value": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Tag value.",
-						},
-					},
-				},
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			//compute
 			"create_time": {
@@ -103,15 +90,15 @@ func resourceTencentCloudClbInstanceTopicCreate(d *schema.ResourceData, meta int
 		params["partition_count"] = partitionCount
 	}
 	if tags, ok := d.GetOk("tags"); ok {
-		params["tags"] = tags.([]interface{})
+		params["tags"] = tags.(map[string]interface{})
 	}
 	resp, err := clbService.CreateTopic(ctx, params)
 	if err != nil {
-		log.Printf("[CRITAL]%s create clb log topic failed, reason:%+v", logId, err)
+		log.Printf("[CRITAL]%s create tencentcloud_clb_log_topic failed, reason:%+v", logId, err)
 		return err
 	}
 	if resp == nil || resp.Response == nil || resp.Response.TopicId == nil {
-		log.Printf("[CRITAL]%s create clb log topic failed, response is nil, logId=%s", logId, logId)
+		log.Printf("[CRITAL]%s create tencentcloud_clb_log_topic failed, response is nil, logId=%s", logId, logId)
 		return fmt.Errorf("create clb log topic failed, response is nil")
 	}
 
@@ -156,9 +143,12 @@ func resourceTencentCloudClbInstanceTopicRead(d *schema.ResourceData, meta inter
 		return err
 	}
 	if res == nil {
-		log.Printf("[CRUD] clb log topic id=%s", id)
+		if d.IsNewResource() {
+			return fmt.Errorf("reading resource `tencentcloud_clb_log_topic` %s failed after creation", id)
+		}
+		log.Printf("[WARN] tencentcloud_clb_log_topic not found with id=%s", id)
 		d.SetId("")
-		return fmt.Errorf("resource `logTopic` %s does not exist", id)
+		return nil
 	}
 	_ = d.Set("log_set_id", res.LogsetId)
 	_ = d.Set("topic_name", res.TopicName)
@@ -166,21 +156,16 @@ func resourceTencentCloudClbInstanceTopicRead(d *schema.ResourceData, meta inter
 	_ = d.Set("status", res.Status)
 
 	if res.Tags != nil {
-		tagsList := make([]map[string]interface{}, 0, len(res.Tags))
+		tagsMap := make(map[string]string, len(res.Tags))
 		for _, tag := range res.Tags {
 			if tag == nil {
 				continue
 			}
-			tagMap := make(map[string]interface{})
-			if tag.Key != nil {
-				tagMap["key"] = *tag.Key
+			if tag.Key != nil && tag.Value != nil {
+				tagsMap[*tag.Key] = *tag.Value
 			}
-			if tag.Value != nil {
-				tagMap["value"] = *tag.Value
-			}
-			tagsList = append(tagsList, tagMap)
 		}
-		_ = d.Set("tags", tagsList)
+		_ = d.Set("tags", tagsMap)
 	}
 
 	return nil
@@ -220,20 +205,13 @@ func resourceTencentCloudClbInstanceTopicUpdate(d *schema.ResourceData, meta int
 		request := cls.NewModifyTopicRequest()
 		request.TopicId = &topicId
 		if v, ok := d.GetOk("tags"); ok {
-			tagsList := v.([]interface{})
-			if len(tagsList) > 0 {
-				clsTags := make([]*cls.Tag, 0, len(tagsList))
-				for _, tag := range tagsList {
-					tagMap, ok := tag.(map[string]interface{})
-					if !ok {
-						continue
-					}
-					clsTag := &cls.Tag{}
-					if key, ok := tagMap["key"].(string); ok {
-						clsTag.Key = helper.String(key)
-					}
-					if value, ok := tagMap["value"].(string); ok {
-						clsTag.Value = helper.String(value)
+			tagsMap := v.(map[string]interface{})
+			if len(tagsMap) > 0 {
+				clsTags := make([]*cls.Tag, 0, len(tagsMap))
+				for key, value := range tagsMap {
+					clsTag := &cls.Tag{
+						Key:   helper.String(key),
+						Value: helper.String(value.(string)),
 					}
 					clsTags = append(clsTags, clsTag)
 				}

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic.md
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic.md
@@ -7,6 +7,10 @@ resource "tencentcloud_clb_log_topic" "example" {
   log_set_id = "2ed70190-bf06-4777-980d-2d8a327a2554"
   topic_name = "tf-example"
   status     = true
+  tags {
+    key   = "env"
+    value = "prod"
+  }
 }
 ```
 

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic.md
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic.md
@@ -7,9 +7,8 @@ resource "tencentcloud_clb_log_topic" "example" {
   log_set_id = "2ed70190-bf06-4777-980d-2d8a327a2554"
   topic_name = "tf-example"
   status     = true
-  tags {
-    key   = "env"
-    value = "prod"
+  tags = {
+    env = "prod"
   }
 }
 ```

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic_test.go
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic_test.go
@@ -27,6 +27,32 @@ func TestAccTencentCloudClbInstanceTopic(t *testing.T) {
 					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "topic_name", "clb-topic-test"),
 				),
 			},
+			{
+				Config: testAccClbInstanceTopicWithTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClbInstanceTopicExists("tencentcloud_clb_log_topic.topic"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "topic_name", "clb-topic-test"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.0.key", "env"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.0.value", "prod"),
+				),
+			},
+			{
+				Config: testAccClbInstanceTopicWithTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClbInstanceTopicExists("tencentcloud_clb_log_topic.topic"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "topic_name", "clb-topic-test"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.0.key", "team"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.0.value", "dev"),
+				),
+			},
+			{
+				Config: testAccClbInstanceTopic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClbInstanceTopicExists("tencentcloud_clb_log_topic.topic"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "topic_name", "clb-topic-test"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -64,5 +90,35 @@ resource "tencentcloud_clb_log_set" "set1" {
 resource "tencentcloud_clb_log_topic" "topic" {
     log_set_id = tencentcloud_clb_log_set.set1.id
     topic_name="clb-topic-test"
+}
+`
+
+const testAccClbInstanceTopicWithTags = `
+resource "tencentcloud_clb_log_set" "set1" {
+    period = 7
+}
+
+resource "tencentcloud_clb_log_topic" "topic" {
+    log_set_id = tencentcloud_clb_log_set.set1.id
+    topic_name = "clb-topic-test"
+    tags {
+      key   = "env"
+      value = "prod"
+    }
+}
+`
+
+const testAccClbInstanceTopicWithTagsUpdate = `
+resource "tencentcloud_clb_log_set" "set1" {
+    period = 7
+}
+
+resource "tencentcloud_clb_log_topic" "topic" {
+    log_set_id = tencentcloud_clb_log_set.set1.id
+    topic_name = "clb-topic-test"
+    tags {
+      key   = "team"
+      value = "dev"
+    }
 }
 `

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic_test.go
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic_test.go
@@ -32,8 +32,7 @@ func TestAccTencentCloudClbInstanceTopic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClbInstanceTopicExists("tencentcloud_clb_log_topic.topic"),
 					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "topic_name", "clb-topic-test"),
-					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.0.key", "env"),
-					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.0.value", "prod"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.env", "prod"),
 				),
 			},
 			{
@@ -41,8 +40,7 @@ func TestAccTencentCloudClbInstanceTopic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClbInstanceTopicExists("tencentcloud_clb_log_topic.topic"),
 					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "topic_name", "clb-topic-test"),
-					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.0.key", "team"),
-					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.0.value", "dev"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.team", "dev"),
 				),
 			},
 			{
@@ -50,7 +48,7 @@ func TestAccTencentCloudClbInstanceTopic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClbInstanceTopicExists("tencentcloud_clb_log_topic.topic"),
 					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "topic_name", "clb-topic-test"),
-					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.#", "0"),
+					resource.TestCheckResourceAttr("tencentcloud_clb_log_topic.topic", "tags.%", "0"),
 				),
 			},
 		},
@@ -101,9 +99,8 @@ resource "tencentcloud_clb_log_set" "set1" {
 resource "tencentcloud_clb_log_topic" "topic" {
     log_set_id = tencentcloud_clb_log_set.set1.id
     topic_name = "clb-topic-test"
-    tags {
-      key   = "env"
-      value = "prod"
+    tags = {
+      env = "prod"
     }
 }
 `
@@ -116,9 +113,8 @@ resource "tencentcloud_clb_log_set" "set1" {
 resource "tencentcloud_clb_log_topic" "topic" {
     log_set_id = tencentcloud_clb_log_set.set1.id
     topic_name = "clb-topic-test"
-    tags {
-      key   = "team"
-      value = "dev"
+    tags = {
+      team = "dev"
     }
 }
 `

--- a/tencentcloud/services/clb/service_tencentcloud_clb.go
+++ b/tencentcloud/services/clb/service_tencentcloud_clb.go
@@ -1586,6 +1586,25 @@ func (me *ClbService) CreateTopic(ctx context.Context, params map[string]interfa
 		request.PartitionCount = common.Uint64Ptr((uint64)(partitionCount.(int)))
 	}
 
+	if tags, ok := params["tags"].([]interface{}); ok && len(tags) > 0 {
+		tagInfoList := make([]*clb.TagInfo, 0, len(tags))
+		for _, tag := range tags {
+			tagMap, ok := tag.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			tagInfo := &clb.TagInfo{}
+			if key, ok := tagMap["key"].(string); ok {
+				tagInfo.TagKey = common.StringPtr(key)
+			}
+			if value, ok := tagMap["value"].(string); ok {
+				tagInfo.TagValue = common.StringPtr(value)
+			}
+			tagInfoList = append(tagInfoList, tagInfo)
+		}
+		request.Tags = tagInfoList
+	}
+
 	err = resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		ratelimit.Check(request.GetAction())
 		resp, ok := me.client.UseClbClient().CreateTopic(request)

--- a/tencentcloud/services/clb/service_tencentcloud_clb.go
+++ b/tencentcloud/services/clb/service_tencentcloud_clb.go
@@ -1586,19 +1586,12 @@ func (me *ClbService) CreateTopic(ctx context.Context, params map[string]interfa
 		request.PartitionCount = common.Uint64Ptr((uint64)(partitionCount.(int)))
 	}
 
-	if tags, ok := params["tags"].([]interface{}); ok && len(tags) > 0 {
+	if tags, ok := params["tags"].(map[string]interface{}); ok && len(tags) > 0 {
 		tagInfoList := make([]*clb.TagInfo, 0, len(tags))
-		for _, tag := range tags {
-			tagMap, ok := tag.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			tagInfo := &clb.TagInfo{}
-			if key, ok := tagMap["key"].(string); ok {
-				tagInfo.TagKey = common.StringPtr(key)
-			}
-			if value, ok := tagMap["value"].(string); ok {
-				tagInfo.TagValue = common.StringPtr(value)
+		for key, value := range tags {
+			tagInfo := &clb.TagInfo{
+				TagKey:   common.StringPtr(key),
+				TagValue: common.StringPtr(value.(string)),
 			}
 			tagInfoList = append(tagInfoList, tagInfo)
 		}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/client.go
@@ -154,12 +154,20 @@ func NewAssociateBudgetResponse() (response *AssociateBudgetResponse) {
 
 // AssociateBudget
 // 将Budget关联到企业型模型路由实例或企业型实例下的Key。资源已关联其他Budget时，本次请求会替换为新的Budget。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  UNSUPPORTEDOPERATION_BUDGETONLYSUPPORTSENTERPRISE = "UnsupportedOperation.BudgetOnlySupportsEnterprise"
 func (c *Client) AssociateBudget(request *AssociateBudgetRequest) (response *AssociateBudgetResponse, err error) {
     return c.AssociateBudgetWithContext(context.Background(), request)
 }
 
 // AssociateBudget
 // 将Budget关联到企业型模型路由实例或企业型实例下的Key。资源已关联其他Budget时，本次请求会替换为新的Budget。
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  UNSUPPORTEDOPERATION_BUDGETONLYSUPPORTSENTERPRISE = "UnsupportedOperation.BudgetOnlySupportsEnterprise"
 func (c *Client) AssociateBudgetWithContext(ctx context.Context, request *AssociateBudgetRequest) (response *AssociateBudgetResponse, err error) {
     if request == nil {
         request = NewAssociateBudgetRequest()

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/errors.go
@@ -194,6 +194,9 @@ const (
 	// 操作不支持。
 	UNSUPPORTEDOPERATION = "UnsupportedOperation"
 
+	// Budget只支持企业型实例
+	UNSUPPORTEDOPERATION_BUDGETONLYSUPPORTSENTERPRISE = "UnsupportedOperation.BudgetOnlySupportsEnterprise"
+
 	// UnsupportedOperation.InvalidModelRouterStatus
 	UNSUPPORTEDOPERATION_INVALIDMODELROUTERSTATUS = "UnsupportedOperation.InvalidModelRouterStatus"
 

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/models.go
@@ -911,26 +911,25 @@ func (r *BatchRegisterTargetsResponse) FromJsonString(s string) error {
 }
 
 type BatchTarget struct {
-	// 监听器 ID。
+	// <p>监听器 ID。</p>
 	ListenerId *string `json:"ListenerId,omitnil,omitempty" name:"ListenerId"`
 
-	// 绑定端口。
+	// <p>绑定端口。</p>
 	Port *int64 `json:"Port,omitnil,omitempty" name:"Port"`
 
-	// 子机 ID。表示绑定主网卡主 IP。
+	// <p>子机 ID。表示绑定主网卡主 IP。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 绑定 IP 时需要传入此参数，支持弹性网卡的 IP 和其他内网 IP，如果是弹性网卡则必须先绑定至CVM，然后才能绑定到负载均衡实例。
-	// 注意：参数 InstanceId、EniIp 只能传入一个且必须传入一个。如果绑定双栈IPV6子机，必须传该参数。
+	// <p>绑定 IP 时需要传入此参数，支持弹性网卡的 IP 和其他内网 IP，如果是弹性网卡则必须先绑定至CVM，然后才能绑定到负载均衡实例。注意：参数 InstanceId、EniIp 只能传入一个且必须传入一个。如果绑定双栈IPV6子机，必须传该参数。如果是跨地域绑定，则必须传该参数，不支持传InstanceId参数。</p>
 	EniIp *string `json:"EniIp,omitnil,omitempty" name:"EniIp"`
 
-	// 子机权重，范围[0, 100]。绑定时如果不存在，则默认为10。
+	// <p>子机权重，范围[0, 100]。绑定时如果不存在，则默认为10。</p>
 	Weight *int64 `json:"Weight,omitnil,omitempty" name:"Weight"`
 
-	// 七层规则 ID。7层负载均衡该参数必填
+	// <p>七层规则 ID。7层负载均衡该参数必填</p>
 	LocationId *string `json:"LocationId,omitnil,omitempty" name:"LocationId"`
 
-	// 标签。
+	// <p>标签。</p>
 	Tag *string `json:"Tag,omitnil,omitempty" name:"Tag"`
 }
 
@@ -2880,6 +2879,9 @@ type CreateModelRequestParams struct {
 
 	// <p>是否校验服务提供商的SSL证书</p>
 	VerifySSL *bool `json:"VerifySSL,omitnil,omitempty" name:"VerifySSL"`
+
+	// <p>健康检查配置</p>
+	HealthCheckConfig *ServiceProviderHealthCheckConfigInput `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
 }
 
 type CreateModelRequest struct {
@@ -2923,6 +2925,9 @@ type CreateModelRequest struct {
 
 	// <p>是否校验服务提供商的SSL证书</p>
 	VerifySSL *bool `json:"VerifySSL,omitnil,omitempty" name:"VerifySSL"`
+
+	// <p>健康检查配置</p>
+	HealthCheckConfig *ServiceProviderHealthCheckConfigInput `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
 }
 
 func (r *CreateModelRequest) ToJsonString() string {
@@ -2950,6 +2955,7 @@ func (r *CreateModelRequest) FromJsonString(s string) error {
 	delete(f, "HostHeader")
 	delete(f, "Tags")
 	delete(f, "VerifySSL")
+	delete(f, "HealthCheckConfig")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateModelRequest has unknown keys!", "")
 	}
@@ -3010,7 +3016,7 @@ type CreateModelRouterRequestParams struct {
 	// <p>限速配置</p>
 	RateLimitConfig *RateLimitConfigForModelRouter `json:"RateLimitConfig,omitnil,omitempty" name:"RateLimitConfig"`
 
-	// <p>路由配置</p>
+	// <p>路由配置</p><p>新创建实例时，默认会开启粘连路由</p>
 	RouterSetting *RouterSettingWithoutFallBack `json:"RouterSetting,omitnil,omitempty" name:"RouterSetting"`
 
 	// <p>模型路由实例的网络协议</p><p>枚举值：</p><ul><li>HTTP： HTTP协议</li><li>HTTPS： HTTPS协议</li></ul>
@@ -3030,6 +3036,12 @@ type CreateModelRouterRequestParams struct {
 
 	// <p>客户端Token，用于保证请求的幂等性。  从您的客户端生成一个参数值，确保不同请求间该参数值唯一。ClientToken只支持ASCII字符。</p>
 	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+
+	// <p>弹性公网IP的ID</p>
+	EipAddressId *string `json:"EipAddressId,omitnil,omitempty" name:"EipAddressId"`
+
+	// <p>单位</p><p>取值范围：[1, 2048]</p><p>单位：Mbps</p>
+	Bandwidth *uint64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
 }
 
 type CreateModelRouterRequest struct {
@@ -3059,7 +3071,7 @@ type CreateModelRouterRequest struct {
 	// <p>限速配置</p>
 	RateLimitConfig *RateLimitConfigForModelRouter `json:"RateLimitConfig,omitnil,omitempty" name:"RateLimitConfig"`
 
-	// <p>路由配置</p>
+	// <p>路由配置</p><p>新创建实例时，默认会开启粘连路由</p>
 	RouterSetting *RouterSettingWithoutFallBack `json:"RouterSetting,omitnil,omitempty" name:"RouterSetting"`
 
 	// <p>模型路由实例的网络协议</p><p>枚举值：</p><ul><li>HTTP： HTTP协议</li><li>HTTPS： HTTPS协议</li></ul>
@@ -3079,6 +3091,12 @@ type CreateModelRouterRequest struct {
 
 	// <p>客户端Token，用于保证请求的幂等性。  从您的客户端生成一个参数值，确保不同请求间该参数值唯一。ClientToken只支持ASCII字符。</p>
 	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+
+	// <p>弹性公网IP的ID</p>
+	EipAddressId *string `json:"EipAddressId,omitnil,omitempty" name:"EipAddressId"`
+
+	// <p>单位</p><p>取值范围：[1, 2048]</p><p>单位：Mbps</p>
+	Bandwidth *uint64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
 }
 
 func (r *CreateModelRouterRequest) ToJsonString() string {
@@ -3108,6 +3126,8 @@ func (r *CreateModelRouterRequest) FromJsonString(s string) error {
 	delete(f, "VpcId")
 	delete(f, "ModelRouterBillingConfig")
 	delete(f, "ClientToken")
+	delete(f, "EipAddressId")
+	delete(f, "Bandwidth")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateModelRouterRequest has unknown keys!", "")
 	}
@@ -3441,43 +3461,45 @@ func (r *CreateTargetGroupResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateTopicRequestParams struct {
-	// 日志主题的名称。
+	// <p>日志主题的名称。</p>
 	TopicName *string `json:"TopicName,omitnil,omitempty" name:"TopicName"`
 
-	// 主题分区Partition的数量，不传参默认创建1个，最大创建允许10个，分裂/合并操作会改变分区数量，整体上限50个。
+	// <p>主题分区Partition的数量，不传参默认创建1个，最大创建允许10个，分裂/合并操作会改变分区数量，整体上限50个。</p>
 	PartitionCount *uint64 `json:"PartitionCount,omitnil,omitempty" name:"PartitionCount"`
 
-	// 日志类型，ACCESS：访问日志，HEALTH：健康检查日志，默认ACCESS。
+	// <p>日志类型，ACCESS：访问日志，HEALTH：健康检查日志，默认ACCESS。</p>
 	TopicType *string `json:"TopicType,omitnil,omitempty" name:"TopicType"`
 
-	// 存储时间，单位天，默认为 30。
-	// - 日志接入标准存储时，支持1至3600天，值为3640时代表永久保存。
-	// - 日志接入低频存储时，支持7至3600天，值为3640时代表永久保存。
+	// <p>存储时间，单位天，默认为 30。</p><ul><li>日志接入标准存储时，支持1至3600天，值为3640时代表永久保存。</li><li>日志接入低频存储时，支持7至3600天，值为3640时代表永久保存。</li></ul>
 	Period *uint64 `json:"Period,omitnil,omitempty" name:"Period"`
 
-	// 日志主题的存储类型，可选值 HOT（标准存储），COLD（低频存储）；默认为HOT。
+	// <p>日志主题的存储类型，可选值 HOT（标准存储），COLD（低频存储）；默认为HOT。</p>
 	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
+
+	// <p>标签</p><p>最多支持一次传入20个</p>
+	Tags []*TagInfo `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type CreateTopicRequest struct {
 	*tchttp.BaseRequest
 	
-	// 日志主题的名称。
+	// <p>日志主题的名称。</p>
 	TopicName *string `json:"TopicName,omitnil,omitempty" name:"TopicName"`
 
-	// 主题分区Partition的数量，不传参默认创建1个，最大创建允许10个，分裂/合并操作会改变分区数量，整体上限50个。
+	// <p>主题分区Partition的数量，不传参默认创建1个，最大创建允许10个，分裂/合并操作会改变分区数量，整体上限50个。</p>
 	PartitionCount *uint64 `json:"PartitionCount,omitnil,omitempty" name:"PartitionCount"`
 
-	// 日志类型，ACCESS：访问日志，HEALTH：健康检查日志，默认ACCESS。
+	// <p>日志类型，ACCESS：访问日志，HEALTH：健康检查日志，默认ACCESS。</p>
 	TopicType *string `json:"TopicType,omitnil,omitempty" name:"TopicType"`
 
-	// 存储时间，单位天，默认为 30。
-	// - 日志接入标准存储时，支持1至3600天，值为3640时代表永久保存。
-	// - 日志接入低频存储时，支持7至3600天，值为3640时代表永久保存。
+	// <p>存储时间，单位天，默认为 30。</p><ul><li>日志接入标准存储时，支持1至3600天，值为3640时代表永久保存。</li><li>日志接入低频存储时，支持7至3600天，值为3640时代表永久保存。</li></ul>
 	Period *uint64 `json:"Period,omitnil,omitempty" name:"Period"`
 
-	// 日志主题的存储类型，可选值 HOT（标准存储），COLD（低频存储）；默认为HOT。
+	// <p>日志主题的存储类型，可选值 HOT（标准存储），COLD（低频存储）；默认为HOT。</p>
 	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
+
+	// <p>标签</p><p>最多支持一次传入20个</p>
+	Tags []*TagInfo `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 func (r *CreateTopicRequest) ToJsonString() string {
@@ -3497,6 +3519,7 @@ func (r *CreateTopicRequest) FromJsonString(s string) error {
 	delete(f, "TopicType")
 	delete(f, "Period")
 	delete(f, "StorageType")
+	delete(f, "Tags")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateTopicRequest has unknown keys!", "")
 	}
@@ -3505,7 +3528,7 @@ func (r *CreateTopicRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateTopicResponseParams struct {
-	// 日志主题的 ID。
+	// <p>日志主题的 ID。</p>
 	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -7476,6 +7499,9 @@ type DescribeModelNamesRequestParams struct {
 
 	// <p>过滤PrivateCustom类型自建模型。如果传递了此参数，则只返回具有相同VPC Id的模型。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
+
+	// <p>过滤器，Name取值：</p><ul><li>ModelName：按照模型名称过滤。</li><li>ServiceProviderId：按照BYOK ID过滤。</li><li>InputModalitiesUnion：按照模态过滤。</li></ul>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 }
 
 type DescribeModelNamesRequest struct {
@@ -7489,6 +7515,9 @@ type DescribeModelNamesRequest struct {
 
 	// <p>过滤PrivateCustom类型自建模型。如果传递了此参数，则只返回具有相同VPC Id的模型。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
+
+	// <p>过滤器，Name取值：</p><ul><li>ModelName：按照模型名称过滤。</li><li>ServiceProviderId：按照BYOK ID过滤。</li><li>InputModalitiesUnion：按照模态过滤。</li></ul>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
 }
 
 func (r *DescribeModelNamesRequest) ToJsonString() string {
@@ -7506,6 +7535,7 @@ func (r *DescribeModelNamesRequest) FromJsonString(s string) error {
 	delete(f, "Offset")
 	delete(f, "Limit")
 	delete(f, "VpcId")
+	delete(f, "Filters")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeModelNamesRequest has unknown keys!", "")
 	}
@@ -11252,7 +11282,7 @@ type ModelKeyInfoItem struct {
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ServiceProviderName *string `json:"ServiceProviderName,omitnil,omitempty" name:"ServiceProviderName"`
 
-	// <p>模型状态</p><p>枚举值：</p><ul><li>Active： 运行中</li><li>Provisioning： 创建中</li><li>Configuring： 变配中</li><li>Deleting： 删除中</li><li>ProvisionFailed： 创建失败</li><li>ConfigureFailed： 变配失败</li><li>DeletionFailed： 删除失败</li><li>Disabled： 已禁用</li></ul>
+	// <p>模型状态</p><p>枚举值：</p><ul><li>Active： 运行中</li><li>Provisioning： 创建中</li><li>Configuring： 变配中</li></ul>
 	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
 
 	// <p>子网 ID</p>
@@ -11268,6 +11298,9 @@ type ModelKeyInfoItem struct {
 	// <p>VPC 实例 ID</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
+
+	// <p>健康检查配置</p>
+	HealthCheckConfig *ServiceProviderHealthCheckConfigOutput `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
 }
 
 type ModelNameAggregatedItem struct {
@@ -11289,6 +11322,20 @@ type ModelRouterBillingConfigInput struct {
 	SlaType *string `json:"SlaType,omitnil,omitempty" name:"SlaType"`
 
 	// <p>是否关联资源包抵扣</p><p>枚举值：</p><ul><li>true： 关联</li><li>false： 不关联</li></ul>
+	AssociateResourcePackage *bool `json:"AssociateResourcePackage,omitnil,omitempty" name:"AssociateResourcePackage"`
+}
+
+type ModelRouterBillingConfigOutput struct {
+	// <p>模型路由计费模式</p><p>枚举值：</p><ul><li>POSTPAID_BY_HOUR： 按量计费</li><li>RESOURCE_PACKAGE： 按资源包抵扣</li></ul>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ChargeType *string `json:"ChargeType,omitnil,omitempty" name:"ChargeType"`
+
+	// <p>实例规格</p><p>枚举值：</p><ul><li>t1.nano-01： 入门版</li><li>t1.nano-02： 轻量版</li><li>t1.nano-03： 轻量增强版</li><li>t1.micro-01： 微型版</li><li>t1.micro-02： 基础版</li><li>t1.small-01： 标准版</li><li>t1.small-02： 标准增强版</li><li>t1.medium-01： 进阶版</li><li>t1.medium-02： 进阶增强版</li><li>t1.large-01： 专业版</li><li>t1.large-02： 专业增强版</li><li>t1.xlarge-01： 旗舰版</li><li>t1.xlarge-02： 至尊版</li></ul>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SlaType *string `json:"SlaType,omitnil,omitempty" name:"SlaType"`
+
+	// <p>是否关联资源包抵扣</p><p>枚举值：</p><ul><li>true： 关联</li><li>false： 不关联</li></ul>
+	// 注意：此字段可能返回 null，表示取不到有效值。
 	AssociateResourcePackage *bool `json:"AssociateResourcePackage,omitnil,omitempty" name:"AssociateResourcePackage"`
 }
 
@@ -11367,6 +11414,9 @@ type ModelRouterDetail struct {
 
 	// <p>弹性公网IP的ID</p>
 	EipAddressId *string `json:"EipAddressId,omitnil,omitempty" name:"EipAddressId"`
+
+	// <p>计费信息</p>
+	BillingConfig *ModelRouterBillingConfigOutput `json:"BillingConfig,omitnil,omitempty" name:"BillingConfig"`
 }
 
 type ModelRouterLog struct {
@@ -11590,10 +11640,14 @@ type ModelRouterSet struct {
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
 	// <p>带宽</p><p>单位：Mbps</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
 	Bandwidth *uint64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
 
 	// <p>弹性公网IP的ID</p>
 	EipAddressId *string `json:"EipAddressId,omitnil,omitempty" name:"EipAddressId"`
+
+	// <p>计费信息</p>
+	BillingConfig *ModelRouterBillingConfigOutput `json:"BillingConfig,omitnil,omitempty" name:"BillingConfig"`
 }
 
 type ModelTestResult struct {
@@ -14902,6 +14956,9 @@ type RouterSettingWithFallBack struct {
 	// <p>L2模型组内路由调度算法参数</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	RoutingStrategyArgs *RoutingStrategyArgs `json:"RoutingStrategyArgs,omitnil,omitempty" name:"RoutingStrategyArgs"`
+
+	// <p>粘连配置参数</p>
+	StickyConfig *StickyConfig `json:"StickyConfig,omitnil,omitempty" name:"StickyConfig"`
 }
 
 type RouterSettingWithoutFallBack struct {
@@ -14916,6 +14973,9 @@ type RouterSettingWithoutFallBack struct {
 
 	// <p>CMR实例级别请求组内重试次数</p><p>取值范围：[0, 5]</p><p>默认值：2</p>
 	NumRetries *uint64 `json:"NumRetries,omitnil,omitempty" name:"NumRetries"`
+
+	// <p>粘连路由配置参数</p>
+	StickyConfig *StickyConfig `json:"StickyConfig,omitnil,omitempty" name:"StickyConfig"`
 }
 
 type RoutingStrategyArgs struct {
@@ -14990,53 +15050,52 @@ type RuleHealth struct {
 }
 
 type RuleInput struct {
-	// 转发规则的路径。长度限制为：1~200。
+	// <p>转发规则的路径。长度限制为：1~200。</p>
 	Url *string `json:"Url,omitnil,omitempty" name:"Url"`
 
-	// 转发规则的域名。长度限制为：1~80。Domain和Domains只需要传一个，单域名规则传Domain，多域名规则传Domains。
+	// <p>转发规则的域名。长度限制为：1~80。Domain和Domains只需要传一个，单域名规则传Domain，多域名规则传Domains。</p>
 	Domain *string `json:"Domain,omitnil,omitempty" name:"Domain"`
 
-	// 会话保持时间。设置为0表示关闭会话保持，开启会话保持可取值30~86400，单位：秒。
+	// <p>会话保持时间。设置为0表示关闭会话保持，开启会话保持可取值30~86400，单位：秒。</p>
 	SessionExpireTime *int64 `json:"SessionExpireTime,omitnil,omitempty" name:"SessionExpireTime"`
 
-	// 健康检查信息。详情请参见：[健康检查](https://cloud.tencent.com/document/product/214/6097)
+	// <p>健康检查信息。详情请参见：<a href="https://cloud.tencent.com/document/product/214/6097">健康检查</a></p>
 	HealthCheck *HealthCheck `json:"HealthCheck,omitnil,omitempty" name:"HealthCheck"`
 
-	// 证书信息；此参数和MultiCertInfo不能同时传入。
+	// <p>证书信息；此参数和MultiCertInfo不能同时传入。</p>
 	Certificate *CertificateInput `json:"Certificate,omitnil,omitempty" name:"Certificate"`
 
-	// 规则的请求转发方式，可选值：WRR、LEAST_CONN、IP_HASH
-	// 分别表示按权重轮询、最小连接数、按IP哈希， 默认为 WRR。
+	// <p>规则的请求转发方式，可选值：WRR、LEAST_CONN、IP_HASH<br>分别表示按权重轮询、最小连接数、按IP哈希， 默认为 WRR。</p>
 	Scheduler *string `json:"Scheduler,omitnil,omitempty" name:"Scheduler"`
 
-	// 负载均衡与后端服务之间的转发协议，目前支持 HTTP/HTTPS/GRPC/GRPCS/TRPC，TRPC暂未对外开放，默认HTTP。
+	// <p>负载均衡与后端服务之间的转发协议，目前支持 HTTP/HTTPS/GRPC/GRPCS/TRPC，TRPC暂未对外开放，默认HTTP。</p>
 	ForwardType *string `json:"ForwardType,omitnil,omitempty" name:"ForwardType"`
 
-	// 是否将该域名设为默认域名，注意，一个监听器下只能设置一个默认域名。
+	// <p>是否将该域名设为默认域名，注意，一个监听器下只能设置一个默认域名。</p>
 	DefaultServer *bool `json:"DefaultServer,omitnil,omitempty" name:"DefaultServer"`
 
-	// 是否开启Http2，注意，只有HTTPS域名才能开启Http2。
+	// <p>是否开启Http2，注意，只有HTTPS域名才能开启Http2。</p>
 	Http2 *bool `json:"Http2,omitnil,omitempty" name:"Http2"`
 
-	// 后端目标类型，NODE表示绑定普通节点，TARGETGROUP表示绑定目标组
+	// <p>后端目标类型，NODE表示绑定普通节点，TARGETGROUP表示绑定目标组</p><p>枚举值：</p><ul><li>NODE： 绑定普通节点</li><li>TARGETGROUP： 绑定目标组 v1</li><li>TARGETGROUP-V2： 绑定目标组 v2</li></ul>
 	TargetType *string `json:"TargetType,omitnil,omitempty" name:"TargetType"`
 
-	// TRPC被调服务器路由，ForwardType为TRPC时必填。目前暂未对外开放。
+	// <p>TRPC被调服务器路由，ForwardType为TRPC时必填。目前暂未对外开放。</p>
 	TrpcCallee *string `json:"TrpcCallee,omitnil,omitempty" name:"TrpcCallee"`
 
-	// TRPC调用服务接口，ForwardType为TRPC时必填。目前暂未对外开放
+	// <p>TRPC调用服务接口，ForwardType为TRPC时必填。目前暂未对外开放</p>
 	TrpcFunc *string `json:"TrpcFunc,omitnil,omitempty" name:"TrpcFunc"`
 
-	// 是否开启QUIC，注意，只有HTTPS域名才能开启QUIC
+	// <p>是否开启QUIC，注意，只有HTTPS域名才能开启QUIC</p>
 	Quic *bool `json:"Quic,omitnil,omitempty" name:"Quic"`
 
-	// 转发规则的域名列表。每个域名的长度限制为：1~80。Domain和Domains只需要传一个，单域名规则传Domain，多域名规则传Domains。
+	// <p>转发规则的域名列表。每个域名的长度限制为：1~80。Domain和Domains只需要传一个，单域名规则传Domain，多域名规则传Domains。</p>
 	Domains []*string `json:"Domains,omitnil,omitempty" name:"Domains"`
 
-	// 证书信息，支持同时传入不同算法类型的多本服务端证书；此参数和Certificate不能同时传入。
+	// <p>证书信息，支持同时传入不同算法类型的多本服务端证书；此参数和Certificate不能同时传入。</p>
 	MultiCertInfo *MultiCertInfo `json:"MultiCertInfo,omitnil,omitempty" name:"MultiCertInfo"`
 
-	// 自定义cookie名
+	// <p>自定义cookie名</p>
 	CookieName *string `json:"CookieName,omitnil,omitempty" name:"CookieName"`
 }
 
@@ -15202,6 +15261,16 @@ type ServiceProviderCoefficient struct {
 
 	// <p>BYOK 实例（ServiceProvider）名称。</p>
 	ServiceProviderName *string `json:"ServiceProviderName,omitnil,omitempty" name:"ServiceProviderName"`
+}
+
+type ServiceProviderHealthCheckConfigInput struct {
+	// <p>是否开启健康检查</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul>
+	HealthCheckEnabled *bool `json:"HealthCheckEnabled,omitnil,omitempty" name:"HealthCheckEnabled"`
+}
+
+type ServiceProviderHealthCheckConfigOutput struct {
+	// <p>是否开启健康检查</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul>
+	HealthCheckEnabled *bool `json:"HealthCheckEnabled,omitnil,omitempty" name:"HealthCheckEnabled"`
 }
 
 type ServiceProviderItem struct {
@@ -15676,6 +15745,11 @@ type SpecAvailability struct {
 
 	// 规格可用性。资源可用性，"Available"：可用，"Unavailable"：不可用
 	Availability *string `json:"Availability,omitnil,omitempty" name:"Availability"`
+}
+
+type StickyConfig struct {
+	// <p>是否开启粘连路由</p>
+	Enabled *bool `json:"Enabled,omitnil,omitempty" name:"Enabled"`
 }
 
 type TagInfo struct {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.164"
+	params["RequestClient"] = "SDK_GO_1.3.165"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1253,7 +1253,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam/v20220331
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.150
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.164
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.164
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.165
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors

--- a/website/docs/r/clb_log_topic.html.markdown
+++ b/website/docs/r/clb_log_topic.html.markdown
@@ -18,6 +18,10 @@ resource "tencentcloud_clb_log_topic" "example" {
   log_set_id = "2ed70190-bf06-4777-980d-2d8a327a2554"
   topic_name = "tf-example"
   status     = true
+  tags {
+    key   = "env"
+    value = "prod"
+  }
 }
 ```
 
@@ -28,6 +32,12 @@ The following arguments are supported:
 * `log_set_id` - (Required, String, ForceNew) Log topic of CLB instance.
 * `topic_name` - (Required, String, ForceNew) Log topic of CLB instance.
 * `status` - (Optional, Bool) The status of log topic. true: enable; false: disable. Default is true.
+* `tags` - (Optional, List) Tags of clb log topic.
+
+The `tags` object supports the following:
+
+* `key` - (Required, String) Tag key.
+* `value` - (Optional, String) Tag value.
 
 ## Attributes Reference
 

--- a/website/docs/r/clb_log_topic.html.markdown
+++ b/website/docs/r/clb_log_topic.html.markdown
@@ -18,9 +18,8 @@ resource "tencentcloud_clb_log_topic" "example" {
   log_set_id = "2ed70190-bf06-4777-980d-2d8a327a2554"
   topic_name = "tf-example"
   status     = true
-  tags {
-    key   = "env"
-    value = "prod"
+  tags = {
+    env = "prod"
   }
 }
 ```
@@ -32,12 +31,7 @@ The following arguments are supported:
 * `log_set_id` - (Required, String, ForceNew) Log topic of CLB instance.
 * `topic_name` - (Required, String, ForceNew) Log topic of CLB instance.
 * `status` - (Optional, Bool) The status of log topic. true: enable; false: disable. Default is true.
-* `tags` - (Optional, List) Tags of clb log topic.
-
-The `tags` object supports the following:
-
-* `key` - (Required, String) Tag key.
-* `value` - (Optional, String) Tag value.
+* `tags` - (Optional, Map) Tags of clb log topic.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add tags parameter support to the tencentcloud_clb_log_topic resource, allowing users to configure and manage tags on CLB log topics through Terraform. The new optional tags parameter is passed to the CreateTopic/ModifyTopic APIs and read from the DescribeTopics API response. Backward compatible - existing configurations continue working without changes.