### PR TITLE
feat(cls): [137633723] add tencentcloud_cls_splunk_deliver resource

### DIFF
--- a/.changelog/4459.txt
+++ b/.changelog/4459.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_cls_splunk_deliver
+```

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.164
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.168
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.168
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130

--- a/go.sum
+++ b/go.sum
@@ -921,8 +921,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165 h1:sQRHq9c
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165/go.mod h1:s88/DboRoSIkZNA9/lmXt1ja4LGDG+A+4ZwbqLrCZMQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40 h1:bhPBpfz0w3mdVyEolvXrtELUf+gE00O0WnAYIHZq70s=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40/go.mod h1:taTki0q8SHBIUFhjtnDA5UkiVic/WaPQzTqoXeGH3Ns=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.164 h1:GZWaZ0zrTkS/tHqFTxv4WYgEvnBL1pUImUO01veSy58=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.164/go.mod h1:XhaMuzTbyJ2RdwSEqU1FQ2OT+yP9lqikvYklkWwmgXA=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.168 h1:KSmWenxgxRAhPwcliPzmjlCIuw6FxJ0Ui+jLo6Tw7+0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.168/go.mod h1:Sg1S+xcKj1zOCAJ6zeS1rs0ozHk1fPjXka1qZbDr0Kk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.414/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.486/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.533/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
@@ -1002,7 +1002,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.159/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.162/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.164/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.165/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.168 h1:RSvCt6hidp57WSP6iAEDeD63O6ipu+55Gd+ZS3rl3dE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.168/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=

--- a/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/design.md
+++ b/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/design.md
@@ -1,0 +1,86 @@
+## Context
+
+腾讯云 CLS 服务已提供 Splunk 投递相关的云 API（`CreateSplunkDeliver`、`DescribeSplunkDelivers`、`ModifySplunkDeliver`、`DeleteSplunkDeliver`），且对应的 Go SDK 已存在于 vendor 中。当前 Terraform Provider 尚未封装这些 API，需要新增 `tencentcloud_cls_splunk_deliver` 资源。
+
+该资源属于 RESOURCE_KIND_GENERAL 类型，需要实现完整的 CRUD + Import 能力。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提供 `tencentcloud_cls_splunk_deliver` 资源，支持 Splunk 投递任务的创建、读取、更新、删除和导入
+- Schema 设计覆盖所有云 API 参数，包括嵌套复杂类型（`net_info`、`metadata_info`、`external_role`）
+- 使用 `task_id` 和 `topic_id` 联合 ID（`task_id#topic_id`）作为 Terraform 资源 ID
+- 遵循现有 CLS 资源（如 `tencentcloud_cls_cos_shipper`）的代码风格和模式
+
+**Non-Goals:**
+- 不修改已有 CLS 资源或数据源
+- 不新增数据源（datasource），仅创建资源
+
+## Decisions
+
+### 1. 资源 ID 设计：使用联合 ID `task_id#topic_id`
+
+**决策**: 资源 ID 使用 `task_id` + `tccommon.FILED_SP` + `topic_id` 格式。
+
+**理由**: `DeleteSplunkDeliver` 和 `ModifySplunkDeliver` 接口都需要同时传入 `TaskId` 和 `TopicId`，且 `DescribeSplunkDelivers` 的查询需要 `TopicId`。将两者联合存储可以确保 Read/Update/Delete 操作都能获取到必要的参数。
+
+**备选方案**: 仅使用 `task_id` 作为 ID。但这样在 Read/Delete 时无法获取 `topic_id`，需要额外做 API 查询，增加复杂度。
+
+### 2. Schema 嵌套类型设计
+
+**决策**: 对于 `NetInfo`、`MetadataInfo`、`ExternalRole` 三个复杂类型，使用 `TypeList` + `MaxItems: 1` 的嵌套 schema 结构。
+
+**理由**: 与现有 CLS 资源（如 `cos_shipper` 的 `compress`、`content` 块）保持一致。`TypeList` + `MaxItems: 1` 是 Terraform Plugin SDK v2 中表示单个嵌套对象的惯用模式。
+
+**`net_info` 子字段**:
+- `host` (Required, TypeString): 网络地址
+- `port` (Required, TypeInt): 端口
+- `token` (Required, TypeString): 认证 token
+- `net_type` (Required, TypeInt): 网络类型，1=内网，2=外网
+- `vpc_id` (Optional, TypeString): 所属网络（内网时必填）
+- `virtual_gateway_type` (Optional, TypeInt): 网络服务类型（内网时必填）
+- `is_ssl` (Optional, TypeBool): 是否使用 SSL
+
+**`metadata_info` 子字段**:
+- `format` (Required, TypeString): 数据格式，rawlog/json
+- `meta_fields` (Required, TypeSet of TypeString): 投递字段
+- `enable_tag` (Required, TypeBool): 是否投递 TAG 字段
+- `tag_json_tiled` (Optional, TypeBool): JSON 是否平铺
+
+**`external_role` 子字段**:
+- `role_arn` (Required, TypeString): 跨账户投递角色 RoleArn
+- `external_id` (Required, TypeString): 跨账户投递角色名称
+
+### 3. Enable 字段处理
+
+**决策**: `enable` 字段设为 Optional + Computed。
+
+**理由**: `CreateSplunkDeliver` 接口不支持 `Enable` 参数，但 `ModifySplunkDeliver` 支持，且 `DescribeSplunkDelivers` 的响应中包含 `Enable`。创建时由云 API 默认开启，用户可在后续通过 Update 修改。
+
+### 4. Read 操作：通过 DescribeSplunkDelivers 列表接口查询
+
+**决策**: Read 操作使用 `DescribeSplunkDelivers` 接口，通过 `Filters` 参数按 `taskId` 过滤，查询单个投递任务。
+
+**理由**: 该接口是当前唯一可用的查询接口，支持按 `taskId` 过滤。Read 时需从 ID 中解析出 `task_id` 和 `topic_id`，设置 `TopicId` 和 `Filters` 参数。
+
+### 5. 异步操作处理
+
+**决策**: 不在 Schema 中声明 Timeouts 块，Create/Update/Delete 操作使用 retry 机制处理临时失败。
+
+**理由**: 根据云 API 文档，这些接口为同步接口，不涉及异步等待。仅在网络波动或临时错误时使用 `tccommon.RetryError` 和 `tccommon.ReadRetryTimeout` 进行重试。
+
+### 6. Import 支持
+
+**决策**: 支持通过联合 ID `task_id#topic_id` 导入已有资源。
+
+**理由**: 用户可能已有通过控制台或其他方式创建的 Splunk 投递任务，需要纳入 Terraform 管理。
+
+## Risks / Trade-offs
+
+- **[风险] DescribeSplunkDelivers 是列表接口，无单独查询接口**: 需要通过 Filters 精确过滤，若过滤结果为空或返回多条，需要做异常处理。→ 缓解：Read 时若 `Infos` 为空，记录日志后 `d.SetId("")`；若返回多条，取第一条并记录警告。
+- **[风险] NetInfo 中 Token 是敏感信息**: Terraform state 中会明文存储。→ 缓解：与现有 CLS 资源行为一致，由用户自行管理 state 安全。
+- **[风险] 复杂嵌套类型可能导致 plan diff 问题**: `TypeList` 嵌套结构在 Terraform 中可能出现不必要的 diff。→ 缓解：在 Read 方法中设置所有字段时进行 nil 检查，避免 service 端返回 null 与 terraform 配置默认值不一致导致的 diff。
+
+## Open Questions
+
+<!-- 无待解决问题 -->

--- a/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/proposal.md
+++ b/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+腾讯云 CLS（日志服务）支持将日志数据投递到 Splunk，但当前 Terraform Provider 缺少对 Splunk 投递任务的管理能力。用户无法通过 IaC 方式自动化创建、配置和管理 Splunk 投递任务，需要手动在控制台操作，增加了运维复杂度和出错风险。新增此资源可以让用户通过 Terraform 统一管理 CLS 日志到 Splunk 的投递链路。
+
+## What Changes
+
+- 新增 `tencentcloud_cls_splunk_deliver` Terraform 资源，支持 Splunk 投递任务的完整 CRUD 生命周期管理
+- 通过 `CreateSplunkDeliver` API 创建 Splunk 投递任务
+- 通过 `DescribeSplunkDelivers` API 查询 Splunk 投递任务详情
+- 通过 `ModifySplunkDeliver` API 修改 Splunk 投递任务配置
+- 通过 `DeleteSplunkDeliver` API 删除 Splunk 投递任务
+- 支持资源导入（import），通过 `task_id` 和 `topic_id` 联合 ID 导入已有投递任务
+
+## Capabilities
+
+### New Capabilities
+- `cls-splunk-deliver-resource`: 提供 CLS Splunk 投递任务的 Terraform 资源管理能力，包括创建、读取、更新、删除和导入操作
+
+### Modified Capabilities
+<!-- No existing capabilities are modified -->
+
+## Impact
+
+- 新增文件: `tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go`
+- 新增文件: `tencentcloud/services/cls/resource_tc_cls_splunk_deliver_test.go`
+- 新增文件: `tencentcloud/services/cls/resource_tc_cls_splunk_deliver.md`
+- 修改文件: `tencentcloud/provider.go` - 注册新资源
+- 修改文件: `tencentcloud/provider.md` - 添加资源文档入口
+- 依赖: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016` (已存在于 vendor 中)

--- a/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/specs/cls-splunk-deliver-resource/spec.md
+++ b/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/specs/cls-splunk-deliver-resource/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Resource schema definition
+The `tencentcloud_cls_splunk_deliver` resource SHALL expose all parameters supported by the CLS Splunk Deliver APIs in its Terraform schema, including `topic_id`, `name`, `net_info`, `metadata_info`, `has_service_log`, `index_ack`, `source`, `source_type`, `index`, `channel`, `dsl_filter`, `external_role`, and `enable`.
+
+#### Scenario: Schema contains all required fields
+- **WHEN** a user inspects the `tencentcloud_cls_splunk_deliver` resource schema
+- **THEN** the schema SHALL include `topic_id` (Required), `name` (Required), `net_info` (Required, TypeList, MaxItems:1), and `metadata_info` (Required, TypeList, MaxItems:1)
+
+#### Scenario: Schema contains all optional fields
+- **WHEN** a user inspects the `tencentcloud_cls_splunk_deliver` resource schema
+- **THEN** the schema SHALL include `has_service_log` (Optional), `index_ack` (Optional), `source` (Optional), `source_type` (Optional), `index` (Optional), `channel` (Optional), `dsl_filter` (Optional), `external_role` (Optional, TypeList, MaxItems:1), and `enable` (Optional, Computed)
+
+#### Scenario: Computed attributes
+- **WHEN** a user inspects the `tencentcloud_cls_splunk_deliver` resource schema
+- **THEN** the schema SHALL include `task_id` (Computed) as the unique identifier returned by the Create API
+
+### Requirement: Create operation
+The resource SHALL create a Splunk deliver task via the `CreateSplunkDeliver` API, setting the resource ID to `task_id#topic_id` on success.
+
+#### Scenario: Successful creation
+- **WHEN** a user applies a Terraform configuration with valid `topic_id`, `name`, `net_info`, and `metadata_info`
+- **THEN** the provider SHALL call `CreateSplunkDeliver` API and set the resource ID to the format `{task_id}#{topic_id}`
+
+#### Scenario: Create API returns empty task_id
+- **WHEN** the `CreateSplunkDeliver` API returns a response with nil or empty `TaskId`
+- **THEN** the provider SHALL return a `NonRetryableError` with an appropriate error message
+
+### Requirement: Read operation
+The resource SHALL read the Splunk deliver task state via the `DescribeSplunkDelivers` API using `topic_id` and `task_id` filter.
+
+#### Scenario: Successful read
+- **WHEN** the provider reads an existing Splunk deliver task
+- **THEN** the provider SHALL call `DescribeSplunkDelivers` with `TopicId` and `Filters` containing `taskId` filter, and set all schema attributes from the response
+
+#### Scenario: Task not found in read
+- **WHEN** the `DescribeSplunkDelivers` API returns empty `Infos` array
+- **THEN** the provider SHALL log the current resource ID and call `d.SetId("")` to remove the resource from state
+
+#### Scenario: Read response fields are nil
+- **WHEN** the `DescribeSplunkDelivers` API returns an `Infos` entry with some nil fields
+- **THEN** the provider SHALL skip setting those nil fields in the Terraform state
+
+### Requirement: Update operation
+The resource SHALL update a Splunk deliver task via the `ModifySplunkDeliver` API.
+
+#### Scenario: Successful update
+- **WHEN** a user modifies the `name` or other mutable field of an existing Splunk deliver task
+- **THEN** the provider SHALL call `ModifySplunkDeliver` API with the updated parameters and then call `Read` to refresh state
+
+#### Scenario: Update with immutable fields
+- **WHEN** a user attempts to modify `topic_id` (which is immutable)
+- **THEN** the `topic_id` field SHALL be marked as `ForceNew`, triggering resource recreation instead of update
+
+### Requirement: Delete operation
+The resource SHALL delete a Splunk deliver task via the `DeleteSplunkDeliver` API.
+
+#### Scenario: Successful deletion
+- **WHEN** a user destroys a Terraform-managed Splunk deliver task
+- **THEN** the provider SHALL call `DeleteSplunkDeliver` API with the `TaskId` and `TopicId` parsed from the resource ID
+
+### Requirement: Import operation
+The resource SHALL support importing existing Splunk deliver tasks using the `task_id#topic_id` format as the import ID.
+
+#### Scenario: Successful import
+- **WHEN** a user imports a resource with `terraform import tencentcloud_cls_splunk_deliver.example task-xxx#topic-yyy`
+- **THEN** the provider SHALL parse the import ID, set the resource ID, and call `Read` to populate the state
+
+### Requirement: Retry logic for API calls
+All CRUD operations SHALL use `tccommon.ReadRetryTimeout` as the timeout and wrap errors with `tccommon.RetryError()` for transient failures.
+
+#### Scenario: Transient API failure during create
+- **WHEN** the `CreateSplunkDeliver` API returns a transient error
+- **THEN** the provider SHALL retry the request within the retry timeout period
+
+#### Scenario: Persistent API failure
+- **WHEN** the API consistently returns errors beyond the retry timeout
+- **THEN** the provider SHALL return the final error to the user
+
+### Requirement: Provider registration
+The resource SHALL be registered in the TencentCloud provider so it is available for use.
+
+#### Scenario: Resource registered in provider
+- **WHEN** the provider is initialized
+- **THEN** `tencentcloud_cls_splunk_deliver` SHALL be a valid resource type that maps to the resource implementation

--- a/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/tasks.md
+++ b/openspec/changes/archive/2026-08-27-add-cls-splunk-deliver-resource/tasks.md
@@ -1,0 +1,48 @@
+## 1. 资源 Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go` 中定义 `ResourceTencentCloudClsSplunkDeliver` 函数，创建 schema 包含所有顶层字段（`topic_id`、`name`、`enable`、`has_service_log`、`index_ack`、`source`、`source_type`、`index`、`channel`、`dsl_filter`、`task_id`）
+- [x] 1.2 定义 `net_info` 嵌套 TypeList（MaxItems:1）schema，包含 `host`、`port`、`token`、`net_type`、`vpc_id`、`virtual_gateway_type`、`is_ssl`
+- [x] 1.3 定义 `metadata_info` 嵌套 TypeList（MaxItems:1）schema，包含 `format`、`meta_fields`（TypeSet）、`enable_tag`、`tag_json_tiled`
+- [x] 1.4 定义 `external_role` 嵌套 TypeList（MaxItems:1）schema，包含 `role_arn`、`external_id`
+
+## 2. Create 操作实现
+
+- [x] 2.1 实现 `resourceTencentCloudClsSplunkDeliverCreate` 函数：从 schema 中读取参数，构建 `CreateSplunkDeliverRequest`，调用 API
+- [x] 2.2 在 Create 中使用 `tccommon.ReadRetryTimeout` 和 `tccommon.RetryError` 进行 retry 处理
+- [x] 2.3 检查 Create 返回值是否为空/nil，若 `TaskId` 为空则返回 `NonRetryableError`
+- [x] 2.4 使用 `task_id#topic_id` 格式设置资源 ID，然后调用 Read 刷新状态
+
+## 3. Read 操作实现
+
+- [x] 3.1 实现 `resourceTencentCloudClsSplunkDeliverRead` 函数：从 ID 解析 `task_id` 和 `topic_id`，构建 `DescribeSplunkDeliversRequest`
+- [x] 3.2 使用 `Filters` 按 `taskId` 过滤，设置 `Limit` 为最大值 100
+- [x] 3.3 检查响应是否为空，若 `Infos` 为空则记录日志后 `d.SetId("")`
+- [x] 3.4 在 set 字段前检查 Response 中每个字段是否为 nil，nil 则不设置
+
+## 4. Update 操作实现
+
+- [x] 4.1 实现 `resourceTencentCloudClsSplunkDeliverUpdate` 函数：从 ID 解析参数，构建 `ModifySplunkDeliverRequest`
+- [x] 4.2 使用 `d.HasChange()` 检测变更字段，仅将变更的字段设置到请求中
+- [x] 4.3 调用 API 后调用 Read 刷新状态
+
+## 5. Delete 操作实现
+
+- [x] 5.1 实现 `resourceTencentCloudClsSplunkDeliverDelete` 函数：从 ID 解析 `task_id` 和 `topic_id`，构建 `DeleteSplunkDeliverRequest`
+- [x] 5.2 使用 `tccommon.ReadRetryTimeout` 和 `tccommon.RetryError` 进行 retry 处理
+
+## 6. Import 支持
+
+- [x] 6.1 在 schema 中添加 `Importer` 配置，支持 `task_id#topic_id` 格式导入
+
+## 7. Provider 注册
+
+- [x] 7.1 在 `tencentcloud/provider.go` 中注册 `tencentcloud_cls_splunk_deliver` 资源
+- [x] 7.2 在 `tencentcloud/provider.md` 中添加资源文档入口
+
+## 8. 单元测试
+
+- [x] 8.1 创建 `tencentcloud/services/cls/resource_tc_cls_splunk_deliver_test.go`，使用 gomonkey mock 云 API 进行单元测试
+
+## 9. 文档
+
+- [x] 9.1 创建 `tencentcloud/services/cls/resource_tc_cls_splunk_deliver.md`，包含资源描述、Example Usage 和 Import 示例

--- a/openspec/specs/cls-splunk-deliver-resource/spec.md
+++ b/openspec/specs/cls-splunk-deliver-resource/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Resource schema definition
+The `tencentcloud_cls_splunk_deliver` resource SHALL expose all parameters supported by the CLS Splunk Deliver APIs in its Terraform schema, including `topic_id`, `name`, `net_info`, `metadata_info`, `has_service_log`, `index_ack`, `source`, `source_type`, `index`, `channel`, `dsl_filter`, `external_role`, and `enable`.
+
+#### Scenario: Schema contains all required fields
+- **WHEN** a user inspects the `tencentcloud_cls_splunk_deliver` resource schema
+- **THEN** the schema SHALL include `topic_id` (Required), `name` (Required), `net_info` (Required, TypeList, MaxItems:1), and `metadata_info` (Required, TypeList, MaxItems:1)
+
+#### Scenario: Schema contains all optional fields
+- **WHEN** a user inspects the `tencentcloud_cls_splunk_deliver` resource schema
+- **THEN** the schema SHALL include `has_service_log` (Optional), `index_ack` (Optional), `source` (Optional), `source_type` (Optional), `index` (Optional), `channel` (Optional), `dsl_filter` (Optional), `external_role` (Optional, TypeList, MaxItems:1), and `enable` (Optional, Computed)
+
+#### Scenario: Computed attributes
+- **WHEN** a user inspects the `tencentcloud_cls_splunk_deliver` resource schema
+- **THEN** the schema SHALL include `task_id` (Computed) as the unique identifier returned by the Create API
+
+### Requirement: Create operation
+The resource SHALL create a Splunk deliver task via the `CreateSplunkDeliver` API, setting the resource ID to `task_id#topic_id` on success.
+
+#### Scenario: Successful creation
+- **WHEN** a user applies a Terraform configuration with valid `topic_id`, `name`, `net_info`, and `metadata_info`
+- **THEN** the provider SHALL call `CreateSplunkDeliver` API and set the resource ID to the format `{task_id}#{topic_id}`
+
+#### Scenario: Create API returns empty task_id
+- **WHEN** the `CreateSplunkDeliver` API returns a response with nil or empty `TaskId`
+- **THEN** the provider SHALL return a `NonRetryableError` with an appropriate error message
+
+### Requirement: Read operation
+The resource SHALL read the Splunk deliver task state via the `DescribeSplunkDelivers` API using `topic_id` and `task_id` filter.
+
+#### Scenario: Successful read
+- **WHEN** the provider reads an existing Splunk deliver task
+- **THEN** the provider SHALL call `DescribeSplunkDelivers` with `TopicId` and `Filters` containing `taskId` filter, and set all schema attributes from the response
+
+#### Scenario: Task not found in read
+- **WHEN** the `DescribeSplunkDelivers` API returns empty `Infos` array
+- **THEN** the provider SHALL log the current resource ID and call `d.SetId("")` to remove the resource from state
+
+#### Scenario: Read response fields are nil
+- **WHEN** the `DescribeSplunkDelivers` API returns an `Infos` entry with some nil fields
+- **THEN** the provider SHALL skip setting those nil fields in the Terraform state
+
+### Requirement: Update operation
+The resource SHALL update a Splunk deliver task via the `ModifySplunkDeliver` API.
+
+#### Scenario: Successful update
+- **WHEN** a user modifies the `name` or other mutable field of an existing Splunk deliver task
+- **THEN** the provider SHALL call `ModifySplunkDeliver` API with the updated parameters and then call `Read` to refresh state
+
+#### Scenario: Update with immutable fields
+- **WHEN** a user attempts to modify `topic_id` (which is immutable)
+- **THEN** the `topic_id` field SHALL be marked as `ForceNew`, triggering resource recreation instead of update
+
+### Requirement: Delete operation
+The resource SHALL delete a Splunk deliver task via the `DeleteSplunkDeliver` API.
+
+#### Scenario: Successful deletion
+- **WHEN** a user destroys a Terraform-managed Splunk deliver task
+- **THEN** the provider SHALL call `DeleteSplunkDeliver` API with the `TaskId` and `TopicId` parsed from the resource ID
+
+### Requirement: Import operation
+The resource SHALL support importing existing Splunk deliver tasks using the `task_id#topic_id` format as the import ID.
+
+#### Scenario: Successful import
+- **WHEN** a user imports a resource with `terraform import tencentcloud_cls_splunk_deliver.example task-xxx#topic-yyy`
+- **THEN** the provider SHALL parse the import ID, set the resource ID, and call `Read` to populate the state
+
+### Requirement: Retry logic for API calls
+All CRUD operations SHALL use `tccommon.ReadRetryTimeout` as the timeout and wrap errors with `tccommon.RetryError()` for transient failures.
+
+#### Scenario: Transient API failure during create
+- **WHEN** the `CreateSplunkDeliver` API returns a transient error
+- **THEN** the provider SHALL retry the request within the retry timeout period
+
+#### Scenario: Persistent API failure
+- **WHEN** the API consistently returns errors beyond the retry timeout
+- **THEN** the provider SHALL return the final error to the user
+
+### Requirement: Provider registration
+The resource SHALL be registered in the TencentCloud provider so it is available for use.
+
+#### Scenario: Resource registered in provider
+- **WHEN** the provider is initialized
+- **THEN** `tencentcloud_cls_splunk_deliver` SHALL be a valid resource type that maps to the resource implementation

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -2101,6 +2101,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_cls_config_attachment":                                                    cls.ResourceTencentCloudClsConfigAttachment(),
 			"tencentcloud_cls_machine_group":                                                        cls.ResourceTencentCloudClsMachineGroup(),
 			"tencentcloud_cls_cos_shipper":                                                          cls.ResourceTencentCloudClsCosShipper(),
+			"tencentcloud_cls_splunk_deliver":                                                       cls.ResourceTencentCloudClsSplunkDeliver(),
 			"tencentcloud_cls_index":                                                                cls.ResourceTencentCloudClsIndex(),
 			"tencentcloud_cls_alarm":                                                                cls.ResourceTencentCloudClsAlarm(),
 			"tencentcloud_cls_alarm_notice":                                                         cls.ResourceTencentCloudClsAlarmNotice(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1527,6 +1527,7 @@ tencentcloud_cls_open_service_operation
 tencentcloud_cls_dlc_deliver
 tencentcloud_cls_console
 tencentcloud_cls_metric_subscribe
+tencentcloud_cls_splunk_deliver
 
 Data Source
 tencentcloud_cls_shipper_tasks

--- a/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go
+++ b/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go
@@ -19,8 +19,8 @@ func ResourceTencentCloudClsSplunkDeliver() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTencentCloudClsSplunkDeliverCreate,
 		Read:   resourceTencentCloudClsSplunkDeliverRead,
-		Delete: resourceTencentCloudClsSplunkDeliverDelete,
 		Update: resourceTencentCloudClsSplunkDeliverUpdate,
+		Delete: resourceTencentCloudClsSplunkDeliverDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -95,13 +95,13 @@ func ResourceTencentCloudClsSplunkDeliver() *schema.Resource {
 						},
 						"meta_fields": {
 							Type:        schema.TypeSet,
-							Required:    true,
+							Optional:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: "Delivery fields, including __SOURCE__, __FILENAME__, __TIMESTAMP__, __HOSTNAME__, __PKG_ID__.",
 						},
 						"enable_tag": {
 							Type:        schema.TypeBool,
-							Required:    true,
+							Optional:    true,
 							Description: "Whether to deliver __TAG__ field.",
 						},
 						"tag_json_tiled": {
@@ -173,6 +173,7 @@ func ResourceTencentCloudClsSplunkDeliver() *schema.Resource {
 				Computed:    true,
 				Description: "Delivery task enable status. 0: disable, 1: enable.",
 			},
+			// computed
 			"task_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -185,9 +186,8 @@ func ResourceTencentCloudClsSplunkDeliver() *schema.Resource {
 func resourceTencentCloudClsSplunkDeliverCreate(d *schema.ResourceData, meta interface{}) error {
 	defer tccommon.LogElapsed("resource.tencentcloud_cls_splunk_deliver.create")()
 
-	logId := tccommon.GetLogId(tccommon.ContextNil)
-
 	var (
+		logId    = tccommon.GetLogId(tccommon.ContextNil)
 		request  = cls.NewCreateSplunkDeliverRequest()
 		response *cls.CreateSplunkDeliverResponse
 		topicId  string
@@ -328,7 +328,7 @@ func resourceTencentCloudClsSplunkDeliverCreate(d *schema.ResourceData, meta int
 	}
 
 	taskId := *response.Response.TaskId
-	d.SetId(strings.Join([]string{taskId, topicId}, tccommon.FILED_SP))
+	d.SetId(strings.Join([]string{topicId, taskId}, tccommon.FILED_SP))
 	return resourceTencentCloudClsSplunkDeliverRead(d, meta)
 }
 
@@ -342,10 +342,11 @@ func resourceTencentCloudClsSplunkDeliverRead(d *schema.ResourceData, meta inter
 	id := d.Id()
 	idSplit := strings.Split(id, tccommon.FILED_SP)
 	if len(idSplit) != 2 {
-		return fmt.Errorf("splunk_deliver id is invalid, id format should be task_id#topic_id, got: %s", id)
+		return fmt.Errorf("splunk_deliver id is invalid, id format should be topic_id#task_id, got: %s", id)
 	}
-	taskId := idSplit[0]
-	topicId := idSplit[1]
+
+	topicId := idSplit[0]
+	taskId := idSplit[1]
 
 	request := cls.NewDescribeSplunkDeliversRequest()
 	request.TopicId = helper.String(topicId)
@@ -359,7 +360,7 @@ func resourceTencentCloudClsSplunkDeliverRead(d *schema.ResourceData, meta inter
 
 	var response *cls.DescribeSplunkDeliversResponse
 	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().DescribeSplunkDelivers(request)
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().DescribeSplunkDeliversWithContext(ctx, request)
 		if e != nil {
 			return tccommon.RetryError(e)
 		} else {
@@ -379,8 +380,6 @@ func resourceTencentCloudClsSplunkDeliverRead(d *schema.ResourceData, meta inter
 		log.Printf("[CRITAL]%s read cls splunk_deliver failed, reason:%+v", logId, err)
 		return err
 	}
-
-	_ = ctx
 
 	if response.Response.Infos == nil || len(response.Response.Infos) == 0 {
 		log.Printf("[CRUD] cls splunk_deliver id=%s, read empty, skip SetId", d.Id())
@@ -485,21 +484,15 @@ func resourceTencentCloudClsSplunkDeliverUpdate(d *schema.ResourceData, meta int
 	id := d.Id()
 	idSplit := strings.Split(id, tccommon.FILED_SP)
 	if len(idSplit) != 2 {
-		return fmt.Errorf("splunk_deliver id is invalid, id format should be task_id#topic_id, got: %s", id)
+		return fmt.Errorf("splunk_deliver id is invalid, id format should be topic_id#task_id, got: %s", id)
 	}
-	taskId := idSplit[0]
-	topicId := idSplit[1]
+
+	topicId := idSplit[0]
+	taskId := idSplit[1]
 
 	request := cls.NewModifySplunkDeliverRequest()
 	request.TaskId = helper.String(taskId)
 	request.TopicId = helper.String(topicId)
-
-	immutableArgs := []string{"topic_id"}
-	for _, v := range immutableArgs {
-		if d.HasChange(v) {
-			return fmt.Errorf("argument `%s` cannot be changed", v)
-		}
-	}
 
 	if d.HasChange("name") {
 		if v, ok := d.GetOk("name"); ok {
@@ -657,10 +650,11 @@ func resourceTencentCloudClsSplunkDeliverDelete(d *schema.ResourceData, meta int
 	id := d.Id()
 	idSplit := strings.Split(id, tccommon.FILED_SP)
 	if len(idSplit) != 2 {
-		return fmt.Errorf("splunk_deliver id is invalid, id format should be task_id#topic_id, got: %s", id)
+		return fmt.Errorf("splunk_deliver id is invalid, id format should be topic_id#task_id, got: %s", id)
 	}
-	taskId := idSplit[0]
+
 	topicId := idSplit[1]
+	taskId := idSplit[0]
 
 	request := cls.NewDeleteSplunkDeliverRequest()
 	request.TaskId = helper.String(taskId)

--- a/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go
+++ b/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go
@@ -335,6 +335,34 @@ func resourceTencentCloudClsSplunkDeliverCreate(d *schema.ResourceData, meta int
 
 	taskId := *response.Response.TaskId
 	d.SetId(strings.Join([]string{topicId, taskId}, tccommon.FILED_SP))
+
+	// enable
+	if v, ok := d.GetOkExists("enable"); ok {
+		enable := v.(int)
+		if enable == 0 {
+			request := cls.NewModifySplunkDeliverRequest()
+			request.TaskId = helper.String(taskId)
+			request.TopicId = helper.String(topicId)
+			request.Enable = helper.IntInt64(0)
+
+			err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+				result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().ModifySplunkDeliver(request)
+				if e != nil {
+					return tccommon.RetryError(e)
+				} else {
+					log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+						logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+				}
+				return nil
+			})
+
+			if err != nil {
+				log.Printf("[CRITAL]%s update cls splunk_deliver failed, reason:%+v", logId, err)
+				return err
+			}
+		}
+	}
+
 	return resourceTencentCloudClsSplunkDeliverRead(d, meta)
 }
 

--- a/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go
+++ b/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go
@@ -71,11 +71,13 @@ func ResourceTencentCloudClsSplunkDeliver() *schema.Resource {
 						"virtual_gateway_type": {
 							Type:        schema.TypeInt,
 							Optional:    true,
+							Computed:    true,
 							Description: "Network service type. Required when net_type is internal network. 0: CVM, 3: Direct Connect Gateway, 11: CCN, 1025: CLB.",
 						},
 						"is_ssl": {
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Computed:    true,
 							Description: "Whether to use SSL. Default is false.",
 						},
 					},
@@ -102,11 +104,13 @@ func ResourceTencentCloudClsSplunkDeliver() *schema.Resource {
 						"enable_tag": {
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Computed:    true,
 							Description: "Whether to deliver __TAG__ field.",
 						},
 						"tag_json_tiled": {
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Computed:    true,
 							Description: "Whether to flatten JSON. Required when enable_tag is true.",
 						},
 					},
@@ -115,11 +119,13 @@ func ResourceTencentCloudClsSplunkDeliver() *schema.Resource {
 			"has_service_log": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "Whether to enable service log. 1: disable, 2: enable. Default: enable.",
 			},
 			"index_ack": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "Whether to enable indexer. 1: disable, 2: enable. Default: 1.",
 			},
 			"source": {
@@ -653,8 +659,8 @@ func resourceTencentCloudClsSplunkDeliverDelete(d *schema.ResourceData, meta int
 		return fmt.Errorf("splunk_deliver id is invalid, id format should be topic_id#task_id, got: %s", id)
 	}
 
-	topicId := idSplit[1]
-	taskId := idSplit[0]
+	topicId := idSplit[0]
+	taskId := idSplit[1]
 
 	request := cls.NewDeleteSplunkDeliverRequest()
 	request.TaskId = helper.String(taskId)

--- a/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go
+++ b/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.go
@@ -1,0 +1,686 @@
+package cls
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	cls "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudClsSplunkDeliver() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudClsSplunkDeliverCreate,
+		Read:   resourceTencentCloudClsSplunkDeliverRead,
+		Delete: resourceTencentCloudClsSplunkDeliverDelete,
+		Update: resourceTencentCloudClsSplunkDeliverUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"topic_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Log topic ID.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Splunk deliver task name.",
+			},
+			"net_info": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: "Splunk deliver task target network information.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Network address.",
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Port.",
+						},
+						"token": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Authentication token.",
+						},
+						"net_type": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Network type. 1: internal network, 2: external network.",
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "VPC ID. Required when net_type is internal network.",
+						},
+						"virtual_gateway_type": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Network service type. Required when net_type is internal network. 0: CVM, 3: Direct Connect Gateway, 11: CCN, 1025: CLB.",
+						},
+						"is_ssl": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether to use SSL. Default is false.",
+						},
+					},
+				},
+			},
+			"metadata_info": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: "Splunk deliver task metadata information.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"format": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Data format. Valid values: rawlog, json.",
+						},
+						"meta_fields": {
+							Type:        schema.TypeSet,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "Delivery fields, including __SOURCE__, __FILENAME__, __TIMESTAMP__, __HOSTNAME__, __PKG_ID__.",
+						},
+						"enable_tag": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "Whether to deliver __TAG__ field.",
+						},
+						"tag_json_tiled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether to flatten JSON. Required when enable_tag is true.",
+						},
+					},
+				},
+			},
+			"has_service_log": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Whether to enable service log. 1: disable, 2: enable. Default: enable.",
+			},
+			"index_ack": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Whether to enable indexer. 1: disable, 2: enable. Default: 1.",
+			},
+			"source": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Advanced configuration - data source. No more than 64 characters.",
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Advanced configuration - data source type. No more than 64 characters.",
+			},
+			"index": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Advanced configuration - Splunk index. No more than 64 characters.",
+			},
+			"channel": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Advanced configuration - channel. Required if indexer is enabled.",
+			},
+			"dsl_filter": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Log pre-filtering DSL statement for raw data written to Splunk.",
+			},
+			"external_role": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Advanced configuration - cross-account delivery role authorization information.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role_arn": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Cross-account delivery role RoleArn.",
+						},
+						"external_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Cross-account delivery role name.",
+						},
+					},
+				},
+			},
+			"enable": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Delivery task enable status. 0: disable, 1: enable.",
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Splunk deliver task ID.",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudClsSplunkDeliverCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_cls_splunk_deliver.create")()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	var (
+		request  = cls.NewCreateSplunkDeliverRequest()
+		response *cls.CreateSplunkDeliverResponse
+		topicId  string
+	)
+
+	if v, ok := d.GetOk("topic_id"); ok {
+		topicId = v.(string)
+		request.TopicId = helper.String(topicId)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		request.Name = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("net_info"); ok {
+		netInfoList := v.([]interface{})
+		if len(netInfoList) == 1 {
+			netInfoMap := netInfoList[0].(map[string]interface{})
+			netInfo := cls.NetInfo{}
+			if v, ok := netInfoMap["host"]; ok {
+				netInfo.Host = helper.String(v.(string))
+			}
+			if v, ok := netInfoMap["port"]; ok {
+				netInfo.Port = helper.IntUint64(v.(int))
+			}
+			if v, ok := netInfoMap["token"]; ok {
+				netInfo.Token = helper.String(v.(string))
+			}
+			if v, ok := netInfoMap["net_type"]; ok {
+				netInfo.NetType = helper.IntUint64(v.(int))
+			}
+			if v, ok := netInfoMap["vpc_id"]; ok {
+				netInfo.VpcId = helper.String(v.(string))
+			}
+			if v, ok := netInfoMap["virtual_gateway_type"]; ok {
+				netInfo.VirtualGatewayType = helper.IntUint64(v.(int))
+			}
+			if v, ok := netInfoMap["is_ssl"]; ok {
+				netInfo.IsSSL = helper.Bool(v.(bool))
+			}
+			request.NetInfo = &netInfo
+		}
+	}
+
+	if v, ok := d.GetOk("metadata_info"); ok {
+		metadataInfoList := v.([]interface{})
+		if len(metadataInfoList) == 1 {
+			metadataInfoMap := metadataInfoList[0].(map[string]interface{})
+			metadataInfo := cls.MetadataInfo{}
+			if v, ok := metadataInfoMap["format"]; ok {
+				metadataInfo.Format = helper.String(v.(string))
+			}
+			if v, ok := metadataInfoMap["meta_fields"]; ok {
+				metaFields := v.(*schema.Set).List()
+				for _, mf := range metaFields {
+					metadataInfo.MetaFields = append(metadataInfo.MetaFields, helper.String(mf.(string)))
+				}
+			}
+			if v, ok := metadataInfoMap["enable_tag"]; ok {
+				metadataInfo.EnableTag = helper.Bool(v.(bool))
+			}
+			if v, ok := metadataInfoMap["tag_json_tiled"]; ok {
+				metadataInfo.TagJsonTiled = helper.Bool(v.(bool))
+			}
+			request.MetadataInfo = &metadataInfo
+		}
+	}
+
+	if v, ok := d.GetOkExists("has_service_log"); ok {
+		request.HasServiceLog = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOkExists("index_ack"); ok {
+		request.IndexAck = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOk("source"); ok {
+		request.Source = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("source_type"); ok {
+		request.SourceType = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("index"); ok {
+		request.Index = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("channel"); ok {
+		request.Channel = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("dsl_filter"); ok {
+		request.DSLFilter = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("external_role"); ok {
+		externalRoleList := v.([]interface{})
+		if len(externalRoleList) == 1 {
+			externalRoleMap := externalRoleList[0].(map[string]interface{})
+			externalRole := cls.ExternalRole{}
+			if v, ok := externalRoleMap["role_arn"]; ok {
+				externalRole.RoleArn = helper.String(v.(string))
+			}
+			if v, ok := externalRoleMap["external_id"]; ok {
+				externalRole.ExternalId = helper.String(v.(string))
+			}
+			request.ExternalRole = &externalRole
+		}
+	}
+
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().CreateSplunkDeliver(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Create cls splunk_deliver failed, Response is nil."))
+		}
+
+		response = result
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s create cls splunk_deliver failed, reason:%+v", logId, err)
+		return err
+	}
+
+	log.Printf("[CRUD] cls splunk_deliver create, logId=%s, topicId=%s", logId, topicId)
+
+	if response.Response.TaskId == nil || *response.Response.TaskId == "" {
+		return fmt.Errorf("splunk_deliver TaskId is nil or empty.")
+	}
+
+	taskId := *response.Response.TaskId
+	d.SetId(strings.Join([]string{taskId, topicId}, tccommon.FILED_SP))
+	return resourceTencentCloudClsSplunkDeliverRead(d, meta)
+}
+
+func resourceTencentCloudClsSplunkDeliverRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_cls_splunk_deliver.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+	id := d.Id()
+	idSplit := strings.Split(id, tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("splunk_deliver id is invalid, id format should be task_id#topic_id, got: %s", id)
+	}
+	taskId := idSplit[0]
+	topicId := idSplit[1]
+
+	request := cls.NewDescribeSplunkDeliversRequest()
+	request.TopicId = helper.String(topicId)
+	request.Filters = []*cls.Filter{
+		{
+			Key:    helper.String("taskId"),
+			Values: []*string{helper.String(taskId)},
+		},
+	}
+	request.Limit = helper.IntUint64(100)
+
+	var response *cls.DescribeSplunkDeliversResponse
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().DescribeSplunkDelivers(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe cls splunk_deliver failed, Response is nil."))
+		}
+
+		response = result
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s read cls splunk_deliver failed, reason:%+v", logId, err)
+		return err
+	}
+
+	_ = ctx
+
+	if response.Response.Infos == nil || len(response.Response.Infos) == 0 {
+		log.Printf("[CRUD] cls splunk_deliver id=%s, read empty, skip SetId", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	info := response.Response.Infos[0]
+
+	_ = d.Set("topic_id", info.TopicId)
+	_ = d.Set("task_id", info.TaskId)
+
+	if info.Name != nil {
+		_ = d.Set("name", info.Name)
+	}
+
+	if info.Enable != nil {
+		_ = d.Set("enable", info.Enable)
+	}
+
+	if info.NetInfo != nil {
+		netInfoMap := map[string]interface{}{
+			"host":  info.NetInfo.Host,
+			"token": info.NetInfo.Token,
+		}
+		if info.NetInfo.Port != nil {
+			netInfoMap["port"] = info.NetInfo.Port
+		}
+		if info.NetInfo.NetType != nil {
+			netInfoMap["net_type"] = info.NetInfo.NetType
+		}
+		if info.NetInfo.VpcId != nil {
+			netInfoMap["vpc_id"] = info.NetInfo.VpcId
+		}
+		if info.NetInfo.VirtualGatewayType != nil {
+			netInfoMap["virtual_gateway_type"] = info.NetInfo.VirtualGatewayType
+		}
+		if info.NetInfo.IsSSL != nil {
+			netInfoMap["is_ssl"] = info.NetInfo.IsSSL
+		}
+		_ = d.Set("net_info", []interface{}{netInfoMap})
+	}
+
+	if info.Metadata != nil {
+		metadataInfoMap := map[string]interface{}{
+			"format":      info.Metadata.Format,
+			"meta_fields": info.Metadata.MetaFields,
+		}
+		if info.Metadata.EnableTag != nil {
+			metadataInfoMap["enable_tag"] = info.Metadata.EnableTag
+		}
+		if info.Metadata.TagJsonTiled != nil {
+			metadataInfoMap["tag_json_tiled"] = info.Metadata.TagJsonTiled
+		}
+		_ = d.Set("metadata_info", []interface{}{metadataInfoMap})
+	}
+
+	if info.HasServiceLog != nil {
+		_ = d.Set("has_service_log", info.HasServiceLog)
+	}
+
+	if info.IndexAck != nil {
+		_ = d.Set("index_ack", info.IndexAck)
+	}
+
+	if info.Source != nil {
+		_ = d.Set("source", info.Source)
+	}
+
+	if info.SourceType != nil {
+		_ = d.Set("source_type", info.SourceType)
+	}
+
+	if info.Index != nil {
+		_ = d.Set("index", info.Index)
+	}
+
+	if info.Channel != nil {
+		_ = d.Set("channel", info.Channel)
+	}
+
+	if info.DSLFilter != nil {
+		_ = d.Set("dsl_filter", info.DSLFilter)
+	}
+
+	if info.ExternalRole != nil {
+		externalRoleMap := map[string]interface{}{
+			"role_arn":    info.ExternalRole.RoleArn,
+			"external_id": info.ExternalRole.ExternalId,
+		}
+		_ = d.Set("external_role", []interface{}{externalRoleMap})
+	}
+
+	return nil
+}
+
+func resourceTencentCloudClsSplunkDeliverUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_cls_splunk_deliver.update")()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	id := d.Id()
+	idSplit := strings.Split(id, tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("splunk_deliver id is invalid, id format should be task_id#topic_id, got: %s", id)
+	}
+	taskId := idSplit[0]
+	topicId := idSplit[1]
+
+	request := cls.NewModifySplunkDeliverRequest()
+	request.TaskId = helper.String(taskId)
+	request.TopicId = helper.String(topicId)
+
+	immutableArgs := []string{"topic_id"}
+	for _, v := range immutableArgs {
+		if d.HasChange(v) {
+			return fmt.Errorf("argument `%s` cannot be changed", v)
+		}
+	}
+
+	if d.HasChange("name") {
+		if v, ok := d.GetOk("name"); ok {
+			request.Name = helper.String(v.(string))
+		}
+	}
+
+	if d.HasChange("enable") {
+		if v, ok := d.GetOkExists("enable"); ok {
+			request.Enable = helper.IntInt64(v.(int))
+		}
+	}
+
+	if d.HasChange("net_info") {
+		if v, ok := d.GetOk("net_info"); ok {
+			netInfoList := v.([]interface{})
+			if len(netInfoList) == 1 {
+				netInfoMap := netInfoList[0].(map[string]interface{})
+				netInfo := cls.NetInfo{}
+				if v, ok := netInfoMap["host"]; ok {
+					netInfo.Host = helper.String(v.(string))
+				}
+				if v, ok := netInfoMap["port"]; ok {
+					netInfo.Port = helper.IntUint64(v.(int))
+				}
+				if v, ok := netInfoMap["token"]; ok {
+					netInfo.Token = helper.String(v.(string))
+				}
+				if v, ok := netInfoMap["net_type"]; ok {
+					netInfo.NetType = helper.IntUint64(v.(int))
+				}
+				if v, ok := netInfoMap["vpc_id"]; ok {
+					netInfo.VpcId = helper.String(v.(string))
+				}
+				if v, ok := netInfoMap["virtual_gateway_type"]; ok {
+					netInfo.VirtualGatewayType = helper.IntUint64(v.(int))
+				}
+				if v, ok := netInfoMap["is_ssl"]; ok {
+					netInfo.IsSSL = helper.Bool(v.(bool))
+				}
+				request.NetInfo = &netInfo
+			}
+		}
+	}
+
+	if d.HasChange("metadata_info") {
+		if v, ok := d.GetOk("metadata_info"); ok {
+			metadataInfoList := v.([]interface{})
+			if len(metadataInfoList) == 1 {
+				metadataInfoMap := metadataInfoList[0].(map[string]interface{})
+				metadataInfo := cls.MetadataInfo{}
+				if v, ok := metadataInfoMap["format"]; ok {
+					metadataInfo.Format = helper.String(v.(string))
+				}
+				if v, ok := metadataInfoMap["meta_fields"]; ok {
+					metaFields := v.(*schema.Set).List()
+					for _, mf := range metaFields {
+						metadataInfo.MetaFields = append(metadataInfo.MetaFields, helper.String(mf.(string)))
+					}
+				}
+				if v, ok := metadataInfoMap["enable_tag"]; ok {
+					metadataInfo.EnableTag = helper.Bool(v.(bool))
+				}
+				if v, ok := metadataInfoMap["tag_json_tiled"]; ok {
+					metadataInfo.TagJsonTiled = helper.Bool(v.(bool))
+				}
+				request.MetadataInfo = &metadataInfo
+			}
+		}
+	}
+
+	if d.HasChange("has_service_log") {
+		if v, ok := d.GetOkExists("has_service_log"); ok {
+			request.HasServiceLog = helper.IntInt64(v.(int))
+		}
+	}
+
+	if d.HasChange("index_ack") {
+		if v, ok := d.GetOkExists("index_ack"); ok {
+			request.IndexAck = helper.IntInt64(v.(int))
+		}
+	}
+
+	if d.HasChange("source") {
+		if v, ok := d.GetOk("source"); ok {
+			request.Source = helper.String(v.(string))
+		}
+	}
+
+	if d.HasChange("source_type") {
+		if v, ok := d.GetOk("source_type"); ok {
+			request.SourceType = helper.String(v.(string))
+		}
+	}
+
+	if d.HasChange("index") {
+		if v, ok := d.GetOk("index"); ok {
+			request.Index = helper.String(v.(string))
+		}
+	}
+
+	if d.HasChange("channel") {
+		if v, ok := d.GetOk("channel"); ok {
+			request.Channel = helper.String(v.(string))
+		}
+	}
+
+	if d.HasChange("dsl_filter") {
+		if v, ok := d.GetOk("dsl_filter"); ok {
+			request.DSLFilter = helper.String(v.(string))
+		}
+	}
+
+	if d.HasChange("external_role") {
+		if v, ok := d.GetOk("external_role"); ok {
+			externalRoleList := v.([]interface{})
+			if len(externalRoleList) == 1 {
+				externalRoleMap := externalRoleList[0].(map[string]interface{})
+				externalRole := cls.ExternalRole{}
+				if v, ok := externalRoleMap["role_arn"]; ok {
+					externalRole.RoleArn = helper.String(v.(string))
+				}
+				if v, ok := externalRoleMap["external_id"]; ok {
+					externalRole.ExternalId = helper.String(v.(string))
+				}
+				request.ExternalRole = &externalRole
+			}
+		}
+	}
+
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().ModifySplunkDeliver(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s update cls splunk_deliver failed, reason:%+v", logId, err)
+		return err
+	}
+
+	return resourceTencentCloudClsSplunkDeliverRead(d, meta)
+}
+
+func resourceTencentCloudClsSplunkDeliverDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_cls_splunk_deliver.delete")()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	id := d.Id()
+	idSplit := strings.Split(id, tccommon.FILED_SP)
+	if len(idSplit) != 2 {
+		return fmt.Errorf("splunk_deliver id is invalid, id format should be task_id#topic_id, got: %s", id)
+	}
+	taskId := idSplit[0]
+	topicId := idSplit[1]
+
+	request := cls.NewDeleteSplunkDeliverRequest()
+	request.TaskId = helper.String(taskId)
+	request.TopicId = helper.String(topicId)
+
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().DeleteSplunkDeliver(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[CRITAL]%s delete cls splunk_deliver failed, reason:%+v", logId, err)
+		return err
+	}
+
+	return nil
+}

--- a/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.md
+++ b/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.md
@@ -1,0 +1,50 @@
+Provides a resource to create a CLS splunk deliver.
+
+Example Usage
+
+```hcl
+resource "tencentcloud_cls_logset" "example" {
+  logset_name = "tf-example"
+}
+
+resource "tencentcloud_cls_topic" "example" {
+  topic_name           = "tf-example"
+  logset_id            = tencentcloud_cls_logset.example.id
+  auto_split           = false
+  max_split_partitions = 20
+  partition_count      = 1
+  period               = 10
+  storage_type         = "hot"
+}
+
+resource "tencentcloud_cls_splunk_deliver" "example" {
+  topic_id = tencentcloud_cls_topic.example.id
+  name     = "tf-example"
+
+  net_info {
+    host     = "10.0.0.1"
+    port     = 8088
+    token    = "your-splunk-token"
+    net_type = 2
+    is_ssl   = true
+  }
+
+  metadata_info {
+    format = "json"
+    meta_fields = [
+      "__SOURCE__",
+      "__FILENAME__",
+      "__TIMESTAMP__",
+    ]
+    enable_tag = true
+  }
+}
+```
+
+Import
+
+cls splunk deliver can be imported using the id, e.g.
+
+```
+$ terraform import tencentcloud_cls_splunk_deliver.example task-xxx#topic-yyy
+```

--- a/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.md
+++ b/tencentcloud/services/cls/resource_tc_cls_splunk_deliver.md
@@ -3,28 +3,15 @@ Provides a resource to create a CLS splunk deliver.
 Example Usage
 
 ```hcl
-resource "tencentcloud_cls_logset" "example" {
-  logset_name = "tf-example"
-}
-
-resource "tencentcloud_cls_topic" "example" {
-  topic_name           = "tf-example"
-  logset_id            = tencentcloud_cls_logset.example.id
-  auto_split           = false
-  max_split_partitions = 20
-  partition_count      = 1
-  period               = 10
-  storage_type         = "hot"
-}
-
 resource "tencentcloud_cls_splunk_deliver" "example" {
-  topic_id = tencentcloud_cls_topic.example.id
-  name     = "tf-example"
+  topic_id  = "eb417b1d-fc00-46f2-85f7-47ca0848a6b3"
+  name      = "tf-example"
+  index_ack = 1
 
   net_info {
-    host     = "10.0.0.1"
+    host     = "110.11.22.106"
     port     = 8088
-    token    = "your-splunk-token"
+    token    = "e27274fb-****-****-****-****00206282"
     net_type = 2
     is_ssl   = true
   }
@@ -32,19 +19,18 @@ resource "tencentcloud_cls_splunk_deliver" "example" {
   metadata_info {
     format = "json"
     meta_fields = [
-      "__SOURCE__",
+      "__HOSTNAME__",
       "__FILENAME__",
       "__TIMESTAMP__",
     ]
-    enable_tag = true
   }
 }
 ```
 
 Import
 
-cls splunk deliver can be imported using the id, e.g.
+cls splunk deliver can be imported using the topicId#taskId, e.g.
 
 ```
-$ terraform import tencentcloud_cls_splunk_deliver.example task-xxx#topic-yyy
+terraform import tencentcloud_cls_splunk_deliver.example eb417b1d-fc00-46f2-85f7-47ca0848a6b3#716dae34-7eba-4b09-a3d9-6fe8e510e236
 ```

--- a/tencentcloud/services/cls/resource_tc_cls_splunk_deliver_test.go
+++ b/tencentcloud/services/cls/resource_tc_cls_splunk_deliver_test.go
@@ -1,0 +1,418 @@
+package cls_test
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	cls "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	localcls "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cls"
+)
+
+type mockMetaForSplunkDeliver struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForSplunkDeliver) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForSplunkDeliver{}
+
+func newMockMetaForSplunkDeliver() *mockMetaForSplunkDeliver {
+	return &mockMetaForSplunkDeliver{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrSplunkDeliver(s string) *string {
+	return &s
+}
+
+func ptrUint64SplunkDeliver(v uint64) *uint64 {
+	return &v
+}
+
+func ptrInt64SplunkDeliver(v int64) *int64 {
+	return &v
+}
+
+func ptrBoolSplunkDeliver(v bool) *bool {
+	return &v
+}
+
+// TestSplunkDeliver_Create tests the Create operation
+func TestSplunkDeliver_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForSplunkDeliver().client, "UseClsClient", clsClient)
+
+	var capturedRequest *cls.CreateSplunkDeliverRequest
+	patches.ApplyMethodFunc(clsClient, "CreateSplunkDeliver", func(request *cls.CreateSplunkDeliverRequest) (*cls.CreateSplunkDeliverResponse, error) {
+		capturedRequest = request
+		resp := cls.NewCreateSplunkDeliverResponse()
+		resp.Response = &cls.CreateSplunkDeliverResponseParams{
+			TaskId:    ptrStrSplunkDeliver("task-test-123"),
+			RequestId: ptrStrSplunkDeliver("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(clsClient, "DescribeSplunkDelivers", func(request *cls.DescribeSplunkDeliversRequest) (*cls.DescribeSplunkDeliversResponse, error) {
+		resp := cls.NewDescribeSplunkDeliversResponse()
+		resp.Response = &cls.DescribeSplunkDeliversResponseParams{
+			Infos: []*cls.SplunkDeliverInfo{
+				{
+					TaskId:  ptrStrSplunkDeliver("task-test-123"),
+					TopicId: ptrStrSplunkDeliver("topic-test-123"),
+					Name:    ptrStrSplunkDeliver("test-deliver"),
+					Enable:  ptrInt64SplunkDeliver(1),
+					NetInfo: &cls.NetInfo{
+						Host:    ptrStrSplunkDeliver("10.0.0.1"),
+						Port:    ptrUint64SplunkDeliver(8088),
+						Token:   ptrStrSplunkDeliver("test-token"),
+						NetType: ptrUint64SplunkDeliver(2),
+						IsSSL:   ptrBoolSplunkDeliver(true),
+					},
+					Metadata: &cls.MetadataInfo{
+						Format:     ptrStrSplunkDeliver("json"),
+						MetaFields: []*string{ptrStrSplunkDeliver("__SOURCE__"), ptrStrSplunkDeliver("__FILENAME__")},
+						EnableTag:  ptrBoolSplunkDeliver(true),
+					},
+					IndexAck: ptrInt64SplunkDeliver(1),
+				},
+			},
+			Total:     ptrUint64SplunkDeliver(1),
+			RequestId: ptrStrSplunkDeliver("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForSplunkDeliver()
+	res := localcls.ResourceTencentCloudClsSplunkDeliver()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"topic_id": "topic-test-123",
+		"name":     "test-deliver",
+		"net_info": []interface{}{
+			map[string]interface{}{
+				"host":     "10.0.0.1",
+				"port":     8088,
+				"token":    "test-token",
+				"net_type": 2,
+				"is_ssl":   true,
+			},
+		},
+		"metadata_info": []interface{}{
+			map[string]interface{}{
+				"format": "json",
+				"meta_fields": schema.NewSet(schema.HashString, []interface{}{
+					"__SOURCE__",
+					"__FILENAME__",
+				}),
+				"enable_tag": true,
+			},
+		},
+		"index_ack": 1,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "task-test-123#topic-test-123", d.Id())
+	assert.NotNil(t, capturedRequest)
+	assert.NotNil(t, capturedRequest.Name)
+	assert.Equal(t, "test-deliver", *capturedRequest.Name)
+	assert.NotNil(t, capturedRequest.NetInfo)
+	assert.Equal(t, "10.0.0.1", *capturedRequest.NetInfo.Host)
+}
+
+// TestSplunkDeliver_Create_NilTaskId tests Create with nil TaskId
+func TestSplunkDeliver_Create_NilTaskId(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForSplunkDeliver().client, "UseClsClient", clsClient)
+
+	patches.ApplyMethodFunc(clsClient, "CreateSplunkDeliver", func(request *cls.CreateSplunkDeliverRequest) (*cls.CreateSplunkDeliverResponse, error) {
+		resp := cls.NewCreateSplunkDeliverResponse()
+		resp.Response = &cls.CreateSplunkDeliverResponseParams{
+			TaskId:    nil,
+			RequestId: ptrStrSplunkDeliver("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForSplunkDeliver()
+	res := localcls.ResourceTencentCloudClsSplunkDeliver()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"topic_id": "topic-test-123",
+		"name":     "test-deliver",
+		"net_info": []interface{}{
+			map[string]interface{}{
+				"host":     "10.0.0.1",
+				"port":     8088,
+				"token":    "test-token",
+				"net_type": 2,
+			},
+		},
+		"metadata_info": []interface{}{
+			map[string]interface{}{
+				"format": "json",
+				"meta_fields": schema.NewSet(schema.HashString, []interface{}{
+					"__SOURCE__",
+				}),
+				"enable_tag": true,
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "TaskId")
+}
+
+// TestSplunkDeliver_Read tests the Read operation
+func TestSplunkDeliver_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForSplunkDeliver().client, "UseClsClient", clsClient)
+
+	patches.ApplyMethodFunc(clsClient, "DescribeSplunkDelivers", func(request *cls.DescribeSplunkDeliversRequest) (*cls.DescribeSplunkDeliversResponse, error) {
+		resp := cls.NewDescribeSplunkDeliversResponse()
+		resp.Response = &cls.DescribeSplunkDeliversResponseParams{
+			Infos: []*cls.SplunkDeliverInfo{
+				{
+					TaskId:  ptrStrSplunkDeliver("task-test-123"),
+					TopicId: ptrStrSplunkDeliver("topic-test-123"),
+					Name:    ptrStrSplunkDeliver("test-deliver"),
+					Enable:  ptrInt64SplunkDeliver(1),
+					NetInfo: &cls.NetInfo{
+						Host:    ptrStrSplunkDeliver("10.0.0.1"),
+						Port:    ptrUint64SplunkDeliver(8088),
+						Token:   ptrStrSplunkDeliver("test-token"),
+						NetType: ptrUint64SplunkDeliver(2),
+						IsSSL:   ptrBoolSplunkDeliver(true),
+					},
+					Metadata: &cls.MetadataInfo{
+						Format:     ptrStrSplunkDeliver("json"),
+						MetaFields: []*string{ptrStrSplunkDeliver("__SOURCE__"), ptrStrSplunkDeliver("__FILENAME__")},
+						EnableTag:  ptrBoolSplunkDeliver(true),
+					},
+					HasServiceLog: ptrInt64SplunkDeliver(2),
+					IndexAck:      ptrInt64SplunkDeliver(1),
+					Source:        ptrStrSplunkDeliver("test-source"),
+					SourceType:    ptrStrSplunkDeliver("test-source-type"),
+					Index:         ptrStrSplunkDeliver("main"),
+					Channel:       ptrStrSplunkDeliver("test-channel"),
+					DSLFilter:     ptrStrSplunkDeliver(""),
+				},
+			},
+			Total:     ptrUint64SplunkDeliver(1),
+			RequestId: ptrStrSplunkDeliver("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForSplunkDeliver()
+	res := localcls.ResourceTencentCloudClsSplunkDeliver()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"topic_id": "topic-test-123",
+		"name":     "test-deliver",
+	})
+	d.SetId("task-test-123#topic-test-123")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-deliver", d.Get("name"))
+	assert.Equal(t, "main", d.Get("index"))
+	assert.Equal(t, "test-source", d.Get("source"))
+	assert.Equal(t, "test-source-type", d.Get("source_type"))
+	assert.Equal(t, "test-channel", d.Get("channel"))
+}
+
+// TestSplunkDeliver_Read_EmptyInfos tests Read with empty Infos
+func TestSplunkDeliver_Read_EmptyInfos(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForSplunkDeliver().client, "UseClsClient", clsClient)
+
+	patches.ApplyMethodFunc(clsClient, "DescribeSplunkDelivers", func(request *cls.DescribeSplunkDeliversRequest) (*cls.DescribeSplunkDeliversResponse, error) {
+		resp := cls.NewDescribeSplunkDeliversResponse()
+		resp.Response = &cls.DescribeSplunkDeliversResponseParams{
+			Infos:     []*cls.SplunkDeliverInfo{},
+			Total:     ptrUint64SplunkDeliver(0),
+			RequestId: ptrStrSplunkDeliver("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForSplunkDeliver()
+	res := localcls.ResourceTencentCloudClsSplunkDeliver()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"topic_id": "topic-test-123",
+		"name":     "test-deliver",
+	})
+	d.SetId("task-test-123#topic-test-123")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestSplunkDeliver_Update tests the Update operation
+func TestSplunkDeliver_Update(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForSplunkDeliver().client, "UseClsClient", clsClient)
+
+	var capturedModifyRequest *cls.ModifySplunkDeliverRequest
+	patches.ApplyMethodFunc(clsClient, "ModifySplunkDeliver", func(request *cls.ModifySplunkDeliverRequest) (*cls.ModifySplunkDeliverResponse, error) {
+		capturedModifyRequest = request
+		resp := cls.NewModifySplunkDeliverResponse()
+		resp.Response = &cls.ModifySplunkDeliverResponseParams{
+			RequestId: ptrStrSplunkDeliver("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(clsClient, "DescribeSplunkDelivers", func(request *cls.DescribeSplunkDeliversRequest) (*cls.DescribeSplunkDeliversResponse, error) {
+		resp := cls.NewDescribeSplunkDeliversResponse()
+		resp.Response = &cls.DescribeSplunkDeliversResponseParams{
+			Infos: []*cls.SplunkDeliverInfo{
+				{
+					TaskId:  ptrStrSplunkDeliver("task-test-123"),
+					TopicId: ptrStrSplunkDeliver("topic-test-123"),
+					Name:    ptrStrSplunkDeliver("updated-name"),
+					Enable:  ptrInt64SplunkDeliver(0),
+					NetInfo: &cls.NetInfo{
+						Host:    ptrStrSplunkDeliver("10.0.0.2"),
+						Port:    ptrUint64SplunkDeliver(8089),
+						Token:   ptrStrSplunkDeliver("new-token"),
+						NetType: ptrUint64SplunkDeliver(2),
+					},
+					Metadata: &cls.MetadataInfo{
+						Format:     ptrStrSplunkDeliver("rawlog"),
+						MetaFields: []*string{ptrStrSplunkDeliver("__SOURCE__")},
+						EnableTag:  ptrBoolSplunkDeliver(false),
+					},
+				},
+			},
+			Total:     ptrUint64SplunkDeliver(1),
+			RequestId: ptrStrSplunkDeliver("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForSplunkDeliver()
+	res := localcls.ResourceTencentCloudClsSplunkDeliver()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"topic_id": "topic-test-123",
+		"name":     "test-deliver",
+		"net_info": []interface{}{
+			map[string]interface{}{
+				"host":     "10.0.0.1",
+				"port":     8088,
+				"token":    "test-token",
+				"net_type": 2,
+			},
+		},
+		"metadata_info": []interface{}{
+			map[string]interface{}{
+				"format": "json",
+				"meta_fields": schema.NewSet(schema.HashString, []interface{}{
+					"__SOURCE__",
+				}),
+				"enable_tag": true,
+			},
+		},
+	})
+	d.SetId("task-test-123#topic-test-123")
+
+	// Simulate name change
+	_ = d.Set("name", "updated-name")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedModifyRequest)
+	assert.NotNil(t, capturedModifyRequest.Name)
+	assert.Equal(t, "updated-name", *capturedModifyRequest.Name)
+}
+
+// TestSplunkDeliver_Delete tests the Delete operation
+func TestSplunkDeliver_Delete(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForSplunkDeliver().client, "UseClsClient", clsClient)
+
+	var capturedDeleteRequest *cls.DeleteSplunkDeliverRequest
+	patches.ApplyMethodFunc(clsClient, "DeleteSplunkDeliver", func(request *cls.DeleteSplunkDeliverRequest) (*cls.DeleteSplunkDeliverResponse, error) {
+		capturedDeleteRequest = request
+		resp := cls.NewDeleteSplunkDeliverResponse()
+		resp.Response = &cls.DeleteSplunkDeliverResponseParams{
+			RequestId: ptrStrSplunkDeliver("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForSplunkDeliver()
+	res := localcls.ResourceTencentCloudClsSplunkDeliver()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"topic_id": "topic-test-123",
+		"name":     "test-deliver",
+	})
+	d.SetId("task-test-123#topic-test-123")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedDeleteRequest)
+	assert.Equal(t, "task-test-123", *capturedDeleteRequest.TaskId)
+	assert.Equal(t, "topic-test-123", *capturedDeleteRequest.TopicId)
+}
+
+// TestSplunkDeliver_Schema tests the schema definition
+func TestSplunkDeliver_Schema(t *testing.T) {
+	res := localcls.ResourceTencentCloudClsSplunkDeliver()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "topic_id")
+	assert.Contains(t, res.Schema, "name")
+	assert.Contains(t, res.Schema, "net_info")
+	assert.Contains(t, res.Schema, "metadata_info")
+	assert.Contains(t, res.Schema, "external_role")
+	assert.Contains(t, res.Schema, "enable")
+	assert.Contains(t, res.Schema, "task_id")
+
+	topicIdSchema := res.Schema["topic_id"]
+	assert.True(t, topicIdSchema.Required)
+	assert.True(t, topicIdSchema.ForceNew)
+
+	nameSchema := res.Schema["name"]
+	assert.True(t, nameSchema.Required)
+
+	enableSchema := res.Schema["enable"]
+	assert.True(t, enableSchema.Optional)
+	assert.True(t, enableSchema.Computed)
+
+	taskIdSchema := res.Schema["task_id"]
+	assert.True(t, taskIdSchema.Computed)
+}
+
+// TestSplunkDeliver_Import tests the import configuration
+func TestSplunkDeliver_Import(t *testing.T) {
+	res := localcls.ResourceTencentCloudClsSplunkDeliver()
+
+	assert.NotNil(t, res.Importer)
+	assert.NotNil(t, res.Importer.State)
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/models.go
@@ -4156,66 +4156,62 @@ func (r *CreateEsRechargeResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateExportRequestParams struct {
-	// 日志主题Id
-	// - 通过[获取日志主题列表](https://cloud.tencent.com/document/product/614/56454)获取日志主题Id。
+	// <p>日志主题Id</p><ul><li>通过<a href="https://cloud.tencent.com/document/product/614/56454">获取日志主题列表</a>获取日志主题Id。</li></ul>
 	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
 
-	// 日志导出数量,  最大值5000万
+	// <p>日志导出数量,  最大值5000万</p>
 	Count *uint64 `json:"Count,omitnil,omitempty" name:"Count"`
 
-	// 日志导出检索语句，不支持<a href="https://cloud.tencent.com/document/product/614/44061" target="_blank">[SQL语句]</a>
+	// <p>日志导出检索语句，不支持<a href="https://cloud.tencent.com/document/product/614/44061" target="_blank">[SQL语句]</a></p>
 	Query *string `json:"Query,omitnil,omitempty" name:"Query"`
 
-	// 日志导出起始时间，毫秒时间戳
+	// <p>日志导出起始时间，毫秒时间戳</p>
 	From *int64 `json:"From,omitnil,omitempty" name:"From"`
 
-	// 日志导出结束时间，毫秒时间戳
+	// <p>日志导出结束时间，毫秒时间戳</p>
 	To *int64 `json:"To,omitnil,omitempty" name:"To"`
 
-	// 日志导出时间排序。desc，asc，默认为desc
+	// <p>日志导出时间排序。desc，asc，默认为desc</p>
 	Order *string `json:"Order,omitnil,omitempty" name:"Order"`
 
-	// 日志导出数据格式。json，csv，默认为json
+	// <p>日志导出数据格式。json，csv，默认为json</p>
 	Format *string `json:"Format,omitnil,omitempty" name:"Format"`
 
-	// 语法规则,  默认值为0。
-	// 0：Lucene语法，1：CQL语法。
+	// <p>检索语法规则，默认值为1，推荐使用1 。</p><ul><li>0：Lucene语法</li><li>1：CQL语法（CLS Query Language，日志服务专用检索语法）</li></ul><p>详细说明参见<a href="https://cloud.tencent.com/document/product/614/47044#RetrievesConditionalRules" target="_blank">检索条件语法规则</a>。</p>
 	SyntaxRule *uint64 `json:"SyntaxRule,omitnil,omitempty" name:"SyntaxRule"`
 
-	// 导出字段
+	// <p>导出字段</p>
 	DerivedFields []*string `json:"DerivedFields,omitnil,omitempty" name:"DerivedFields"`
 }
 
 type CreateExportRequest struct {
 	*tchttp.BaseRequest
 	
-	// 日志主题Id
-	// - 通过[获取日志主题列表](https://cloud.tencent.com/document/product/614/56454)获取日志主题Id。
+	// <p>日志主题Id</p><ul><li>通过<a href="https://cloud.tencent.com/document/product/614/56454">获取日志主题列表</a>获取日志主题Id。</li></ul>
 	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
 
-	// 日志导出数量,  最大值5000万
+	// <p>日志导出数量,  最大值5000万</p>
 	Count *uint64 `json:"Count,omitnil,omitempty" name:"Count"`
 
-	// 日志导出检索语句，不支持<a href="https://cloud.tencent.com/document/product/614/44061" target="_blank">[SQL语句]</a>
+	// <p>日志导出检索语句，不支持<a href="https://cloud.tencent.com/document/product/614/44061" target="_blank">[SQL语句]</a></p>
 	Query *string `json:"Query,omitnil,omitempty" name:"Query"`
 
-	// 日志导出起始时间，毫秒时间戳
+	// <p>日志导出起始时间，毫秒时间戳</p>
 	From *int64 `json:"From,omitnil,omitempty" name:"From"`
 
-	// 日志导出结束时间，毫秒时间戳
+	// <p>日志导出结束时间，毫秒时间戳</p>
 	To *int64 `json:"To,omitnil,omitempty" name:"To"`
 
-	// 日志导出时间排序。desc，asc，默认为desc
+	// <p>日志导出时间排序。desc，asc，默认为desc</p>
 	Order *string `json:"Order,omitnil,omitempty" name:"Order"`
 
-	// 日志导出数据格式。json，csv，默认为json
+	// <p>日志导出数据格式。json，csv，默认为json</p>
 	Format *string `json:"Format,omitnil,omitempty" name:"Format"`
 
-	// 语法规则,  默认值为0。
-	// 0：Lucene语法，1：CQL语法。
+	// <p>检索语法规则，默认值为1，推荐使用1 。</p><ul><li>0：Lucene语法</li><li>1：CQL语法（CLS Query Language，日志服务专用检索语法）</li></ul><p>详细说明参见<a href="https://cloud.tencent.com/document/product/614/47044#RetrievesConditionalRules" target="_blank">检索条件语法规则</a>。</p>
 	SyntaxRule *uint64 `json:"SyntaxRule,omitnil,omitempty" name:"SyntaxRule"`
 
-	// 导出字段
+	// <p>导出字段</p>
 	DerivedFields []*string `json:"DerivedFields,omitnil,omitempty" name:"DerivedFields"`
 }
 
@@ -4248,7 +4244,7 @@ func (r *CreateExportRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateExportResponseParams struct {
-	// 日志导出ID。
+	// <p>日志导出ID。</p>
 	ExportId *string `json:"ExportId,omitnil,omitempty" name:"ExportId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -15643,6 +15639,9 @@ type ExportInfo struct {
 
 	// <p>导出字段</p>
 	DerivedFields []*string `json:"DerivedFields,omitnil,omitempty" name:"DerivedFields"`
+
+	// <p>日志导出创建时间，毫秒时间戳</p><p>单位：ms</p>
+	CreateTimestamp *uint64 `json:"CreateTimestamp,omitnil,omitempty" name:"CreateTimestamp"`
 }
 
 type ExternalRole struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1259,7 +1259,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.164
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.168
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.168

--- a/website/docs/r/cls_splunk_deliver.html.markdown
+++ b/website/docs/r/cls_splunk_deliver.html.markdown
@@ -14,28 +14,15 @@ Provides a resource to create a CLS splunk deliver.
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_cls_logset" "example" {
-  logset_name = "tf-example"
-}
-
-resource "tencentcloud_cls_topic" "example" {
-  topic_name           = "tf-example"
-  logset_id            = tencentcloud_cls_logset.example.id
-  auto_split           = false
-  max_split_partitions = 20
-  partition_count      = 1
-  period               = 10
-  storage_type         = "hot"
-}
-
 resource "tencentcloud_cls_splunk_deliver" "example" {
-  topic_id = tencentcloud_cls_topic.example.id
-  name     = "tf-example"
+  topic_id  = "eb417b1d-fc00-46f2-85f7-47ca0848a6b3"
+  name      = "tf-example"
+  index_ack = 1
 
   net_info {
-    host     = "10.0.0.1"
+    host     = "110.11.22.106"
     port     = 8088
-    token    = "your-splunk-token"
+    token    = "e27274fb-****-****-****-****00206282"
     net_type = 2
     is_ssl   = true
   }
@@ -43,11 +30,10 @@ resource "tencentcloud_cls_splunk_deliver" "example" {
   metadata_info {
     format = "json"
     meta_fields = [
-      "__SOURCE__",
+      "__HOSTNAME__",
       "__FILENAME__",
       "__TIMESTAMP__",
     ]
-    enable_tag = true
   }
 }
 ```
@@ -77,9 +63,9 @@ The `external_role` object supports the following:
 
 The `metadata_info` object supports the following:
 
-* `enable_tag` - (Required, Bool) Whether to deliver __TAG__ field.
 * `format` - (Required, String) Data format. Valid values: rawlog, json.
-* `meta_fields` - (Required, Set) Delivery fields, including __SOURCE__, __FILENAME__, __TIMESTAMP__, __HOSTNAME__, __PKG_ID__.
+* `enable_tag` - (Optional, Bool) Whether to deliver __TAG__ field.
+* `meta_fields` - (Optional, Set) Delivery fields, including __SOURCE__, __FILENAME__, __TIMESTAMP__, __HOSTNAME__, __PKG_ID__.
 * `tag_json_tiled` - (Optional, Bool) Whether to flatten JSON. Required when enable_tag is true.
 
 The `net_info` object supports the following:
@@ -102,9 +88,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-cls splunk deliver can be imported using the id, e.g.
+cls splunk deliver can be imported using the topicId#taskId, e.g.
 
 ```
-$ terraform import tencentcloud_cls_splunk_deliver.example task-xxx#topic-yyy
+terraform import tencentcloud_cls_splunk_deliver.example eb417b1d-fc00-46f2-85f7-47ca0848a6b3#716dae34-7eba-4b09-a3d9-6fe8e510e236
 ```
 

--- a/website/docs/r/cls_splunk_deliver.html.markdown
+++ b/website/docs/r/cls_splunk_deliver.html.markdown
@@ -1,0 +1,110 @@
+---
+subcategory: "Cloud Log Service(CLS)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_cls_splunk_deliver"
+sidebar_current: "docs-tencentcloud-resource-cls_splunk_deliver"
+description: |-
+  Provides a resource to create a CLS splunk deliver.
+---
+
+# tencentcloud_cls_splunk_deliver
+
+Provides a resource to create a CLS splunk deliver.
+
+## Example Usage
+
+```hcl
+resource "tencentcloud_cls_logset" "example" {
+  logset_name = "tf-example"
+}
+
+resource "tencentcloud_cls_topic" "example" {
+  topic_name           = "tf-example"
+  logset_id            = tencentcloud_cls_logset.example.id
+  auto_split           = false
+  max_split_partitions = 20
+  partition_count      = 1
+  period               = 10
+  storage_type         = "hot"
+}
+
+resource "tencentcloud_cls_splunk_deliver" "example" {
+  topic_id = tencentcloud_cls_topic.example.id
+  name     = "tf-example"
+
+  net_info {
+    host     = "10.0.0.1"
+    port     = 8088
+    token    = "your-splunk-token"
+    net_type = 2
+    is_ssl   = true
+  }
+
+  metadata_info {
+    format = "json"
+    meta_fields = [
+      "__SOURCE__",
+      "__FILENAME__",
+      "__TIMESTAMP__",
+    ]
+    enable_tag = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata_info` - (Required, List) Splunk deliver task metadata information.
+* `name` - (Required, String) Splunk deliver task name.
+* `net_info` - (Required, List) Splunk deliver task target network information.
+* `topic_id` - (Required, String, ForceNew) Log topic ID.
+* `channel` - (Optional, String) Advanced configuration - channel. Required if indexer is enabled.
+* `dsl_filter` - (Optional, String) Log pre-filtering DSL statement for raw data written to Splunk.
+* `enable` - (Optional, Int) Delivery task enable status. 0: disable, 1: enable.
+* `external_role` - (Optional, List) Advanced configuration - cross-account delivery role authorization information.
+* `has_service_log` - (Optional, Int) Whether to enable service log. 1: disable, 2: enable. Default: enable.
+* `index_ack` - (Optional, Int) Whether to enable indexer. 1: disable, 2: enable. Default: 1.
+* `index` - (Optional, String) Advanced configuration - Splunk index. No more than 64 characters.
+* `source_type` - (Optional, String) Advanced configuration - data source type. No more than 64 characters.
+* `source` - (Optional, String) Advanced configuration - data source. No more than 64 characters.
+
+The `external_role` object supports the following:
+
+* `external_id` - (Required, String) Cross-account delivery role name.
+* `role_arn` - (Required, String) Cross-account delivery role RoleArn.
+
+The `metadata_info` object supports the following:
+
+* `enable_tag` - (Required, Bool) Whether to deliver __TAG__ field.
+* `format` - (Required, String) Data format. Valid values: rawlog, json.
+* `meta_fields` - (Required, Set) Delivery fields, including __SOURCE__, __FILENAME__, __TIMESTAMP__, __HOSTNAME__, __PKG_ID__.
+* `tag_json_tiled` - (Optional, Bool) Whether to flatten JSON. Required when enable_tag is true.
+
+The `net_info` object supports the following:
+
+* `host` - (Required, String) Network address.
+* `net_type` - (Required, Int) Network type. 1: internal network, 2: external network.
+* `port` - (Required, Int) Port.
+* `token` - (Required, String) Authentication token.
+* `is_ssl` - (Optional, Bool) Whether to use SSL. Default is false.
+* `virtual_gateway_type` - (Optional, Int) Network service type. Required when net_type is internal network. 0: CVM, 3: Direct Connect Gateway, 11: CCN, 1025: CLB.
+* `vpc_id` - (Optional, String) VPC ID. Required when net_type is internal network.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `task_id` - Splunk deliver task ID.
+
+
+## Import
+
+cls splunk deliver can be imported using the id, e.g.
+
+```
+$ terraform import tencentcloud_cls_splunk_deliver.example task-xxx#topic-yyy
+```
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -1806,6 +1806,9 @@
                                     <a href="/docs/providers/tencentcloud/r/cls_scheduled_sql.html">tencentcloud_cls_scheduled_sql</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/r/cls_splunk_deliver.html">tencentcloud_cls_splunk_deliver</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/r/cls_topic.html">tencentcloud_cls_topic</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add tencentcloud_cls_splunk_deliver resource for CLS (Cloud Log Service) Splunk delivery configuration.

This resource supports:
- Create/Read/Update/Delete operations for Splunk delivery tasks
- Network configuration (net_info) with host, port, token, SSL support
- Metadata configuration (metadata_info) with format, meta_fields, tag support
- Cross-account delivery role authorization (external_role)
- Advanced configuration options (source, source_type, index, channel, DSL filter)