### PR TITLE
fix(monitor): [137500650] deprecated resource `tencentcloud_monitor_tmp_scrape_job` 

### DIFF
--- a/.changelog/4454.txt
+++ b/.changelog/4454.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_monitor_tmp_scrape_job: This resource has been deprecated.
+```

--- a/tencentcloud/services/tmp/resource_tc_monitor_tmp_scrape_job.go
+++ b/tencentcloud/services/tmp/resource_tc_monitor_tmp_scrape_job.go
@@ -18,10 +18,11 @@ import (
 
 func ResourceTencentCloudMonitorTmpScrapeJob() *schema.Resource {
 	return &schema.Resource{
-		Read:   resourceTencentCloudMonitorTmpScrapeJobRead,
-		Create: resourceTencentCloudMonitorTmpScrapeJobCreate,
-		Update: resourceTencentCloudMonitorTmpScrapeJobUpdate,
-		Delete: resourceTencentCloudMonitorTmpScrapeJobDelete,
+		DeprecationMessage: "This resource has been deprecated in Terraform TencentCloud provider version 1.83.26.",
+		Read:               resourceTencentCloudMonitorTmpScrapeJobRead,
+		Create:             resourceTencentCloudMonitorTmpScrapeJobCreate,
+		Update:             resourceTencentCloudMonitorTmpScrapeJobUpdate,
+		Delete:             resourceTencentCloudMonitorTmpScrapeJobDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/tencentcloud/services/tmp/resource_tc_monitor_tmp_scrape_job.md
+++ b/tencentcloud/services/tmp/resource_tc_monitor_tmp_scrape_job.md
@@ -1,5 +1,7 @@
 Provides a resource to create a monitor tmpScrapeJob
 
+~> **NOTE:** This resource has been deprecated in Terraform TencentCloud provider version 1.83.26.
+
 Example Usage
 
 ```hcl

--- a/website/docs/r/monitor_tmp_scrape_job.html.markdown
+++ b/website/docs/r/monitor_tmp_scrape_job.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Provides a resource to create a monitor tmpScrapeJob
 
+~> **NOTE:** This resource has been deprecated in Terraform TencentCloud provider version 1.83.26.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--
Thanks for contributing to terraform-provider-tencentcloud!
Please fill in the sections below to help reviewers understand your change.
See CONTRIBUTING.md for project conventions.
-->

## What

<!-- Describe the change in 1-3 sentences. -->

## Why

<!-- The problem this change solves, or the new capability it enables. -->

## Type of change

- [ ] New SDKv2 resource / data source
- [ ] New framework resource / data source
- [ ] Modification to an existing resource / data source
- [ ] Bug fix
- [ ] Refactor / internal-only change
- [ ] Documentation only

## Checklist

- [ ] `make build` succeeds locally
- [ ] `make fmt` produces no diff
- [ ] `make lint` passes (or pre-existing failures are unrelated)
- [ ] `make check-mux` passes (SDKv2 + framework mux compatibility)
- [ ] **Confirmed the resource/data source type name is not already
      registered in the other stack** (CI's `make check-mux` enforces
      this; please double-check before opening the PR)
- [ ] Acceptance tests added or updated (or skipped with justification)
- [ ] Website docs updated under `website/docs/r/` or `website/docs/d/`
- [ ] `go.mod` changes are accompanied by `go mod vendor` in the same commit
- [ ] Changelog entry added under `.changelog/<PR>.txt` (if user-facing)

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to: tricky logic,
unusual SDK quirks, breaking changes, etc. -->
