### PR TITLE
feat(ckafka): [137637997]add tencentcloud_ckafka_routes data source

### DIFF
--- a/.changelog/4463.txt
+++ b/.changelog/4463.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_ckafka_routes
+```

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cfw v1.3.112
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs v1.0.600
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.165
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.164

--- a/go.sum
+++ b/go.sum
@@ -915,8 +915,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs v1.0.600 h1:qSpp4
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs v1.0.600/go.mod h1:xud1dQ7Rc23yC5kS00TYRrvZ/A+94EOkwquaI6xGVac=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695 h1:FGwsF1/PgY+M92bEC+0NH4tJkI8i0qjrLbZWVjLXOAY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695/go.mod h1:HAasVoWz8ed6kAg7Q/DTg+8uZXiOgW7lmJeAGGrquEQ=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133 h1:u69hqN3/tI7y5o9b106CFhwAwFsQXZt1QqCxwZjbQ2Y=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133/go.mod h1:9Ex1k11ifCKOpUVYRXn53HgXpDVuEEuJ+qJSLMBGoM0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.165 h1:CpNyChYwEyO/fjM1f0KQY1pWgvDn+XftDdgi2LaXMeg=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.165/go.mod h1:cvbOkDX2rAK1Xcb65kGnWHJZMvLvxcc8i4N7OLEdNlo=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165 h1:sQRHq9cZ2TOPqTl86exaNKZ/B7RKvCEviQRvqgC8cqI=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165/go.mod h1:s88/DboRoSIkZNA9/lmXt1ja4LGDG+A+4ZwbqLrCZMQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40 h1:bhPBpfz0w3mdVyEolvXrtELUf+gE00O0WnAYIHZq70s=
@@ -991,7 +991,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.125/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.129/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.133/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.139/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=

--- a/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/design.md
+++ b/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/design.md
@@ -1,0 +1,69 @@
+## Context
+
+当前 Terraform Provider for TencentCloud 已支持 CKafka 路由资源的管理（`tencentcloud_ckafka_route`），涵盖创建、读取、更新、删除等操作，服务层 `service_tencentcloud_ckafka.go` 中已存在 `DescribeCkafkaRouteById` 方法用于按 `instanceId + routeId` 查询单条路由。
+
+但是该方法是按单条路由 ID 查询的，且未暴露为数据源。用户需要一个 `RESOURCE_KIND_DATASOURCE` 类型数据源 `tencentcloud_ckafka_routes`，以便通过 `DescribeRoute` 接口查询实例下所有路由信息（或按 `routeId` / `main_route_flag` 过滤），并在 Terraform 配置中引用路由详情。
+
+云 API `DescribeRoute` 为同步接口（查看路由信息），入参为 `InstanceId`（必填）、`RouteId`（可选，int64）、`MainRouteFlag`（可选，bool），出参为 `Response.Result`（`RouteResponse` 类型，内含 `Routers` 列表）。每个 `Route` 包含接入方式、路由 ID、网络类型、VIP 列表、域名、子网、VPC、状态等字段；`VipList` 与 `BrokerVipList` 均为 `VipEntity` 列表（`Vip` string、`Vport` string）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 新增 `tencentcloud_ckafka_routes` 数据源，封装 `DescribeRoute` 接口
+- 支持按 `instance_id`（必填）、`route_id`（可选）、`main_route_flag`（可选）查询路由
+- 将路由列表展开平铺到 schema 顶层，每个路由元素包含其全部字段（含嵌套的 `vip_list`、`broker_vip_list`）
+- 正确处理 API 返回为空的情况：retry 块内返回 `NonRetryableError`，避免清空 state
+- 在 `provider.go` 中注册新数据源
+- 提供对应的 `.md` 文档与 `_test.go` 单元测试（使用 gomonkey mock 云 API）
+
+**Non-Goals:**
+- 不修改已有的 `tencentcloud_ckafka_route` 资源行为
+- 不实现路由的创建/更新/删除（这些由资源承担）
+- 不暴露分页参数（`DescribeRoute` 接口本身无分页字段）
+
+## Decisions
+
+### 1. 数据源命名与文件组织
+
+采用 `tencentcloud_ckafka_routes`（复数），与现有数据源命名风格一致（如 `tencentcloud_ckafka_instances`、`tencentcloud_ckafka_acls`）。文件命名为 `data_source_tc_ckafka_routes.go`，遵循项目规范。
+
+### 2. 服务层方法设计
+
+现有 `DescribeCkafkaRouteById` 仅支持 `instanceId + routeId` 两个参数，缺少 `main_route_flag` 支持，且返回单条 `*ckafka.Route`。为满足数据源需求，新增服务层方法 `DescribeCkafkaRouteByFilter`，接收 `instanceId`、`routeId`、`mainRouteFlag` 参数，返回 `*ckafka.RouteResponse`（即 `Response.Result`），使数据源能够获取完整路由列表并支持全部三个入参。
+
+**为什么不复用 `DescribeCkafkaRouteById`**：该方法签名固定为 `routeId int64`，无法表达"不传 routeId"和"传 mainRouteFlag"的语义；且返回单条 Route 会丢失列表语义。新增独立方法更清晰，也不影响现有资源逻辑。
+
+### 3. Schema 结构
+
+根据项目约束，数据源列表型数据禁止再嵌套一层 `xxx_set`/`xxx_list` 包裹结构，应将列表展开。因此：
+- 顶层输出字段为 `routers`（`TypeList`），每个元素为 `schema.Resource`，包含平铺的路由字段
+- `vip_list`、`broker_vip_list` 为 `TypeList`，元素为含 `vip`、`vport` 的 `schema.Resource`
+- `result` 字段映射 `Response.Result`，由于 `RouteResponse` 仅含 `Routers` 一个字段，为避免冗余嵌套，不单独设置 `result` 包装层，直接使用 `routers` 列表承载所有路由信息
+
+### 4. 数据源 ID 设置
+
+数据源为只读查询，使用 `helper.BuildToken()` 生成随机 ID（参考 `tencentcloud_igtm_instance_list` 模式），而非使用 `instance_id`，因为同一实例可能被多次查询。
+
+### 5. retry 与空响应处理
+
+在 Read 函数的 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 块内调用服务层方法。若云 API 返回空（`response == nil` / `response.Response == nil` / `response.Response.Result == nil`），直接返回 `NonRetryableError`，不执行 `d.SetId("")`，避免因 API 短暂波动清空 state。在 retry 失败路径保留 `log.Printf("[DATASOURCE] read empty, skip SetId")` 日志。
+
+### 6. 字段类型映射
+
+- `route_id`（int64）→ `schema.TypeInt`
+- `access_type`（int64）→ `schema.TypeInt`
+- `vip_type`（int64）→ `schema.TypeInt`
+- `domain_port`（int64）→ `schema.TypeInt`
+- `status`（int64）→ `schema.TypeInt`
+- `domain`、`delete_timestamp`、`subnet`、`vpc_id`、`note`（string）→ `schema.TypeString`
+- `vip_list`、`broker_vip_list`（`[]*VipEntity`）→ `schema.TypeList`，元素含 `vip`（string）、`vport`（string）
+
+### 7. 测试策略
+
+按项目要求，新增资源使用 gomonkey mock 云 API 进行单元测试，不使用 Terraform 验收测试套件。mock `DescribeRoute` 的返回值，验证 Read 函数对响应的字段映射与 `d.Set` 逻辑。
+
+## Risks / Trade-offs
+
+- **[API 返回字段可能为 null]** → 部分字段（如 `domain`、`subnet`、`vpc_id`、`note`、`status`）云 API 注释标注可能返回 null。在 `d.Set` 前逐一判断 nil，避免空指针。
+- **[复用现有服务层方法 vs 新增方法]** → 选择新增 `DescribeCkafkaRouteByFilter` 以完整支持三入参并返回列表，代价是多一个服务层方法，但保持了与现有 `DescribeCkafkaRouteById` 的隔离，降低回归风险。
+- **[无分页]** → `DescribeRoute` 接口无分页参数，路由数量由实例规格决定，通常不会过大，不存在分页缺失风险。

--- a/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/proposal.md
+++ b/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+用户需要通过 Terraform 查询 CKafka 实例的路由信息。当前 Provider 已经支持 CKafka 路由资源的管理（`tencentcloud_ckafka_route`），但缺少查询路由信息的数据源，导致用户无法在 Terraform 配置中读取已有路由的详细信息（如接入方式、VIP 列表、域名、状态等）用于引用、校验或自动化编排。
+
+## What Changes
+
+- 新增 Data Source: `tencentcloud_ckafka_routes`
+- 实现对 CKafka API `DescribeRoute` 接口的调用，查询指定实例的路由信息
+- 支持以下输入参数：
+  - `instance_id`（必填）：CKafka 实例 ID
+  - `route_id`（可选）：路由 ID，用于精确查询单条路由
+  - `main_route_flag`（可选）：是否显示主路由
+- 返回路由信息列表 `routers`，每个路由包含：
+  - `access_type`：实例接入方式
+  - `route_id`：路由 ID
+  - `vip_type`：路由网络类型
+  - `vip_list`：虚拟 IP 列表（含 `vip`、`vport`）
+  - `domain`：域名
+  - `domain_port`：域名端口
+  - `delete_timestamp`：删除时间戳
+  - `subnet`：子网 ID
+  - `broker_vip_list`：broker 虚拟 IP 列表（含 `vip`、`vport`）
+  - `vpc_id`：私有网络 ID
+  - `note`：备注信息
+  - `status`：路由状态
+
+## Capabilities
+
+### New Capabilities
+- `ckafka-routes-datasource`: 查询 CKafka 实例路由信息的数据源能力，封装 `DescribeRoute` 接口，支持按实例 ID、路由 ID、主路由标志查询路由列表
+
+### Modified Capabilities
+<!-- 无需修改现有 spec 级别行为 -->
+
+## Impact
+
+- **新增能力**: CKafka 实例路由信息查询
+- **受影响的服务**: CKafka (tencentcloud/services/ckafka)
+- **新增文件**:
+  - `tencentcloud/services/ckafka/data_source_tc_ckafka_routes.go`
+  - `tencentcloud/services/ckafka/data_source_tc_ckafka_routes.md`
+  - `tencentcloud/services/ckafka/data_source_tc_ckafka_routes_test.go`
+  - `tencentcloud/services/ckafka/service_tencentcloud_ckafka.go`（新增 `DescribeCkafkaRouteByFilter` 服务方法）
+- **修改文件**:
+  - `tencentcloud/provider.go`：注册新数据源
+  - `tencentcloud/provider.md`：由 `make doc` 自动生成
+- **API 依赖**:
+  - CKafka API v20190819: `DescribeRoute`
+  - 文档: https://cloud.tencent.com/document/api/597/40835
+- **兼容性**: 无破坏性变更，纯新增功能

--- a/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/specs/ckafka-routes-datasource/spec.md
+++ b/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/specs/ckafka-routes-datasource/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Data Source Schema Definition
+
+`tencentcloud_ckafka_routes` 数据源 SHALL 支持以下输入参数与输出属性。
+
+**Input Parameters:**
+- `instance_id` (String, Required): CKafka 实例 ID
+- `route_id` (Int, Optional): 路由 ID，用于精确查询单条路由
+- `main_route_flag` (Bool, Optional): 是否显示主路由
+- `result_output_file` (String, Optional): 输出结果到文件
+
+**Output Attributes:**
+- `routers` (List): 路由信息列表，每个元素包含：
+  - `access_type` (Int): 实例接入方式（0: PLAINTEXT, 1: SASL_PLAINTEXT, 2: SSL, 3: SASL_SSL）
+  - `route_id` (Int): 路由 ID
+  - `vip_type` (Int): 路由网络类型（3: vpc 路由, 7: 内部支撑路由, 1: 公网路由）
+  - `vip_list` (List): 虚拟 IP 列表，每个元素含 `vip` (String)、`vport` (String)
+  - `domain` (String): 域名
+  - `domain_port` (Int): 域名端口
+  - `delete_timestamp` (String): 删除时间戳
+  - `subnet` (String): 子网 ID
+  - `broker_vip_list` (List): broker 虚拟 IP 列表，每个元素含 `vip` (String)、`vport` (String)
+  - `vpc_id` (String): 私有网络 ID
+  - `note` (String): 备注信息
+  - `status` (Int): 路由状态（1: 创建中, 2: 创建成功, 3: 创建失败, 4: 删除中, 6: 删除失败）
+
+#### Scenario: Query all routes by instance id
+
+```hcl
+data "tencentcloud_ckafka_routes" "example" {
+  instance_id = "ckafka-bqwlyrg8"
+}
+
+output "routes" {
+  value = data.tencentcloud_ckafka_routes.example.routers
+}
+```
+- **WHEN** user provides only `instance_id`
+- **THEN** the data source calls `DescribeRoute` with that instance ID
+- **AND** returns all routes of the instance in `routers`
+
+#### Scenario: Query a specific route by route id
+
+- **WHEN** user provides `instance_id` and `route_id`
+- **THEN** the data source calls `DescribeRoute` with both parameters
+- **AND** returns the matching route in `routers`
+
+#### Scenario: Query routes including main route
+
+- **WHEN** user provides `instance_id` and sets `main_route_flag = true`
+- **THEN** the data source calls `DescribeRoute` with `MainRouteFlag` set to true
+- **AND** returns the route list including the main route created at instance creation
+
+#### Scenario: Output to file
+
+- **WHEN** user specifies `result_output_file` parameter
+- **THEN** the route information is written to the specified file in JSON format
+
+### Requirement: API Integration
+
+数据源 SHALL 集成 CKafka API v20190819 的 `DescribeRoute` 接口。
+
+#### Scenario: API call execution
+
+- **WHEN** the data source is read
+- **THEN** it calls the service layer method `DescribeCkafkaRouteByFilter` which invokes `DescribeRoute`
+- **AND** wraps the API call in `resource.Retry(tccommon.ReadRetryTimeout, ...)` for retry handling
+- **AND** uses `tccommon.RetryError()` to wrap API errors for retry classification
+- **AND** logs API calls using `tccommon.LogElapsed` and debug logging
+
+### Requirement: Error Handling
+
+数据源 SHALL 正确处理空响应与各类错误情况。
+
+#### Scenario: API returns empty response
+
+- **WHEN** the `DescribeRoute` response is nil, or `response.Response` is nil, or `response.Response.Result` is nil, or `len(response.Response.Result.Routers) == 0`
+- **THEN** the data source returns a `NonRetryableError` within the retry block
+- **AND** does NOT call `d.SetId("")` to avoid clearing state on transient API fluctuation
+- **AND** logs `log.Printf("[DATASOURCE] read empty, skip SetId")` on the retry failure path
+
+#### Scenario: Instance not found
+
+- **WHEN** the specified CKafka instance does not exist
+- **THEN** the data source returns the API error message indicating the instance was not found
+
+#### Scenario: Network or service error
+
+- **WHEN** the API call fails due to network issues or service unavailability
+- **THEN** the data source retries according to the configured retry policy
+- **AND** returns an appropriate error if all retries fail

--- a/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/tasks.md
+++ b/openspec/changes/archive/2026-08-28-add-ckafka-routes-datasource/tasks.md
@@ -1,0 +1,34 @@
+## 1. 服务层方法实现
+
+- [x] 1.1 在 `tencentcloud/services/ckafka/service_tencentcloud_ckafka.go` 中新增 `DescribeCkafkaRouteByFilter` 方法，接收 `instanceId`、`routeId`、`mainRouteFlag` 参数，构造 `DescribeRouteRequest` 并调用 `DescribeRoute`，返回 `*ckafka.RouteResponse`
+- [x] 1.2 方法中添加 `ratelimit.Check`、错误日志 defer、`response == nil` / `response.Response == nil` / `response.Response.Result == nil` 校验
+
+## 2. 数据源核心功能实现
+
+- [x] 2.1 创建 `tencentcloud/services/ckafka/data_source_tc_ckafka_routes.go` 文件
+- [x] 2.2 实现 `DataSourceTencentCloudCkafkaRoutes()` Schema 定义：输入参数 `instance_id`(Required)、`route_id`(Optional,Int)、`main_route_flag`(Optional,Bool)、`result_output_file`(Optional)；输出 `routers`(TypeList)，元素含 `access_type`、`route_id`、`vip_type`、`vip_list`(vip/vport)、`domain`、`domain_port`、`delete_timestamp`、`subnet`、`broker_vip_list`(vip/vport)、`vpc_id`、`note`、`status`
+- [x] 2.3 实现 `dataSourceTencentCloudCkafkaRoutesRead` 函数：`defer tccommon.LogElapsed` 与 `defer tccommon.InconsistentCheck`
+- [x] 2.4 在 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 块内调用 `service.DescribeCkafkaRouteByFilter`，使用 `tccommon.RetryError` 包装错误
+- [x] 2.5 retry 块内检查返回为空（`result == nil` / `len(result.Routers) == 0`）时返回 `NonRetryableError`，不执行 `d.SetId("")`，并在失败路径保留 `log.Printf("[DATASOURCE] read empty, skip SetId")` 日志
+- [x] 2.6 遍历 `result.Routers`，逐字段判断 nil 后 `d.Set` 到 `routers` 列表（含嵌套 `vip_list`、`broker_vip_list` 的展开）
+- [x] 2.7 使用 `helper.BuildToken()` 设置数据源 ID
+- [x] 2.8 处理 `result_output_file` 输出
+
+## 3. 集成到 Provider
+
+- [x] 3.1 在 `tencentcloud/provider.go` 的 `DataSourcesMap` 中注册 `tencentcloud_ckafka_routes`，参考 `tencentcloud_ckafka_version` 注册位置
+
+## 4. 编写文档
+
+- [x] 4.1 创建 `tencentcloud/services/ckafka/data_source_tc_ckafka_routes.md`，一句话描述带上 CKafka 产品名，包含 Example Usage，不添加 Argument/Attribute Reference
+
+## 5. 编写单元测试
+
+- [x] 5.1 创建 `tencentcloud/services/ckafka/data_source_tc_ckafka_routes_test.go`，使用 gomonkey mock 云 API `DescribeRoute` 返回值
+- [x] 5.2 编写测试用例验证 Read 函数对响应字段的映射逻辑（`routers` 列表展开、嵌套 `vip_list`/`broker_vip_list`、nil 字段跳过）
+
+## 6. 验证（收尾阶段由 tfpacer-finalize 执行）
+
+- [ ] 6.1 运行 `gofmt` 格式化代码（由 tfpacer-finalize skill 执行）
+- [ ] 6.2 运行 `make doc` 生成 `website/docs/` 文档与 `provider.md`（由 tfpacer-finalize skill 执行）
+- [ ] 6.3 在 `.changelog/` 下生成 changelog 文件（由 tfpacer-finalize skill 执行）

--- a/openspec/specs/ckafka-routes-datasource/spec.md
+++ b/openspec/specs/ckafka-routes-datasource/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Data Source Schema Definition
+
+`tencentcloud_ckafka_routes` 数据源 SHALL 支持以下输入参数与输出属性。
+
+**Input Parameters:**
+- `instance_id` (String, Required): CKafka 实例 ID
+- `route_id` (Int, Optional): 路由 ID，用于精确查询单条路由
+- `main_route_flag` (Bool, Optional): 是否显示主路由
+- `result_output_file` (String, Optional): 输出结果到文件
+
+**Output Attributes:**
+- `routers` (List): 路由信息列表，每个元素包含：
+  - `access_type` (Int): 实例接入方式（0: PLAINTEXT, 1: SASL_PLAINTEXT, 2: SSL, 3: SASL_SSL）
+  - `route_id` (Int): 路由 ID
+  - `vip_type` (Int): 路由网络类型（3: vpc 路由, 7: 内部支撑路由, 1: 公网路由）
+  - `vip_list` (List): 虚拟 IP 列表，每个元素含 `vip` (String)、`vport` (String)
+  - `domain` (String): 域名
+  - `domain_port` (Int): 域名端口
+  - `delete_timestamp` (String): 删除时间戳
+  - `subnet` (String): 子网 ID
+  - `broker_vip_list` (List): broker 虚拟 IP 列表，每个元素含 `vip` (String)、`vport` (String)
+  - `vpc_id` (String): 私有网络 ID
+  - `note` (String): 备注信息
+  - `status` (Int): 路由状态（1: 创建中, 2: 创建成功, 3: 创建失败, 4: 删除中, 6: 删除失败）
+
+#### Scenario: Query all routes by instance id
+
+```hcl
+data "tencentcloud_ckafka_routes" "example" {
+  instance_id = "ckafka-bqwlyrg8"
+}
+
+output "routes" {
+  value = data.tencentcloud_ckafka_routes.example.routers
+}
+```
+- **WHEN** user provides only `instance_id`
+- **THEN** the data source calls `DescribeRoute` with that instance ID
+- **AND** returns all routes of the instance in `routers`
+
+#### Scenario: Query a specific route by route id
+
+- **WHEN** user provides `instance_id` and `route_id`
+- **THEN** the data source calls `DescribeRoute` with both parameters
+- **AND** returns the matching route in `routers`
+
+#### Scenario: Query routes including main route
+
+- **WHEN** user provides `instance_id` and sets `main_route_flag = true`
+- **THEN** the data source calls `DescribeRoute` with `MainRouteFlag` set to true
+- **AND** returns the route list including the main route created at instance creation
+
+#### Scenario: Output to file
+
+- **WHEN** user specifies `result_output_file` parameter
+- **THEN** the route information is written to the specified file in JSON format
+
+### Requirement: API Integration
+
+数据源 SHALL 集成 CKafka API v20190819 的 `DescribeRoute` 接口。
+
+#### Scenario: API call execution
+
+- **WHEN** the data source is read
+- **THEN** it calls the service layer method `DescribeCkafkaRouteByFilter` which invokes `DescribeRoute`
+- **AND** wraps the API call in `resource.Retry(tccommon.ReadRetryTimeout, ...)` for retry handling
+- **AND** uses `tccommon.RetryError()` to wrap API errors for retry classification
+- **AND** logs API calls using `tccommon.LogElapsed` and debug logging
+
+### Requirement: Error Handling
+
+数据源 SHALL 正确处理空响应与各类错误情况。
+
+#### Scenario: API returns empty response
+
+- **WHEN** the `DescribeRoute` response is nil, or `response.Response` is nil, or `response.Response.Result` is nil, or `len(response.Response.Result.Routers) == 0`
+- **THEN** the data source returns a `NonRetryableError` within the retry block
+- **AND** does NOT call `d.SetId("")` to avoid clearing state on transient API fluctuation
+- **AND** logs `log.Printf("[DATASOURCE] read empty, skip SetId")` on the retry failure path
+
+#### Scenario: Instance not found
+
+- **WHEN** the specified CKafka instance does not exist
+- **THEN** the data source returns the API error message indicating the instance was not found
+
+#### Scenario: Network or service error
+
+- **WHEN** the API call fails due to network issues or service unavailability
+- **THEN** the data source retries according to the configured retry policy
+- **AND** returns an appropriate error if all retries fail

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -878,6 +878,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_ckafka_topic_sync_replica":                              ckafka.DataSourceTencentCloudCkafkaTopicSyncReplica(),
 			"tencentcloud_ckafka_version":                                         ckafka.DataSourceTencentCloudCkafkaVersion(),
 			"tencentcloud_ckafka_zone":                                            ckafka.DataSourceTencentCloudCkafkaZone(),
+			"tencentcloud_ckafka_routes":                                          ckafka.DataSourceTencentCloudCkafkaRoutes(),
 			"tencentcloud_audit_cos_regions":                                      cloudaudit.DataSourceTencentCloudAuditCosRegions(),
 			"tencentcloud_audit_key_alias":                                        cloudaudit.DataSourceTencentCloudAuditKeyAlias(),
 			"tencentcloud_audits":                                                 cloudaudit.DataSourceTencentCloudAudits(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -229,6 +229,7 @@ tencentcloud_ckafka_topic_subscribe_group
 tencentcloud_ckafka_topic_sync_replica
 tencentcloud_ckafka_zone
 tencentcloud_ckafka_version
+tencentcloud_ckafka_routes
 
 Resource
 tencentcloud_ckafka_instance

--- a/tencentcloud/services/ckafka/data_source_tc_ckafka_routes.go
+++ b/tencentcloud/services/ckafka/data_source_tc_ckafka_routes.go
@@ -1,0 +1,269 @@
+package ckafka
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	ckafka "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudCkafkaRoutes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudCkafkaRoutesRead,
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Id of the ckafka instance.",
+			},
+
+			"route_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Route id, used to query a specific route.",
+			},
+
+			"main_route_flag": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to display the main route. When set to true, the main route created at instance creation will be additionally returned.",
+			},
+
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+
+			"routers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of ckafka routes. Each element contains the following attributes:",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Instance access type. 0: PLAINTEXT, 1: SASL_PLAINTEXT, 2: SSL, 3: SASL_SSL.",
+						},
+						"route_id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Route id.",
+						},
+						"vip_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Routing network type. 3: vpc routing, 7: internal support routing, 1: public network routing.",
+						},
+						"vip_list": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Virtual IP list.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vip": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Virtual IP.",
+									},
+									"vport": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Virtual port.",
+									},
+								},
+							},
+						},
+						"domain": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Domain.",
+						},
+						"domain_port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Domain port.",
+						},
+						"delete_timestamp": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Delete timestamp.",
+						},
+						"subnet": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Subnet id.",
+						},
+						"broker_vip_list": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Virtual IP list (1 to 1 broker nodes).",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vip": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Virtual IP.",
+									},
+									"vport": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Virtual port.",
+									},
+								},
+							},
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Vpc id.",
+						},
+						"note": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Remark.",
+						},
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Route status. 1: creating, 2: created, 3: create failed, 4: deleting, 6: delete failed.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudCkafkaRoutesRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_ckafka_routes.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId      = tccommon.GetLogId(nil)
+		ctx        = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service    = CkafkaService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	var routeId *int64
+	if v, ok := d.GetOkExists("route_id"); ok {
+		routeId = helper.IntInt64(v.(int))
+	}
+
+	var mainRouteFlag *bool
+	if v, ok := d.GetOkExists("main_route_flag"); ok {
+		mainRouteFlag = helper.Bool(v.(bool))
+	}
+
+	var respData *ckafka.RouteResponse
+	reqErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		result, e := service.DescribeCkafkaRouteByFilter(ctx, instanceId, routeId, mainRouteFlag)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if result == nil || len(result.Routers) == 0 {
+			log.Printf("[DATASOURCE] read empty, skip SetId, instance_id=%s", instanceId)
+			return resource.NonRetryableError(fmt.Errorf("ckafka routes is empty, instance_id=%s", instanceId))
+		}
+
+		respData = result
+		return nil
+	})
+
+	if reqErr != nil {
+		return reqErr
+	}
+
+	routersList := make([]map[string]interface{}, 0, len(respData.Routers))
+	for _, route := range respData.Routers {
+		routeMap := map[string]interface{}{}
+		if route.AccessType != nil {
+			routeMap["access_type"] = route.AccessType
+		}
+
+		if route.RouteId != nil {
+			routeMap["route_id"] = route.RouteId
+		}
+
+		if route.VipType != nil {
+			routeMap["vip_type"] = route.VipType
+		}
+
+		vipList := make([]map[string]interface{}, 0, len(route.VipList))
+		for _, vip := range route.VipList {
+			vipMap := map[string]interface{}{}
+			if vip.Vip != nil {
+				vipMap["vip"] = vip.Vip
+			}
+			if vip.Vport != nil {
+				vipMap["vport"] = vip.Vport
+			}
+			vipList = append(vipList, vipMap)
+		}
+		routeMap["vip_list"] = vipList
+
+		if route.Domain != nil {
+			routeMap["domain"] = route.Domain
+		}
+
+		if route.DomainPort != nil {
+			routeMap["domain_port"] = route.DomainPort
+		}
+
+		if route.DeleteTimestamp != nil {
+			routeMap["delete_timestamp"] = route.DeleteTimestamp
+		}
+
+		if route.Subnet != nil {
+			routeMap["subnet"] = route.Subnet
+		}
+
+		brokerVipList := make([]map[string]interface{}, 0, len(route.BrokerVipList))
+		for _, brokerVip := range route.BrokerVipList {
+			brokerVipMap := map[string]interface{}{}
+			if brokerVip.Vip != nil {
+				brokerVipMap["vip"] = brokerVip.Vip
+			}
+			if brokerVip.Vport != nil {
+				brokerVipMap["vport"] = brokerVip.Vport
+			}
+			brokerVipList = append(brokerVipList, brokerVipMap)
+		}
+		routeMap["broker_vip_list"] = brokerVipList
+
+		if route.VpcId != nil {
+			routeMap["vpc_id"] = route.VpcId
+		}
+
+		if route.Note != nil {
+			routeMap["note"] = route.Note
+		}
+
+		if route.Status != nil {
+			routeMap["status"] = route.Status
+		}
+
+		routersList = append(routersList, routeMap)
+	}
+
+	_ = d.Set("routers", routersList)
+
+	d.SetId(helper.BuildToken())
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), routersList); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/ckafka/data_source_tc_ckafka_routes.md
+++ b/tencentcloud/services/ckafka/data_source_tc_ckafka_routes.md
@@ -1,0 +1,13 @@
+Use this data source to query detailed information of CKafka routes
+
+Example Usage
+
+```hcl
+data "tencentcloud_ckafka_routes" "example" {
+  instance_id = "ckafka-bqwlyrg8"
+}
+
+output "routes" {
+  value = data.tencentcloud_ckafka_routes.example.routers
+}
+```

--- a/tencentcloud/services/ckafka/data_source_tc_ckafka_routes.md
+++ b/tencentcloud/services/ckafka/data_source_tc_ckafka_routes.md
@@ -4,7 +4,9 @@ Example Usage
 
 ```hcl
 data "tencentcloud_ckafka_routes" "example" {
-  instance_id = "ckafka-bqwlyrg8"
+  instance_id = "ckafka-exampleabc"
+  main_route_flag = true
+  route_id = 123
 }
 
 output "routes" {

--- a/tencentcloud/services/ckafka/data_source_tc_ckafka_routes_test.go
+++ b/tencentcloud/services/ckafka/data_source_tc_ckafka_routes_test.go
@@ -1,0 +1,336 @@
+package ckafka_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	ckafka "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	localckafka "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/ckafka"
+)
+
+// -----------------------------------------------------------------------------
+// Mock-based tests for tencentcloud_ckafka_routes data source Read path.
+//
+// go test ./tencentcloud/services/ckafka/ -run "TestCkafkaRoutesDataSource" -v -count=1 -gcflags="all=-l"
+// -----------------------------------------------------------------------------
+
+type mockMetaCkafkaRoutesDataSource struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaCkafkaRoutesDataSource) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaCkafkaRoutesDataSource{}
+
+func newMockMetaCkafkaRoutesDataSource() *mockMetaCkafkaRoutesDataSource {
+	return &mockMetaCkafkaRoutesDataSource{client: &connectivity.TencentCloudClient{}}
+}
+
+func routesPtrString(s string) *string { return &s }
+func routesPtrInt64(v int64) *int64    { return &v }
+
+// buildCkafkaRoute builds a Route with all fields populated for the Read path.
+func buildCkafkaRoute(routeId int64, status int64) *ckafka.Route {
+	return &ckafka.Route{
+		AccessType: routesPtrInt64(0),
+		RouteId:    routesPtrInt64(routeId),
+		VipType:    routesPtrInt64(3),
+		VipList: []*ckafka.VipEntity{
+			{
+				Vip:   routesPtrString("10.0.0.1"),
+				Vport: routesPtrString("9092"),
+			},
+		},
+		Domain:          routesPtrString("ckafka-route.example.com"),
+		DomainPort:      routesPtrInt64(9092),
+		DeleteTimestamp: routesPtrString(""),
+		Subnet:          routesPtrString("subnet-j5vja918"),
+		BrokerVipList: []*ckafka.VipEntity{
+			{
+				Vip:   routesPtrString("10.0.0.2"),
+				Vport: routesPtrString("9093"),
+			},
+		},
+		VpcId:  routesPtrString("vpc-axrsmmrv"),
+		Note:   routesPtrString("test route"),
+		Status: routesPtrInt64(status),
+	}
+}
+
+// TestCkafkaRoutesDataSource_Read_Basic verifies that the Read function maps
+// the DescribeRoute response into the routers list, including nested
+// vip_list/broker_vip_list expansion.
+func TestCkafkaRoutesDataSource_Read_Basic(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaRoutesDataSource().client, "UseCkafkaClient", ckafkaClient)
+
+	instanceId := "ckafka-routes-test"
+	patches.ApplyMethodFunc(ckafkaClient, "DescribeRoute", func(request *ckafka.DescribeRouteRequest) (*ckafka.DescribeRouteResponse, error) {
+		resp := ckafka.NewDescribeRouteResponse()
+		resp.Response = &ckafka.DescribeRouteResponseParams{
+			Result: &ckafka.RouteResponse{
+				Routers: []*ckafka.Route{
+					buildCkafkaRoute(135912, 2),
+				},
+			},
+			RequestId: routesPtrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCkafkaRoutesDataSource()
+	res := localckafka.DataSourceTencentCloudCkafkaRoutes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": instanceId,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	routers := d.Get("routers").([]interface{})
+	assert.Equal(t, 1, len(routers))
+
+	route := routers[0].(map[string]interface{})
+	assert.Equal(t, int64(0), route["access_type"])
+	assert.Equal(t, int64(135912), route["route_id"])
+	assert.Equal(t, int64(3), route["vip_type"])
+	assert.Equal(t, "ckafka-route.example.com", route["domain"])
+	assert.Equal(t, int64(9092), route["domain_port"])
+	assert.Equal(t, "subnet-j5vja918", route["subnet"])
+	assert.Equal(t, "vpc-axrsmmrv", route["vpc_id"])
+	assert.Equal(t, "test route", route["note"])
+	assert.Equal(t, int64(2), route["status"])
+
+	vipList := route["vip_list"].([]interface{})
+	assert.Equal(t, 1, len(vipList))
+	vip := vipList[0].(map[string]interface{})
+	assert.Equal(t, "10.0.0.1", vip["vip"])
+	assert.Equal(t, "9092", vip["vport"])
+
+	brokerVipList := route["broker_vip_list"].([]interface{})
+	assert.Equal(t, 1, len(brokerVipList))
+	brokerVip := brokerVipList[0].(map[string]interface{})
+	assert.Equal(t, "10.0.0.2", brokerVip["vip"])
+	assert.Equal(t, "9093", brokerVip["vport"])
+}
+
+// TestCkafkaRoutesDataSource_Read_MultipleRoutes verifies that multiple routes
+// in the response are all mapped into the routers list.
+func TestCkafkaRoutesDataSource_Read_MultipleRoutes(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaRoutesDataSource().client, "UseCkafkaClient", ckafkaClient)
+
+	instanceId := "ckafka-routes-multi"
+	patches.ApplyMethodFunc(ckafkaClient, "DescribeRoute", func(request *ckafka.DescribeRouteRequest) (*ckafka.DescribeRouteResponse, error) {
+		resp := ckafka.NewDescribeRouteResponse()
+		resp.Response = &ckafka.DescribeRouteResponseParams{
+			Result: &ckafka.RouteResponse{
+				Routers: []*ckafka.Route{
+					buildCkafkaRoute(1, 2),
+					buildCkafkaRoute(2, 2),
+				},
+			},
+			RequestId: routesPtrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCkafkaRoutesDataSource()
+	res := localckafka.DataSourceTencentCloudCkafkaRoutes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": instanceId,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	routers := d.Get("routers").([]interface{})
+	assert.Equal(t, 2, len(routers))
+}
+
+// TestCkafkaRoutesDataSource_Read_WithRouteId verifies that the route_id
+// optional parameter is passed through to the request.
+func TestCkafkaRoutesDataSource_Read_WithRouteId(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaRoutesDataSource().client, "UseCkafkaClient", ckafkaClient)
+
+	instanceId := "ckafka-routes-routeid"
+	var capturedRouteId *int64
+	var capturedMainRouteFlag *bool
+	patches.ApplyMethodFunc(ckafkaClient, "DescribeRoute", func(request *ckafka.DescribeRouteRequest) (*ckafka.DescribeRouteResponse, error) {
+		capturedRouteId = request.RouteId
+		capturedMainRouteFlag = request.MainRouteFlag
+		resp := ckafka.NewDescribeRouteResponse()
+		resp.Response = &ckafka.DescribeRouteResponseParams{
+			Result: &ckafka.RouteResponse{
+				Routers: []*ckafka.Route{
+					buildCkafkaRoute(135912, 2),
+				},
+			},
+			RequestId: routesPtrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCkafkaRoutesDataSource()
+	res := localckafka.DataSourceTencentCloudCkafkaRoutes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id":     instanceId,
+		"route_id":        135912,
+		"main_route_flag": true,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedRouteId)
+	assert.Equal(t, int64(135912), *capturedRouteId)
+	assert.NotNil(t, capturedMainRouteFlag)
+	assert.True(t, *capturedMainRouteFlag)
+}
+
+// TestCkafkaRoutesDataSource_Read_NilFieldsSkipped verifies that nil fields in
+// the response route are skipped (not set) without causing panics.
+func TestCkafkaRoutesDataSource_Read_NilFieldsSkipped(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaRoutesDataSource().client, "UseCkafkaClient", ckafkaClient)
+
+	instanceId := "ckafka-routes-nil"
+	patches.ApplyMethodFunc(ckafkaClient, "DescribeRoute", func(request *ckafka.DescribeRouteRequest) (*ckafka.DescribeRouteResponse, error) {
+		resp := ckafka.NewDescribeRouteResponse()
+		resp.Response = &ckafka.DescribeRouteResponseParams{
+			Result: &ckafka.RouteResponse{
+				Routers: []*ckafka.Route{
+					{
+						// Only RouteId is set; all other fields are nil.
+						RouteId: routesPtrInt64(1),
+					},
+				},
+			},
+			RequestId: routesPtrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCkafkaRoutesDataSource()
+	res := localckafka.DataSourceTencentCloudCkafkaRoutes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": instanceId,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	routers := d.Get("routers").([]interface{})
+	assert.Equal(t, 1, len(routers))
+	route := routers[0].(map[string]interface{})
+	assert.Equal(t, int64(1), route["route_id"])
+	// nil fields should yield zero values
+	assert.Equal(t, 0, route["access_type"])
+	assert.Equal(t, "", route["domain"])
+}
+
+// TestCkafkaRoutesDataSource_Read_EmptyResponse verifies that when the
+// DescribeRoute response returns an empty routers list, the Read function
+// returns an error (NonRetryableError) and does not clear the id.
+func TestCkafkaRoutesDataSource_Read_EmptyResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaRoutesDataSource().client, "UseCkafkaClient", ckafkaClient)
+
+	instanceId := "ckafka-routes-empty"
+	patches.ApplyMethodFunc(ckafkaClient, "DescribeRoute", func(request *ckafka.DescribeRouteRequest) (*ckafka.DescribeRouteResponse, error) {
+		resp := ckafka.NewDescribeRouteResponse()
+		resp.Response = &ckafka.DescribeRouteResponseParams{
+			Result: &ckafka.RouteResponse{
+				Routers: []*ckafka.Route{},
+			},
+			RequestId: routesPtrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCkafkaRoutesDataSource()
+	res := localckafka.DataSourceTencentCloudCkafkaRoutes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": instanceId,
+	})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}
+
+// TestCkafkaRoutesDataSource_Read_NilResult verifies that when the
+// DescribeRoute response returns nil Result, the Read function returns an
+// error (NonRetryableError).
+func TestCkafkaRoutesDataSource_Read_NilResult(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaRoutesDataSource().client, "UseCkafkaClient", ckafkaClient)
+
+	instanceId := "ckafka-routes-nil-result"
+	patches.ApplyMethodFunc(ckafkaClient, "DescribeRoute", func(request *ckafka.DescribeRouteRequest) (*ckafka.DescribeRouteResponse, error) {
+		resp := ckafka.NewDescribeRouteResponse()
+		resp.Response = &ckafka.DescribeRouteResponseParams{
+			Result:    nil,
+			RequestId: routesPtrString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaCkafkaRoutesDataSource()
+	res := localckafka.DataSourceTencentCloudCkafkaRoutes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": instanceId,
+	})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}
+
+// TestCkafkaRoutesDataSource_Read_APIError verifies that when the DescribeRoute
+// API returns an error, the Read function returns the error.
+func TestCkafkaRoutesDataSource_Read_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	ckafkaClient := &ckafka.Client{}
+	patches.ApplyMethodReturn(newMockMetaCkafkaRoutesDataSource().client, "UseCkafkaClient", ckafkaClient)
+
+	instanceId := "ckafka-routes-api-error"
+	patches.ApplyMethodFunc(ckafkaClient, "DescribeRoute", func(request *ckafka.DescribeRouteRequest) (*ckafka.DescribeRouteResponse, error) {
+		return nil, context.DeadlineExceeded
+	})
+
+	meta := newMockMetaCkafkaRoutesDataSource()
+	res := localckafka.DataSourceTencentCloudCkafkaRoutes()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"instance_id": instanceId,
+	})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}

--- a/tencentcloud/services/ckafka/service_tencentcloud_ckafka.go
+++ b/tencentcloud/services/ckafka/service_tencentcloud_ckafka.go
@@ -1774,6 +1774,41 @@ func (me *CkafkaService) DescribeCkafkaRouteById(ctx context.Context, instanceId
 	return
 }
 
+func (me *CkafkaService) DescribeCkafkaRouteByFilter(ctx context.Context, instanceId string, routeId *int64, mainRouteFlag *bool) (routeResponse *ckafka.RouteResponse, errRet error) {
+	logId := tccommon.GetLogId(ctx)
+
+	request := ckafka.NewDescribeRouteRequest()
+	request.InstanceId = &instanceId
+	if routeId != nil {
+		request.RouteId = routeId
+	}
+	if mainRouteFlag != nil {
+		request.MainRouteFlag = mainRouteFlag
+	}
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	ratelimit.Check(request.GetAction())
+
+	response, err := me.client.UseCkafkaClient().DescribeRoute(request)
+	if err != nil {
+		errRet = err
+		return
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+	if response == nil || response.Response == nil || response.Response.Result == nil {
+		return
+	}
+
+	routeResponse = response.Response.Result
+	return
+}
+
 func (me *CkafkaService) DeleteCkafkaRouteById(ctx context.Context, instanceId string, routeId int64) (errRet error) {
 	logId := tccommon.GetLogId(ctx)
 

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/client.go
@@ -45,6 +45,64 @@ func NewClient(credential common.CredentialIface, region string, clientProfile *
 }
 
 
+func NewAssociateRoutesSecurityGroupRequest() (request *AssociateRoutesSecurityGroupRequest) {
+    request = &AssociateRoutesSecurityGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ckafka", APIVersion, "AssociateRoutesSecurityGroup")
+    
+    
+    return
+}
+
+func NewAssociateRoutesSecurityGroupResponse() (response *AssociateRoutesSecurityGroupResponse) {
+    response = &AssociateRoutesSecurityGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// AssociateRoutesSecurityGroup
+// 绑定路由安全组
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) AssociateRoutesSecurityGroup(request *AssociateRoutesSecurityGroupRequest) (response *AssociateRoutesSecurityGroupResponse, err error) {
+    return c.AssociateRoutesSecurityGroupWithContext(context.Background(), request)
+}
+
+// AssociateRoutesSecurityGroup
+// 绑定路由安全组
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) AssociateRoutesSecurityGroupWithContext(ctx context.Context, request *AssociateRoutesSecurityGroupRequest) (response *AssociateRoutesSecurityGroupResponse, err error) {
+    if request == nil {
+        request = NewAssociateRoutesSecurityGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ckafka", APIVersion, "AssociateRoutesSecurityGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("AssociateRoutesSecurityGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewAssociateRoutesSecurityGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewAuthorizeTokenRequest() (request *AuthorizeTokenRequest) {
     request = &AuthorizeTokenRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1471,6 +1529,62 @@ func (c *Client) CreateRouteWithContext(ctx context.Context, request *CreateRout
     return
 }
 
+func NewCreateThrottleRuleRequest() (request *CreateThrottleRuleRequest) {
+    request = &CreateThrottleRuleRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ckafka", APIVersion, "CreateThrottleRule")
+    
+    
+    return
+}
+
+func NewCreateThrottleRuleResponse() (response *CreateThrottleRuleResponse) {
+    response = &CreateThrottleRuleResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateThrottleRule
+// 实例限流规则相关接口
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) CreateThrottleRule(request *CreateThrottleRuleRequest) (response *CreateThrottleRuleResponse, err error) {
+    return c.CreateThrottleRuleWithContext(context.Background(), request)
+}
+
+// CreateThrottleRule
+// 实例限流规则相关接口
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) CreateThrottleRuleWithContext(ctx context.Context, request *CreateThrottleRuleRequest) (response *CreateThrottleRuleResponse, err error) {
+    if request == nil {
+        request = NewCreateThrottleRuleRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ckafka", APIVersion, "CreateThrottleRule")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateThrottleRule require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateThrottleRuleResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateTokenRequest() (request *CreateTokenRequest) {
     request = &CreateTokenRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -2509,6 +2623,62 @@ func (c *Client) DeleteRouteTriggerTimeWithContext(ctx context.Context, request 
     request.SetContext(ctx)
     
     response = NewDeleteRouteTriggerTimeResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteThrottleRuleRequest() (request *DeleteThrottleRuleRequest) {
+    request = &DeleteThrottleRuleRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ckafka", APIVersion, "DeleteThrottleRule")
+    
+    
+    return
+}
+
+func NewDeleteThrottleRuleResponse() (response *DeleteThrottleRuleResponse) {
+    response = &DeleteThrottleRuleResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteThrottleRule
+// 删除实例限流规则
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteThrottleRule(request *DeleteThrottleRuleRequest) (response *DeleteThrottleRuleResponse, err error) {
+    return c.DeleteThrottleRuleWithContext(context.Background(), request)
+}
+
+// DeleteThrottleRule
+// 删除实例限流规则
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DeleteThrottleRuleWithContext(ctx context.Context, request *DeleteThrottleRuleRequest) (response *DeleteThrottleRuleResponse, err error) {
+    if request == nil {
+        request = NewDeleteThrottleRuleRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ckafka", APIVersion, "DeleteThrottleRule")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteThrottleRule require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteThrottleRuleResponse()
     err = c.Send(request, response)
     return
 }
@@ -4577,6 +4747,58 @@ func (c *Client) DescribeTaskStatusWithContext(ctx context.Context, request *Des
     return
 }
 
+func NewDescribeThrottleRulesRequest() (request *DescribeThrottleRulesRequest) {
+    request = &DescribeThrottleRulesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ckafka", APIVersion, "DescribeThrottleRules")
+    
+    
+    return
+}
+
+func NewDescribeThrottleRulesResponse() (response *DescribeThrottleRulesResponse) {
+    response = &DescribeThrottleRulesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeThrottleRules
+// 获取实例限流规则列表
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeThrottleRules(request *DescribeThrottleRulesRequest) (response *DescribeThrottleRulesResponse, err error) {
+    return c.DescribeThrottleRulesWithContext(context.Background(), request)
+}
+
+// DescribeThrottleRules
+// 获取实例限流规则列表
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeThrottleRulesWithContext(ctx context.Context, request *DescribeThrottleRulesRequest) (response *DescribeThrottleRulesResponse, err error) {
+    if request == nil {
+        request = NewDescribeThrottleRulesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ckafka", APIVersion, "DescribeThrottleRules")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeThrottleRules require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeThrottleRulesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeTopicRequest() (request *DescribeTopicRequest) {
     request = &DescribeTopicRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -5215,6 +5437,64 @@ func (c *Client) DescribeUserWithContext(ctx context.Context, request *DescribeU
     request.SetContext(ctx)
     
     response = NewDescribeUserResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDisassociateRoutesSecurityGroupRequest() (request *DisassociateRoutesSecurityGroupRequest) {
+    request = &DisassociateRoutesSecurityGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ckafka", APIVersion, "DisassociateRoutesSecurityGroup")
+    
+    
+    return
+}
+
+func NewDisassociateRoutesSecurityGroupResponse() (response *DisassociateRoutesSecurityGroupResponse) {
+    response = &DisassociateRoutesSecurityGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DisassociateRoutesSecurityGroup
+// 解绑路由安全组
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) DisassociateRoutesSecurityGroup(request *DisassociateRoutesSecurityGroupRequest) (response *DisassociateRoutesSecurityGroupResponse, err error) {
+    return c.DisassociateRoutesSecurityGroupWithContext(context.Background(), request)
+}
+
+// DisassociateRoutesSecurityGroup
+// 解绑路由安全组
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) DisassociateRoutesSecurityGroupWithContext(ctx context.Context, request *DisassociateRoutesSecurityGroupRequest) (response *DisassociateRoutesSecurityGroupResponse, err error) {
+    if request == nil {
+        request = NewDisassociateRoutesSecurityGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ckafka", APIVersion, "DisassociateRoutesSecurityGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DisassociateRoutesSecurityGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDisassociateRoutesSecurityGroupResponse()
     err = c.Send(request, response)
     return
 }
@@ -6293,6 +6573,66 @@ func (c *Client) ModifyPasswordWithContext(ctx context.Context, request *ModifyP
     return
 }
 
+func NewModifyRouteSecurityGroupsRequest() (request *ModifyRouteSecurityGroupsRequest) {
+    request = &ModifyRouteSecurityGroupsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ckafka", APIVersion, "ModifyRouteSecurityGroups")
+    
+    
+    return
+}
+
+func NewModifyRouteSecurityGroupsResponse() (response *ModifyRouteSecurityGroupsResponse) {
+    response = &ModifyRouteSecurityGroupsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyRouteSecurityGroups
+// 修改路由安全组关联
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_NOTALLOWEDEMPTY = "InvalidParameterValue.NotAllowedEmpty"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+func (c *Client) ModifyRouteSecurityGroups(request *ModifyRouteSecurityGroupsRequest) (response *ModifyRouteSecurityGroupsResponse, err error) {
+    return c.ModifyRouteSecurityGroupsWithContext(context.Background(), request)
+}
+
+// ModifyRouteSecurityGroups
+// 修改路由安全组关联
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_NOTALLOWEDEMPTY = "InvalidParameterValue.NotAllowedEmpty"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+func (c *Client) ModifyRouteSecurityGroupsWithContext(ctx context.Context, request *ModifyRouteSecurityGroupsRequest) (response *ModifyRouteSecurityGroupsResponse, err error) {
+    if request == nil {
+        request = NewModifyRouteSecurityGroupsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ckafka", APIVersion, "ModifyRouteSecurityGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyRouteSecurityGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyRouteSecurityGroupsResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyRoutineMaintenanceTaskRequest() (request *ModifyRoutineMaintenanceTaskRequest) {
     request = &ModifyRoutineMaintenanceTaskRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -6365,6 +6705,62 @@ func (c *Client) ModifyRoutineMaintenanceTaskWithContext(ctx context.Context, re
     request.SetContext(ctx)
     
     response = NewModifyRoutineMaintenanceTaskResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyThrottleRuleRequest() (request *ModifyThrottleRuleRequest) {
+    request = &ModifyThrottleRuleRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ckafka", APIVersion, "ModifyThrottleRule")
+    
+    
+    return
+}
+
+func NewModifyThrottleRuleResponse() (response *ModifyThrottleRuleResponse) {
+    response = &ModifyThrottleRuleResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyThrottleRule
+// 修改限流规则接口
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifyThrottleRule(request *ModifyThrottleRuleRequest) (response *ModifyThrottleRuleResponse, err error) {
+    return c.ModifyThrottleRuleWithContext(context.Background(), request)
+}
+
+// ModifyThrottleRule
+// 修改限流规则接口
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) ModifyThrottleRuleWithContext(ctx context.Context, request *ModifyThrottleRuleRequest) (response *ModifyThrottleRuleResponse, err error) {
+    if request == nil {
+        request = NewModifyThrottleRuleRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ckafka", APIVersion, "ModifyThrottleRule")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyThrottleRule require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyThrottleRuleResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819/models.go
@@ -134,6 +134,70 @@ type Assignment struct {
 }
 
 // Predefined struct for user
+type AssociateRoutesSecurityGroupRequestParams struct {
+	// 绑定路由的列表
+	InstanceRoutes []*InstanceRoute `json:"InstanceRoutes,omitnil,omitempty" name:"InstanceRoutes"`
+
+	// 安全组id
+	SecurityGroupId *string `json:"SecurityGroupId,omitnil,omitempty" name:"SecurityGroupId"`
+}
+
+type AssociateRoutesSecurityGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// 绑定路由的列表
+	InstanceRoutes []*InstanceRoute `json:"InstanceRoutes,omitnil,omitempty" name:"InstanceRoutes"`
+
+	// 安全组id
+	SecurityGroupId *string `json:"SecurityGroupId,omitnil,omitempty" name:"SecurityGroupId"`
+}
+
+func (r *AssociateRoutesSecurityGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *AssociateRoutesSecurityGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceRoutes")
+	delete(f, "SecurityGroupId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "AssociateRoutesSecurityGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type AssociateRoutesSecurityGroupResponseParams struct {
+	// 返回结果
+	Result *SecurityGroupRouteOperateResp `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type AssociateRoutesSecurityGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *AssociateRoutesSecurityGroupResponseParams `json:"Response"`
+}
+
+func (r *AssociateRoutesSecurityGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *AssociateRoutesSecurityGroupResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type AuthorizeTokenRequestParams struct {
 	// ckafka集群实例Id, 可通过[DescribeInstances](https://cloud.tencent.com/document/product/597/40835)接口获取
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
@@ -1332,6 +1396,9 @@ type CreateConnectResourceRequestParams struct {
 	// <p>MQTT配置，Type为 MQTT 时必填</p>
 	MqttConnectParam *MqttConnectParam `json:"MqttConnectParam,omitnil,omitempty" name:"MqttConnectParam"`
 
+	// <p>Iceberg配置，Type为ICEBERG时必填</p>
+	IcebergConnectParam *IcebergConnectParam `json:"IcebergConnectParam,omitnil,omitempty" name:"IcebergConnectParam"`
+
 	// <p>标签列表</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
@@ -1381,6 +1448,9 @@ type CreateConnectResourceRequest struct {
 	// <p>MQTT配置，Type为 MQTT 时必填</p>
 	MqttConnectParam *MqttConnectParam `json:"MqttConnectParam,omitnil,omitempty" name:"MqttConnectParam"`
 
+	// <p>Iceberg配置，Type为ICEBERG时必填</p>
+	IcebergConnectParam *IcebergConnectParam `json:"IcebergConnectParam,omitnil,omitempty" name:"IcebergConnectParam"`
+
 	// <p>标签列表</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
@@ -1411,6 +1481,7 @@ func (r *CreateConnectResourceRequest) FromJsonString(s string) error {
 	delete(f, "DorisConnectParam")
 	delete(f, "KafkaConnectParam")
 	delete(f, "MqttConnectParam")
+	delete(f, "IcebergConnectParam")
 	delete(f, "Tags")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateConnectResourceRequest has unknown keys!", "")
@@ -2829,6 +2900,112 @@ func (r *CreateRouteResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type CreateThrottleRuleRequestParams struct {
+	// <p>实例Id</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>限流类型:</p><p>枚举值：</p><ul><li>1： 用户/客户端限流</li><li>2： 消费组维度限流</li><li>3： Topic限流</li></ul>
+	ThrottleType *int64 `json:"ThrottleType,omitnil,omitempty" name:"ThrottleType"`
+
+	// <p>消费组名</p>
+	GroupNameList []*string `json:"GroupNameList,omitnil,omitempty" name:"GroupNameList"`
+
+	// <p>消费限流值,生产消费限流值,必填一个单位MB/s</p>
+	ConsumeThrottle *uint64 `json:"ConsumeThrottle,omitnil,omitempty" name:"ConsumeThrottle"`
+
+	// <p>生产限流值,生产消费限流值,单位MB/s</p>
+	ProduceThrottle *uint64 `json:"ProduceThrottle,omitnil,omitempty" name:"ProduceThrottle"`
+
+	// <p>用户客户端id</p>
+	ClientIdList []*string `json:"ClientIdList,omitnil,omitempty" name:"ClientIdList"`
+
+	// <p>用户名</p>
+	UserNameList []*string `json:"UserNameList,omitnil,omitempty" name:"UserNameList"`
+
+	// <p>topic名称</p>
+	TopicNameList []*string `json:"TopicNameList,omitnil,omitempty" name:"TopicNameList"`
+}
+
+type CreateThrottleRuleRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>实例Id</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>限流类型:</p><p>枚举值：</p><ul><li>1： 用户/客户端限流</li><li>2： 消费组维度限流</li><li>3： Topic限流</li></ul>
+	ThrottleType *int64 `json:"ThrottleType,omitnil,omitempty" name:"ThrottleType"`
+
+	// <p>消费组名</p>
+	GroupNameList []*string `json:"GroupNameList,omitnil,omitempty" name:"GroupNameList"`
+
+	// <p>消费限流值,生产消费限流值,必填一个单位MB/s</p>
+	ConsumeThrottle *uint64 `json:"ConsumeThrottle,omitnil,omitempty" name:"ConsumeThrottle"`
+
+	// <p>生产限流值,生产消费限流值,单位MB/s</p>
+	ProduceThrottle *uint64 `json:"ProduceThrottle,omitnil,omitempty" name:"ProduceThrottle"`
+
+	// <p>用户客户端id</p>
+	ClientIdList []*string `json:"ClientIdList,omitnil,omitempty" name:"ClientIdList"`
+
+	// <p>用户名</p>
+	UserNameList []*string `json:"UserNameList,omitnil,omitempty" name:"UserNameList"`
+
+	// <p>topic名称</p>
+	TopicNameList []*string `json:"TopicNameList,omitnil,omitempty" name:"TopicNameList"`
+}
+
+func (r *CreateThrottleRuleRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateThrottleRuleRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "ThrottleType")
+	delete(f, "GroupNameList")
+	delete(f, "ConsumeThrottle")
+	delete(f, "ProduceThrottle")
+	delete(f, "ClientIdList")
+	delete(f, "UserNameList")
+	delete(f, "TopicNameList")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateThrottleRuleRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateThrottleRuleResponseParams struct {
+	// <p>返回信息</p>
+	Result *JgwOperateResponse `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateThrottleRuleResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateThrottleRuleResponseParams `json:"Response"`
+}
+
+func (r *CreateThrottleRuleResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateThrottleRuleResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CreateTokenRequestParams struct {
 	// ckafka集群实例Id,可通过[DescribeInstances](https://cloud.tencent.com/document/product/597/40835)接口获取
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
@@ -3275,109 +3452,88 @@ type CvmAndIpInfo struct {
 }
 
 type DatahubResource struct {
-	// 资源类型  type类型如下: 
-	// KAFKA,
-	// EB_ES,
-	// EB_COS,
-	// EB_CLS,
-	// EB_,
-	// MONGODB,
-	// HTTP,
-	// TDW,
-	// ES,
-	// CLICKHOUSE,
-	// DTS,
-	// CLS,
-	// COS,
-	// TOPIC,
-	// MYSQL,
-	// MQTT,
-	// MYSQL_DATA,
-	// DORIS,
-	// POSTGRESQL,
-	// TDSQL_C_POSTGRESQL,
-	// TDSQL_POSTGRESQL,
-	// WAREHOUSE_POSTGRESQL,
-	// TDSQL_C_MYSQL,
-	// MARIADB,
-	// SQLSERVER,
-	// CTSDB,
-	// SCF
-	// 
+	// <p>资源类型  type类型如下:<br>KAFKA,<br>EB_ES,<br>EB_COS,<br>EB_CLS,<br>EB_,<br>MONGODB,<br>HTTP,<br>TDW,<br>ES,<br>CLICKHOUSE,<br>DTS,<br>CLS,<br>COS,<br>TOPIC,<br>MYSQL,<br>MQTT,<br>MYSQL_DATA,<br>DORIS,<br>POSTGRESQL,<br>TDSQL_C_POSTGRESQL,<br>TDSQL_POSTGRESQL,<br>WAREHOUSE_POSTGRESQL,<br>TDSQL_C_MYSQL,<br>MARIADB,<br>SQLSERVER,<br>CTSDB,<br>SCF</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// ckafka配置，Type为KAFKA时必填
+	// <p>ckafka配置，Type为KAFKA时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	KafkaParam *KafkaParam `json:"KafkaParam,omitnil,omitempty" name:"KafkaParam"`
 
-	// EB配置，Type为EB时必填
+	// <p>EB配置，Type为EB时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	EventBusParam *EventBusParam `json:"EventBusParam,omitnil,omitempty" name:"EventBusParam"`
 
-	// MongoDB配置，Type为MONGODB时必填
+	// <p>MongoDB配置，Type为MONGODB时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MongoDBParam *MongoDBParam `json:"MongoDBParam,omitnil,omitempty" name:"MongoDBParam"`
 
-	// Es配置，Type为ES时必填
+	// <p>Es配置，Type为ES时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	EsParam *EsParam `json:"EsParam,omitnil,omitempty" name:"EsParam"`
 
-	// Tdw配置，Type为TDW时必填
+	// <p>Tdw配置，Type为TDW时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	TdwParam *TdwParam `json:"TdwParam,omitnil,omitempty" name:"TdwParam"`
 
-	// Dts配置，Type为DTS时必填
+	// <p>Dts配置，Type为DTS时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	DtsParam *DtsParam `json:"DtsParam,omitnil,omitempty" name:"DtsParam"`
 
-	// ClickHouse配置，Type为CLICKHOUSE时必填
+	// <p>ClickHouse配置，Type为CLICKHOUSE时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ClickHouseParam *ClickHouseParam `json:"ClickHouseParam,omitnil,omitempty" name:"ClickHouseParam"`
 
-	// Cls配置，Type为CLS时必填
+	// <p>Cls配置，Type为CLS时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ClsParam *ClsParam `json:"ClsParam,omitnil,omitempty" name:"ClsParam"`
 
-	// Cos配置，Type为COS时必填
+	// <p>Cos配置，Type为COS时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	CosParam *CosParam `json:"CosParam,omitnil,omitempty" name:"CosParam"`
 
-	// MySQL配置，Type为MYSQL时必填
+	// <p>MySQL配置，Type为MYSQL时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MySQLParam *MySQLParam `json:"MySQLParam,omitnil,omitempty" name:"MySQLParam"`
 
-	// PostgreSQL配置，Type为POSTGRESQL或TDSQL_C_POSTGRESQL时必填
+	// <p>PostgreSQL配置，Type为POSTGRESQL或TDSQL_C_POSTGRESQL时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	PostgreSQLParam *PostgreSQLParam `json:"PostgreSQLParam,omitnil,omitempty" name:"PostgreSQLParam"`
 
-	// Topic配置，Type为Topic时必填
+	// <p>Topic配置，Type为Topic时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	TopicParam *TopicParam `json:"TopicParam,omitnil,omitempty" name:"TopicParam"`
 
-	// MariaDB配置，Type为MARIADB时必填
+	// <p>MariaDB配置，Type为MARIADB时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MariaDBParam *MariaDBParam `json:"MariaDBParam,omitnil,omitempty" name:"MariaDBParam"`
 
-	// SQLServer配置，Type为SQLSERVER时必填
+	// <p>SQLServer配置，Type为SQLSERVER时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	SQLServerParam *SQLServerParam `json:"SQLServerParam,omitnil,omitempty" name:"SQLServerParam"`
 
-	// Ctsdb配置，Type为CTSDB时必填
+	// <p>Ctsdb配置，Type为CTSDB时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	CtsdbParam *CtsdbParam `json:"CtsdbParam,omitnil,omitempty" name:"CtsdbParam"`
 
-	// Scf配置，Type为SCF时必填
+	// <p>Scf配置，Type为SCF时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ScfParam *ScfParam `json:"ScfParam,omitnil,omitempty" name:"ScfParam"`
 
-	// MQTT配置，Type为 MQTT 时必填
+	// <p>MQTT配置，Type为 MQTT 时必填</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MqttParam *MqttParam `json:"MqttParam,omitnil,omitempty" name:"MqttParam"`
+
+	// <p>IceBerg配置</p>
+	IcebergParam *IcebergParam `json:"IcebergParam,omitnil,omitempty" name:"IcebergParam"`
 }
 
 type DatahubTaskIdRes struct {
-	// 任务id
+	// <p>任务id</p>
 	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>DatahubId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DatahubId *string `json:"DatahubId,omitnil,omitempty" name:"DatahubId"`
 }
 
 type DatahubTaskInfo struct {
@@ -3428,6 +3584,9 @@ type DatahubTaskInfo struct {
 
 	// <p>任务是否自动扩容标识</p><p>枚举值：</p><ul><li>true： 自动扩容</li><li>false： 手动扩容</li></ul><p>默认值：true</p>
 	AutoExpandFlag *bool `json:"AutoExpandFlag,omitnil,omitempty" name:"AutoExpandFlag"`
+
+	// <p>不影响任务执行的警告信息</p>
+	WarnMessage *string `json:"WarnMessage,omitnil,omitempty" name:"WarnMessage"`
 }
 
 type DatahubTopicDTO struct {
@@ -3880,26 +4039,26 @@ func (r *DeleteGroupResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteGroupSubscribeTopicRequestParams struct {
-	// ckafka集群实例Id
+	// <p>ckafka集群实例Id</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 消费分组名称
+	// <p>消费分组名称</p>
 	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
 
-	// 主题名
+	// <p>主题名</p>
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 }
 
 type DeleteGroupSubscribeTopicRequest struct {
 	*tchttp.BaseRequest
 	
-	// ckafka集群实例Id
+	// <p>ckafka集群实例Id</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// 消费分组名称
+	// <p>消费分组名称</p>
 	Group *string `json:"Group,omitnil,omitempty" name:"Group"`
 
-	// 主题名
+	// <p>主题名</p>
 	Topic *string `json:"Topic,omitnil,omitempty" name:"Topic"`
 }
 
@@ -3926,7 +4085,7 @@ func (r *DeleteGroupSubscribeTopicRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteGroupSubscribeTopicResponseParams struct {
-	// 返回结果
+	// <p>返回结果</p>
 	Result *JgwOperateResponse `json:"Result,omitnil,omitempty" name:"Result"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -4199,6 +4358,70 @@ func (r *DeleteRouteTriggerTimeResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteRouteTriggerTimeResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteThrottleRuleRequestParams struct {
+	// 限流规则Id
+	ThrottleRuleId *string `json:"ThrottleRuleId,omitnil,omitempty" name:"ThrottleRuleId"`
+
+	// 实例标识
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type DeleteThrottleRuleRequest struct {
+	*tchttp.BaseRequest
+	
+	// 限流规则Id
+	ThrottleRuleId *string `json:"ThrottleRuleId,omitnil,omitempty" name:"ThrottleRuleId"`
+
+	// 实例标识
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *DeleteThrottleRuleRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteThrottleRuleRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ThrottleRuleId")
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteThrottleRuleRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteThrottleRuleResponseParams struct {
+	// 返回信息
+	Result *JgwOperateResponse `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteThrottleRuleResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteThrottleRuleResponseParams `json:"Response"`
+}
+
+func (r *DeleteThrottleRuleResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteThrottleRuleResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -4783,6 +5006,9 @@ type DescribeConnectResource struct {
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MqttConnectParam *MqttConnectParam `json:"MqttConnectParam,omitnil,omitempty" name:"MqttConnectParam"`
 
+	// <p>Iceberg配置，Type为ICEBERG时返回</p>
+	IcebergConnectParam *IcebergConnectParam `json:"IcebergConnectParam,omitnil,omitempty" name:"IcebergConnectParam"`
+
 	// <p>标签列表</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
@@ -4896,8 +5122,14 @@ type DescribeConnectResourceResp struct {
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MqttConnectParam *MqttConnectParam `json:"MqttConnectParam,omitnil,omitempty" name:"MqttConnectParam"`
 
+	// <p>Iceberg配置，Type为ICEBERG时返回</p>
+	IcebergConnectParam *IcebergConnectParam `json:"IcebergConnectParam,omitnil,omitempty" name:"IcebergConnectParam"`
+
 	// <p>标签列表</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>iceberg数据库和表信息</p>
+	IcebergDatabases []*IcebergDatabaseInfo `json:"IcebergDatabases,omitnil,omitempty" name:"IcebergDatabases"`
 }
 
 // Predefined struct for user
@@ -5339,6 +5571,9 @@ type DescribeDatahubTaskRes struct {
 
 	// <p>自动扩容 true:自动扩容 false:手动扩容</p><p>默认值：true</p>
 	AutoExpandFlag *bool `json:"AutoExpandFlag,omitnil,omitempty" name:"AutoExpandFlag"`
+
+	// <p>不影响任务执行的警告信息</p>
+	WarnMessage *string `json:"WarnMessage,omitnil,omitempty" name:"WarnMessage"`
 }
 
 // Predefined struct for user
@@ -6653,6 +6888,91 @@ func (r *DescribeTaskStatusResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeThrottleRulesRequestParams struct {
+	// <p>实例Id</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>关键字</p>
+	SearchWord *string `json:"SearchWord,omitnil,omitempty" name:"SearchWord"`
+
+	// <p>返回数量，不填则默认为20，最大值200</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// <p>偏移数，默认为0</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>限流维度</p><p>枚举值：</p><ul><li>1： 实例维度限流</li><li>2： topic维度限流</li></ul><p>默认值：1</p>
+	ThrottleDimension *int64 `json:"ThrottleDimension,omitnil,omitempty" name:"ThrottleDimension"`
+}
+
+type DescribeThrottleRulesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>实例Id</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>关键字</p>
+	SearchWord *string `json:"SearchWord,omitnil,omitempty" name:"SearchWord"`
+
+	// <p>返回数量，不填则默认为20，最大值200</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// <p>偏移数，默认为0</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>限流维度</p><p>枚举值：</p><ul><li>1： 实例维度限流</li><li>2： topic维度限流</li></ul><p>默认值：1</p>
+	ThrottleDimension *int64 `json:"ThrottleDimension,omitnil,omitempty" name:"ThrottleDimension"`
+}
+
+func (r *DescribeThrottleRulesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeThrottleRulesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "SearchWord")
+	delete(f, "Limit")
+	delete(f, "Offset")
+	delete(f, "ThrottleDimension")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeThrottleRulesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeThrottleRulesResponseParams struct {
+	// <p>返回信息</p>
+	Result *ThrottleRuleResult `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeThrottleRulesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeThrottleRulesResponseParams `json:"Response"`
+}
+
+func (r *DescribeThrottleRulesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeThrottleRulesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeTopicAttributesRequestParams struct {
 	// ckafka集群实例Id，可通过[DescribeInstances](https://cloud.tencent.com/document/product/597/40835)接口获取
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
@@ -6741,6 +7061,9 @@ type DescribeTopicDetailRequestParams struct {
 
 	// <p>目前支持 ReplicaNum （副本数）筛选</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>搜索topic时是否忽略大小写敏感</p>
+	SearchWordIgnoreCaseFlag *bool `json:"SearchWordIgnoreCaseFlag,omitnil,omitempty" name:"SearchWordIgnoreCaseFlag"`
 }
 
 type DescribeTopicDetailRequest struct {
@@ -6769,6 +7092,9 @@ type DescribeTopicDetailRequest struct {
 
 	// <p>目前支持 ReplicaNum （副本数）筛选</p>
 	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>搜索topic时是否忽略大小写敏感</p>
+	SearchWordIgnoreCaseFlag *bool `json:"SearchWordIgnoreCaseFlag,omitnil,omitempty" name:"SearchWordIgnoreCaseFlag"`
 }
 
 func (r *DescribeTopicDetailRequest) ToJsonString() string {
@@ -6791,6 +7117,7 @@ func (r *DescribeTopicDetailRequest) FromJsonString(s string) error {
 	delete(f, "OrderBy")
 	delete(f, "OrderType")
 	delete(f, "Filters")
+	delete(f, "SearchWordIgnoreCaseFlag")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTopicDetailRequest has unknown keys!", "")
 	}
@@ -7389,6 +7716,70 @@ func (r *DescribeUserResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type DisassociateRoutesSecurityGroupRequestParams struct {
+	// 解绑路由的列表
+	InstanceRoutes []*InstanceRoute `json:"InstanceRoutes,omitnil,omitempty" name:"InstanceRoutes"`
+
+	// 安全组id
+	SecurityGroupId *string `json:"SecurityGroupId,omitnil,omitempty" name:"SecurityGroupId"`
+}
+
+type DisassociateRoutesSecurityGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// 解绑路由的列表
+	InstanceRoutes []*InstanceRoute `json:"InstanceRoutes,omitnil,omitempty" name:"InstanceRoutes"`
+
+	// 安全组id
+	SecurityGroupId *string `json:"SecurityGroupId,omitnil,omitempty" name:"SecurityGroupId"`
+}
+
+func (r *DisassociateRoutesSecurityGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DisassociateRoutesSecurityGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceRoutes")
+	delete(f, "SecurityGroupId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DisassociateRoutesSecurityGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DisassociateRoutesSecurityGroupResponseParams struct {
+	// 返回结果
+	Result *SecurityGroupRouteOperateResp `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DisassociateRoutesSecurityGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *DisassociateRoutesSecurityGroupResponseParams `json:"Response"`
+}
+
+func (r *DisassociateRoutesSecurityGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DisassociateRoutesSecurityGroupResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type DorisConnectParam struct {
 	// Doris jdbc 负载均衡连接 port，通常映射到 fe 的 9030 端口
 	Port *int64 `json:"Port,omitnil,omitempty" name:"Port"`
@@ -7573,118 +7964,145 @@ type DynamicRetentionTime struct {
 }
 
 type EsConnectParam struct {
-	// Es的连接port
+	// <p>Es的连接port</p>
 	Port *int64 `json:"Port,omitnil,omitempty" name:"Port"`
 
-	// Es连接源的用户名
+	// <p>Es连接源的用户名</p>
 	UserName *string `json:"UserName,omitnil,omitempty" name:"UserName"`
 
-	// Es连接源的密码
+	// <p>Es连接源的密码</p>
 	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
-	// Es连接源的实例资源
+	// <p>Es连接源的实例资源</p>
 	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// Es连接源是否为自建集群
+	// <p>Es连接源是否为自建集群</p>
 	SelfBuilt *bool `json:"SelfBuilt,omitnil,omitempty" name:"SelfBuilt"`
 
-	// Es连接源的实例vip，当为腾讯云实例时，必填
+	// <p>Es连接源的实例vip，当为腾讯云实例时，必填</p>
 	ServiceVip *string `json:"ServiceVip,omitnil,omitempty" name:"ServiceVip"`
 
-	// Es连接源的vpcId，当为腾讯云实例时，必填
+	// <p>Es连接源的vpcId，当为腾讯云实例时，必填</p>
 	UniqVpcId *string `json:"UniqVpcId,omitnil,omitempty" name:"UniqVpcId"`
 
-	// 是否更新到关联的Datahub任务
+	// <p>是否更新到关联的Datahub任务</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	IsUpdate *bool `json:"IsUpdate,omitnil,omitempty" name:"IsUpdate"`
+
+	// <p>es类型</p><p>枚举值：</p><ul><li>CLUSTER： 普通集群es</li><li>SERVERLESS： serverless形态es</li></ul>
+	EsType *string `json:"EsType,omitnil,omitempty" name:"EsType"`
+
+	// <p>es版本</p><p>默认值：7.14.2</p>
+	EsVersion *string `json:"EsVersion,omitnil,omitempty" name:"EsVersion"`
+
+	// <p>endpointUrl，es的serverless版本的访问入口地址</p>
+	EndpointUrl *string `json:"EndpointUrl,omitnil,omitempty" name:"EndpointUrl"`
+
+	// <p>集群版 ES 连接协议，默认http协议</p><p>枚举值：</p><ul><li>http： http协议</li><li>https： https协议</li></ul>
+	Protocol *string `json:"Protocol,omitnil,omitempty" name:"Protocol"`
 }
 
 type EsModifyConnectParam struct {
-	// Es连接源的实例资源【不支持修改】
+	// <p>Es连接源的实例资源【不支持修改】</p>
 	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// Es的连接port【不支持修改】
+	// <p>Es的连接port【不支持修改】</p>
 	Port *int64 `json:"Port,omitnil,omitempty" name:"Port"`
 
-	// Es连接源的实例vip【不支持修改】
+	// <p>Es连接源的实例vip【不支持修改】</p>
 	ServiceVip *string `json:"ServiceVip,omitnil,omitempty" name:"ServiceVip"`
 
-	// Es连接源的vpcId【不支持修改】
+	// <p>Es连接源的vpcId【不支持修改】</p>
 	UniqVpcId *string `json:"UniqVpcId,omitnil,omitempty" name:"UniqVpcId"`
 
-	// Es连接源的用户名
+	// <p>Es连接源的用户名</p>
 	UserName *string `json:"UserName,omitnil,omitempty" name:"UserName"`
 
-	// Es连接源的密码
+	// <p>Es连接源的密码</p>
 	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
-	// Es连接源是否为自建集群【不支持修改】
+	// <p>Es连接源是否为自建集群【不支持修改】</p>
 	SelfBuilt *bool `json:"SelfBuilt,omitnil,omitempty" name:"SelfBuilt"`
 
-	// 是否更新到关联的Datahub任务
+	// <p>是否更新到关联的Datahub任务</p>
 	IsUpdate *bool `json:"IsUpdate,omitnil,omitempty" name:"IsUpdate"`
+
+	// <p>es类型</p><p>枚举值：</p><ul><li>CLUSTER： 普通集群es</li><li>SERVERLESS： serverless形态es</li></ul>
+	EsType *string `json:"EsType,omitnil,omitempty" name:"EsType"`
+
+	// <p>es版本，默认7.14.2</p><p>默认值：7.14.2</p>
+	EsVersion *string `json:"EsVersion,omitnil,omitempty" name:"EsVersion"`
+
+	// <p>endpointUrl，es的serverless版本的访问入口地址</p>
+	EndpointUrl *string `json:"EndpointUrl,omitnil,omitempty" name:"EndpointUrl"`
+
+	// <p>集群版 ES 连接协议，默认http协议</p><p>枚举值：</p><ul><li>http： http协议</li><li>https： https协议</li></ul>
+	Protocol *string `json:"Protocol,omitnil,omitempty" name:"Protocol"`
 }
 
 type EsParam struct {
-	// Es实例资源Id
+	// <p>Es实例资源Id</p>
 	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// Es的连接port
+	// <p>Es的连接port</p>
 	Port *int64 `json:"Port,omitnil,omitempty" name:"Port"`
 
-	// Es用户名
+	// <p>Es用户名</p>
 	UserName *string `json:"UserName,omitnil,omitempty" name:"UserName"`
 
-	// Es密码
+	// <p>Es密码</p>
 	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
-	// 是否为自建集群
+	// <p>是否为自建集群</p>
 	SelfBuilt *bool `json:"SelfBuilt,omitnil,omitempty" name:"SelfBuilt"`
 
-	// 实例vip
+	// <p>实例vip</p>
 	ServiceVip *string `json:"ServiceVip,omitnil,omitempty" name:"ServiceVip"`
 
-	// 实例的vpcId
+	// <p>实例的vpcId</p>
 	UniqVpcId *string `json:"UniqVpcId,omitnil,omitempty" name:"UniqVpcId"`
 
-	// Es是否抛弃解析失败的消息
+	// <p>Es是否抛弃解析失败的消息</p>
 	DropInvalidMessage *bool `json:"DropInvalidMessage,omitnil,omitempty" name:"DropInvalidMessage"`
 
-	// Es自定义index名称
+	// <p>Es自定义index名称</p>
 	Index *string `json:"Index,omitnil,omitempty" name:"Index"`
 
-	// Es自定义日期后缀
+	// <p>Es自定义日期后缀</p>
 	DateFormat *string `json:"DateFormat,omitnil,omitempty" name:"DateFormat"`
 
-	// 非json格式数据的自定义key
+	// <p>非json格式数据的自定义key</p>
 	ContentKey *string `json:"ContentKey,omitnil,omitempty" name:"ContentKey"`
 
-	// Es是否抛弃非json格式的消息
+	// <p>Es是否抛弃非json格式的消息</p>
 	DropInvalidJsonMessage *bool `json:"DropInvalidJsonMessage,omitnil,omitempty" name:"DropInvalidJsonMessage"`
 
-	// 转储到Es中的文档ID取值字段名
+	// <p>转储到Es中的文档ID取值字段名</p>
 	DocumentIdField *string `json:"DocumentIdField,omitnil,omitempty" name:"DocumentIdField"`
 
-	// Es自定义index名称的类型，STRING，JSONPATH，默认为STRING
+	// <p>Es自定义index名称的类型，STRING，JSONPATH，默认为STRING</p>
 	IndexType *string `json:"IndexType,omitnil,omitempty" name:"IndexType"`
 
-	// 当设置成员参数DropInvalidMessageToCls设置为true时,DropInvalidMessage参数失效
+	// <p>当设置成员参数DropInvalidMessageToCls设置为true时,DropInvalidMessage参数失效</p>
 	DropCls *DropCls `json:"DropCls,omitnil,omitempty" name:"DropCls"`
 
-	// 转储到ES的消息为Database的binlog时，如果需要同步数据库操作，即增删改的操作到ES时填写数据库表主键
+	// <p>转储到ES的消息为Database的binlog时，如果需要同步数据库操作，即增删改的操作到ES时填写数据库表主键</p>
 	DatabasePrimaryKey *string `json:"DatabasePrimaryKey,omitnil,omitempty" name:"DatabasePrimaryKey"`
 
-	// 死信队列
+	// <p>死信队列</p>
 	DropDlq *FailureParam `json:"DropDlq,omitnil,omitempty" name:"DropDlq"`
 
-	// 使用数据订阅格式导入 es 时，消息与 es 索引字段映射关系。不填默认为默认字段匹配
+	// <p>使用数据订阅格式导入 es 时，消息与 es 索引字段映射关系。不填默认为默认字段匹配</p>
 	RecordMappingList []*EsRecordMapping `json:"RecordMappingList,omitnil,omitempty" name:"RecordMappingList"`
 
-	// 消息要映射为 es 索引中 @timestamp 的字段，如果当前配置为空，则使用消息的时间戳进行映射
+	// <p>消息要映射为 es 索引中 @timestamp 的字段，如果当前配置为空，则使用消息的时间戳进行映射</p>
 	DateField *string `json:"DateField,omitnil,omitempty" name:"DateField"`
 
-	// 用来区分当前索引映射，属于新建索引还是存量索引。"EXIST_MAPPING"：从存量索引中选择；"NEW_MAPPING"：新建索引
+	// <p>用来区分当前索引映射，属于新建索引还是存量索引。&quot;EXIST_MAPPING&quot;：从存量索引中选择；&quot;NEW_MAPPING&quot;：新建索引</p>
 	RecordMappingMode *string `json:"RecordMappingMode,omitnil,omitempty" name:"RecordMappingMode"`
+
+	// <p>集群版 ES 连接协议，默认http协议</p><p>枚举值：</p><ul><li>http： http协议</li><li>https： https协议</li></ul>
+	Protocol *string `json:"Protocol,omitnil,omitempty" name:"Protocol"`
 }
 
 type EsRecordMapping struct {
@@ -8285,6 +8703,72 @@ type GroupResponse struct {
 
 	// 消费分组配额
 	GroupCountQuota *uint64 `json:"GroupCountQuota,omitnil,omitempty" name:"GroupCountQuota"`
+}
+
+type IcebergConnectParam struct {
+	// <p>EMR实例的HiveMetaStore节点IP</p><p>参数格式：多个使用英文分号;分隔</p><p>创建连接时必选，编辑连接时不接收该参数</p>
+	ServiceVip *string `json:"ServiceVip,omitnil,omitempty" name:"ServiceVip"`
+
+	// <p>EMR实例ID</p><p>创建连接时必选，编辑连接时不接收该参数</p>
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
+
+	// <p>EMR实例的集群网络vpcId</p><p>创建连接时必选，编辑连接时不接收该参数</p>
+	UniqVpcId *string `json:"UniqVpcId,omitnil,omitempty" name:"UniqVpcId"`
+
+	// <p>认证类型</p><p>枚举值：</p><ul><li>NONE： 无认证</li><li>KERBEROS： Kerberos认证</li></ul><p>开启Kerberos认证的EMR实例，此处需传入KERBEROS，创建连接时必选，编辑连接时非必选</p>
+	AuthType *string `json:"AuthType,omitnil,omitempty" name:"AuthType"`
+
+	// <p>EMR实例的HiveMetaStore节点IP绑定的弹性网卡Id列表</p><p>数量和顺序必须与ServiceVip字段中的多个IP对应，创建连接时必选，编辑连接时不接收该参数</p>
+	EniIdList []*string `json:"EniIdList,omitnil,omitempty" name:"EniIdList"`
+
+	// <p>Catalog数据目录类型</p><p>枚举值：</p><ul><li>HIVE： Hive Catalog</li></ul><p>默认值：HIVE</p><p>仅支持Hive Catalog</p>
+	CatalogType *string `json:"CatalogType,omitnil,omitempty" name:"CatalogType"`
+
+	// <p>用于Kerberos认证的user.keytab文件的内容</p><p>入参限制：文件内容需使用Base64编码</p><p>AuthType为KERBEROS时必传</p>
+	KeyTabContent *string `json:"KeyTabContent,omitnil,omitempty" name:"KeyTabContent"`
+
+	// <p>用于Kerberos认证的krb5.conf文件的内容</p><p>入参限制：文件内容需使用Base64编码</p><p>AuthType为KERBEROS时必传</p>
+	KRB5ConfContent *string `json:"KRB5ConfContent,omitnil,omitempty" name:"KRB5ConfContent"`
+
+	// <p>用户的Kerberos身份凭证</p>
+	KerberosUserPrincipal *string `json:"KerberosUserPrincipal,omitnil,omitempty" name:"KerberosUserPrincipal"`
+
+	// <p>HiveMetastore服务端配置的Kerberos Principal</p><p>hive-site.xml中hive.metastore.kerberos.principal的值</p>
+	KerberosPrincipal *string `json:"KerberosPrincipal,omitnil,omitempty" name:"KerberosPrincipal"`
+
+	// <p>是否更新并重启所有关联的连接器任务</p><p>编辑连接时使用，如果不传，则根据认证类型及认证参数是否发生变化，来判断是否更新并重启所有关联的连接器任务</p>
+	IsUpdate *bool `json:"IsUpdate,omitnil,omitempty" name:"IsUpdate"`
+}
+
+type IcebergDatabaseInfo struct {
+	// <p>数据库名</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>表名称</p>
+	Tables []*string `json:"Tables,omitnil,omitempty" name:"Tables"`
+}
+
+type IcebergParam struct {
+	// <p>Iceberg 连接资源 (EMR 实例)</p>
+	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
+
+	// <p>目标数据库名（Hive catalog 下的 namespace），必填</p>
+	Database *string `json:"Database,omitnil,omitempty" name:"Database"`
+
+	// <p>目标表名</p>
+	TableName *string `json:"TableName,omitnil,omitempty" name:"TableName"`
+
+	// <p>消息解析格式，当前仅支持 JSON</p><p>枚举值：</p><ul><li>JSON： JSON解析格式</li></ul>
+	SchemeType *string `json:"SchemeType,omitnil,omitempty" name:"SchemeType"`
+
+	// <p>表字段扩展开关</p><p>枚举值：</p><ul><li>true： 开</li><li>false： 关</li></ul>
+	EnableFieldExtension *bool `json:"EnableFieldExtension,omitnil,omitempty" name:"EnableFieldExtension"`
+
+	// <p>Upset/CDC 模式，默认off</p><p>枚举值：</p><ul><li>Off： Off</li><li>UPSERT： UPSERT</li><li>CDC： CDC</li></ul>
+	UpsertMode *string `json:"UpsertMode,omitnil,omitempty" name:"UpsertMode"`
+
+	// <p>主键字段：UPSERT / CDC 模式必填（多个字段以英文逗号分隔）</p>
+	PrimaryKeys *string `json:"PrimaryKeys,omitnil,omitempty" name:"PrimaryKeys"`
 }
 
 // Predefined struct for user
@@ -9504,6 +9988,9 @@ type ModifyConnectResourceRequestParams struct {
 
 	// <p>MQTT配置，Type为 MQTT 时必填</p>
 	MqttConnectParam *MqttConnectParam `json:"MqttConnectParam,omitnil,omitempty" name:"MqttConnectParam"`
+
+	// <p>Iceberg配置，Type为ICEBERG时必填</p>
+	IcebergConnectParam *IcebergConnectParam `json:"IcebergConnectParam,omitnil,omitempty" name:"IcebergConnectParam"`
 }
 
 type ModifyConnectResourceRequest struct {
@@ -9556,6 +10043,9 @@ type ModifyConnectResourceRequest struct {
 
 	// <p>MQTT配置，Type为 MQTT 时必填</p>
 	MqttConnectParam *MqttConnectParam `json:"MqttConnectParam,omitnil,omitempty" name:"MqttConnectParam"`
+
+	// <p>Iceberg配置，Type为ICEBERG时必填</p>
+	IcebergConnectParam *IcebergConnectParam `json:"IcebergConnectParam,omitnil,omitempty" name:"IcebergConnectParam"`
 }
 
 func (r *ModifyConnectResourceRequest) ToJsonString() string {
@@ -9586,6 +10076,7 @@ func (r *ModifyConnectResourceRequest) FromJsonString(s string) error {
 	delete(f, "DorisConnectParam")
 	delete(f, "KafkaConnectParam")
 	delete(f, "MqttConnectParam")
+	delete(f, "IcebergConnectParam")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyConnectResourceRequest has unknown keys!", "")
 	}
@@ -9941,13 +10432,13 @@ type ModifyInstanceAttributesRequestParams struct {
 	// <p>实例删除保护开关: 1 开启  0 关闭</p>
 	DeleteProtectionEnable *int64 `json:"DeleteProtectionEnable,omitnil,omitempty" name:"DeleteProtectionEnable"`
 
-	// <p>实例级别消息保留大小</p>单位：byte<br>默认值：-1<br><p>实例级别消息保留大小</p>
+	// <p>实例级别消息保留大小</p><p>单位：byte</p><p>默认值：-1</p><p>实例级别消息保留大小</p>
 	RetentionBytes *int64 `json:"RetentionBytes,omitnil,omitempty" name:"RetentionBytes"`
 
 	// <p>是否封禁高风险admin接口; true则封禁高风险adminApi; 关闭后不支持打开,仅专业版支持; 默认是false 对高风险admin接口不做处理</p>
 	AdminSecurity *bool `json:"AdminSecurity,omitnil,omitempty" name:"AdminSecurity"`
 
-	// <p>事务ID最大空闲时间，超时未提交的事务将被标记为过期</p>取值范围：[3600000, 604800000]<br>单位：ms
+	// <p>事务ID最大空闲时间，超时未提交的事务将被标记为过期</p><p>取值范围：[3600000, 604800000]</p><p>单位：ms</p>
 	TransactionalIdExpirationMs *int64 `json:"TransactionalIdExpirationMs,omitnil,omitempty" name:"TransactionalIdExpirationMs"`
 }
 
@@ -9987,13 +10478,13 @@ type ModifyInstanceAttributesRequest struct {
 	// <p>实例删除保护开关: 1 开启  0 关闭</p>
 	DeleteProtectionEnable *int64 `json:"DeleteProtectionEnable,omitnil,omitempty" name:"DeleteProtectionEnable"`
 
-	// <p>实例级别消息保留大小</p>单位：byte<br>默认值：-1<br><p>实例级别消息保留大小</p>
+	// <p>实例级别消息保留大小</p><p>单位：byte</p><p>默认值：-1</p><p>实例级别消息保留大小</p>
 	RetentionBytes *int64 `json:"RetentionBytes,omitnil,omitempty" name:"RetentionBytes"`
 
 	// <p>是否封禁高风险admin接口; true则封禁高风险adminApi; 关闭后不支持打开,仅专业版支持; 默认是false 对高风险admin接口不做处理</p>
 	AdminSecurity *bool `json:"AdminSecurity,omitnil,omitempty" name:"AdminSecurity"`
 
-	// <p>事务ID最大空闲时间，超时未提交的事务将被标记为过期</p>取值范围：[3600000, 604800000]<br>单位：ms
+	// <p>事务ID最大空闲时间，超时未提交的事务将被标记为过期</p><p>取值范围：[3600000, 604800000]</p><p>单位：ms</p>
 	TransactionalIdExpirationMs *int64 `json:"TransactionalIdExpirationMs,omitnil,omitempty" name:"TransactionalIdExpirationMs"`
 }
 
@@ -10211,6 +10702,72 @@ func (r *ModifyPasswordResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ModifyRouteSecurityGroupsRequestParams struct {
+	// 实例路由
+	InstanceRoute *InstanceRoute `json:"InstanceRoute,omitnil,omitempty" name:"InstanceRoute"`
+
+	// 修改后的安全组有序列表。
+	// 注意:不指定此参数或传空列表则代表解绑所有关联的安全组。
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+}
+
+type ModifyRouteSecurityGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// 实例路由
+	InstanceRoute *InstanceRoute `json:"InstanceRoute,omitnil,omitempty" name:"InstanceRoute"`
+
+	// 修改后的安全组有序列表。
+	// 注意:不指定此参数或传空列表则代表解绑所有关联的安全组。
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+}
+
+func (r *ModifyRouteSecurityGroupsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyRouteSecurityGroupsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceRoute")
+	delete(f, "SecurityGroupIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyRouteSecurityGroupsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyRouteSecurityGroupsResponseParams struct {
+	// 	返回结果
+	Result *SecurityGroupRouteOperateResp `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyRouteSecurityGroupsResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyRouteSecurityGroupsResponseParams `json:"Response"`
+}
+
+func (r *ModifyRouteSecurityGroupsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyRouteSecurityGroupsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyRoutineMaintenanceTaskRequestParams struct {
 	// ckafka集群实例id,可通过[DescribeInstances](https://cloud.tencent.com/document/product/597/40835)接口获取
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
@@ -10334,6 +10891,77 @@ func (r *ModifyRoutineMaintenanceTaskResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyRoutineMaintenanceTaskResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyThrottleRuleRequestParams struct {
+	// 规则标识
+	ThrottleRuleId *uint64 `json:"ThrottleRuleId,omitnil,omitempty" name:"ThrottleRuleId"`
+
+	// 实例Id
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// 消费限流值单位MB/s
+	ConsumeThrottle *uint64 `json:"ConsumeThrottle,omitnil,omitempty" name:"ConsumeThrottle"`
+}
+
+type ModifyThrottleRuleRequest struct {
+	*tchttp.BaseRequest
+	
+	// 规则标识
+	ThrottleRuleId *uint64 `json:"ThrottleRuleId,omitnil,omitempty" name:"ThrottleRuleId"`
+
+	// 实例Id
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// 消费限流值单位MB/s
+	ConsumeThrottle *uint64 `json:"ConsumeThrottle,omitnil,omitempty" name:"ConsumeThrottle"`
+}
+
+func (r *ModifyThrottleRuleRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyThrottleRuleRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ThrottleRuleId")
+	delete(f, "InstanceId")
+	delete(f, "ConsumeThrottle")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyThrottleRuleRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyThrottleRuleResponseParams struct {
+	// 返回信息
+	Result *JgwOperateResponse `json:"Result,omitnil,omitempty" name:"Result"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyThrottleRuleResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyThrottleRuleResponseParams `json:"Response"`
+}
+
+func (r *ModifyThrottleRuleResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyThrottleRuleResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -11331,7 +11959,7 @@ func (r *ResumeDatahubTaskResponse) FromJsonString(s string) error {
 }
 
 type Route struct {
-	// <p>实例接入方式0：PLAINTEXT (明文方式，没有带用户信息老版本及社区版本都支持)1：SASL_PLAINTEXT（明文方式，不过在数据开始时，会通过SASL方式登录鉴权，仅社区版本支持）2：SSL（SSL加密通信，没有带用户信息，老版本及社区版本都支持）3：SASL_SSL（SSL加密通信，在数据开始时，会通过SASL方式登录鉴权，仅社区版本支持）</p>
+	// <p>实例接入方式<br>0：PLAINTEXT (明文方式，没有带用户信息老版本及社区版本都支持)<br>1：SASL_PLAINTEXT（明文方式，不过在数据开始时，会通过SASL方式登录鉴权，仅社区版本支持）<br>2：SSL（SSL加密通信，没有带用户信息，老版本及社区版本都支持）<br>3：SASL_SSL（SSL加密通信，在数据开始时，会通过SASL方式登录鉴权，仅社区版本支持）</p>
 	AccessType *int64 `json:"AccessType,omitnil,omitempty" name:"AccessType"`
 
 	// <p>路由Id</p>
@@ -11490,16 +12118,16 @@ type SQLServerParam struct {
 }
 
 type SaleInfo struct {
-	// 手动设置的flag标志，true表示售罄，false表示可售。
+	// <p>手动设置的flag标志，true表示售罄，false表示可售。</p>
 	Flag *bool `json:"Flag,omitnil,omitempty" name:"Flag"`
 
-	// ckafka版本号(1.1.1/2.4.2/0.10.2)
+	// <p>ckafka版本号(1.1.1/2.4.2/0.10.2)</p>
 	Version *string `json:"Version,omitnil,omitempty" name:"Version"`
 
-	// 专业版、标准版标志
+	// <p>专业版、标准版标志</p>
 	Platform *string `json:"Platform,omitnil,omitempty" name:"Platform"`
 
-	// 售罄标志：true售罄
+	// <p>售罄标志：true售罄</p>
 	SoldOut *bool `json:"SoldOut,omitnil,omitempty" name:"SoldOut"`
 }
 
@@ -11545,6 +12173,16 @@ type SecurityGroupRoute struct {
 
 	// 路由vip
 	Vip *string `json:"Vip,omitnil,omitempty" name:"Vip"`
+}
+
+type SecurityGroupRouteOperateResp struct {
+	// 操作返回的code，0为正常，非0为错误
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ReturnCode *string `json:"ReturnCode,omitnil,omitempty" name:"ReturnCode"`
+
+	// 操作返回的信息
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ReturnMessage *string `json:"ReturnMessage,omitnil,omitempty" name:"ReturnMessage"`
 }
 
 type SecurityGroupRouteResp struct {
@@ -11694,6 +12332,40 @@ type TdwParam struct {
 
 	// <p>TDW端口，默认8099</p>
 	TdwPort *int64 `json:"TdwPort,omitnil,omitempty" name:"TdwPort"`
+}
+
+type ThrottleRuleDetail struct {
+	// <p>限流规则标识</p>
+	ThrottleRuleId *uint64 `json:"ThrottleRuleId,omitnil,omitempty" name:"ThrottleRuleId"`
+
+	// <p>限流类型</p><p>枚举值：</p><ul><li>1： 用户/客户端限流</li><li>2： 消费组限流</li><li>3： topic限流</li></ul>
+	ThrottleType *int64 `json:"ThrottleType,omitnil,omitempty" name:"ThrottleType"`
+
+	// <p>客户端id</p>
+	ClientId *string `json:"ClientId,omitnil,omitempty" name:"ClientId"`
+
+	// <p>用户名</p>
+	UserName *string `json:"UserName,omitnil,omitempty" name:"UserName"`
+
+	// <p>消费限流值,单位MB/s</p>
+	ConsumeThrottle *uint64 `json:"ConsumeThrottle,omitnil,omitempty" name:"ConsumeThrottle"`
+
+	// <p>更新时间</p>
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>topic名称</p>
+	TopicName *string `json:"TopicName,omitnil,omitempty" name:"TopicName"`
+
+	// <p>topicId</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+}
+
+type ThrottleRuleResult struct {
+	// 总数量
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 规则列表
+	ThrottleRuleList []*ThrottleRuleDetail `json:"ThrottleRuleList,omitnil,omitempty" name:"ThrottleRuleList"`
 }
 
 type Topic struct {
@@ -11897,27 +12569,27 @@ type TopicMessageHeapRanking struct {
 }
 
 type TopicParam struct {
-	// 单独售卖Topic的Topic名称
+	// <p>单独售卖Topic的Topic名称</p>
 	Resource *string `json:"Resource,omitnil,omitempty" name:"Resource"`
 
-	// Offset类型，最开始位置earliest，最新位置latest，时间点位置timestamp
+	// <p>Offset类型，最开始位置earliest，最新位置latest，时间点位置timestamp</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	OffsetType *string `json:"OffsetType,omitnil,omitempty" name:"OffsetType"`
 
-	// Offset类型为timestamp时必传，传时间戳，精确到秒
+	// <p>Offset类型为timestamp时必传，传时间戳，精确到秒</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
 
-	// Topic的TopicId【出参】
+	// <p>Topic的TopicId【出参】</p>
 	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
 
-	// 写入Topic时是否进行压缩，不开启填"none"，开启的话，可选择"gzip", "snappy", "lz4"中的一个进行填写。
+	// <p>写入Topic时是否进行压缩，不开启填&quot;none&quot;，开启的话，可选择&quot;gzip&quot;, &quot;snappy&quot;, &quot;lz4&quot;中的一个进行填写。</p>
 	CompressionType *string `json:"CompressionType,omitnil,omitempty" name:"CompressionType"`
 
-	// 使用的Topic是否需要自动创建（目前只支持SOURCE流入任务）
+	// <p>使用的Topic是否需要自动创建（目前只支持SOURCE流入任务）</p>
 	UseAutoCreateTopic *bool `json:"UseAutoCreateTopic,omitnil,omitempty" name:"UseAutoCreateTopic"`
 
-	// 源topic消息1条扩增成msgMultiple条写入目标topic(该参数目前只有ckafka流入ckafka适用)
+	// <p>源topic消息1条扩增成msgMultiple条写入目标topic(该参数目前只有ckafka流入ckafka适用)</p>
 	MsgMultiple *int64 `json:"MsgMultiple,omitnil,omitempty" name:"MsgMultiple"`
 }
 
@@ -12040,7 +12712,7 @@ type UpgradeBrokerVersionRequestParams struct {
 	// <p>ckafka集群实例Id</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// <p>版本升级类型</p><p>枚举值：</p><ul><li>1： 小版本迁移升级(推荐)</li></ul>
+	// <p>版本升级类型</p><p>枚举值：</p><ul><li>1： 小版本迁移升级(推荐)</li><li>5： 小版原地升级</li></ul>
 	Type *int64 `json:"Type,omitnil,omitempty" name:"Type"`
 
 	// <p>版本号</p>
@@ -12059,7 +12731,7 @@ type UpgradeBrokerVersionRequest struct {
 	// <p>ckafka集群实例Id</p>
 	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
 
-	// <p>版本升级类型</p><p>枚举值：</p><ul><li>1： 小版本迁移升级(推荐)</li></ul>
+	// <p>版本升级类型</p><p>枚举值：</p><ul><li>1： 小版本迁移升级(推荐)</li><li>5： 小版原地升级</li></ul>
 	Type *int64 `json:"Type,omitnil,omitempty" name:"Type"`
 
 	// <p>版本号</p>

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1250,7 +1250,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs/v20201112
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam/v20220331
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.133
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.165
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165

--- a/website/docs/d/ckafka_routes.html.markdown
+++ b/website/docs/d/ckafka_routes.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Cloud Kafka(ckafka)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_ckafka_routes"
+sidebar_current: "docs-tencentcloud-datasource-ckafka_routes"
+description: |-
+  Use this data source to query detailed information of CKafka routes
+---
+
+# tencentcloud_ckafka_routes
+
+Use this data source to query detailed information of CKafka routes
+
+## Example Usage
+
+```hcl
+data "tencentcloud_ckafka_routes" "example" {
+  instance_id = "ckafka-bqwlyrg8"
+}
+
+output "routes" {
+  value = data.tencentcloud_ckafka_routes.example.routers
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String) Id of the ckafka instance.
+* `main_route_flag` - (Optional, Bool) Whether to display the main route. When set to true, the main route created at instance creation will be additionally returned.
+* `result_output_file` - (Optional, String) Used to save results.
+* `route_id` - (Optional, Int) Route id, used to query a specific route.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `routers` - A list of ckafka routes. Each element contains the following attributes:
+  * `access_type` - Instance access type. 0: PLAINTEXT, 1: SASL_PLAINTEXT, 2: SSL, 3: SASL_SSL.
+  * `broker_vip_list` - Virtual IP list (1 to 1 broker nodes).
+    * `vip` - Virtual IP.
+    * `vport` - Virtual port.
+  * `delete_timestamp` - Delete timestamp.
+  * `domain_port` - Domain port.
+  * `domain` - Domain.
+  * `note` - Remark.
+  * `route_id` - Route id.
+  * `status` - Route status. 1: creating, 2: created, 3: create failed, 4: deleting, 6: delete failed.
+  * `subnet` - Subnet id.
+  * `vip_list` - Virtual IP list.
+    * `vip` - Virtual IP.
+    * `vport` - Virtual port.
+  * `vip_type` - Routing network type. 3: vpc routing, 7: internal support routing, 1: public network routing.
+  * `vpc_id` - Vpc id.
+
+

--- a/website/docs/d/ckafka_routes.html.markdown
+++ b/website/docs/d/ckafka_routes.html.markdown
@@ -15,7 +15,9 @@ Use this data source to query detailed information of CKafka routes
 
 ```hcl
 data "tencentcloud_ckafka_routes" "example" {
-  instance_id = "ckafka-bqwlyrg8"
+  instance_id     = "ckafka-exampleabc"
+  main_route_flag = true
+  route_id        = 123
 }
 
 output "routes" {

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -1489,6 +1489,9 @@
                                     <a href="/docs/providers/tencentcloud/d/ckafka_region.html">tencentcloud_ckafka_region</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/d/ckafka_routes.html">tencentcloud_ckafka_routes</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/d/ckafka_task_status.html">tencentcloud_ckafka_task_status</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add a new data source `tencentcloud_ckafka_routes` to query CKafka instance route information via the `DescribeRoute` API. Supports filtering by `instance_id` (required), `route_id` (optional), and `main_route_flag` (optional). Returns a `routers` list with route details including access type, VIP list, domain, status, etc.