### PR TITLE
feat(crs): [137477945] add redis instance password policy config resource

### DIFF
--- a/.changelog/4462.txt
+++ b/.changelog/4462.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+tencentcloud_redis_instance_password_policy_config
+```

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.157
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/privatedns v1.1.42
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/pts v1.0.762
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.73
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.168
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/rum v1.0.744
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf v1.3.101
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.0.748

--- a/go.sum
+++ b/go.sum
@@ -973,7 +973,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.49/go.mod h
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.58/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.61/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.68/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.73/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.80/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.93/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.95/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1083,8 +1082,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/privatedns v1.1.42 h1:i
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/privatedns v1.1.42/go.mod h1:nhF6hHhT7CJZC03MMwL1/QYDI/0q9rAcW/4tf0nhfFc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/pts v1.0.762 h1:rZDKucVVtTnmnbZFDyh6t47dHswkb2oSuOxOHTTkygA=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/pts v1.0.762/go.mod h1:QB/XcdVZ8mhRgk90XuXd+2Smfo8emTo0wHIUsygEaKs=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.73 h1:9vzHHaI6oZK7h/8M0ir8l/m6FYXmZ8eJY9A8Wpsailc=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.73/go.mod h1:xcxqytUctZoQencIHJbIzqOCosZ6nmgE2cJRdI8LxxQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.168 h1:rfg7CV7ExLD19X+qoZYuyIanvGdP1fvNSNXbkd2DzIY=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.168/go.mod h1:Up2cGHWgc2j389uG/OBaOOMHmO0+BVjmymJSuxoYFAg=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/region v1.3.40 h1:De6erEvLFCeJly/LoV24q5oFm+462In9H9K05myjA20=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/region v1.3.40/go.mod h1:PQkz7GB68bpdMFkDHyVS3WFHMcKKUl1NP0Imih7fau4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/rum v1.0.744 h1:Z6xqpgnVPQfw2Yx/c2z6n30LfNodK4JEgMca1WpfOrY=

--- a/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/design.md
+++ b/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/design.md
@@ -1,0 +1,64 @@
+## Context
+
+腾讯云 Redis 实例支持配置密码复杂度策略（密码最小总长度、字母/数字/特殊字符最小数量、是否启用），目前仅能通过控制台或云 API 管理。Provider 中 Redis 服务位于 `tencentcloud/services/crs/` 包，已有 `tencentcloud_redis_connection_config`、`tencentcloud_redis_backup_config` 等配置型资源作为参考。
+
+本资源为 RESOURCE_KIND_CONFIG 类型：配置随实例存在而存在，只需 Read + Update（RU）接口，无独立 Create/Delete。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提供声明式管理 Redis 实例密码复杂度策略的 Terraform 资源
+- 支持 `enabled`、`min_letter_count`、`min_digit_count`、`min_special_count`、`min_length` 字段的读取与更新
+- 支持 Import（使用 instance_id 导入）
+- 遵循项目现有配置型资源模式（参考 `tencentcloud_redis_connection_config`）
+
+**Non-Goals:**
+- 不管理 Redis 实例本身的生命周期（由 `tencentcloud_redis_instance` 负责）
+- 不实现 Delete 真实操作（无对应云 API，配置随实例存在）
+- 不暴露 `password_policy` 嵌套对象作为中间 schema 层（按规则将字段平铺到顶层）
+
+## Decisions
+
+### 1. 字段平铺而非嵌套 password_policy 对象
+
+**决策**: 将 `PasswordPolicy` 的子字段（`enabled`、`min_letter_count`、`min_digit_count`、`min_special_count`、`min_length`）平铺到资源 schema 顶层，不创建 `password_policy` 嵌套层。
+
+**理由**: 云 API 出参中 `PasswordPolicy` 是单对象（非列表），用户需求映射也将其展开为顶层字段。按代码生成规则，避免多余的嵌套层使每个字段可直接 set/read。
+
+**替代方案**: 使用 `password_policy` TypeList(MaxItems=1) 嵌套对象 —— 增加不必要的复杂度，且与需求映射不一致。
+
+### 2. 资源 ID 使用 instance_id
+
+**决策**: `d.SetId(instanceId)`，资源 ID 即实例 ID。
+
+**理由**: 这是单例配置（每个实例只有一份密码策略），符合 RESOURCE_KIND_CONFIG 模式。与 `tencentcloud_redis_connection_config` 一致。
+
+### 3. Create = SetId + Update 模式
+
+**决策**: Create 函数设置 `d.SetId(instanceId)` 后直接调用 Update 函数。
+
+**理由**: 配置型资源无独立创建接口，首次 apply 即为修改配置。遵循 `tencentcloud_redis_connection_config` 等现有资源的模式。
+
+### 4. 同步接口，无需异步轮询
+
+**决策**: `ModifyInstancePasswordPolicy` 返回值仅含 `RequestId`，不含 `TaskId`，为同步接口，调用后直接调用 Read 刷新状态即可，无需 `DescribeTaskInfo` 轮询。
+
+**理由**: 经 vendor 中云 API 模型确认，`ModifyInstancePasswordPolicyResponse` 无 TaskId 字段。
+
+### 5. Delete 为 no-op
+
+**决策**: Delete 函数不做任何操作，仅返回 nil。
+
+**理由**: 云 API 无"重置/删除密码策略"接口，密码策略配置随实例存在而存在。terraform destroy 仅从 state 中移除。
+
+### 6. 可选字段在 Update 中使用 GetOkExists
+
+**决策**: `enabled` 为必填字段使用 `GetOk`；`min_letter_count`、`min_digit_count`、`min_special_count`、`min_length` 为可选字段使用 `GetOkExists`，允许设置为 0。
+
+**理由**: 这些计数字段取值范围为 [1,16]（min_length 为 [8,64]），但在 Terraform 中可选字段需支持用户不设置或设置具体值，使用 `GetOkExists` 区分"未设置"与"设置为 0"。
+
+## Risks / Trade-offs
+
+- **[实例不存在导致 Read 清空 state]** → 在 Read 中，若 `DescribeInstancePasswordPolicy` 返回实例不存在错误或空响应，先打印 `log.Printf("[CRUD] ... id=%s", d.Id())` 保留现场，再 `d.SetId("")`。
+- **[ModifyInstancePasswordPolicy 可能因实例状态不可操作而失败]** → 使用 `tccommon.RetryError` 包装错误，让外层 retry 重试；不可重试错误（如实例不存在）返回 `NonRetryableError`。
+- **[可选字段传 0 与未传值的区分]** → 使用 `GetOkExists` 处理可选整数字段，避免 0 值被误判为未设置。

--- a/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/proposal.md
+++ b/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Redis 实例密码复杂度策略目前无法通过 Terraform 管理，用户只能登录腾讯云控制台手动配置。这限制了安全合规自动化能力——用户无法以基础设施即代码方式统一管理 Redis 实例的密码策略（启用开关、字母/数字/特殊字符最小数量、密码最小总长度），难以在多实例、多环境下保持一致的安全基线。
+
+## What Changes
+
+- 新增 Terraform 配置型资源 `tencentcloud_redis_instance_password_policy_config`，用于管理 Redis 实例的密码复杂度策略配置。
+- 资源使用 `instance_id` 作为资源 ID（单例配置，资源存在即配置存在）。
+- Create = SetId + Update（遵循 RESOURCE_KIND_CONFIG 模式）；Read 调用 `DescribeInstancePasswordPolicy`；Update 调用 `ModifyInstancePasswordPolicy`；Delete 为 no-op（配置随实例存在，无独立删除接口）。
+- 在 `tencentcloud/provider.go` 和 `tencentcloud/provider.md` 中注册新资源。
+- 新增资源文档 `resource_tc_redis_instance_password_policy_config.md`。
+- 新增单元测试 `resource_tc_redis_instance_password_policy_config_test.go`（使用 gomonkey mock 云 API）。
+
+## Capabilities
+
+### New Capabilities
+- `redis-instance-password-policy-config`: 管理 Redis 实例密码复杂度策略配置（启用状态、字母/数字/特殊字符最小数量、密码最小总长度）的读取与更新。
+
+### Modified Capabilities
+
+无。
+
+## Impact
+
+- **新增文件**:
+  - `tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config.go`
+  - `tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config_test.go`
+  - `tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config.md`
+- **修改文件**:
+  - `tencentcloud/provider.go` — 注册 `tencentcloud_redis_instance_password_policy_config`
+  - `tencentcloud/provider.md` — 添加资源声明
+- **云 API 依赖**:
+  - `DescribeInstancePasswordPolicy`（redis/v20180412）— 读取密码策略
+  - `ModifyInstancePasswordPolicy`（redis/v20180412）— 修改密码策略
+- **向后兼容性**: 完全向后兼容，新增资源不影响现有功能。
+- **异步行为**: 两个接口均为同步接口，`ModifyInstancePasswordPolicy` 不返回 TaskId，无需异步轮询。

--- a/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/specs/redis-instance-password-policy-config/spec.md
+++ b/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/specs/redis-instance-password-policy-config/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: 资源 Schema 定义
+
+资源 `tencentcloud_redis_instance_password_policy_config` SHALL 定义以下 schema 字段：
+- `instance_id`（String, Required, ForceNew）— Redis 实例 ID
+- `enabled`（Bool, Required）— 是否启用密码复杂度策略
+- `min_letter_count`（Int, Optional, Computed）— 大小写字母最小字符数，取值范围 [1,16]
+- `min_digit_count`（Int, Optional, Computed）— 数字字符最小字符数，取值范围 [1,16]
+- `min_special_count`（Int, Optional, Computed）— 特殊字符最小字符数，取值范围 [1,16]
+- `min_length`（Int, Optional, Computed）— 密码最小总长度，取值范围 [8,64]
+
+字段 SHALL 平铺在 schema 顶层，不使用 `password_policy` 嵌套对象层。
+
+#### Scenario: Schema 包含所有字段
+- **WHEN** 定义资源 schema
+- **THEN** schema 包含 `instance_id`、`enabled`、`min_letter_count`、`min_digit_count`、`min_special_count`、`min_length` 六个顶层字段
+
+#### Scenario: instance_id 为 ForceNew
+- **WHEN** 用户在 apply 后修改 `instance_id`
+- **THEN** Terraform 销毁并重建资源
+
+#### Scenario: 可选计数字段支持不设置
+- **WHEN** 用户未设置 `min_letter_count`、`min_digit_count`、`min_special_count`、`min_length`
+- **THEN** 这些字段在 schema 中为 Optional + Computed，由云 API 返回值填充
+
+### Requirement: Create 操作
+
+Create 操作 SHALL 设置资源 ID 为 `instance_id`，然后调用 Update 操作完成配置写入。
+
+#### Scenario: 首次创建配置
+- **WHEN** 用户 apply 一个新的 `tencentcloud_redis_instance_password_policy_config` 资源
+- **THEN** 资源 ID 被设置为 `instance_id` 的值
+- **AND** 调用 `ModifyInstancePasswordPolicy` 写入密码策略配置
+- **AND** 调用 Read 刷新状态
+
+### Requirement: Read 操作
+
+Read 操作 SHALL 调用 `DescribeInstancePasswordPolicy` 读取当前密码策略，并设置所有字段到 state。
+
+#### Scenario: 成功读取密码策略
+- **WHEN** Read 调用 `DescribeInstancePasswordPolicy` 成功返回
+- **THEN** 将 `enabled`、`min_letter_count`、`min_digit_count`、`min_special_count`、`min_length` 设置到 state
+- **AND** 在设置每个字段前检查云 API 返回值是否为 nil，为 nil 则不设置
+
+#### Scenario: 实例不存在
+- **WHEN** Read 调用 `DescribeInstancePasswordPolicy` 返回实例不存在或空响应
+- **THEN** 先打印 `log.Printf("[CRUD] redis_instance_password_policy_config id=%s", d.Id())` 保留现场
+- **AND** 调用 `d.SetId("")` 从 state 移除资源
+
+### Requirement: Update 操作
+
+Update 操作 SHALL 调用 `ModifyInstancePasswordPolicy` 更新密码策略，请求中包含 `InstanceId` 和 `PasswordPolicy` 对象。
+
+#### Scenario: 成功更新密码策略
+- **WHEN** Update 调用 `ModifyInstancePasswordPolicy` 成功
+- **THEN** 调用 Read 刷新状态
+- **AND** 不需要异步轮询（接口为同步）
+
+#### Scenario: 更新失败可重试
+- **WHEN** Update 调用 `ModifyInstancePasswordPolicy` 返回网络错误等可重试错误
+- **THEN** 使用 `tccommon.RetryError` 包装错误，由外层 retry 重试
+
+#### Scenario: 更新失败不可重试
+- **WHEN** Update 调用 `ModifyInstancePasswordPolicy` 返回实例不存在等不可重试错误
+- **THEN** 返回 `NonRetryableError`
+
+### Requirement: Delete 操作
+
+Delete 操作 SHALL 为 no-op，不调用任何云 API。
+
+#### Scenario: 删除资源
+- **WHEN** 用户执行 terraform destroy
+- **THEN** 资源从 state 移除，不调用云 API
+
+### Requirement: Import 支持
+
+资源 SHALL 支持 Import，使用 `instance_id` 作为导入 ID。
+
+#### Scenario: 导入已存在的密码策略配置
+- **WHEN** 用户执行 `terraform import tencentcloud_redis_instance_password_policy_config.xxx <instance_id>`
+- **THEN** 资源被导入到 state，调用 Read 填充字段
+
+### Requirement: Provider 注册
+
+资源 SHALL 在 `tencentcloud/provider.go` 的 ResourcesMap 中注册为 `tencentcloud_redis_instance_password_policy_config`。
+
+#### Scenario: 资源已注册
+- **WHEN** 检查 provider.go
+- **THEN** ResourcesMap 中存在 `tencentcloud_redis_instance_password_policy_config` 映射到 `crs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()`
+
+### Requirement: 单元测试
+
+资源 SHALL 提供单元测试文件 `resource_tc_redis_instance_password_policy_config_test.go`，使用 gomonkey mock 云 API 进行业务逻辑测试。
+
+#### Scenario: 单元测试覆盖 CRUD
+- **WHEN** 运行单元测试
+- **THEN** 测试覆盖 Create、Read、Update、Delete 的业务逻辑
+- **AND** 使用 gomonkey mock `DescribeInstancePasswordPolicy` 和 `ModifyInstancePasswordPolicy` 接口

--- a/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/tasks.md
+++ b/openspec/changes/archive/2026-08-27-add-redis-instance-password-policy-config/tasks.md
@@ -1,0 +1,37 @@
+## 1. 资源实现
+
+- [x] 1.1 创建 `tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config.go`，定义 `ResourceTencentCloudRedisInstancePasswordPolicyConfig()` schema 函数
+- [x] 1.2 实现 schema：`instance_id`(String, Required, ForceNew)、`enabled`(Bool, Required)、`min_letter_count`(Int, Optional, Computed)、`min_digit_count`(Int, Optional, Computed)、`min_special_count`(Int, Optional, Computed)、`min_length`(Int, Optional, Computed)，字段平铺在顶层
+- [x] 1.3 添加 Import 支持（`schema.ImportStatePassthrough`）
+- [x] 1.4 实现 `resourceTencentCloudRedisInstancePasswordPolicyConfigCreate`：设置 `d.SetId(instanceId)` 后调用 Update
+- [x] 1.5 实现 `resourceTencentCloudRedisInstancePasswordPolicyConfigRead`：调用 `DescribeInstancePasswordPolicy`，设置字段前检查 nil；空响应先打印 `log.Printf("[CRUD] redis_instance_password_policy_config id=%s", d.Id())` 再 `d.SetId("")`
+- [x] 1.6 实现 `resourceTencentCloudRedisInstancePasswordPolicyConfigUpdate`：调用 `ModifyInstancePasswordPolicy`，用 `resource.Retry(tccommon.WriteRetryTimeout)` + `tccommon.RetryError` 包装错误，retry 块外调用 Read 刷新
+- [x] 1.7 实现 `resourceTencentCloudRedisInstancePasswordPolicyConfigDelete`：no-op，返回 nil
+
+## 2. Provider 注册
+
+- [x] 2.1 在 `tencentcloud/provider.go` 的 ResourcesMap 中注册 `tencentcloud_redis_instance_password_policy_config` → `crs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()`
+- [x] 2.2 在 `tencentcloud/provider.md` 中添加 `tencentcloud_redis_instance_password_policy_config` 资源声明
+
+## 3. 文档
+
+- [x] 3.1 创建 `tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config.md`，包含一句话描述（带云产品名称 redis）、Example Usage、Import 示例（说明使用 instance_id 导入）
+- [x] 3.2 运行 `make doc` 生成 `website/docs/r/redis_instance_password_policy_config.html.markdown`（由收尾阶段 tfpacer-finalize skill 执行）
+
+## 4. 单元测试
+
+- [x] 4.1 创建 `tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config_test.go`，使用 gomonkey mock `DescribeInstancePasswordPolicy` 和 `ModifyInstancePasswordPolicy` 接口
+- [x] 4.2 编写 Create 业务逻辑测试（mock ModifyInstancePasswordPolicy 成功 + Read 回填）
+- [x] 4.3 编写 Update 业务逻辑测试（mock ModifyInstancePasswordPolicy 成功）
+- [x] 4.4 编写 Read 业务逻辑测试（mock DescribeInstancePasswordPolicy 返回完整策略 + 返回空的场景）
+- [x] 4.5 确保 error 返回值均被检查，必不出错的函数用 `_ =` 处理
+
+## 5. 代码正确性检查
+
+- [x] 5.1 确认 `ModifyInstancePasswordPolicy` 请求参数（InstanceId、PasswordPolicy.Enabled/MinLetterCount/MinDigitCount/MinSpecialCount/MinLength）均在云 API 入参中存在
+- [x] 5.2 确认 `DescribeInstancePasswordPolicy` 出参字段（PasswordPolicy.Enabled/MinLetterCount/MinDigitCount/MinSpecialCount/MinLength）与 schema 字段一一对应
+- [x] 5.3 确认 Read 中设置字段前均检查 nil，Create 中检查返回值非空
+
+## 6. 收尾
+
+- [x] 6.1 由 tfpacer-finalize skill 执行 `gofmt`、`make doc`、生成 changelog 并推送

--- a/openspec/specs/redis-instance-password-policy-config/spec.md
+++ b/openspec/specs/redis-instance-password-policy-config/spec.md
@@ -1,0 +1,103 @@
+# redis-instance-password-policy-config Specification
+
+## Purpose
+TBD - created by archiving change add-redis-instance-password-policy-config. Update Purpose after archive.
+## Requirements
+### Requirement: 资源 Schema 定义
+
+资源 `tencentcloud_redis_instance_password_policy_config` SHALL 定义以下 schema 字段：
+- `instance_id`（String, Required, ForceNew）— Redis 实例 ID
+- `enabled`（Bool, Required）— 是否启用密码复杂度策略
+- `min_letter_count`（Int, Optional, Computed）— 大小写字母最小字符数，取值范围 [1,16]
+- `min_digit_count`（Int, Optional, Computed）— 数字字符最小字符数，取值范围 [1,16]
+- `min_special_count`（Int, Optional, Computed）— 特殊字符最小字符数，取值范围 [1,16]
+- `min_length`（Int, Optional, Computed）— 密码最小总长度，取值范围 [8,64]
+
+字段 SHALL 平铺在 schema 顶层，不使用 `password_policy` 嵌套对象层。
+
+#### Scenario: Schema 包含所有字段
+- **WHEN** 定义资源 schema
+- **THEN** schema 包含 `instance_id`、`enabled`、`min_letter_count`、`min_digit_count`、`min_special_count`、`min_length` 六个顶层字段
+
+#### Scenario: instance_id 为 ForceNew
+- **WHEN** 用户在 apply 后修改 `instance_id`
+- **THEN** Terraform 销毁并重建资源
+
+#### Scenario: 可选计数字段支持不设置
+- **WHEN** 用户未设置 `min_letter_count`、`min_digit_count`、`min_special_count`、`min_length`
+- **THEN** 这些字段在 schema 中为 Optional + Computed，由云 API 返回值填充
+
+### Requirement: Create 操作
+
+Create 操作 SHALL 设置资源 ID 为 `instance_id`，然后调用 Update 操作完成配置写入。
+
+#### Scenario: 首次创建配置
+- **WHEN** 用户 apply 一个新的 `tencentcloud_redis_instance_password_policy_config` 资源
+- **THEN** 资源 ID 被设置为 `instance_id` 的值
+- **AND** 调用 `ModifyInstancePasswordPolicy` 写入密码策略配置
+- **AND** 调用 Read 刷新状态
+
+### Requirement: Read 操作
+
+Read 操作 SHALL 调用 `DescribeInstancePasswordPolicy` 读取当前密码策略，并设置所有字段到 state。
+
+#### Scenario: 成功读取密码策略
+- **WHEN** Read 调用 `DescribeInstancePasswordPolicy` 成功返回
+- **THEN** 将 `enabled`、`min_letter_count`、`min_digit_count`、`min_special_count`、`min_length` 设置到 state
+- **AND** 在设置每个字段前检查云 API 返回值是否为 nil，为 nil 则不设置
+
+#### Scenario: 实例不存在
+- **WHEN** Read 调用 `DescribeInstancePasswordPolicy` 返回实例不存在或空响应
+- **THEN** 先打印 `log.Printf("[CRUD] redis_instance_password_policy_config id=%s", d.Id())` 保留现场
+- **AND** 调用 `d.SetId("")` 从 state 移除资源
+
+### Requirement: Update 操作
+
+Update 操作 SHALL 调用 `ModifyInstancePasswordPolicy` 更新密码策略，请求中包含 `InstanceId` 和 `PasswordPolicy` 对象。
+
+#### Scenario: 成功更新密码策略
+- **WHEN** Update 调用 `ModifyInstancePasswordPolicy` 成功
+- **THEN** 调用 Read 刷新状态
+- **AND** 不需要异步轮询（接口为同步）
+
+#### Scenario: 更新失败可重试
+- **WHEN** Update 调用 `ModifyInstancePasswordPolicy` 返回网络错误等可重试错误
+- **THEN** 使用 `tccommon.RetryError` 包装错误，由外层 retry 重试
+
+#### Scenario: 更新失败不可重试
+- **WHEN** Update 调用 `ModifyInstancePasswordPolicy` 返回实例不存在等不可重试错误
+- **THEN** 返回 `NonRetryableError`
+
+### Requirement: Delete 操作
+
+Delete 操作 SHALL 为 no-op，不调用任何云 API。
+
+#### Scenario: 删除资源
+- **WHEN** 用户执行 terraform destroy
+- **THEN** 资源从 state 移除，不调用云 API
+
+### Requirement: Import 支持
+
+资源 SHALL 支持 Import，使用 `instance_id` 作为导入 ID。
+
+#### Scenario: 导入已存在的密码策略配置
+- **WHEN** 用户执行 `terraform import tencentcloud_redis_instance_password_policy_config.xxx <instance_id>`
+- **THEN** 资源被导入到 state，调用 Read 填充字段
+
+### Requirement: Provider 注册
+
+资源 SHALL 在 `tencentcloud/provider.go` 的 ResourcesMap 中注册为 `tencentcloud_redis_instance_password_policy_config`。
+
+#### Scenario: 资源已注册
+- **WHEN** 检查 provider.go
+- **THEN** ResourcesMap 中存在 `tencentcloud_redis_instance_password_policy_config` 映射到 `crs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()`
+
+### Requirement: 单元测试
+
+资源 SHALL 提供单元测试文件 `resource_tc_redis_instance_password_policy_config_test.go`，使用 gomonkey mock 云 API 进行业务逻辑测试。
+
+#### Scenario: 单元测试覆盖 CRUD
+- **WHEN** 运行单元测试
+- **THEN** 测试覆盖 Create、Read、Update、Delete 的业务逻辑
+- **AND** 使用 gomonkey mock `DescribeInstancePasswordPolicy` 和 `ModifyInstancePasswordPolicy` 接口
+

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1708,6 +1708,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_redis_security_group_attachment":                                          crs.ResourceTencentCloudRedisSecurityGroupAttachment(),
 			"tencentcloud_redis_log_delivery":                                                       crs.ResourceTencentCloudRedisLogDelivery(),
 			"tencentcloud_redis_audit_log":                                                          crs.ResourceTencentCloudRedisAuditLog(),
+			"tencentcloud_redis_instance_password_policy_config":                                    crs.ResourceTencentCloudRedisInstancePasswordPolicyConfig(),
 			"tencentcloud_as_load_balancer":                                                         as.ResourceTencentCloudAsLoadBalancer(),
 			"tencentcloud_as_scaling_config":                                                        as.ResourceTencentCloudAsScalingConfig(),
 			"tencentcloud_as_scaling_group":                                                         as.ResourceTencentCloudAsScalingGroup(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1037,6 +1037,7 @@ tencentcloud_redis_security_group_attachment
 tencentcloud_redis_connection_config
 tencentcloud_redis_log_delivery
 tencentcloud_redis_audit_log
+tencentcloud_redis_instance_password_policy_config
 
 Serverless Cloud Function(SCF)
 Data Source

--- a/tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config.go
+++ b/tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config.go
@@ -1,0 +1,215 @@
+package crs
+
+import (
+	"context"
+	"log"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	redis "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func ResourceTencentCloudRedisInstancePasswordPolicyConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTencentCloudRedisInstancePasswordPolicyConfigCreate,
+		Read:   resourceTencentCloudRedisInstancePasswordPolicyConfigRead,
+		Update: resourceTencentCloudRedisInstancePasswordPolicyConfigUpdate,
+		Delete: resourceTencentCloudRedisInstancePasswordPolicyConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Required:    true,
+				ForceNew:    true,
+				Type:        schema.TypeString,
+				Description: "The ID of redis instance.",
+			},
+
+			"enabled": {
+				Required:    true,
+				Type:        schema.TypeBool,
+				Description: "Whether to enable the instance-level password complexity policy. true: enable; false: disable.",
+			},
+
+			"min_letter_count": {
+				Optional:    true,
+				Computed:    true,
+				Type:        schema.TypeInt,
+				Description: "The minimum number of letters (uppercase and lowercase). Value range: [1,16].",
+			},
+
+			"min_digit_count": {
+				Optional:    true,
+				Computed:    true,
+				Type:        schema.TypeInt,
+				Description: "The minimum number of digit characters. Value range: [1,16].",
+			},
+
+			"min_special_count": {
+				Optional:    true,
+				Computed:    true,
+				Type:        schema.TypeInt,
+				Description: "The minimum number of special characters. Value range: [1,16].",
+			},
+
+			"min_length": {
+				Optional:    true,
+				Computed:    true,
+				Type:        schema.TypeInt,
+				Description: "The minimum total length of the password. Value range: [8,64].",
+			},
+		},
+	}
+}
+
+func resourceTencentCloudRedisInstancePasswordPolicyConfigCreate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_redis_instance_password_policy_config.create")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		instanceId string
+	)
+	if v, ok := d.GetOk("instance_id"); ok {
+		instanceId = v.(string)
+	}
+
+	d.SetId(instanceId)
+
+	return resourceTencentCloudRedisInstancePasswordPolicyConfigUpdate(d, meta)
+}
+
+func resourceTencentCloudRedisInstancePasswordPolicyConfigRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_redis_instance_password_policy_config.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+	instanceId := d.Id()
+
+	request := redis.NewDescribeInstancePasswordPolicyRequest()
+	request.InstanceId = helper.String(instanceId)
+
+	var passwordPolicy *redis.PasswordPolicy
+	var notFound bool
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseRedisClient().DescribeInstancePasswordPolicyWithContext(ctx, request)
+		if e != nil {
+			if ee, ok := e.(*sdkErrors.TencentCloudSDKError); ok {
+				if ee.Code == "ResourceNotFound.InstanceNotExists" {
+					return resource.NonRetryableError(e)
+				}
+			}
+			return tccommon.RetryError(e)
+		}
+		if result == nil || result.Response == nil || result.Response.PasswordPolicy == nil {
+			notFound = true
+			return nil
+		}
+		passwordPolicy = result.Response.PasswordPolicy
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s read redis_instance_password_policy_config failed, reason:%+v", logId, err)
+		return err
+	}
+
+	if notFound {
+		log.Printf("[CRUD] redis_instance_password_policy_config id=%s", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if passwordPolicy != nil {
+		if passwordPolicy.Enabled != nil {
+			_ = d.Set("enabled", passwordPolicy.Enabled)
+		}
+		if passwordPolicy.MinLetterCount != nil {
+			_ = d.Set("min_letter_count", passwordPolicy.MinLetterCount)
+		}
+		if passwordPolicy.MinDigitCount != nil {
+			_ = d.Set("min_digit_count", passwordPolicy.MinDigitCount)
+		}
+		if passwordPolicy.MinSpecialCount != nil {
+			_ = d.Set("min_special_count", passwordPolicy.MinSpecialCount)
+		}
+		if passwordPolicy.MinLength != nil {
+			_ = d.Set("min_length", passwordPolicy.MinLength)
+		}
+	}
+
+	return nil
+}
+
+func resourceTencentCloudRedisInstancePasswordPolicyConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_redis_instance_password_policy_config.update")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+	instanceId := d.Id()
+	request := redis.NewModifyInstancePasswordPolicyRequest()
+	request.InstanceId = helper.String(instanceId)
+
+	passwordPolicy := &redis.PasswordPolicy{}
+
+	if v, ok := d.GetOk("enabled"); ok {
+		passwordPolicy.Enabled = helper.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOkExists("min_letter_count"); ok {
+		passwordPolicy.MinLetterCount = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOkExists("min_digit_count"); ok {
+		passwordPolicy.MinDigitCount = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOkExists("min_special_count"); ok {
+		passwordPolicy.MinSpecialCount = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOkExists("min_length"); ok {
+		passwordPolicy.MinLength = helper.IntInt64(v.(int))
+	}
+
+	request.PasswordPolicy = passwordPolicy
+
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseRedisClient().ModifyInstancePasswordPolicyWithContext(ctx, request)
+		if e != nil {
+			if ee, ok := e.(*sdkErrors.TencentCloudSDKError); ok {
+				if ee.Code == "ResourceNotFound.InstanceNotExists" {
+					return resource.NonRetryableError(e)
+				}
+			}
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s update redis_instance_password_policy_config failed, reason:%+v", logId, err)
+		return err
+	}
+
+	return resourceTencentCloudRedisInstancePasswordPolicyConfigRead(d, meta)
+}
+
+func resourceTencentCloudRedisInstancePasswordPolicyConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("resource.tencentcloud_redis_instance_password_policy_config.delete")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	return nil
+}

--- a/tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config.md
+++ b/tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config.md
@@ -1,0 +1,53 @@
+Provides a resource to manage redis instance password policy config
+
+Example Usage
+
+Manage the password complexity policy of a redis instance
+
+```hcl
+data "tencentcloud_redis_zone_config" "zone" {
+  type_id = 7
+}
+
+resource "tencentcloud_vpc" "vpc" {
+  cidr_block = "10.0.0.0/16"
+  name       = "tf_redis_vpc"
+}
+
+resource "tencentcloud_subnet" "subnet" {
+  vpc_id            = tencentcloud_vpc.vpc.id
+  availability_zone = data.tencentcloud_redis_zone_config.zone.list[0].zone
+  name              = "tf_redis_subnet"
+  cidr_block        = "10.0.1.0/24"
+}
+
+resource "tencentcloud_redis_instance" "example" {
+  availability_zone  = data.tencentcloud_redis_zone_config.zone.list[0].zone
+  type_id            = data.tencentcloud_redis_zone_config.zone.list[0].type_id
+  password           = "Password@123"
+  mem_size           = 8192
+  redis_shard_num    = data.tencentcloud_redis_zone_config.zone.list[0].redis_shard_nums[0]
+  redis_replicas_num = data.tencentcloud_redis_zone_config.zone.list[0].redis_replicas_nums[0]
+  name               = "tf_example"
+  port               = 6379
+  vpc_id             = tencentcloud_vpc.vpc.id
+  subnet_id          = tencentcloud_subnet.subnet.id
+}
+
+resource "tencentcloud_redis_instance_password_policy_config" "example" {
+  instance_id       = tencentcloud_redis_instance.example.id
+  enabled           = true
+  min_letter_count  = 1
+  min_digit_count   = 1
+  min_special_count = 1
+  min_length        = 8
+}
+```
+
+Import
+
+redis instance password policy config can be imported using the instance_id, e.g.
+
+```
+$ terraform import tencentcloud_redis_instance_password_policy_config.example crs-cqdfdzvt
+```

--- a/tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config_test.go
+++ b/tencentcloud/services/crs/resource_tc_redis_instance_password_policy_config_test.go
@@ -1,0 +1,287 @@
+package crs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	redis "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	svccrs "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/crs"
+)
+
+// mockMetaForRedisInstancePasswordPolicyConfig implements tccommon.ProviderMeta
+type mockMetaForRedisInstancePasswordPolicyConfig struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForRedisInstancePasswordPolicyConfig) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForRedisInstancePasswordPolicyConfig{}
+
+func newMockMetaForRedisInstancePasswordPolicyConfig() *mockMetaForRedisInstancePasswordPolicyConfig {
+	return &mockMetaForRedisInstancePasswordPolicyConfig{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrBoolPasswordPolicy(v bool) *bool {
+	return &v
+}
+
+func ptrInt64PasswordPolicy(v int64) *int64 {
+	return &v
+}
+
+func ptrStrPasswordPolicy(s string) *string {
+	return &s
+}
+
+// go test ./tencentcloud/services/crs/ -run "TestRedisInstancePasswordPolicyConfig" -v -count=1 -gcflags="all=-l"
+
+// TestRedisInstancePasswordPolicyConfig_Schema tests the schema definition
+func TestRedisInstancePasswordPolicyConfig_Schema(t *testing.T) {
+	res := svccrs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()
+
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Importer)
+
+	// Required fields
+	assert.Contains(t, res.Schema, "instance_id")
+	assert.True(t, res.Schema["instance_id"].Required)
+	assert.True(t, res.Schema["instance_id"].ForceNew)
+
+	assert.Contains(t, res.Schema, "enabled")
+	assert.True(t, res.Schema["enabled"].Required)
+
+	// Optional + Computed fields
+	for _, field := range []string{"min_letter_count", "min_digit_count", "min_special_count", "min_length"} {
+		assert.Contains(t, res.Schema, field)
+		assert.True(t, res.Schema[field].Optional)
+		assert.True(t, res.Schema[field].Computed)
+	}
+}
+
+// TestRedisInstancePasswordPolicyConfig_Read_Success tests Read populates fields from PasswordPolicy
+func TestRedisInstancePasswordPolicyConfig_Read_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	redisClient := &redis.Client{}
+	patches.ApplyMethodReturn(newMockMetaForRedisInstancePasswordPolicyConfig().client, "UseRedisClient", redisClient)
+
+	patches.ApplyMethodFunc(redisClient, "DescribeInstancePasswordPolicyWithContext", func(ctx context.Context, request *redis.DescribeInstancePasswordPolicyRequest) (*redis.DescribeInstancePasswordPolicyResponse, error) {
+		assert.Equal(t, "crs-cqdfdzvt", *request.InstanceId)
+		resp := redis.NewDescribeInstancePasswordPolicyResponse()
+		resp.Response = &redis.DescribeInstancePasswordPolicyResponseParams{
+			PasswordPolicy: &redis.PasswordPolicy{
+				Enabled:         ptrBoolPasswordPolicy(true),
+				MinLetterCount:  ptrInt64PasswordPolicy(2),
+				MinDigitCount:   ptrInt64PasswordPolicy(3),
+				MinSpecialCount: ptrInt64PasswordPolicy(1),
+				MinLength:       ptrInt64PasswordPolicy(12),
+			},
+			RequestId: ptrStrPasswordPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForRedisInstancePasswordPolicyConfig()
+	res := svccrs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": "crs-cqdfdzvt",
+		"enabled":     true,
+	})
+	d.SetId("crs-cqdfdzvt")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "crs-cqdfdzvt", d.Get("instance_id"))
+	assert.Equal(t, true, d.Get("enabled"))
+	assert.Equal(t, 2, d.Get("min_letter_count"))
+	assert.Equal(t, 3, d.Get("min_digit_count"))
+	assert.Equal(t, 1, d.Get("min_special_count"))
+	assert.Equal(t, 12, d.Get("min_length"))
+}
+
+// TestRedisInstancePasswordPolicyConfig_Read_NilPasswordPolicy tests Read clears state when PasswordPolicy is nil
+func TestRedisInstancePasswordPolicyConfig_Read_NilPasswordPolicy(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	redisClient := &redis.Client{}
+	patches.ApplyMethodReturn(newMockMetaForRedisInstancePasswordPolicyConfig().client, "UseRedisClient", redisClient)
+
+	patches.ApplyMethodFunc(redisClient, "DescribeInstancePasswordPolicyWithContext", func(ctx context.Context, request *redis.DescribeInstancePasswordPolicyRequest) (*redis.DescribeInstancePasswordPolicyResponse, error) {
+		resp := redis.NewDescribeInstancePasswordPolicyResponse()
+		resp.Response = &redis.DescribeInstancePasswordPolicyResponseParams{
+			PasswordPolicy: nil,
+			RequestId:      ptrStrPasswordPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForRedisInstancePasswordPolicyConfig()
+	res := svccrs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": "crs-cqdfdzvt",
+		"enabled":     true,
+	})
+	d.SetId("crs-cqdfdzvt")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestRedisInstancePasswordPolicyConfig_Read_InstanceNotExists tests Read returns error when instance not found
+func TestRedisInstancePasswordPolicyConfig_Read_InstanceNotExists(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	redisClient := &redis.Client{}
+	patches.ApplyMethodReturn(newMockMetaForRedisInstancePasswordPolicyConfig().client, "UseRedisClient", redisClient)
+
+	patches.ApplyMethodFunc(redisClient, "DescribeInstancePasswordPolicyWithContext", func(ctx context.Context, request *redis.DescribeInstancePasswordPolicyRequest) (*redis.DescribeInstancePasswordPolicyResponse, error) {
+		return nil, sdkErrors.NewTencentCloudSDKError("ResourceNotFound.InstanceNotExists", "Instance not found", "fake-request-id")
+	})
+
+	meta := newMockMetaForRedisInstancePasswordPolicyConfig()
+	res := svccrs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": "crs-cqdfdzvt",
+		"enabled":     true,
+	})
+	d.SetId("crs-cqdfdzvt")
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}
+
+// TestRedisInstancePasswordPolicyConfig_Create_Success tests Create sets ID and delegates to Update
+func TestRedisInstancePasswordPolicyConfig_Create_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	redisClient := &redis.Client{}
+	patches.ApplyMethodReturn(newMockMetaForRedisInstancePasswordPolicyConfig().client, "UseRedisClient", redisClient)
+
+	// Mock ModifyInstancePasswordPolicyWithContext for Update
+	patches.ApplyMethodFunc(redisClient, "ModifyInstancePasswordPolicyWithContext", func(ctx context.Context, request *redis.ModifyInstancePasswordPolicyRequest) (*redis.ModifyInstancePasswordPolicyResponse, error) {
+		assert.Equal(t, "crs-cqdfdzvt", *request.InstanceId)
+		assert.NotNil(t, request.PasswordPolicy)
+		assert.Equal(t, true, *request.PasswordPolicy.Enabled)
+		resp := redis.NewModifyInstancePasswordPolicyResponse()
+		resp.Response = &redis.ModifyInstancePasswordPolicyResponseParams{
+			RequestId: ptrStrPasswordPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeInstancePasswordPolicyWithContext for Read
+	patches.ApplyMethodFunc(redisClient, "DescribeInstancePasswordPolicyWithContext", func(ctx context.Context, request *redis.DescribeInstancePasswordPolicyRequest) (*redis.DescribeInstancePasswordPolicyResponse, error) {
+		resp := redis.NewDescribeInstancePasswordPolicyResponse()
+		resp.Response = &redis.DescribeInstancePasswordPolicyResponseParams{
+			PasswordPolicy: &redis.PasswordPolicy{
+				Enabled:         ptrBoolPasswordPolicy(true),
+				MinLetterCount:  ptrInt64PasswordPolicy(1),
+				MinDigitCount:   ptrInt64PasswordPolicy(1),
+				MinSpecialCount: ptrInt64PasswordPolicy(1),
+				MinLength:       ptrInt64PasswordPolicy(8),
+			},
+			RequestId: ptrStrPasswordPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForRedisInstancePasswordPolicyConfig()
+	res := svccrs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id":       "crs-cqdfdzvt",
+		"enabled":           true,
+		"min_letter_count":  1,
+		"min_digit_count":   1,
+		"min_special_count": 1,
+		"min_length":        8,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "crs-cqdfdzvt", d.Id())
+	assert.Equal(t, true, d.Get("enabled"))
+	assert.Equal(t, 8, d.Get("min_length"))
+}
+
+// TestRedisInstancePasswordPolicyConfig_Update_Success tests Update calls ModifyInstancePasswordPolicy and refreshes
+func TestRedisInstancePasswordPolicyConfig_Update_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	redisClient := &redis.Client{}
+	patches.ApplyMethodReturn(newMockMetaForRedisInstancePasswordPolicyConfig().client, "UseRedisClient", redisClient)
+
+	// Mock ModifyInstancePasswordPolicyWithContext
+	patches.ApplyMethodFunc(redisClient, "ModifyInstancePasswordPolicyWithContext", func(ctx context.Context, request *redis.ModifyInstancePasswordPolicyRequest) (*redis.ModifyInstancePasswordPolicyResponse, error) {
+		assert.Equal(t, "crs-cqdfdzvt", *request.InstanceId)
+		assert.NotNil(t, request.PasswordPolicy)
+		assert.Equal(t, false, *request.PasswordPolicy.Enabled)
+		resp := redis.NewModifyInstancePasswordPolicyResponse()
+		resp.Response = &redis.ModifyInstancePasswordPolicyResponseParams{
+			RequestId: ptrStrPasswordPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeInstancePasswordPolicyWithContext for Read
+	patches.ApplyMethodFunc(redisClient, "DescribeInstancePasswordPolicyWithContext", func(ctx context.Context, request *redis.DescribeInstancePasswordPolicyRequest) (*redis.DescribeInstancePasswordPolicyResponse, error) {
+		resp := redis.NewDescribeInstancePasswordPolicyResponse()
+		resp.Response = &redis.DescribeInstancePasswordPolicyResponseParams{
+			PasswordPolicy: &redis.PasswordPolicy{
+				Enabled:         ptrBoolPasswordPolicy(false),
+				MinLetterCount:  ptrInt64PasswordPolicy(2),
+				MinDigitCount:   ptrInt64PasswordPolicy(2),
+				MinSpecialCount: ptrInt64PasswordPolicy(2),
+				MinLength:       ptrInt64PasswordPolicy(16),
+			},
+			RequestId: ptrStrPasswordPolicy("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForRedisInstancePasswordPolicyConfig()
+	res := svccrs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id":       "crs-cqdfdzvt",
+		"enabled":           false,
+		"min_letter_count":  2,
+		"min_digit_count":   2,
+		"min_special_count": 2,
+		"min_length":        16,
+	})
+	d.SetId("crs-cqdfdzvt")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, false, d.Get("enabled"))
+	assert.Equal(t, 16, d.Get("min_length"))
+}
+
+// TestRedisInstancePasswordPolicyConfig_Delete_NoOp tests Delete is a no-op
+func TestRedisInstancePasswordPolicyConfig_Delete_NoOp(t *testing.T) {
+	meta := newMockMetaForRedisInstancePasswordPolicyConfig()
+	res := svccrs.ResourceTencentCloudRedisInstancePasswordPolicyConfig()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": "crs-cqdfdzvt",
+		"enabled":     true,
+	})
+	d.SetId("crs-cqdfdzvt")
+
+	err := res.Delete(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "crs-cqdfdzvt", d.Id())
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412/client.go
@@ -3103,6 +3103,56 @@ func (c *Client) DescribeInstanceParamsWithContext(ctx context.Context, request 
     return
 }
 
+func NewDescribeInstancePasswordPolicyRequest() (request *DescribeInstancePasswordPolicyRequest) {
+    request = &DescribeInstancePasswordPolicyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("redis", APIVersion, "DescribeInstancePasswordPolicy")
+    
+    
+    return
+}
+
+func NewDescribeInstancePasswordPolicyResponse() (response *DescribeInstancePasswordPolicyResponse) {
+    response = &DescribeInstancePasswordPolicyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeInstancePasswordPolicy
+// 查询指定实例当前密码复杂度配置
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCENOTEXISTS = "ResourceNotFound.InstanceNotExists"
+func (c *Client) DescribeInstancePasswordPolicy(request *DescribeInstancePasswordPolicyRequest) (response *DescribeInstancePasswordPolicyResponse, err error) {
+    return c.DescribeInstancePasswordPolicyWithContext(context.Background(), request)
+}
+
+// DescribeInstancePasswordPolicy
+// 查询指定实例当前密码复杂度配置
+//
+// 可能返回的错误码:
+//  RESOURCENOTFOUND_INSTANCENOTEXISTS = "ResourceNotFound.InstanceNotExists"
+func (c *Client) DescribeInstancePasswordPolicyWithContext(ctx context.Context, request *DescribeInstancePasswordPolicyRequest) (response *DescribeInstancePasswordPolicyResponse, err error) {
+    if request == nil {
+        request = NewDescribeInstancePasswordPolicyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "redis", APIVersion, "DescribeInstancePasswordPolicy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeInstancePasswordPolicy require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeInstancePasswordPolicyResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeInstanceSecurityGroupRequest() (request *DescribeInstanceSecurityGroupRequest) {
     request = &DescribeInstanceSecurityGroupRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -3556,15 +3606,10 @@ func NewDescribeLogsResponse() (response *DescribeLogsResponse) {
 // 查询日志
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_SYSTEMERROR = "FailedOperation.SystemError"
-//  FAILEDOPERATION_UNKNOWN = "FailedOperation.Unknown"
-//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  INVALIDPARAMETER_EMPTYPARAM = "InvalidParameter.EmptyParam"
-//  INVALIDPARAMETER_INVALIDPARAMETER = "InvalidParameter.InvalidParameter"
-//  INVALIDPARAMETER_PERMISSIONDENIED = "InvalidParameter.PermissionDenied"
-//  UNAUTHORIZEDOPERATION_NOCAMAUTHED = "UnauthorizedOperation.NoCAMAuthed"
-//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+//  FAILEDOPERATION_SERVICEACCESSERROR = "FailedOperation.ServiceAccessError"
+//  INVALIDPARAMETER_INVALIDPARAMETERERROR = "InvalidParameter.InvalidParameterError"
+//  INVALIDPARAMETERVALUE_DATACONVERTERROR = "InvalidParameterValue.DataConvertError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 func (c *Client) DescribeLogs(request *DescribeLogsRequest) (response *DescribeLogsResponse, err error) {
     return c.DescribeLogsWithContext(context.Background(), request)
 }
@@ -3573,15 +3618,10 @@ func (c *Client) DescribeLogs(request *DescribeLogsRequest) (response *DescribeL
 // 查询日志
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION_SYSTEMERROR = "FailedOperation.SystemError"
-//  FAILEDOPERATION_UNKNOWN = "FailedOperation.Unknown"
-//  INTERNALERROR_DBOPERATIONFAILED = "InternalError.DbOperationFailed"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  INVALIDPARAMETER_EMPTYPARAM = "InvalidParameter.EmptyParam"
-//  INVALIDPARAMETER_INVALIDPARAMETER = "InvalidParameter.InvalidParameter"
-//  INVALIDPARAMETER_PERMISSIONDENIED = "InvalidParameter.PermissionDenied"
-//  UNAUTHORIZEDOPERATION_NOCAMAUTHED = "UnauthorizedOperation.NoCAMAuthed"
-//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+//  FAILEDOPERATION_SERVICEACCESSERROR = "FailedOperation.ServiceAccessError"
+//  INVALIDPARAMETER_INVALIDPARAMETERERROR = "InvalidParameter.InvalidParameterError"
+//  INVALIDPARAMETERVALUE_DATACONVERTERROR = "InvalidParameterValue.DataConvertError"
+//  INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 func (c *Client) DescribeLogsWithContext(ctx context.Context, request *DescribeLogsRequest) (response *DescribeLogsResponse, err error) {
     if request == nil {
         request = NewDescribeLogsRequest()
@@ -6159,6 +6199,64 @@ func (c *Client) ModifyInstancePasswordWithContext(ctx context.Context, request 
     request.SetContext(ctx)
     
     response = NewModifyInstancePasswordResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyInstancePasswordPolicyRequest() (request *ModifyInstancePasswordPolicyRequest) {
+    request = &ModifyInstancePasswordPolicyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("redis", APIVersion, "ModifyInstancePasswordPolicy")
+    
+    
+    return
+}
+
+func NewModifyInstancePasswordPolicyResponse() (response *ModifyInstancePasswordPolicyResponse) {
+    response = &ModifyInstancePasswordPolicyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyInstancePasswordPolicy
+// 本接口（ModifyInstancePasswordPolicy）用于修改实例密码复杂度。
+//
+// 可能返回的错误码:
+//  INTERNALERROR_INSTANCENOTFOUNDERROR = "InternalError.InstanceNotFoundError"
+//  RESOURCENOTFOUND_INSTANCENOTEXISTS = "ResourceNotFound.InstanceNotExists"
+//  RESOURCENOTFOUND_INSTANCENOTFOUND = "ResourceNotFound.InstanceNotFound"
+//  RESOURCEUNAVAILABLE_INSTANCENOTSUPPORTOPERATION = "ResourceUnavailable.InstanceNotSupportOperation"
+//  UNSUPPORTEDOPERATION_INSTANCENOTOPERATION = "UnsupportedOperation.InstanceNotOperation"
+func (c *Client) ModifyInstancePasswordPolicy(request *ModifyInstancePasswordPolicyRequest) (response *ModifyInstancePasswordPolicyResponse, err error) {
+    return c.ModifyInstancePasswordPolicyWithContext(context.Background(), request)
+}
+
+// ModifyInstancePasswordPolicy
+// 本接口（ModifyInstancePasswordPolicy）用于修改实例密码复杂度。
+//
+// 可能返回的错误码:
+//  INTERNALERROR_INSTANCENOTFOUNDERROR = "InternalError.InstanceNotFoundError"
+//  RESOURCENOTFOUND_INSTANCENOTEXISTS = "ResourceNotFound.InstanceNotExists"
+//  RESOURCENOTFOUND_INSTANCENOTFOUND = "ResourceNotFound.InstanceNotFound"
+//  RESOURCEUNAVAILABLE_INSTANCENOTSUPPORTOPERATION = "ResourceUnavailable.InstanceNotSupportOperation"
+//  UNSUPPORTEDOPERATION_INSTANCENOTOPERATION = "UnsupportedOperation.InstanceNotOperation"
+func (c *Client) ModifyInstancePasswordPolicyWithContext(ctx context.Context, request *ModifyInstancePasswordPolicyRequest) (response *ModifyInstancePasswordPolicyResponse, err error) {
+    if request == nil {
+        request = NewModifyInstancePasswordPolicyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "redis", APIVersion, "ModifyInstancePasswordPolicy")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyInstancePasswordPolicy require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyInstancePasswordPolicyResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412/errors.go
@@ -53,6 +53,9 @@ const (
 	// 暂时笼统的定义这个错误码。
 	FAILEDOPERATION_REDOFLOWFAILED = "FailedOperation.RedoFlowFailed"
 
+	// 访问服务Log失败，请稍后重试。如果持续不成功，请联系客服进行处理
+	FAILEDOPERATION_SERVICEACCESSERROR = "FailedOperation.ServiceAccessError"
+
 	// 设置规则失败。
 	FAILEDOPERATION_SETRULELOCATIONFAILED = "FailedOperation.SetRuleLocationFailed"
 
@@ -82,6 +85,9 @@ const (
 
 	// 执行Http请求失败。
 	INTERNALERROR_EXECHTTPREQUESTERROR = "InternalError.ExecHttpRequestError"
+
+	// 找不到该实例。
+	INTERNALERROR_INSTANCENOTFOUNDERROR = "InternalError.InstanceNotFoundError"
 
 	// 无操作权限。
 	INTERNALERROR_INSTANCEOPERATEPERMISSIONERROR = "InternalError.InstanceOperatePermissionError"
@@ -113,6 +119,9 @@ const (
 	// 业务参数错误。
 	INVALIDPARAMETER_INVALIDPARAMETER = "InvalidParameter.InvalidParameter"
 
+	// 非法的参数。
+	INVALIDPARAMETER_INVALIDPARAMETERERROR = "InvalidParameter.InvalidParameterError"
+
 	// 不是vpc网络下实例。
 	INVALIDPARAMETER_ISNOTVPCINSTANCE = "InvalidParameter.IsNotVpcInstance"
 
@@ -140,11 +149,17 @@ const (
 	// 业务校验不通过。
 	INVALIDPARAMETERVALUE_CHECKNOTPASS = "InvalidParameterValue.CheckNotPass"
 
+	// 数据转换失败
+	INVALIDPARAMETERVALUE_DATACONVERTERROR = "InvalidParameterValue.DataConvertError"
+
 	// 重命名，命名规则错误。
 	INVALIDPARAMETERVALUE_INSTANCENAMERULEERROR = "InvalidParameterValue.InstanceNameRuleError"
 
 	// 请求购买的实例类型错误（TypeId 1:集群版；2:主从版,即原主从版)。
 	INVALIDPARAMETERVALUE_INVALIDINSTANCETYPEID = "InvalidParameterValue.InvalidInstanceTypeId"
+
+	// 非法的入参。
+	INVALIDPARAMETERVALUE_INVALIDPARAMETERVALUEERROR = "InvalidParameterValue.InvalidParameterValueError"
 
 	// vpc网络下，vpcid 子网id 非法。
 	INVALIDPARAMETERVALUE_INVALIDSUBNETID = "InvalidParameterValue.InvalidSubnetId"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412/models.go
@@ -578,21 +578,27 @@ func (r *ChangeMasterInstanceResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ChangeReplicaToMasterRequestParams struct {
-	// 指定实例 ID。例如：crs-xjhsdj****。请登录[Redis控制台](https://console.cloud.tencent.com/redis)在实例列表复制实例 ID。
+	// <p>指定实例 ID。例如：crs-xjhsdj****。请登录<a href="https://console.cloud.tencent.com/redis">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 副本节点组 ID，请通过接口[DescribeInstanceZoneInfo](https://cloud.tencent.com/document/product/239/50312)获取多 AZ备节点组的 ID 信息。单 AZ，则无需配置该参数。
+	// <p>副本节点组 ID，请通过接口<a href="https://cloud.tencent.com/document/product/239/50312">DescribeInstanceZoneInfo</a>获取多 AZ备节点组的 ID 信息。单 AZ，则无需配置该参数。</p>
 	GroupId *int64 `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>紧急模式。</p><p>枚举值：</p><ul><li>false： 标准模式（安全推荐）</li><li>true： 极速模式：（高危加速）跳过校验、极速提主。高位操作，极易在异常情况下产生单主节点。</li></ul><p>默认值：false</p>
+	Emergency *bool `json:"Emergency,omitnil,omitempty" name:"Emergency"`
 }
 
 type ChangeReplicaToMasterRequest struct {
 	*tchttp.BaseRequest
 	
-	// 指定实例 ID。例如：crs-xjhsdj****。请登录[Redis控制台](https://console.cloud.tencent.com/redis)在实例列表复制实例 ID。
+	// <p>指定实例 ID。例如：crs-xjhsdj****。请登录<a href="https://console.cloud.tencent.com/redis">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 副本节点组 ID，请通过接口[DescribeInstanceZoneInfo](https://cloud.tencent.com/document/product/239/50312)获取多 AZ备节点组的 ID 信息。单 AZ，则无需配置该参数。
+	// <p>副本节点组 ID，请通过接口<a href="https://cloud.tencent.com/document/product/239/50312">DescribeInstanceZoneInfo</a>获取多 AZ备节点组的 ID 信息。单 AZ，则无需配置该参数。</p>
 	GroupId *int64 `json:"GroupId,omitnil,omitempty" name:"GroupId"`
+
+	// <p>紧急模式。</p><p>枚举值：</p><ul><li>false： 标准模式（安全推荐）</li><li>true： 极速模式：（高危加速）跳过校验、极速提主。高位操作，极易在异常情况下产生单主节点。</li></ul><p>默认值：false</p>
+	Emergency *bool `json:"Emergency,omitnil,omitempty" name:"Emergency"`
 }
 
 func (r *ChangeReplicaToMasterRequest) ToJsonString() string {
@@ -609,6 +615,7 @@ func (r *ChangeReplicaToMasterRequest) FromJsonString(s string) error {
 	}
 	delete(f, "InstanceId")
 	delete(f, "GroupId")
+	delete(f, "Emergency")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ChangeReplicaToMasterRequest has unknown keys!", "")
 	}
@@ -617,7 +624,7 @@ func (r *ChangeReplicaToMasterRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ChangeReplicaToMasterResponseParams struct {
-	// 异步任务ID。
+	// <p>异步任务ID。</p>
 	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -774,145 +781,159 @@ func (r *ClearInstanceResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CloneInstancesRequestParams struct {
-	// 指定待克隆的源实例 ID。例如：crs-xjhsdj****。请登录[Redis控制台](https://console.cloud.tencent.com/redis)在实例列表复制实例 ID。
+	// <p>指定待克隆的源实例 ID。例如：crs-xjhsdj****。请登录<a href="https://console.cloud.tencent.com/redis">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 单次克隆实例的数量。
-	// - 包年包月每次购买最大数量为100。
-	// - 按量计费每次购买最大数量为30。
+	// <p>单次克隆实例的数量。</p><ul><li>包年包月每次购买最大数量为100。</li><li>按量计费每次购买最大数量为30。</li></ul>
 	GoodsNum *uint64 `json:"GoodsNum,omitnil,omitempty" name:"GoodsNum"`
 
-	// 克隆实例所属的可用区ID。当前所支持的可用区 ID，请参见[地域和可用区](https://cloud.tencent.com/document/product/239/4106) 。
+	// <p>克隆实例所属的可用区ID。当前所支持的可用区 ID，请参见<a href="https://cloud.tencent.com/document/product/239/4106">地域和可用区</a> 。</p>
 	ZoneId *uint64 `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 付费方式。<ul><li>0：按量计费。</li><li>1：包年包月。</li></ul>
+	// <p>付费方式。<ul><li>0：按量计费。</li><li>1：包年包月。</li></ul></p>
 	BillingMode *int64 `json:"BillingMode,omitnil,omitempty" name:"BillingMode"`
 
-	// 购买实例时长。<ul><li>单位：月。</li><li>付费方式选择包年包月计费时，取值范围为[1,2,3,4,5,6,7,8,9,10,11,12,24,36,48,60]。</li><li>付费方式选择按量计费时，设置为1。</li></ul>
+	// <p>购买实例时长。<ul><li>单位：月。</li><li>付费方式选择包年包月计费时，取值范围为[1,2,3,4,5,6,7,8,9,10,11,12,24,36,48,60]。</li><li>付费方式选择按量计费时，设置为1。</li></ul></p>
 	Period *uint64 `json:"Period,omitnil,omitempty" name:"Period"`
 
-	// 安全组ID。请通过 [DescribeInstanceSecurityGroup](https://cloud.tencent.com/document/product/239/34447) 接口获取实例的安全组 ID。
+	// <p>安全组ID。请通过 <a href="https://cloud.tencent.com/document/product/239/34447">DescribeInstanceSecurityGroup</a> 接口获取实例的安全组 ID。</p>
 	SecurityGroupIdList []*string `json:"SecurityGroupIdList,omitnil,omitempty" name:"SecurityGroupIdList"`
 
-	// 克隆实例使用的备份ID。请通过接口[DescribeInstanceBackups](https://cloud.tencent.com/document/product/239/20011)获取备份ID。
+	// <p>克隆实例使用的备份ID。请通过接口<a href="https://cloud.tencent.com/document/product/239/20011">DescribeInstanceBackups</a>获取备份ID。</p>
 	BackupId *string `json:"BackupId,omitnil,omitempty" name:"BackupId"`
 
-	// 配置克隆实例是否支持免密访问。开启 SSL 与外网均不支持免密访问。<ul><li>true：免密实例，</li><li>false：非免密实例。默认为非免密实例。</li></ul>
+	// <p>配置克隆实例是否支持免密访问。开启 SSL 与外网均不支持免密访问。<ul><li>true：免密实例，</li><li>false：非免密实例。默认为非免密实例。</li></ul></p>
 	NoAuth *bool `json:"NoAuth,omitnil,omitempty" name:"NoAuth"`
 
-	// 配置克隆实例的私有网络ID。如果未配置该参数，默认选择基础网络。
+	// <p>配置克隆实例的私有网络ID。如果未配置该参数，默认选择基础网络。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// 配置克隆实例所属私有网络的子网。基础网络时该参数无需配置。
+	// <p>配置克隆实例所属私有网络的子网。基础网络时该参数无需配置。</p>
 	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
-	// 克隆实例的名称。<br>仅支持长度小于60的中文、英文或者数字，短划线"-"、下划线"_"。</br>
+	// <p>克隆实例的名称。<br>仅支持长度小于60的中文、英文或者数字，短划线&quot;-&quot;、下划线&quot;_&quot;。<br></p>
 	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
 
-	// 克隆实例的访问密码。<ul><li>当输入参数<b>NoAuth</b>为<b>true</b>时，可不设置该参数。</li><li>当实例为Redis2.8、4.0和5.0时，其密码格式为：8-30个字符，至少包含小写字母、大写字母、数字和字符 ()`~!@#$%^&*-+=_|{}[]:;<>,.?/ 中的2种，不能以"/"开头；</li><li>当实例为CKV 3.2时，其密码格式为：8-30个字符，必须包含字母和数字，且不包含其他字符。</li></ul>
+	// <p>克隆实例的访问密码。<ul><li>当输入参数<b>NoAuth</b>为<b>true</b>时，可不设置该参数。</li><li>当实例为Redis2.8、4.0和5.0时，其密码格式为：8-30个字符，至少包含小写字母、大写字母、数字和字符 ()`~!@#$%^&amp;*-+=_|{}[]:;&lt;&gt;,.?/ 中的2种，不能以&quot;/&quot;开头；</li><li>当实例为CKV 3.2时，其密码格式为：8-30个字符，必须包含字母和数字，且不包含其他字符。</li></ul></p>
 	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
-	// 自动续费标识。<ul><li>0：默认状态，手动续费。</li><li>1：自动续费。</li><li>2：不自动续费，到期自动隔离。</li></ul>
+	// <p>自动续费标识。<ul><li>0：默认状态，手动续费。</li><li>1：自动续费。</li><li>2：不自动续费，到期自动隔离。</li></ul></p>
 	AutoRenew *uint64 `json:"AutoRenew,omitnil,omitempty" name:"AutoRenew"`
 
-	// 用户自定义的端口，默认为6379，取值范围[1024,65535]。
+	// <p>用户自定义的端口，默认为6379，取值范围[1024,65535]。</p>
 	VPort *uint64 `json:"VPort,omitnil,omitempty" name:"VPort"`
 
-	// 实例的节点信息。<ul><li>目前支持配置节点的类型（主节点或者副本节点），及其节点的可用区信息。具体信息，请参见[RedisNodeInfo](https://cloud.tencent.com/document/product/239/20022#RedisNodeInfo)。</li><li>单可用区部署可不配置该参数。</li></ul>
+	// <p>实例的节点信息。<ul><li>目前支持配置节点的类型（主节点或者副本节点），及其节点的可用区信息。具体信息，请参见<a href="https://cloud.tencent.com/document/product/239/20022#RedisNodeInfo">RedisNodeInfo</a>。</li><li>单可用区部署可不配置该参数。</li></ul></p>
 	NodeSet []*RedisNodeInfo `json:"NodeSet,omitnil,omitempty" name:"NodeSet"`
 
-	// 项目 ID。登录[Redis 控制台](https://console.cloud.tencent.com/redis#/)，可在右上角的<b>账号中心</b> > <b>项目管理</b>中查找项目ID。
+	// <p>项目 ID。登录<a href="https://console.cloud.tencent.com/redis#/">Redis 控制台</a>，可在右上角的<b>账号中心</b> &gt; <b>项目管理</b>中查找项目ID。</p>
 	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
-	// 克隆实例需绑定的标签。
+	// <p>克隆实例需绑定的标签。</p>
 	ResourceTags []*ResourceTag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 
-	// 指定克隆实例相关的参数模板 ID。
-	// - 若不配置该参数，则系统会依据所选择的兼容版本及架构，自动适配对应的默认模板。
-	// - 请通过[DescribeParamTemplates](https://cloud.tencent.com/document/product/239/58750)接口，查询实例的参数模板列表，获取模板 ID 编号。
+	// <p>指定克隆实例相关的参数模板 ID。</p><ul><li>若不配置该参数，则系统会依据所选择的兼容版本及架构，自动适配对应的默认模板。</li><li>请通过<a href="https://cloud.tencent.com/document/product/239/58750">DescribeParamTemplates</a>接口，查询实例的参数模板列表，获取模板 ID 编号。</li></ul>
 	TemplateId *string `json:"TemplateId,omitnil,omitempty" name:"TemplateId"`
 
-	// 指定克隆实例的告警策略 ID。请登录[腾讯云可观测平台控制台](https://console.cloud.tencent.com/monitor/alarm2/policy)，在 <b>告警管理</b> > <b>策略管理</b>页面获取策略 ID 信息。
+	// <p>指定克隆实例的告警策略 ID。请登录<a href="https://console.cloud.tencent.com/monitor/alarm2/policy">腾讯云可观测平台控制台</a>，在 <b>告警管理</b> &gt; <b>策略管理</b>页面获取策略 ID 信息。</p>
 	AlarmPolicyList []*string `json:"AlarmPolicyList,omitnil,omitempty" name:"AlarmPolicyList"`
 
-	// 克隆指定恢复数据的时间。
-	// 仅支持已开通秒级备份的实例
+	// <p>克隆指定恢复数据的时间。<br>仅支持已开通秒级备份的实例</p>
 	CloneTime *string `json:"CloneTime,omitnil,omitempty" name:"CloneTime"`
 
-	// 是否加密密码
+	// <p>是否加密密码</p>
 	EncryptPassword *bool `json:"EncryptPassword,omitnil,omitempty" name:"EncryptPassword"`
+
+	// <p>实例密码复杂度策略</p><p>入参限制：未传或 Enabled=false 视为不启用，按默认规则校验</p>
+	PasswordPolicy *PasswordPolicy `json:"PasswordPolicy,omitnil,omitempty" name:"PasswordPolicy"`
+
+	// <p>是否开启 SSL 加密传输。</p><p>枚举值：</p><ul><li>true： 开启。</li><li>false： 关闭（默认值）。</li></ul><p>默认值：false</p>
+	EnableSSL *bool `json:"EnableSSL,omitnil,omitempty" name:"EnableSSL"`
+
+	// <p>开启 SSL 时，是否将实例的内网 IPv4 地址写入证书的域名别名（SAN）中。仅在 EnableSSL 为 true 时生效。</p><p>枚举值：</p><ul><li>true： 允许使用内网 IP 进行 SSL 证书校验。</li><li>false： 不添加证书的 SAN 扩展信息。</li></ul><p>默认值：false</p>
+	SSLBindPrivateIPv4 *bool `json:"SSLBindPrivateIPv4,omitnil,omitempty" name:"SSLBindPrivateIPv4"`
+
+	// <p>指实例类型</p><p>枚举值：</p><ul><li>local： 通用 I 型</li><li>localv2： 通用 II 型</li></ul><p>不传则默认和原实例类型保持一致</p>
+	ProductVersion *string `json:"ProductVersion,omitnil,omitempty" name:"ProductVersion"`
 }
 
 type CloneInstancesRequest struct {
 	*tchttp.BaseRequest
 	
-	// 指定待克隆的源实例 ID。例如：crs-xjhsdj****。请登录[Redis控制台](https://console.cloud.tencent.com/redis)在实例列表复制实例 ID。
+	// <p>指定待克隆的源实例 ID。例如：crs-xjhsdj****。请登录<a href="https://console.cloud.tencent.com/redis">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 单次克隆实例的数量。
-	// - 包年包月每次购买最大数量为100。
-	// - 按量计费每次购买最大数量为30。
+	// <p>单次克隆实例的数量。</p><ul><li>包年包月每次购买最大数量为100。</li><li>按量计费每次购买最大数量为30。</li></ul>
 	GoodsNum *uint64 `json:"GoodsNum,omitnil,omitempty" name:"GoodsNum"`
 
-	// 克隆实例所属的可用区ID。当前所支持的可用区 ID，请参见[地域和可用区](https://cloud.tencent.com/document/product/239/4106) 。
+	// <p>克隆实例所属的可用区ID。当前所支持的可用区 ID，请参见<a href="https://cloud.tencent.com/document/product/239/4106">地域和可用区</a> 。</p>
 	ZoneId *uint64 `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 付费方式。<ul><li>0：按量计费。</li><li>1：包年包月。</li></ul>
+	// <p>付费方式。<ul><li>0：按量计费。</li><li>1：包年包月。</li></ul></p>
 	BillingMode *int64 `json:"BillingMode,omitnil,omitempty" name:"BillingMode"`
 
-	// 购买实例时长。<ul><li>单位：月。</li><li>付费方式选择包年包月计费时，取值范围为[1,2,3,4,5,6,7,8,9,10,11,12,24,36,48,60]。</li><li>付费方式选择按量计费时，设置为1。</li></ul>
+	// <p>购买实例时长。<ul><li>单位：月。</li><li>付费方式选择包年包月计费时，取值范围为[1,2,3,4,5,6,7,8,9,10,11,12,24,36,48,60]。</li><li>付费方式选择按量计费时，设置为1。</li></ul></p>
 	Period *uint64 `json:"Period,omitnil,omitempty" name:"Period"`
 
-	// 安全组ID。请通过 [DescribeInstanceSecurityGroup](https://cloud.tencent.com/document/product/239/34447) 接口获取实例的安全组 ID。
+	// <p>安全组ID。请通过 <a href="https://cloud.tencent.com/document/product/239/34447">DescribeInstanceSecurityGroup</a> 接口获取实例的安全组 ID。</p>
 	SecurityGroupIdList []*string `json:"SecurityGroupIdList,omitnil,omitempty" name:"SecurityGroupIdList"`
 
-	// 克隆实例使用的备份ID。请通过接口[DescribeInstanceBackups](https://cloud.tencent.com/document/product/239/20011)获取备份ID。
+	// <p>克隆实例使用的备份ID。请通过接口<a href="https://cloud.tencent.com/document/product/239/20011">DescribeInstanceBackups</a>获取备份ID。</p>
 	BackupId *string `json:"BackupId,omitnil,omitempty" name:"BackupId"`
 
-	// 配置克隆实例是否支持免密访问。开启 SSL 与外网均不支持免密访问。<ul><li>true：免密实例，</li><li>false：非免密实例。默认为非免密实例。</li></ul>
+	// <p>配置克隆实例是否支持免密访问。开启 SSL 与外网均不支持免密访问。<ul><li>true：免密实例，</li><li>false：非免密实例。默认为非免密实例。</li></ul></p>
 	NoAuth *bool `json:"NoAuth,omitnil,omitempty" name:"NoAuth"`
 
-	// 配置克隆实例的私有网络ID。如果未配置该参数，默认选择基础网络。
+	// <p>配置克隆实例的私有网络ID。如果未配置该参数，默认选择基础网络。</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// 配置克隆实例所属私有网络的子网。基础网络时该参数无需配置。
+	// <p>配置克隆实例所属私有网络的子网。基础网络时该参数无需配置。</p>
 	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
-	// 克隆实例的名称。<br>仅支持长度小于60的中文、英文或者数字，短划线"-"、下划线"_"。</br>
+	// <p>克隆实例的名称。<br>仅支持长度小于60的中文、英文或者数字，短划线&quot;-&quot;、下划线&quot;_&quot;。<br></p>
 	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
 
-	// 克隆实例的访问密码。<ul><li>当输入参数<b>NoAuth</b>为<b>true</b>时，可不设置该参数。</li><li>当实例为Redis2.8、4.0和5.0时，其密码格式为：8-30个字符，至少包含小写字母、大写字母、数字和字符 ()`~!@#$%^&*-+=_|{}[]:;<>,.?/ 中的2种，不能以"/"开头；</li><li>当实例为CKV 3.2时，其密码格式为：8-30个字符，必须包含字母和数字，且不包含其他字符。</li></ul>
+	// <p>克隆实例的访问密码。<ul><li>当输入参数<b>NoAuth</b>为<b>true</b>时，可不设置该参数。</li><li>当实例为Redis2.8、4.0和5.0时，其密码格式为：8-30个字符，至少包含小写字母、大写字母、数字和字符 ()`~!@#$%^&amp;*-+=_|{}[]:;&lt;&gt;,.?/ 中的2种，不能以&quot;/&quot;开头；</li><li>当实例为CKV 3.2时，其密码格式为：8-30个字符，必须包含字母和数字，且不包含其他字符。</li></ul></p>
 	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
-	// 自动续费标识。<ul><li>0：默认状态，手动续费。</li><li>1：自动续费。</li><li>2：不自动续费，到期自动隔离。</li></ul>
+	// <p>自动续费标识。<ul><li>0：默认状态，手动续费。</li><li>1：自动续费。</li><li>2：不自动续费，到期自动隔离。</li></ul></p>
 	AutoRenew *uint64 `json:"AutoRenew,omitnil,omitempty" name:"AutoRenew"`
 
-	// 用户自定义的端口，默认为6379，取值范围[1024,65535]。
+	// <p>用户自定义的端口，默认为6379，取值范围[1024,65535]。</p>
 	VPort *uint64 `json:"VPort,omitnil,omitempty" name:"VPort"`
 
-	// 实例的节点信息。<ul><li>目前支持配置节点的类型（主节点或者副本节点），及其节点的可用区信息。具体信息，请参见[RedisNodeInfo](https://cloud.tencent.com/document/product/239/20022#RedisNodeInfo)。</li><li>单可用区部署可不配置该参数。</li></ul>
+	// <p>实例的节点信息。<ul><li>目前支持配置节点的类型（主节点或者副本节点），及其节点的可用区信息。具体信息，请参见<a href="https://cloud.tencent.com/document/product/239/20022#RedisNodeInfo">RedisNodeInfo</a>。</li><li>单可用区部署可不配置该参数。</li></ul></p>
 	NodeSet []*RedisNodeInfo `json:"NodeSet,omitnil,omitempty" name:"NodeSet"`
 
-	// 项目 ID。登录[Redis 控制台](https://console.cloud.tencent.com/redis#/)，可在右上角的<b>账号中心</b> > <b>项目管理</b>中查找项目ID。
+	// <p>项目 ID。登录<a href="https://console.cloud.tencent.com/redis#/">Redis 控制台</a>，可在右上角的<b>账号中心</b> &gt; <b>项目管理</b>中查找项目ID。</p>
 	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
-	// 克隆实例需绑定的标签。
+	// <p>克隆实例需绑定的标签。</p>
 	ResourceTags []*ResourceTag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 
-	// 指定克隆实例相关的参数模板 ID。
-	// - 若不配置该参数，则系统会依据所选择的兼容版本及架构，自动适配对应的默认模板。
-	// - 请通过[DescribeParamTemplates](https://cloud.tencent.com/document/product/239/58750)接口，查询实例的参数模板列表，获取模板 ID 编号。
+	// <p>指定克隆实例相关的参数模板 ID。</p><ul><li>若不配置该参数，则系统会依据所选择的兼容版本及架构，自动适配对应的默认模板。</li><li>请通过<a href="https://cloud.tencent.com/document/product/239/58750">DescribeParamTemplates</a>接口，查询实例的参数模板列表，获取模板 ID 编号。</li></ul>
 	TemplateId *string `json:"TemplateId,omitnil,omitempty" name:"TemplateId"`
 
-	// 指定克隆实例的告警策略 ID。请登录[腾讯云可观测平台控制台](https://console.cloud.tencent.com/monitor/alarm2/policy)，在 <b>告警管理</b> > <b>策略管理</b>页面获取策略 ID 信息。
+	// <p>指定克隆实例的告警策略 ID。请登录<a href="https://console.cloud.tencent.com/monitor/alarm2/policy">腾讯云可观测平台控制台</a>，在 <b>告警管理</b> &gt; <b>策略管理</b>页面获取策略 ID 信息。</p>
 	AlarmPolicyList []*string `json:"AlarmPolicyList,omitnil,omitempty" name:"AlarmPolicyList"`
 
-	// 克隆指定恢复数据的时间。
-	// 仅支持已开通秒级备份的实例
+	// <p>克隆指定恢复数据的时间。<br>仅支持已开通秒级备份的实例</p>
 	CloneTime *string `json:"CloneTime,omitnil,omitempty" name:"CloneTime"`
 
-	// 是否加密密码
+	// <p>是否加密密码</p>
 	EncryptPassword *bool `json:"EncryptPassword,omitnil,omitempty" name:"EncryptPassword"`
+
+	// <p>实例密码复杂度策略</p><p>入参限制：未传或 Enabled=false 视为不启用，按默认规则校验</p>
+	PasswordPolicy *PasswordPolicy `json:"PasswordPolicy,omitnil,omitempty" name:"PasswordPolicy"`
+
+	// <p>是否开启 SSL 加密传输。</p><p>枚举值：</p><ul><li>true： 开启。</li><li>false： 关闭（默认值）。</li></ul><p>默认值：false</p>
+	EnableSSL *bool `json:"EnableSSL,omitnil,omitempty" name:"EnableSSL"`
+
+	// <p>开启 SSL 时，是否将实例的内网 IPv4 地址写入证书的域名别名（SAN）中。仅在 EnableSSL 为 true 时生效。</p><p>枚举值：</p><ul><li>true： 允许使用内网 IP 进行 SSL 证书校验。</li><li>false： 不添加证书的 SAN 扩展信息。</li></ul><p>默认值：false</p>
+	SSLBindPrivateIPv4 *bool `json:"SSLBindPrivateIPv4,omitnil,omitempty" name:"SSLBindPrivateIPv4"`
+
+	// <p>指实例类型</p><p>枚举值：</p><ul><li>local： 通用 I 型</li><li>localv2： 通用 II 型</li></ul><p>不传则默认和原实例类型保持一致</p>
+	ProductVersion *string `json:"ProductVersion,omitnil,omitempty" name:"ProductVersion"`
 }
 
 func (r *CloneInstancesRequest) ToJsonString() string {
@@ -948,6 +969,10 @@ func (r *CloneInstancesRequest) FromJsonString(s string) error {
 	delete(f, "AlarmPolicyList")
 	delete(f, "CloneTime")
 	delete(f, "EncryptPassword")
+	delete(f, "PasswordPolicy")
+	delete(f, "EnableSSL")
+	delete(f, "SSLBindPrivateIPv4")
+	delete(f, "ProductVersion")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CloneInstancesRequest has unknown keys!", "")
 	}
@@ -956,15 +981,15 @@ func (r *CloneInstancesRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CloneInstancesResponseParams struct {
-	// 交易的ID。
+	// <p>交易的ID。</p>
 	//
 	// Deprecated: DealId is deprecated.
 	DealId *string `json:"DealId,omitnil,omitempty" name:"DealId"`
 
-	// 克隆实例的 ID。
+	// <p>克隆实例的 ID。</p>
 	InstanceIds []*string `json:"InstanceIds,omitnil,omitempty" name:"InstanceIds"`
 
-	// 订单号。
+	// <p>订单号。</p>
 	DealName *string `json:"DealName,omitnil,omitempty" name:"DealName"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -1050,15 +1075,21 @@ func (r *CloseLogResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CloseSSLRequestParams struct {
-	// 实例 ID。请登录[Redis控制台](https://console.cloud.tencent.com/redis)在实例列表复制实例 ID。
+	// <p>实例 ID。请登录<a href="https://console.cloud.tencent.com/redis">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>SSL地址类型。</p><p>枚举值：</p><ul><li>0：  不限。</li><li>1： 内网IPv4。</li><li>2：  内网IPv6。</li><li>3： 外网。</li><li>-1： 未指定。</li></ul><p>默认值：0</p>
+	AddressType *int64 `json:"AddressType,omitnil,omitempty" name:"AddressType"`
 }
 
 type CloseSSLRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例 ID。请登录[Redis控制台](https://console.cloud.tencent.com/redis)在实例列表复制实例 ID。
+	// <p>实例 ID。请登录<a href="https://console.cloud.tencent.com/redis">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>SSL地址类型。</p><p>枚举值：</p><ul><li>0：  不限。</li><li>1： 内网IPv4。</li><li>2：  内网IPv6。</li><li>3： 外网。</li><li>-1： 未指定。</li></ul><p>默认值：0</p>
+	AddressType *int64 `json:"AddressType,omitnil,omitempty" name:"AddressType"`
 }
 
 func (r *CloseSSLRequest) ToJsonString() string {
@@ -1074,6 +1105,7 @@ func (r *CloseSSLRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "InstanceId")
+	delete(f, "AddressType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CloseSSLRequest has unknown keys!", "")
 	}
@@ -1082,7 +1114,7 @@ func (r *CloseSSLRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CloseSSLResponseParams struct {
-	// 任务ID。
+	// <p>任务ID。</p>
 	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -1182,6 +1214,9 @@ func (r *CreateExportTaskRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateExportTaskResponseParams struct {
+	// <p>文件名称</p>
+	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
+
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
@@ -1204,68 +1239,50 @@ func (r *CreateExportTaskResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateInstanceAccountRequestParams struct {
-	// 实例 ID，请登录[Redis控制台](https://console.cloud.tencent.com/redis)在实例列表复制实例 ID。
+	// <p>实例 ID，请登录<a href="https://console.cloud.tencent.com/redis">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 自定义的访问数据库的账号名称。
-	// - 仅由字母、数字、下划线、中划线组成。
-	// - 长度不能大于32位。
+	// <p>自定义的访问数据库的账号名称。</p><ul><li>仅由字母、数字、下划线、中划线组成。</li><li>长度不能大于32位。</li></ul>
 	AccountName *string `json:"AccountName,omitnil,omitempty" name:"AccountName"`
 
-	// 设置自定义账号的密码。密码复杂度要求如下：
-	// - 字符个数为[8,64]。
-	// - 至少包含小写字母、大写字母、数字和字符 ()`~!@#$%^&*-+=_|{}[]:;<>,.?/ 中的两种。
-	// - 不能以"/"开头。
+	// <p>设置自定义账号的密码。密码复杂度要求如下：</p><ul><li>字符个数为[8,64]。</li><li>至少包含小写字母、大写字母、数字和字符 ()`~!@#$%^&amp;*-+=_|{}[]:;&lt;&gt;,.?/ 中的两种。</li><li>不能以&quot;/&quot;开头。</li></ul>
 	AccountPassword *string `json:"AccountPassword,omitnil,omitempty" name:"AccountPassword"`
 
-	// 指定账号的读请求路由分发至主节点或副本节点。未开启副本只读，不支持选择副本节点。
-	// - master：主节点
-	// - replication：副本节点
+	// <p>指定账号的读请求路由分发至主节点或副本节点。未开启副本只读，不支持选择副本节点。</p><ul><li>master：主节点</li><li>replication：副本节点</li></ul>
 	ReadonlyPolicy []*string `json:"ReadonlyPolicy,omitnil,omitempty" name:"ReadonlyPolicy"`
 
-	// 账户读写权限，支持选择只读与读写权限。
-	// - r：只读。
-	// - rw: 读写。
+	// <p>账户读写权限，支持选择只读与读写权限。</p><ul><li>r：只读。</li><li>rw: 读写。</li></ul>
 	Privilege *string `json:"Privilege,omitnil,omitempty" name:"Privilege"`
 
-	// 账号备注描述信息，长度为[0,64] 字节，支持中文。
+	// <p>账号备注描述信息，长度为[0,64] 字节，支持中文。</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 是否加密密码
+	// <p>是否启用密码加密传输。</p><ul><li>true：加密。</li><li>false：不加密（默认值）。</li></ul>
 	EncryptPassword *bool `json:"EncryptPassword,omitnil,omitempty" name:"EncryptPassword"`
 }
 
 type CreateInstanceAccountRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例 ID，请登录[Redis控制台](https://console.cloud.tencent.com/redis)在实例列表复制实例 ID。
+	// <p>实例 ID，请登录<a href="https://console.cloud.tencent.com/redis">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 自定义的访问数据库的账号名称。
-	// - 仅由字母、数字、下划线、中划线组成。
-	// - 长度不能大于32位。
+	// <p>自定义的访问数据库的账号名称。</p><ul><li>仅由字母、数字、下划线、中划线组成。</li><li>长度不能大于32位。</li></ul>
 	AccountName *string `json:"AccountName,omitnil,omitempty" name:"AccountName"`
 
-	// 设置自定义账号的密码。密码复杂度要求如下：
-	// - 字符个数为[8,64]。
-	// - 至少包含小写字母、大写字母、数字和字符 ()`~!@#$%^&*-+=_|{}[]:;<>,.?/ 中的两种。
-	// - 不能以"/"开头。
+	// <p>设置自定义账号的密码。密码复杂度要求如下：</p><ul><li>字符个数为[8,64]。</li><li>至少包含小写字母、大写字母、数字和字符 ()`~!@#$%^&amp;*-+=_|{}[]:;&lt;&gt;,.?/ 中的两种。</li><li>不能以&quot;/&quot;开头。</li></ul>
 	AccountPassword *string `json:"AccountPassword,omitnil,omitempty" name:"AccountPassword"`
 
-	// 指定账号的读请求路由分发至主节点或副本节点。未开启副本只读，不支持选择副本节点。
-	// - master：主节点
-	// - replication：副本节点
+	// <p>指定账号的读请求路由分发至主节点或副本节点。未开启副本只读，不支持选择副本节点。</p><ul><li>master：主节点</li><li>replication：副本节点</li></ul>
 	ReadonlyPolicy []*string `json:"ReadonlyPolicy,omitnil,omitempty" name:"ReadonlyPolicy"`
 
-	// 账户读写权限，支持选择只读与读写权限。
-	// - r：只读。
-	// - rw: 读写。
+	// <p>账户读写权限，支持选择只读与读写权限。</p><ul><li>r：只读。</li><li>rw: 读写。</li></ul>
 	Privilege *string `json:"Privilege,omitnil,omitempty" name:"Privilege"`
 
-	// 账号备注描述信息，长度为[0,64] 字节，支持中文。
+	// <p>账号备注描述信息，长度为[0,64] 字节，支持中文。</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 是否加密密码
+	// <p>是否启用密码加密传输。</p><ul><li>true：加密。</li><li>false：不加密（默认值）。</li></ul>
 	EncryptPassword *bool `json:"EncryptPassword,omitnil,omitempty" name:"EncryptPassword"`
 }
 
@@ -1296,7 +1313,7 @@ func (r *CreateInstanceAccountRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateInstanceAccountResponseParams struct {
-	// 任务ID。
+	// <p>任务ID。</p>
 	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -1321,7 +1338,7 @@ func (r *CreateInstanceAccountResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateInstancesRequestParams struct {
-	// <p>实例类型。</p><ul><li>2：Redis 2.8 内存版（标准架构）。</li><li>3：CKV 3.2 内存版（标准架构）。</li><li>4：CKV 3.2 内存版（集群架构）。</li><li>6：Redis 4.0 内存版（标准架构）。</li><li>7：Redis 4.0 内存版（集群架构）。</li><li>8：Redis 5.0 内存版（标准架构）。</li><li>9：Redis 5.0 内存版（集群架构）。</li><li>15：Redis 6.2 内存版（标准架构）。</li><li>16：Redis 6.2 内存版（集群架构）。</li><li>17：Redis 7.0 内存版（标准架构）。</li><li>18：Redis 7.0 内存版（集群架构）。</li><li>200：Memcached 1.6 内存版（集群架构）。<br><strong>说明</strong>：CKV 版本当前有存量用户使用，暂时保留。</li></ul>
+	// <p>实例类型。</p><ul><li>2：Redis 2.8 内存版（标准架构）。</li><li>3：CKV 3.2 内存版（标准架构）。</li><li>4：CKV 3.2 内存版（集群架构）。</li><li>6：Redis 4.0 内存版（标准架构）。</li><li>7：Redis 4.0 内存版（集群架构）。</li><li>8：Redis 5.0 内存版（标准架构）。</li><li>9：Redis 5.0 内存版（集群架构）。</li><li>15：Redis 6.2 内存版（标准架构）。</li><li>16：Redis 6.2 内存版（集群架构）。</li><li>17：Redis 7.0 内存版（标准架构）。</li><li>18：Redis 7.0 内存版（集群架构）。</li><li>19：Valkey 8.0 内存版（标准架构）。</li><li>20：Valkey 8.0 内存版（集群架构）。</li><li>21：Valkey 9.0 内存版（标准架构）。</li><li>22：Valkey 9.0 内存版（集群架构）。</li><li>200：Memcached 1.6 内存版（集群架构）。<br><strong>说明</strong>：CKV 版本当前有存量用户使用，暂时保留。</li></ul>
 	TypeId *uint64 `json:"TypeId,omitnil,omitempty" name:"TypeId"`
 
 	// <p>内存容量，单位为MB， 数值需为1024的整数倍。具体规格，请通过 <a href="https://cloud.tencent.com/document/api/239/30600">DescribeProductInfo</a> 接口查询全地域的售卖规格。</p><ul><li><strong>TypeId</strong>为标准架构时，<strong>MemSize</strong>是实例总内存容量；</li><li><strong>TypeId</strong>为集群架构时，<strong>MemSize</strong>是单分片内存容量。</li></ul>
@@ -1399,14 +1416,26 @@ type CreateInstancesRequestParams struct {
 	// <p>告警策略 ID 数组。</p><ul><li>请登录<a href="https://console.cloud.tencent.com/monitor/alarm/policy">腾讯云可观测平台-告警管理-策略管理</a>获取告警策略 ID。</li><li>若不配置该参数，则绑定默认告警策略。默认告警策略具体信息，请登录<a href="https://console.cloud.tencent.com/monitor/alarm/policy">腾讯云可观测平台-告警管理-策略管理</a>查看。</li></ul>
 	AlarmPolicyList []*string `json:"AlarmPolicyList,omitnil,omitempty" name:"AlarmPolicyList"`
 
-	// <p>是否加密密码</p>
+	// <p>是否启用密码加密传输。</p><ul><li>true：加密。</li><li>false：不加密（默认值）。</li></ul>
 	EncryptPassword *bool `json:"EncryptPassword,omitnil,omitempty" name:"EncryptPassword"`
+
+	// <p>实例级密码复杂度策略。未传入或 Enabled=false 时，视为不启用策略，按系统默认规则校验。</p>
+	PasswordPolicy *PasswordPolicy `json:"PasswordPolicy,omitnil,omitempty" name:"PasswordPolicy"`
+
+	// <p>是否开启 SSL 加密传输。</p><ul><li>true：开启。</li><li>false：关闭（默认值）。</li></ul>
+	EnableSSL *bool `json:"EnableSSL,omitnil,omitempty" name:"EnableSSL"`
+
+	// <p>开启 SSL 时，是否将实例的内网 IPv4 地址写入证书的域名别名（SAN）中。仅在 EnableSSL 为 true 时生效。</p><ul><li>true：允许使用内网 IP 进行 SSL 证书校验。</li><li>false：不添加证书的 SAN 扩展信息。</li></ul>
+	SSLBindPrivateIPv4 *bool `json:"SSLBindPrivateIPv4,omitnil,omitempty" name:"SSLBindPrivateIPv4"`
+
+	// <p>实例连接访问模式。</p><ul><li>0：代理模式（Proxy Mode，默认值）。</li><li>1：直连模式（Direct Connect Mode）。</li></ul>
+	ConnectionMode *int64 `json:"ConnectionMode,omitnil,omitempty" name:"ConnectionMode"`
 }
 
 type CreateInstancesRequest struct {
 	*tchttp.BaseRequest
 	
-	// <p>实例类型。</p><ul><li>2：Redis 2.8 内存版（标准架构）。</li><li>3：CKV 3.2 内存版（标准架构）。</li><li>4：CKV 3.2 内存版（集群架构）。</li><li>6：Redis 4.0 内存版（标准架构）。</li><li>7：Redis 4.0 内存版（集群架构）。</li><li>8：Redis 5.0 内存版（标准架构）。</li><li>9：Redis 5.0 内存版（集群架构）。</li><li>15：Redis 6.2 内存版（标准架构）。</li><li>16：Redis 6.2 内存版（集群架构）。</li><li>17：Redis 7.0 内存版（标准架构）。</li><li>18：Redis 7.0 内存版（集群架构）。</li><li>200：Memcached 1.6 内存版（集群架构）。<br><strong>说明</strong>：CKV 版本当前有存量用户使用，暂时保留。</li></ul>
+	// <p>实例类型。</p><ul><li>2：Redis 2.8 内存版（标准架构）。</li><li>3：CKV 3.2 内存版（标准架构）。</li><li>4：CKV 3.2 内存版（集群架构）。</li><li>6：Redis 4.0 内存版（标准架构）。</li><li>7：Redis 4.0 内存版（集群架构）。</li><li>8：Redis 5.0 内存版（标准架构）。</li><li>9：Redis 5.0 内存版（集群架构）。</li><li>15：Redis 6.2 内存版（标准架构）。</li><li>16：Redis 6.2 内存版（集群架构）。</li><li>17：Redis 7.0 内存版（标准架构）。</li><li>18：Redis 7.0 内存版（集群架构）。</li><li>19：Valkey 8.0 内存版（标准架构）。</li><li>20：Valkey 8.0 内存版（集群架构）。</li><li>21：Valkey 9.0 内存版（标准架构）。</li><li>22：Valkey 9.0 内存版（集群架构）。</li><li>200：Memcached 1.6 内存版（集群架构）。<br><strong>说明</strong>：CKV 版本当前有存量用户使用，暂时保留。</li></ul>
 	TypeId *uint64 `json:"TypeId,omitnil,omitempty" name:"TypeId"`
 
 	// <p>内存容量，单位为MB， 数值需为1024的整数倍。具体规格，请通过 <a href="https://cloud.tencent.com/document/api/239/30600">DescribeProductInfo</a> 接口查询全地域的售卖规格。</p><ul><li><strong>TypeId</strong>为标准架构时，<strong>MemSize</strong>是实例总内存容量；</li><li><strong>TypeId</strong>为集群架构时，<strong>MemSize</strong>是单分片内存容量。</li></ul>
@@ -1484,8 +1513,20 @@ type CreateInstancesRequest struct {
 	// <p>告警策略 ID 数组。</p><ul><li>请登录<a href="https://console.cloud.tencent.com/monitor/alarm/policy">腾讯云可观测平台-告警管理-策略管理</a>获取告警策略 ID。</li><li>若不配置该参数，则绑定默认告警策略。默认告警策略具体信息，请登录<a href="https://console.cloud.tencent.com/monitor/alarm/policy">腾讯云可观测平台-告警管理-策略管理</a>查看。</li></ul>
 	AlarmPolicyList []*string `json:"AlarmPolicyList,omitnil,omitempty" name:"AlarmPolicyList"`
 
-	// <p>是否加密密码</p>
+	// <p>是否启用密码加密传输。</p><ul><li>true：加密。</li><li>false：不加密（默认值）。</li></ul>
 	EncryptPassword *bool `json:"EncryptPassword,omitnil,omitempty" name:"EncryptPassword"`
+
+	// <p>实例级密码复杂度策略。未传入或 Enabled=false 时，视为不启用策略，按系统默认规则校验。</p>
+	PasswordPolicy *PasswordPolicy `json:"PasswordPolicy,omitnil,omitempty" name:"PasswordPolicy"`
+
+	// <p>是否开启 SSL 加密传输。</p><ul><li>true：开启。</li><li>false：关闭（默认值）。</li></ul>
+	EnableSSL *bool `json:"EnableSSL,omitnil,omitempty" name:"EnableSSL"`
+
+	// <p>开启 SSL 时，是否将实例的内网 IPv4 地址写入证书的域名别名（SAN）中。仅在 EnableSSL 为 true 时生效。</p><ul><li>true：允许使用内网 IP 进行 SSL 证书校验。</li><li>false：不添加证书的 SAN 扩展信息。</li></ul>
+	SSLBindPrivateIPv4 *bool `json:"SSLBindPrivateIPv4,omitnil,omitempty" name:"SSLBindPrivateIPv4"`
+
+	// <p>实例连接访问模式。</p><ul><li>0：代理模式（Proxy Mode，默认值）。</li><li>1：直连模式（Direct Connect Mode）。</li></ul>
+	ConnectionMode *int64 `json:"ConnectionMode,omitnil,omitempty" name:"ConnectionMode"`
 }
 
 func (r *CreateInstancesRequest) ToJsonString() string {
@@ -1527,6 +1568,10 @@ func (r *CreateInstancesRequest) FromJsonString(s string) error {
 	delete(f, "RedisClusterId")
 	delete(f, "AlarmPolicyList")
 	delete(f, "EncryptPassword")
+	delete(f, "PasswordPolicy")
+	delete(f, "EnableSSL")
+	delete(f, "SSLBindPrivateIPv4")
+	delete(f, "ConnectionMode")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateInstancesRequest has unknown keys!", "")
 	}
@@ -2112,20 +2157,20 @@ func (r *DescribeAutoBackupConfigResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeBackupDetailRequestParams struct {
-	// 实例 ID，请登录[Redis控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
+	// <p>实例 ID，请登录<a href="https://console.cloud.tencent.com/redis/instance/list">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 备份 ID，可通过接口 [DescribeInstanceBackups](https://cloud.tencent.com/document/product/239/20011) 返回的参数 **RedisBackupSet** 获取。
+	// <p>备份 ID，可通过接口 <a href="https://cloud.tencent.com/document/product/239/20011">DescribeInstanceBackups</a> 返回的参数 <strong>RedisBackupSet</strong> 获取。</p>
 	BackupId *string `json:"BackupId,omitnil,omitempty" name:"BackupId"`
 }
 
 type DescribeBackupDetailRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例 ID，请登录[Redis控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
+	// <p>实例 ID，请登录<a href="https://console.cloud.tencent.com/redis/instance/list">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 备份 ID，可通过接口 [DescribeInstanceBackups](https://cloud.tencent.com/document/product/239/20011) 返回的参数 **RedisBackupSet** 获取。
+	// <p>备份 ID，可通过接口 <a href="https://cloud.tencent.com/document/product/239/20011">DescribeInstanceBackups</a> 返回的参数 <strong>RedisBackupSet</strong> 获取。</p>
 	BackupId *string `json:"BackupId,omitnil,omitempty" name:"BackupId"`
 }
 
@@ -2151,53 +2196,53 @@ func (r *DescribeBackupDetailRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeBackupDetailResponseParams struct {
-	// 备份 ID。
+	// <p>备份 ID。</p>
 	BackupId *string `json:"BackupId,omitnil,omitempty" name:"BackupId"`
 
-	// 备份开始时间。
+	// <p>备份开始时间。</p>
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 备份结束时间。
+	// <p>备份结束时间。</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 备份方式。 
-	// 
-	// - 1：手动备份。
-	// -  0：自动备份。
+	// <p>备份方式。 </p><ul><li>1：手动备份。</li><li>0：自动备份。</li></ul>
 	BackupType *string `json:"BackupType,omitnil,omitempty" name:"BackupType"`
 
-	// 备份状态。 
-	// 
-	// - 1：备份被其它流程锁定。
-	// - 2：备份正常，没有被任何流程锁定。
-	// - -1：备份已过期。
-	// - 3：备份正在被导出。
-	// - 4：备份导出成功。
+	// <p>备份状态。 </p><ul><li>1：备份被其它流程锁定。</li><li>2：备份正常，没有被任何流程锁定。</li><li>-1：备份已过期。</li><li>3：备份正在被导出。</li><li>4：备份导出成功。</li></ul>
 	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 备份的备注信息。
+	// <p>备份的备注信息。</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 备份是否被锁定。
-	// 
-	// - 0：未被锁定。
-	// - 1：已被锁定。
+	// <p>备份是否被锁定。</p><ul><li>0：未被锁定。</li><li>1：已被锁定。</li></ul>
 	Locked *int64 `json:"Locked,omitnil,omitempty" name:"Locked"`
 
-	// 备份文件大小。单位：Byte。
+	// <p>备份文件大小。单位：Byte。</p>
 	BackupSize *int64 `json:"BackupSize,omitnil,omitempty" name:"BackupSize"`
 
-	// 实例类型。
+	// <p>实例类型。</p>
 	InstanceType *int64 `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
 
-	// 单分片内存规格大小，单位：MB。
+	// <p>单分片内存规格大小，单位：MB。</p>
 	MemSize *int64 `json:"MemSize,omitnil,omitempty" name:"MemSize"`
 
-	// 分片数量。
+	// <p>分片数量。</p>
 	ShardNum *int64 `json:"ShardNum,omitnil,omitempty" name:"ShardNum"`
 
-	// 副本数量。
+	// <p>副本数量。</p>
 	ReplicasNum *int64 `json:"ReplicasNum,omitnil,omitempty" name:"ReplicasNum"`
+
+	// <p>是否已加密。</p><p>枚举值：</p><ul><li>true： 已加密</li><li>false： 未加密</li></ul>
+	Encrypted *bool `json:"Encrypted,omitnil,omitempty" name:"Encrypted"`
+
+	// <p>解密密钥。</p>
+	DecryptKey *string `json:"DecryptKey,omitnil,omitempty" name:"DecryptKey"`
+
+	// <p>KMS的密钥ID。</p>
+	KmsKeyId *string `json:"KmsKeyId,omitnil,omitempty" name:"KmsKeyId"`
+
+	// <p>加密该备份文件的加密算法。</p><p>枚举值：</p><ul><li>AES-256-CBC： 当前仅支持AES-256-CBC</li></ul>
+	KeyAlgorithm *string `json:"KeyAlgorithm,omitnil,omitempty" name:"KeyAlgorithm"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -2908,62 +2953,50 @@ func (r *DescribeInstanceAccountResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeInstanceBackupsRequestParams struct {
-	// 每页输出的备份列表大小。默认大小为20，最大值为 100。
+	// <p>每页输出的备份列表大小。默认大小为20，最大值为 100。</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 分页偏移量，取Limit整数倍。计算公式：offset=limit*(页码-1)。
+	// <p>分页偏移量，取Limit整数倍。计算公式：offset=limit*(页码-1)。</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 待操作的实例ID，可通过 DescribeInstance 接口返回值中的 InstanceId 获取。
+	// <p>待操作的实例ID，可通过 DescribeInstance 接口返回值中的 InstanceId 获取。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 开始时间，格式如：2017-02-08 16:46:34。查询实例在 [beginTime, endTime] 时间段内开始备份的备份列表，查询时间最大跨度30天。
+	// <p>开始时间，格式如：2017-02-08 16:46:34。查询实例在 [beginTime, endTime] 时间段内开始备份的备份列表，查询时间最大跨度30天。</p>
 	BeginTime *string `json:"BeginTime,omitnil,omitempty" name:"BeginTime"`
 
-	// 结束时间，格式如：2017-02-08 19:09:26。查询实例在 [beginTime, endTime] 时间段内开始备份的备份列表，查询时间最大跨度30天。
+	// <p>结束时间，格式如：2017-02-08 19:09:26。查询实例在 [beginTime, endTime] 时间段内开始备份的备份列表，查询时间最大跨度30天。</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 备份任务的状态：
-	// 1：备份在流程中。
-	// 2：备份正常。
-	// 3：备份转RDB文件处理中。
-	// 4：已完成RDB转换。
-	// -1：备份已过期。
-	// -2：备份已删除。
+	// <p>备份任务的状态：<br>1：备份在流程中。<br>2：备份正常。<br>3：备份转RDB文件处理中。<br>4：已完成RDB转换。<br>-1：备份已过期。<br>-2：备份已删除。</p>
 	Status []*int64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 实例名称，支持根据实例名称模糊搜索。
+	// <p>实例名称，支持根据实例名称模糊搜索。</p>
 	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
 }
 
 type DescribeInstanceBackupsRequest struct {
 	*tchttp.BaseRequest
 	
-	// 每页输出的备份列表大小。默认大小为20，最大值为 100。
+	// <p>每页输出的备份列表大小。默认大小为20，最大值为 100。</p>
 	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
-	// 分页偏移量，取Limit整数倍。计算公式：offset=limit*(页码-1)。
+	// <p>分页偏移量，取Limit整数倍。计算公式：offset=limit*(页码-1)。</p>
 	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
-	// 待操作的实例ID，可通过 DescribeInstance 接口返回值中的 InstanceId 获取。
+	// <p>待操作的实例ID，可通过 DescribeInstance 接口返回值中的 InstanceId 获取。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 开始时间，格式如：2017-02-08 16:46:34。查询实例在 [beginTime, endTime] 时间段内开始备份的备份列表，查询时间最大跨度30天。
+	// <p>开始时间，格式如：2017-02-08 16:46:34。查询实例在 [beginTime, endTime] 时间段内开始备份的备份列表，查询时间最大跨度30天。</p>
 	BeginTime *string `json:"BeginTime,omitnil,omitempty" name:"BeginTime"`
 
-	// 结束时间，格式如：2017-02-08 19:09:26。查询实例在 [beginTime, endTime] 时间段内开始备份的备份列表，查询时间最大跨度30天。
+	// <p>结束时间，格式如：2017-02-08 19:09:26。查询实例在 [beginTime, endTime] 时间段内开始备份的备份列表，查询时间最大跨度30天。</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 备份任务的状态：
-	// 1：备份在流程中。
-	// 2：备份正常。
-	// 3：备份转RDB文件处理中。
-	// 4：已完成RDB转换。
-	// -1：备份已过期。
-	// -2：备份已删除。
+	// <p>备份任务的状态：<br>1：备份在流程中。<br>2：备份正常。<br>3：备份转RDB文件处理中。<br>4：已完成RDB转换。<br>-1：备份已过期。<br>-2：备份已删除。</p>
 	Status []*int64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 实例名称，支持根据实例名称模糊搜索。
+	// <p>实例名称，支持根据实例名称模糊搜索。</p>
 	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
 }
 
@@ -2994,10 +3027,10 @@ func (r *DescribeInstanceBackupsRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeInstanceBackupsResponseParams struct {
-	// 备份总数。
+	// <p>备份总数。</p>
 	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 实例的备份数组。
+	// <p>实例的备份数组。</p>
 	BackupSet []*RedisBackupSet `json:"BackupSet,omitnil,omitempty" name:"BackupSet"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -4161,6 +4194,63 @@ func (r *DescribeInstanceParamsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeInstancePasswordPolicyRequestParams struct {
+	// <p>实例 ID。请登录 <a href="https://console.cloud.tencent.com/redis">Redis 控制台</a>在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type DescribeInstancePasswordPolicyRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>实例 ID。请登录 <a href="https://console.cloud.tencent.com/redis">Redis 控制台</a>在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *DescribeInstancePasswordPolicyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeInstancePasswordPolicyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeInstancePasswordPolicyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeInstancePasswordPolicyResponseParams struct {
+	// <p>实例密码复杂度策略。</p>
+	PasswordPolicy *PasswordPolicy `json:"PasswordPolicy,omitnil,omitempty" name:"PasswordPolicy"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeInstancePasswordPolicyResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeInstancePasswordPolicyResponseParams `json:"Response"`
+}
+
+func (r *DescribeInstancePasswordPolicyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeInstancePasswordPolicyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeInstanceSecurityGroupRequestParams struct {
 	// 实例 ID 列表，数组长度限制[0,100]。请登录 [Redis 控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
 	InstanceIds []*string `json:"InstanceIds,omitnil,omitempty" name:"InstanceIds"`
@@ -4854,7 +4944,7 @@ type DescribeLogInstanceListRequestParams struct {
 	// <p>日志子类型。</p><p>枚举值：</p><ul><li>write： 写日志。</li><li>read： 读日志。</li><li>all： 读写日志。</li></ul>
 	LogSubType *string `json:"LogSubType,omitnil,omitempty" name:"LogSubType"`
 
-	// <p>日志开关。不传查询所有日志实例。</p><ul><li>on：开启。</li><li>off：关闭。</li></ul>
+	// <p>日志开关。</p><p>枚举值：</p><ul><li>on： 开启</li><li>off： 关闭</li></ul><p>默认值：off</p>
 	LogSwitch *string `json:"LogSwitch,omitnil,omitempty" name:"LogSwitch"`
 }
 
@@ -4876,7 +4966,7 @@ type DescribeLogInstanceListRequest struct {
 	// <p>日志子类型。</p><p>枚举值：</p><ul><li>write： 写日志。</li><li>read： 读日志。</li><li>all： 读写日志。</li></ul>
 	LogSubType *string `json:"LogSubType,omitnil,omitempty" name:"LogSubType"`
 
-	// <p>日志开关。不传查询所有日志实例。</p><ul><li>on：开启。</li><li>off：关闭。</li></ul>
+	// <p>日志开关。</p><p>枚举值：</p><ul><li>on： 开启</li><li>off： 关闭</li></ul><p>默认值：off</p>
 	LogSwitch *string `json:"LogSwitch,omitnil,omitempty" name:"LogSwitch"`
 }
 
@@ -5939,14 +6029,14 @@ func (r *DescribeReplicationGroupResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeSSLStatusRequestParams struct {
-	// 实例 ID。请登录 [Redis 控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
+	// <p>实例 ID。请登录 <a href="https://console.cloud.tencent.com/redis/instance/list">Redis 控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 }
 
 type DescribeSSLStatusRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例 ID。请登录 [Redis 控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
+	// <p>实例 ID。请登录 <a href="https://console.cloud.tencent.com/redis/instance/list">Redis 控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 }
 
@@ -5971,26 +6061,26 @@ func (r *DescribeSSLStatusRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeSSLStatusResponseParams struct {
-	// SSL 证书下载地址。
+	// <p>SSL 证书下载地址。</p>
 	CertDownloadUrl *string `json:"CertDownloadUrl,omitnil,omitempty" name:"CertDownloadUrl"`
 
-	// 证书下载链接到期时间。
+	// <p>证书下载链接到期时间。</p>
 	UrlExpiredTime *string `json:"UrlExpiredTime,omitnil,omitempty" name:"UrlExpiredTime"`
 
-	// 标识实例开启 SSL 功能。
-	// - true：开启 。
-	// - false：关闭。
+	// <p>标识实例开启 SSL 功能。</p><ul><li>true：开启 。</li><li>false：关闭。</li></ul>
 	SSLConfig *bool `json:"SSLConfig,omitnil,omitempty" name:"SSLConfig"`
 
-	// 标识实例是否支持 SSL特性。
-	// - true：支持。
-	// - false：不支持。
+	// <p>标识实例是否支持 SSL特性。</p><ul><li>true：支持。</li><li>false：不支持。</li></ul>
 	FeatureSupport *bool `json:"FeatureSupport,omitnil,omitempty" name:"FeatureSupport"`
 
-	// 说明配置 SSL 的状态。
-	// - 1: 配置中。
-	// - 2：配置成功。
+	// <p>说明配置 SSL 的状态。</p><ul><li>1: 配置中。</li><li>2：配置成功。</li></ul>
 	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>地址类型</p><p>枚举值：</p><ul><li>0： 不限</li><li>1： 内网IPv4</li><li>2： 内网IPv6</li><li>3： 外网</li><li>-1： 未指定</li></ul>
+	AddressType *int64 `json:"AddressType,omitnil,omitempty" name:"AddressType"`
+
+	// <p>当前加密连接地址</p>
+	EncryptAddress *string `json:"EncryptAddress,omitnil,omitempty" name:"EncryptAddress"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -7692,207 +7782,189 @@ type InstanceSecurityGroupDetail struct {
 }
 
 type InstanceSet struct {
-	// 实例名称。
+	// <p>实例名称。</p>
 	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
 
-	// 实例 ID。
+	// <p>实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 用户AppId。AppId是与账号ID有唯一对应关系的应用 ID，部分腾讯云产品会使用此 AppId。
+	// <p>用户AppId。AppId是与账号ID有唯一对应关系的应用 ID，部分腾讯云产品会使用此 AppId。</p>
 	Appid *int64 `json:"Appid,omitnil,omitempty" name:"Appid"`
 
-	// 项目 ID。
+	// <p>项目 ID。</p>
 	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
-	// 地域 ID。<ul><li>1：广州。</li><li>4：上海。</li><li>5：中国香港。</li><li>7：上海金融。</li> <li>8：北京。</li> <li>9：新加坡。</li> <li>11：深圳金融。</li> <li>15：美西（硅谷）。</li><li>16：成都。</li><li>17：法兰克福。</li><li>18：首尔。</li><li>19：重庆。</li><li>22：美东（弗吉尼亚）。</li><li>23：曼谷。</li><li>25：东京。</li></ul>
+	// <p>地域 ID。<ul><li>1：广州。</li><li>4：上海。</li><li>5：中国香港。</li><li>7：上海金融。</li> <li>8：北京。</li> <li>9：新加坡。</li> <li>11：深圳金融。</li> <li>15：美西（硅谷）。</li><li>16：成都。</li><li>17：法兰克福。</li><li>18：首尔。</li><li>19：重庆。</li><li>22：美东（弗吉尼亚）。</li><li>23：曼谷。</li><li>25：东京。</li></ul></p>
 	RegionId *int64 `json:"RegionId,omitnil,omitempty" name:"RegionId"`
 
-	// 区域 ID。
+	// <p>区域 ID。</p>
 	ZoneId *int64 `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// vpc网络 ID，例如75101。
+	// <p>vpc网络 ID，例如75101。</p>
 	VpcId *int64 `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
-	// vpc网络下子网ID，如：46315。
+	// <p>vpc网络下子网ID，如：46315。</p>
 	SubnetId *int64 `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
 
-	// 实例当前状态。<ul><li>0：待初始化。</li><li>1：实例在流程中。</li><li>2：实例运行中。</li><li>-2：实例已隔离。</li><li>-3：实例待删除。</li></ul>
+	// <p>实例当前状态。<ul><li>0：待初始化。</li><li>1：实例在流程中。</li><li>2：实例运行中。</li><li>-2：实例已隔离。</li><li>-3：实例待删除。</li></ul></p>
 	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 实例 VIP。
+	// <p>实例 VIP。</p>
 	WanIp *string `json:"WanIp,omitnil,omitempty" name:"WanIp"`
 
-	// 实例端口号。
+	// <p>实例端口号。</p>
 	Port *int64 `json:"Port,omitnil,omitempty" name:"Port"`
 
-	// 实例创建时间。格式如：2020-01-15 10:20:00。
+	// <p>实例创建时间。格式如：2020-01-15 10:20:00。</p>
 	Createtime *string `json:"Createtime,omitnil,omitempty" name:"Createtime"`
 
-	// 实例内存容量大小。单位：MB，1MB=1024KB。
+	// <p>实例内存容量大小。单位：MB，1MB=1024KB。</p>
 	Size *float64 `json:"Size,omitnil,omitempty" name:"Size"`
 
-	// 该字段已废弃。请使用腾讯云可观测平台API 接口 [GetMonitorData](https://cloud.tencent.com/document/product/248/31014) 获取实例已使用的内存容量。
+	// <p>该字段已废弃。请使用腾讯云可观测平台API 接口 <a href="https://cloud.tencent.com/document/product/248/31014">GetMonitorData</a> 获取实例已使用的内存容量。</p>
 	//
 	// Deprecated: SizeUsed is deprecated.
 	SizeUsed *float64 `json:"SizeUsed,omitnil,omitempty" name:"SizeUsed"`
 
-	// 实例类型。
-	// - 2：Redis 2.8 内存版（标准架构）。
-	// - 3：CKV 3.2 内存版（标准架构）。
-	// - 4：CKV 3.2 内存版（集群架构）。
-	// - 5：Redis 2.8 内存版（单机）。
-	// - 6：Redis 4.0 内存版（标准架构）。
-	// - 7：Redis 4.0 内存版（集群架构）。
-	// - 8：Redis 5.0 内存版（标准架构）。
-	// - 9：Redis 5.0 内存版（集群架构）。
-	// - 15：Redis 6.2 内存版（标准架构）。
-	// - 16：Redis 6.2 内存版（集群架构）。
-	// - 17：Redis 7.0 内存版（标准架构）。
-	// - 18：Redis 7.0 内存版（集群架构）。
-	// - 200:Memcached 1.6 内存版（集群架构）。
+	// <p>实例类型。</p><p>枚举值：</p><ul><li>2： Redis 2.8 内存版（标准架构）。</li><li>3： CKV 3.2 内存版（标准架构）。</li><li>4： CKV 3.2 内存版（集群架构）。</li><li>5： Redis 2.8 内存版（单机）。</li><li>6： Redis 4.0 内存版（标准架构）。</li><li>7： Redis 4.0 内存版（集群架构）。</li><li>8： Redis 5.0 内存版（标准架构）。</li><li>9： Redis 5.0 内存版（集群架构）。</li><li>15： Redis 6.2 内存版（标准架构）。</li><li>16： Redis 6.2 内存版（集群架构）。</li><li>17： Redis 7.0 内存版（标准架构）。</li><li>18： Redis 7.0 内存版（集群架构）。</li><li>19： Valkey 8.0 内存版（标准架构）。</li><li>20： Valkey 8.0 内存版（集群架构）。</li><li>21： Valkey 8.0 内存版（标准架构）。</li><li>22： Valkey 8.0 内存版（集群架构）。</li><li>200： Memcached 1.6 内存版（集群架构）。</li></ul>
 	Type *int64 `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 实例是否设置自动续费标识。<ul><li>1：设置自动续费。</li><li>0：未设置自动续费。</li></ul>
+	// <p>实例是否设置自动续费标识。<ul><li>1：设置自动续费。</li><li>0：未设置自动续费。</li></ul></p>
 	AutoRenewFlag *int64 `json:"AutoRenewFlag,omitnil,omitempty" name:"AutoRenewFlag"`
 
-	// 包年包月计费实例到期的时间。
+	// <p>包年包月计费实例到期的时间。</p>
 	DeadlineTime *string `json:"DeadlineTime,omitnil,omitempty" name:"DeadlineTime"`
 
-	// 引擎：社区版Redis、腾讯云CKV。
+	// <p>引擎：社区版Redis、腾讯云CKV。</p>
 	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
 
-	// 产品类型。<ul><li>standalone：标准版。</li><li>cluster ：集群版。</li></ul>
+	// <p>产品类型。<ul><li>standalone：标准版。</li><li>cluster ：集群版。</li></ul></p>
 	ProductType *string `json:"ProductType,omitnil,omitempty" name:"ProductType"`
 
-	// vpc网络id，例如vpc-fk33jsf43kgv。
+	// <p>vpc网络id，例如vpc-fk33jsf43kgv。</p>
 	UniqVpcId *string `json:"UniqVpcId,omitnil,omitempty" name:"UniqVpcId"`
 
-	// vpc网络下子网id，例如：subnet-fd3j6l35mm0。
+	// <p>vpc网络下子网id，例如：subnet-fd3j6l35mm0。</p>
 	UniqSubnetId *string `json:"UniqSubnetId,omitnil,omitempty" name:"UniqSubnetId"`
 
-	// 计费模式。<ul><li>0：按量计费。</li><li>1：包年包月。</li></ul>
+	// <p>计费模式。<ul><li>0：按量计费。</li><li>1：包年包月。</li></ul></p>
 	BillingMode *int64 `json:"BillingMode,omitnil,omitempty" name:"BillingMode"`
 
-	// 实例运行状态描述：如”实例运行中“。
+	// <p>实例运行状态描述：如”实例运行中“。</p>
 	InstanceTitle *string `json:"InstanceTitle,omitnil,omitempty" name:"InstanceTitle"`
 
-	// 已隔离实例默认下线时间。按量计费实例隔离后默认两小时后下线，包年包月默认7天后下线。格式如：2020-02-15 10:20:00。
+	// <p>已隔离实例默认下线时间。按量计费实例隔离后默认两小时后下线，包年包月默认7天后下线。格式如：2020-02-15 10:20:00。</p>
 	OfflineTime *string `json:"OfflineTime,omitnil,omitempty" name:"OfflineTime"`
 
-	// 流程中的实例返回的子状态。
-	// - 0：磁盘读写状态。
-	// - 1：磁盘超限只读状态。
+	// <p>流程中的实例返回的子状态。</p><ul><li>0：磁盘读写状态。</li><li>1：磁盘超限只读状态。</li></ul>
 	SubStatus *int64 `json:"SubStatus,omitnil,omitempty" name:"SubStatus"`
 
-	// 反亲和性标签。
+	// <p>反亲和性标签。</p>
 	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 实例节点信息。
+	// <p>实例节点信息。</p>
 	InstanceNode []*InstanceNode `json:"InstanceNode,omitnil,omitempty" name:"InstanceNode"`
 
-	// 分片大小。
+	// <p>分片大小。</p>
 	RedisShardSize *int64 `json:"RedisShardSize,omitnil,omitempty" name:"RedisShardSize"`
 
-	// 分片数量。
+	// <p>分片数量。</p>
 	RedisShardNum *int64 `json:"RedisShardNum,omitnil,omitempty" name:"RedisShardNum"`
 
-	// 副本数量。
+	// <p>副本数量。</p>
 	RedisReplicasNum *int64 `json:"RedisReplicasNum,omitnil,omitempty" name:"RedisReplicasNum"`
 
-	// 计费 ID。
+	// <p>计费 ID。</p>
 	PriceId *int64 `json:"PriceId,omitnil,omitempty" name:"PriceId"`
 
-	// 实例隔离开始的时间。
+	// <p>实例隔离开始的时间。</p>
 	CloseTime *string `json:"CloseTime,omitnil,omitempty" name:"CloseTime"`
 
-	// 从节点读取权重。
-	// - 0：表示关闭副本只读。
-	// - 100：表示开启副本只读。
+	// <p>从节点读取权重。</p><ul><li>0：表示关闭副本只读。</li><li>100：表示开启副本只读。</li></ul>
 	SlaveReadWeight *int64 `json:"SlaveReadWeight,omitnil,omitempty" name:"SlaveReadWeight"`
 
-	// 实例关联的标签信息。
+	// <p>实例关联的标签信息。</p>
 	InstanceTags []*InstanceTagInfo `json:"InstanceTags,omitnil,omitempty" name:"InstanceTags"`
 
-	// 项目名称。
+	// <p>项目名称。</p>
 	ProjectName *string `json:"ProjectName,omitnil,omitempty" name:"ProjectName"`
 
-	// 是否为免密实例。<ul><li>true：免密实例。</li><li>false：非免密实例。</li></ul>
+	// <p>是否为免密实例。<ul><li>true：免密实例。</li><li>false：非免密实例。</li></ul></p>
 	NoAuth *bool `json:"NoAuth,omitnil,omitempty" name:"NoAuth"`
 
-	// 客户端连接数。
+	// <p>客户端连接数。</p>
 	ClientLimit *int64 `json:"ClientLimit,omitnil,omitempty" name:"ClientLimit"`
 
-	// DTS状态（内部参数，用户可忽略）。
+	// <p>DTS状态（内部参数，用户可忽略）。</p>
 	DtsStatus *int64 `json:"DtsStatus,omitnil,omitempty" name:"DtsStatus"`
 
-	// 分片带宽上限，单位MB。
+	// <p>分片带宽上限，单位MB。</p>
 	NetLimit *int64 `json:"NetLimit,omitnil,omitempty" name:"NetLimit"`
 
-	// 免密实例标识（内部参数，用户可忽略）。
+	// <p>免密实例标识（内部参数，用户可忽略）。</p>
 	PasswordFree *int64 `json:"PasswordFree,omitnil,omitempty" name:"PasswordFree"`
 
-	// 该参数存在命名不规范问题，建议用参数IPv6取代。内部参数，用户可忽略。
+	// <p>该参数存在命名不规范问题，建议用参数IPv6取代。内部参数，用户可忽略。</p>
 	Vip6 *string `json:"Vip6,omitnil,omitempty" name:"Vip6"`
 
-	// 内部参数，用户可忽略。
+	// <p>内部参数，用户可忽略。</p>
 	IPv6 *string `json:"IPv6,omitnil,omitempty" name:"IPv6"`
 
-	// 实例只读标识（内部参数，用户可忽略）。
+	// <p>实例只读标识（内部参数，用户可忽略）。</p>
 	ReadOnly *int64 `json:"ReadOnly,omitnil,omitempty" name:"ReadOnly"`
 
-	// 内部参数，用户可忽略。
+	// <p>内部参数，用户可忽略。</p>
 	RemainBandwidthDuration *string `json:"RemainBandwidthDuration,omitnil,omitempty" name:"RemainBandwidthDuration"`
 
-	// Redis实例请忽略该参数。
+	// <p>Redis实例请忽略该参数。</p>
 	DiskSize *int64 `json:"DiskSize,omitnil,omitempty" name:"DiskSize"`
 
-	// 监控版本。<ul><li>1m：1分钟粒度监控。目前该监控粒度已下线，具体信息，请参见[云数据库 Redis 1分钟粒度下线公告](https://cloud.tencent.com/document/product/239/80653)。</li><li>5s：5秒粒度监控。</li></ul>
+	// <p>监控版本。<ul><li>1m：1分钟粒度监控。目前该监控粒度已下线，具体信息，请参见<a href="https://cloud.tencent.com/document/product/239/80653">云数据库 Redis 1分钟粒度下线公告</a>。</li><li>5s：5秒粒度监控。</li></ul></p>
 	MonitorVersion *string `json:"MonitorVersion,omitnil,omitempty" name:"MonitorVersion"`
 
-	// 客户端最大连接数可设置的最小值。
+	// <p>客户端最大连接数可设置的最小值。</p>
 	ClientLimitMin *int64 `json:"ClientLimitMin,omitnil,omitempty" name:"ClientLimitMin"`
 
-	// 客户端最大连接数可设置的最大值。
+	// <p>客户端最大连接数可设置的最大值。</p>
 	ClientLimitMax *int64 `json:"ClientLimitMax,omitnil,omitempty" name:"ClientLimitMax"`
 
-	// 实例的节点详细信息。
-	// 只有多可用区实例会返回。
+	// <p>实例的节点详细信息。<br>只有多可用区实例会返回。</p>
 	NodeSet []*RedisNodeInfo `json:"NodeSet,omitnil,omitempty" name:"NodeSet"`
 
-	// 实例所在的地域信息，比如ap-guangzhou。
+	// <p>实例所在的地域信息，比如ap-guangzhou。</p>
 	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// 外网地址。
+	// <p>外网地址。</p>
 	WanAddress *string `json:"WanAddress,omitnil,omitempty" name:"WanAddress"`
 
-	// 北极星服务地址，内部使用。
+	// <p>北极星服务地址，内部使用。</p>
 	PolarisServer *string `json:"PolarisServer,omitnil,omitempty" name:"PolarisServer"`
 
-	// CDC Redis集群ID。
+	// <p>CDC Redis集群ID。</p>
 	RedisClusterId *string `json:"RedisClusterId,omitnil,omitempty" name:"RedisClusterId"`
 
-	// CDC 集群ID。
+	// <p>CDC 集群ID。</p>
 	DedicatedClusterId *string `json:"DedicatedClusterId,omitnil,omitempty" name:"DedicatedClusterId"`
 
-	// 产品版本。<ul><li>local：本地盘。</li><li>cloud：云盘版。</li><li>cdc：CDC 集群版本。</li></ul>
+	// <p>产品版本。<ul><li>local：本地盘。</li><li>cloud：云盘版。</li><li>cdc：CDC 集群版本。</li></ul></p>
 	ProductVersion *string `json:"ProductVersion,omitnil,omitempty" name:"ProductVersion"`
 
-	// 实例当前Proxy版本。
+	// <p>实例当前Proxy版本。</p>
 	CurrentProxyVersion *string `json:"CurrentProxyVersion,omitnil,omitempty" name:"CurrentProxyVersion"`
 
-	// 实例当前Cache小版本。如果实例加入全球复制组，显示全球复制的内核版本。
+	// <p>实例当前Cache小版本。如果实例加入全球复制组，显示全球复制的内核版本。</p>
 	CurrentRedisVersion *string `json:"CurrentRedisVersion,omitnil,omitempty" name:"CurrentRedisVersion"`
 
-	// 实例可升级Proxy版本。
+	// <p>实例可升级Proxy版本。</p>
 	UpgradeProxyVersion *string `json:"UpgradeProxyVersion,omitnil,omitempty" name:"UpgradeProxyVersion"`
 
-	// 实例可升级Cache小版本。
+	// <p>实例可升级Cache小版本。</p>
 	UpgradeRedisVersion *string `json:"UpgradeRedisVersion,omitnil,omitempty" name:"UpgradeRedisVersion"`
 
-	// 备份模式：- SecondLevelBackup   秒级备份- NormalLevelBackup    普通备份
+	// <p>备份模式。</p><ul><li>SecondLevelBackup：秒级备份。</li><li>NormalLevelBackup：普通备份。</li></ul>
 	BackupMode *string `json:"BackupMode,omitnil,omitempty" name:"BackupMode"`
 
-	// 删除保护开关，0关闭，1开启
+	// <p>实例销毁保护开关。</p><ul><li>0：关闭。</li><li>1：开启。</li></ul>
 	DeleteProtectionSwitch *int64 `json:"DeleteProtectionSwitch,omitnil,omitempty" name:"DeleteProtectionSwitch"`
 }
 
@@ -8711,74 +8783,56 @@ func (r *ModifyDBInstanceSecurityGroupsResponse) FromJsonString(s string) error 
 
 // Predefined struct for user
 type ModifyInstanceAccountRequestParams struct {
-	// 实例 ID，请登录[Redis控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
+	// <p>实例 ID，请登录<a href="https://console.cloud.tencent.com/redis/instance/list">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 指定需修改的账号。
-	// - root：指在创建 Redis 数据库实例时自动生成的账号。用户无法修改其读写权限，仅可修改其请求路由策略。
-	// - 自定义的账号：用户在实例创建成功后手动创建的账号。用户可以随时修改其读写权限与请求路由策略。
+	// <p>指定需修改的账号。</p><ul><li>root：指在创建 Redis 数据库实例时自动生成的账号。用户无法修改其读写权限，仅可修改其请求路由策略。</li><li>自定义的账号：用户在实例创建成功后手动创建的账号。用户可以随时修改其读写权限与请求路由策略。</li></ul>
 	AccountName *string `json:"AccountName,omitnil,omitempty" name:"AccountName"`
 
-	// 指定所修改账号访问的密码。
+	// <p>指定所修改账号访问的密码。</p>
 	AccountPassword *string `json:"AccountPassword,omitnil,omitempty" name:"AccountPassword"`
 
-	// 账号描述信息
+	// <p>账号描述信息</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 指定所修改账号读写请求路由的策略。
-	// - master：表示读写请求路由至主节点。
-	// - replication：表示读写请求路由至从节点。
+	// <p>指定所修改账号读写请求路由的策略。</p><ul><li>master：表示读写请求路由至主节点。</li><li>replication：表示读写请求路由至从节点。</li></ul>
 	ReadonlyPolicy []*string `json:"ReadonlyPolicy,omitnil,omitempty" name:"ReadonlyPolicy"`
 
-	// 指定所修改账号的读写权限。
-	// - r：只读。
-	// - w：只写。
-	// - rw：读写。
+	// <p>指定所修改账号的读写权限。</p><ul><li>r：只读。</li><li>w：只写。</li><li>rw：读写。</li></ul>
 	Privilege *string `json:"Privilege,omitnil,omitempty" name:"Privilege"`
 
-	// 指定是否将默认账号（root）设置为免密账号。自定义账号不支持免密访问。
-	// - true：默认账号（root）设置为免密账号。
-	// - false：默认账号（root）不设置为免密账号。
+	// <p>指定是否将默认账号（root）设置为免密账号。自定义账号不支持免密访问。</p><ul><li>true：默认账号（root）设置为免密账号。</li><li>false：默认账号（root）不设置为免密账号。</li></ul>
 	NoAuth *bool `json:"NoAuth,omitnil,omitempty" name:"NoAuth"`
 
-	// 指定所修改的账号是否加密密码
+	// <p>是否启用密码加密传输。</p><ul><li>true：加密。</li><li>false：不加密（默认值）。</li></ul>
 	EncryptPassword *bool `json:"EncryptPassword,omitnil,omitempty" name:"EncryptPassword"`
 }
 
 type ModifyInstanceAccountRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例 ID，请登录[Redis控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
+	// <p>实例 ID，请登录<a href="https://console.cloud.tencent.com/redis/instance/list">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 指定需修改的账号。
-	// - root：指在创建 Redis 数据库实例时自动生成的账号。用户无法修改其读写权限，仅可修改其请求路由策略。
-	// - 自定义的账号：用户在实例创建成功后手动创建的账号。用户可以随时修改其读写权限与请求路由策略。
+	// <p>指定需修改的账号。</p><ul><li>root：指在创建 Redis 数据库实例时自动生成的账号。用户无法修改其读写权限，仅可修改其请求路由策略。</li><li>自定义的账号：用户在实例创建成功后手动创建的账号。用户可以随时修改其读写权限与请求路由策略。</li></ul>
 	AccountName *string `json:"AccountName,omitnil,omitempty" name:"AccountName"`
 
-	// 指定所修改账号访问的密码。
+	// <p>指定所修改账号访问的密码。</p>
 	AccountPassword *string `json:"AccountPassword,omitnil,omitempty" name:"AccountPassword"`
 
-	// 账号描述信息
+	// <p>账号描述信息</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 指定所修改账号读写请求路由的策略。
-	// - master：表示读写请求路由至主节点。
-	// - replication：表示读写请求路由至从节点。
+	// <p>指定所修改账号读写请求路由的策略。</p><ul><li>master：表示读写请求路由至主节点。</li><li>replication：表示读写请求路由至从节点。</li></ul>
 	ReadonlyPolicy []*string `json:"ReadonlyPolicy,omitnil,omitempty" name:"ReadonlyPolicy"`
 
-	// 指定所修改账号的读写权限。
-	// - r：只读。
-	// - w：只写。
-	// - rw：读写。
+	// <p>指定所修改账号的读写权限。</p><ul><li>r：只读。</li><li>w：只写。</li><li>rw：读写。</li></ul>
 	Privilege *string `json:"Privilege,omitnil,omitempty" name:"Privilege"`
 
-	// 指定是否将默认账号（root）设置为免密账号。自定义账号不支持免密访问。
-	// - true：默认账号（root）设置为免密账号。
-	// - false：默认账号（root）不设置为免密账号。
+	// <p>指定是否将默认账号（root）设置为免密账号。自定义账号不支持免密访问。</p><ul><li>true：默认账号（root）设置为免密账号。</li><li>false：默认账号（root）不设置为免密账号。</li></ul>
 	NoAuth *bool `json:"NoAuth,omitnil,omitempty" name:"NoAuth"`
 
-	// 指定所修改的账号是否加密密码
+	// <p>是否启用密码加密传输。</p><ul><li>true：加密。</li><li>false：不加密（默认值）。</li></ul>
 	EncryptPassword *bool `json:"EncryptPassword,omitnil,omitempty" name:"EncryptPassword"`
 }
 
@@ -8810,7 +8864,7 @@ func (r *ModifyInstanceAccountRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ModifyInstanceAccountResponseParams struct {
-	// 任务ID。
+	// <p>任务ID。</p>
 	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -9330,6 +9384,67 @@ func (r *ModifyInstanceParamsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyInstanceParamsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyInstancePasswordPolicyRequestParams struct {
+	// <p>实例 ID。请登录 <a href="https://console.cloud.tencent.com/redis">Redis 控制台</a>在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>实例的密码复杂度策略控制对象，包含密码长度及各类字符（字母/数字/特殊符号）最小数量的校验指标。</p>
+	PasswordPolicy *PasswordPolicy `json:"PasswordPolicy,omitnil,omitempty" name:"PasswordPolicy"`
+}
+
+type ModifyInstancePasswordPolicyRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>实例 ID。请登录 <a href="https://console.cloud.tencent.com/redis">Redis 控制台</a>在实例列表复制实例 ID。</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>实例的密码复杂度策略控制对象，包含密码长度及各类字符（字母/数字/特殊符号）最小数量的校验指标。</p>
+	PasswordPolicy *PasswordPolicy `json:"PasswordPolicy,omitnil,omitempty" name:"PasswordPolicy"`
+}
+
+func (r *ModifyInstancePasswordPolicyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyInstancePasswordPolicyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "PasswordPolicy")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyInstancePasswordPolicyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyInstancePasswordPolicyResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyInstancePasswordPolicyResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyInstancePasswordPolicyResponseParams `json:"Response"`
+}
+
+func (r *ModifyInstancePasswordPolicyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyInstancePasswordPolicyResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -10137,15 +10252,21 @@ func (r *OpenLogResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type OpenSSLRequestParams struct {
-	// 实例 ID，请登录[Redis控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
+	// <p>实例 ID，请登录<a href="https://console.cloud.tencent.com/redis/instance/list">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>SSL地址类型。</p><p>枚举值：</p><ul><li>0： 不限。</li><li>1： 内网IPv4。</li><li>2： 内网IPv6。</li><li>3： 外网。</li><li>-1： 未指定。</li></ul><p>默认值：0</p>
+	AddressType *int64 `json:"AddressType,omitnil,omitempty" name:"AddressType"`
 }
 
 type OpenSSLRequest struct {
 	*tchttp.BaseRequest
 	
-	// 实例 ID，请登录[Redis控制台](https://console.cloud.tencent.com/redis/instance/list)在实例列表复制实例 ID。
+	// <p>实例 ID，请登录<a href="https://console.cloud.tencent.com/redis/instance/list">Redis控制台</a>在实例列表复制实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>SSL地址类型。</p><p>枚举值：</p><ul><li>0： 不限。</li><li>1： 内网IPv4。</li><li>2： 内网IPv6。</li><li>3： 外网。</li><li>-1： 未指定。</li></ul><p>默认值：0</p>
+	AddressType *int64 `json:"AddressType,omitnil,omitempty" name:"AddressType"`
 }
 
 func (r *OpenSSLRequest) ToJsonString() string {
@@ -10161,6 +10282,7 @@ func (r *OpenSSLRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "InstanceId")
+	delete(f, "AddressType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "OpenSSLRequest has unknown keys!", "")
 	}
@@ -10169,7 +10291,7 @@ func (r *OpenSSLRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type OpenSSLResponseParams struct {
-	// 任务ID。
+	// <p>任务ID。</p>
 	TaskId *int64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -10273,6 +10395,23 @@ type ParameterDetail struct {
 	EnumValue []*string `json:"EnumValue,omitnil,omitempty" name:"EnumValue"`
 }
 
+type PasswordPolicy struct {
+	// <p>是否启用实例级密码复杂度策略。</p><ul><li>true：开启。所有密码变动（创建/重置）必须通过下方定义的复杂度校验。</li><li>false：关闭。不进行复杂度过滤。</li></ul><p>默认值：false</p>
+	Enabled *bool `json:"Enabled,omitnil,omitempty" name:"Enabled"`
+
+	// <p>大小写字母最小字符数。</p><ul><li>取值范围：[1,16]。</li><li>默认值：1。</li></ul>
+	MinLetterCount *int64 `json:"MinLetterCount,omitnil,omitempty" name:"MinLetterCount"`
+
+	// <p>数字字符的最小字符数。</p><ul><li>取值范围：[1,16]。</li><li>默认值：1。</li></ul>
+	MinDigitCount *int64 `json:"MinDigitCount,omitnil,omitempty" name:"MinDigitCount"`
+
+	// <p>特殊字符最小字符数。</p><ul><li>取值范围：[1,16]。</li><li>默认值：1。</li></ul>
+	MinSpecialCount *int64 `json:"MinSpecialCount,omitnil,omitempty" name:"MinSpecialCount"`
+
+	// <p>密码的最小总长度（字符数）。</p><ul><li>取值范围：[8, 64]。</li><li>默认值：8。</li><li>约束限制：密码的最小总长度必须大于或等于 MinLetterCount 、MinDigitCount 与 MinSpecialCount 三个参数之和。</li></ul>
+	MinLength *int64 `json:"MinLength,omitnil,omitempty" name:"MinLength"`
+}
+
 type ProductConf struct {
 	// 产品类型。
 	// - 2：Redis 2.8内存版（标准架构）。
@@ -10346,59 +10485,53 @@ type ProxyNodes struct {
 }
 
 type RedisBackupSet struct {
-	// 备份开始时间。
+	// <p>备份开始时间。</p>
 	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// 备份任务ID。
+	// <p>备份任务ID。</p>
 	BackupId *string `json:"BackupId,omitnil,omitempty" name:"BackupId"`
 
-	// 备份类型。
-	// - 1：凌晨系统发起的自动备份。
-	// - 0：用户发起的手动备份。
+	// <p>备份类型。</p><ul><li>1：凌晨系统发起的自动备份。</li><li>0：用户发起的手动备份。</li></ul>
 	BackupType *string `json:"BackupType,omitnil,omitempty" name:"BackupType"`
 
-	// 备份状态。 
-	// - 1：备份被其它流程锁定。
-	// - 2：备份正常，没有被任何流程锁定。
-	// - -1：备份已过期。
-	// - 3：备份正在被导出。
-	// - 4：备份导出成功。
+	// <p>备份状态。 </p><ul><li>1：备份被其它流程锁定。</li><li>2：备份正常，没有被任何流程锁定。</li><li>-1：备份已过期。</li><li>3：备份正在被导出。</li><li>4：备份导出成功。</li></ul>
 	Status *int64 `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 备份的备注信息。
+	// <p>备份的备注信息。</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 备份是否被锁定。
-	// - 0：未被锁定。
-	// - 1：已被锁定。
+	// <p>备份是否被锁定。</p><ul><li>0：未被锁定。</li><li>1：已被锁定。</li></ul>
 	Locked *int64 `json:"Locked,omitnil,omitempty" name:"Locked"`
 
-	// 内部字段，用户可忽略。
+	// <p>内部字段，用户可忽略。</p>
 	BackupSize *int64 `json:"BackupSize,omitnil,omitempty" name:"BackupSize"`
 
-	// 内部字段，用户可忽略。
+	// <p>内部字段，用户可忽略。</p>
 	FullBackup *int64 `json:"FullBackup,omitnil,omitempty" name:"FullBackup"`
 
-	// 内部字段，用户可忽略。
+	// <p>内部字段，用户可忽略。</p>
 	InstanceType *int64 `json:"InstanceType,omitnil,omitempty" name:"InstanceType"`
 
-	// 实例 ID。
+	// <p>实例 ID。</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 实例名称。
+	// <p>实例名称。</p>
 	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
 
-	// 本地备份所在地域。
+	// <p>本地备份所在地域。</p>
 	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 
-	// 备份结束时间。
+	// <p>备份结束时间。</p>
 	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
 
-	// 备份文件类型。
+	// <p>备份文件类型。</p>
 	FileType *string `json:"FileType,omitnil,omitempty" name:"FileType"`
 
-	// 备份文件过期时间。
+	// <p>备份文件过期时间。</p>
 	ExpireTime *string `json:"ExpireTime,omitnil,omitempty" name:"ExpireTime"`
+
+	// <p>备份文件是否加密</p>
+	Encrypted *bool `json:"Encrypted,omitnil,omitempty" name:"Encrypted"`
 }
 
 type RedisCommonInstanceList struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1385,7 +1385,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/privatedns/v20201028
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/pts v1.0.762
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/pts/v20210728
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.73
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.168
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis/v20180412
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/region v1.3.40

--- a/website/docs/r/redis_instance_password_policy_config.html.markdown
+++ b/website/docs/r/redis_instance_password_policy_config.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "TencentDB for Redis(crs)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_redis_instance_password_policy_config"
+sidebar_current: "docs-tencentcloud-resource-redis_instance_password_policy_config"
+description: |-
+  Provides a resource to manage redis instance password policy config
+---
+
+# tencentcloud_redis_instance_password_policy_config
+
+Provides a resource to manage redis instance password policy config
+
+## Example Usage
+
+### Manage the password complexity policy of a redis instance
+
+```hcl
+data "tencentcloud_redis_zone_config" "zone" {
+  type_id = 7
+}
+
+resource "tencentcloud_vpc" "vpc" {
+  cidr_block = "10.0.0.0/16"
+  name       = "tf_redis_vpc"
+}
+
+resource "tencentcloud_subnet" "subnet" {
+  vpc_id            = tencentcloud_vpc.vpc.id
+  availability_zone = data.tencentcloud_redis_zone_config.zone.list[0].zone
+  name              = "tf_redis_subnet"
+  cidr_block        = "10.0.1.0/24"
+}
+
+resource "tencentcloud_redis_instance" "example" {
+  availability_zone  = data.tencentcloud_redis_zone_config.zone.list[0].zone
+  type_id            = data.tencentcloud_redis_zone_config.zone.list[0].type_id
+  password           = "Password@123"
+  mem_size           = 8192
+  redis_shard_num    = data.tencentcloud_redis_zone_config.zone.list[0].redis_shard_nums[0]
+  redis_replicas_num = data.tencentcloud_redis_zone_config.zone.list[0].redis_replicas_nums[0]
+  name               = "tf_example"
+  port               = 6379
+  vpc_id             = tencentcloud_vpc.vpc.id
+  subnet_id          = tencentcloud_subnet.subnet.id
+}
+
+resource "tencentcloud_redis_instance_password_policy_config" "example" {
+  instance_id       = tencentcloud_redis_instance.example.id
+  enabled           = true
+  min_letter_count  = 1
+  min_digit_count   = 1
+  min_special_count = 1
+  min_length        = 8
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `enabled` - (Required, Bool) Whether to enable the instance-level password complexity policy. true: enable; false: disable.
+* `instance_id` - (Required, String, ForceNew) The ID of redis instance.
+* `min_digit_count` - (Optional, Int) The minimum number of digit characters. Value range: [1,16].
+* `min_length` - (Optional, Int) The minimum total length of the password. Value range: [8,64].
+* `min_letter_count` - (Optional, Int) The minimum number of letters (uppercase and lowercase). Value range: [1,16].
+* `min_special_count` - (Optional, Int) The minimum number of special characters. Value range: [1,16].
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+
+
+
+## Import
+
+redis instance password policy config can be imported using the instance_id, e.g.
+
+```
+$ terraform import tencentcloud_redis_instance_password_policy_config.example crs-cqdfdzvt
+```
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -7202,6 +7202,9 @@
                                     <a href="/docs/providers/tencentcloud/r/redis_instance.html">tencentcloud_redis_instance</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/r/redis_instance_password_policy_config.html">tencentcloud_redis_instance_password_policy_config</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/r/redis_log_delivery.html">tencentcloud_redis_log_delivery</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add a new Terraform config resource `tencentcloud_redis_instance_password_policy_config` to manage Redis instance password complexity policy (enable switch, min letter/number/special char count, min password length).

- Register resource in provider.go and provider.md
- Add resource implementation, docs, and unit tests (gomonkey mock)
- Update redis SDK vendor to support DescribeInstancePasswordPolicy and ModifyInstancePasswordPolicy APIs