### PR TITLE
feat(ses): [136384050] add dkim_option, tag_key and tag_value params to ses_domain resource

### DIFF
--- a/.changelog/4471.txt
+++ b/.changelog/4471.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_ses_domain: support dkim_option, tag_key and tag_value parameters
+```

--- a/.changelog/4471.txt
+++ b/.changelog/4471.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/tencentcloud_ses_domain: support dkim_option, tag_key and tag_value parameters
+resource/tencentcloud_ses_domain: support dkim_option and tag_list parameters
 ```

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/redis v1.3.168
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/rum v1.0.744
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf v1.3.101
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.0.748
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.3.136
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sms v1.0.486
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sqlserver v1.3.68
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssl v1.3.105

--- a/go.sum
+++ b/go.sum
@@ -937,7 +937,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.674/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.691/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.695/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.744/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.748/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.762/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.763/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.824/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -991,6 +990,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.127/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.129/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.130/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.131/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.136/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.139/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1089,8 +1089,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/rum v1.0.744 h1:Z6xqpgn
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/rum v1.0.744/go.mod h1:prlrCvxmnWH4yCkA5cIIjGZMMuuvPs5EuCx1rV+F8jk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf v1.3.101 h1:ir6R+aI/MHFXIx6w4IZ7aPWZfrGL+KBuegniZz34JHs=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf v1.3.101/go.mod h1:alRtVSnlEQS/ODkOI/qhESYq+lMyz8Z1xLAVtTfnrjI=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.0.748 h1:pG2i5MHLmDkn8RC5wGjqRUx2db4L79JmV7qJyFzK5cs=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.0.748/go.mod h1:ZADb5YPBRKNvhdQVl74jPKf9gMCDX8rxtDkBsYMSDfU=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.3.136 h1:PGwraJhUB6f4SzI+/ZTWlxjPNGfNPeIh4H54J76uMD0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.3.136/go.mod h1:bQZ79jqIltjI+RaAktC1mS3dSur3ExKl8htXUgXCIA4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sms v1.0.486 h1:eHLaL+hl5X5f8Apuf2SGVclO3MRev/E3AfA/0aZQGUA=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sms v1.0.486/go.mod h1:MSsho0YlAsoPCOMqdBfwqGd/SMQ0FTGh0a6emBy2X+g=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sqlserver v1.3.68 h1:SBv1Xjq2O3FKQ9YkD4kc9AnF1E5iPdNQrfdEunmamBI=

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/design.md
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/design.md
@@ -14,25 +14,24 @@ Since this resource has no Update operation, all new parameters will be `ForceNe
 
 **Goals:**
 - Expose `DKIMOption` as an optional `dkim_option` schema field (uint64) so users can set DKIM key length at creation.
-- Expose `TagList` (TagKey/TagValue) as optional `tag_key` and `tag_value` schema fields (string) so users can associate a single tag with the domain at creation.
-- Read back `dkim_option`, `tag_key`, and `tag_value` from `GetEmailIdentity` so they appear in Terraform state.
+- Expose `TagList` (TagKey/TagValue) as an optional `tag_list` nested block schema field so users can associate one or more tags with the domain at creation. The `tag_list` block contains `tag_key` and `tag_value` string sub-fields.
+- Read back `dkim_option` and `tag_list` from `GetEmailIdentity` so they appear in Terraform state.
 
 **Non-Goals:**
-- Supporting multiple tags (the cloud API `TagList` is a slice, but the Terraform resource will expose a single tag pair as `tag_key`/`tag_value` for simplicity, matching the requirement mapping).
 - Adding an Update operation to the resource (the resource remains Create-Read-Delete only; new parameters are ForceNew).
 - Modifying the `attributes` computed field behavior.
 
 ## Decisions
 
-### Decision 1: Expose TagList as flat `tag_key` / `tag_value` fields rather than a nested list
+### Decision 1: Expose TagList as a nested `tag_list` block with `tag_key` / `tag_value` sub-fields
 
-**Rationale**: The requirement specifies `TagList.TagKey → TagKey` and `TagList.TagValue → TagValue` as flat schema names. The SES domain resource manages a single domain identity, and the typical use case is a single tag. Flat fields are simpler for users and align with the requirement mapping. The `CreateEmailIdentity` request will construct a `[]*TagList` slice with a single element from these two fields.
+**Rationale**: The cloud API `CreateEmailIdentity` accepts `TagList` as a slice of `TagList` elements, each containing `TagKey` and `TagValue`. To faithfully reflect this structure and support multiple tags, the Terraform resource exposes a `tag_list` block (TypeList) where each block contains `tag_key` and `tag_value` string sub-fields. This aligns with the cloud API's list semantics and the common Terraform pattern for repeated nested blocks.
 
-**Alternative considered**: A nested `tag_list` block schema (TypeList of blocks with `tag_key`/`tag_value`). Rejected because the requirement explicitly maps to flat top-level `TagKey` and `TagValue` schema names.
+**Alternative considered**: Flat top-level `tag_key` / `tag_value` fields. Rejected because it only supports a single tag and does not reflect the list nature of the cloud API `TagList` parameter.
 
 ### Decision 2: New parameters are ForceNew
 
-**Rationale**: The `tencentcloud_ses_domain` resource has no Update operation — only Create, Read, and Delete. The cloud API does not provide an update endpoint for email identity parameters. Therefore `dkim_option`, `tag_key`, and `tag_value` must be `ForceNew: true`, consistent with `email_identity`.
+**Rationale**: The `tencentcloud_ses_domain` resource has no Update operation — only Create, Read, and Delete. The cloud API does not provide an update endpoint for email identity parameters. Therefore `dkim_option` and `tag_list` must be `ForceNew: true`, consistent with `email_identity`.
 
 ### Decision 3: Modify `DescribeSesDomain` service method to return the full `GetEmailIdentityResponseParams`
 
@@ -47,5 +46,4 @@ Since this resource has no Update operation, all new parameters will be `ForceNe
 ## Risks / Trade-offs
 
 - **[Risk] `DescribeSesDomain` signature change may affect callers** → Mitigation: `DescribeSesDomain` is only called from `resourceTencentCloudSesDomainRead`. The signature change is contained within the ses service package. The return type changes from `[]*ses.DNSAttributes` to `*ses.GetEmailIdentityResponseParams`, and the Read function will be updated accordingly.
-- **[Risk] TagList may contain multiple entries in API response** → Mitigation: The Read function will read the first element of the `TagList` slice to populate `tag_key` and `tag_value`, consistent with the single-tag schema design.
 - **[Trade-off] ForceNew on all new parameters** → Users must recreate the domain to change DKIM option or tags. This is acceptable because the SES API does not support updating these fields on an existing identity.

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/design.md
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The `tencentcloud_ses_domain` resource (in `tencentcloud/services/ses/resource_tc_ses_domain.go`) currently only supports the `email_identity` parameter. The resource implements Create, Read, and Delete operations (no Update) using the SES cloud API:
+
+- **Create**: calls `CreateEmailIdentity` with only `EmailIdentity`
+- **Read**: calls `GetEmailIdentity` (via `DescribeSesDomain` service method) and reads DNS `Attributes`
+- **Delete**: calls `DeleteEmailIdentity`
+
+The cloud API `CreateEmailIdentityRequest` already supports `DKIMOption` (*uint64) and `TagList` ([]*TagList) fields. The `GetEmailIdentityResponse` returns `DKIMOption` (*uint64) and `TagList` ([]*TagList) as well. The `TagList` type contains `TagKey` and `TagValue` string fields.
+
+Since this resource has no Update operation, all new parameters will be `ForceNew` — changing them requires recreating the resource.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose `DKIMOption` as an optional `dkim_option` schema field (uint64) so users can set DKIM key length at creation.
+- Expose `TagList` (TagKey/TagValue) as optional `tag_key` and `tag_value` schema fields (string) so users can associate a single tag with the domain at creation.
+- Read back `dkim_option`, `tag_key`, and `tag_value` from `GetEmailIdentity` so they appear in Terraform state.
+
+**Non-Goals:**
+- Supporting multiple tags (the cloud API `TagList` is a slice, but the Terraform resource will expose a single tag pair as `tag_key`/`tag_value` for simplicity, matching the requirement mapping).
+- Adding an Update operation to the resource (the resource remains Create-Read-Delete only; new parameters are ForceNew).
+- Modifying the `attributes` computed field behavior.
+
+## Decisions
+
+### Decision 1: Expose TagList as flat `tag_key` / `tag_value` fields rather than a nested list
+
+**Rationale**: The requirement specifies `TagList.TagKey → TagKey` and `TagList.TagValue → TagValue` as flat schema names. The SES domain resource manages a single domain identity, and the typical use case is a single tag. Flat fields are simpler for users and align with the requirement mapping. The `CreateEmailIdentity` request will construct a `[]*TagList` slice with a single element from these two fields.
+
+**Alternative considered**: A nested `tag_list` block schema (TypeList of blocks with `tag_key`/`tag_value`). Rejected because the requirement explicitly maps to flat top-level `TagKey` and `TagValue` schema names.
+
+### Decision 2: New parameters are ForceNew
+
+**Rationale**: The `tencentcloud_ses_domain` resource has no Update operation — only Create, Read, and Delete. The cloud API does not provide an update endpoint for email identity parameters. Therefore `dkim_option`, `tag_key`, and `tag_value` must be `ForceNew: true`, consistent with `email_identity`.
+
+### Decision 3: Modify `DescribeSesDomain` service method to return the full `GetEmailIdentityResponseParams`
+
+**Rationale**: Currently `DescribeSesDomain` only returns `[]*ses.DNSAttributes` (the `Attributes` field). To read `DKIMOption` and `TagList` from the response, the service method needs to return the full `GetEmailIdentityResponseParams` (or at least the additional fields). The cleanest approach is to return `*ses.GetEmailIdentityResponseParams` so the Read function can access all fields including `Attributes`, `DKIMOption`, and `TagList`.
+
+**Alternative considered**: Add a separate service method for the new fields. Rejected because it would result in a duplicate API call to `GetEmailIdentity`.
+
+### Decision 4: `dkim_option` schema type uses `schema.TypeInt`
+
+**Rationale**: The cloud API uses `*uint64` for `DKIMOption`. In Terraform schema, `schema.TypeInt` is the idiomatic mapping for integer-like values. The Create function will convert the int value to uint64 when building the request.
+
+## Risks / Trade-offs
+
+- **[Risk] `DescribeSesDomain` signature change may affect callers** → Mitigation: `DescribeSesDomain` is only called from `resourceTencentCloudSesDomainRead`. The signature change is contained within the ses service package. The return type changes from `[]*ses.DNSAttributes` to `*ses.GetEmailIdentityResponseParams`, and the Read function will be updated accordingly.
+- **[Risk] TagList may contain multiple entries in API response** → Mitigation: The Read function will read the first element of the `TagList` slice to populate `tag_key` and `tag_value`, consistent with the single-tag schema design.
+- **[Trade-off] ForceNew on all new parameters** → Users must recreate the domain to change DKIM option or tags. This is acceptable because the SES API does not support updating these fields on an existing identity.

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/proposal.md
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `tencentcloud_ses_domain` resource currently only supports setting the `email_identity` field when creating an SES domain. Users cannot configure the DKIM key length or associate tags with the domain at creation time. The SES cloud API (`CreateEmailIdentity`) already supports `DKIMOption` and `TagList` parameters, and `GetEmailIdentity` returns these values, but the Terraform resource does not expose them. This limits users' ability to fully manage SES domain configuration through Terraform.
+
+## What Changes
+
+- Add a new optional `dkim_option` parameter (uint64) to the `tencentcloud_ses_domain` resource schema, allowing users to specify the DKIM key length (0: 1024-bit, 1: 2048-bit) at creation time.
+- Add new optional `tag_key` and `tag_value` parameters (string) to the `tencentcloud_ses_domain` resource schema, allowing users to associate a single tag with the domain at creation time.
+- Populate `dkim_option`, `tag_key`, and `tag_value` from the `GetEmailIdentity` response in the resource Read operation so they are reflected in Terraform state.
+
+## Capabilities
+
+### New Capabilities
+
+- `ses-domain-params`: Adds `dkim_option`, `tag_key`, and `tag_value` parameters to the `tencentcloud_ses_domain` resource, enabling DKIM key length configuration and tag association for SES domains.
+
+### Modified Capabilities
+
+<!-- No existing spec-level requirements are being modified. -->
+
+## Impact
+
+- **Affected code**: `tencentcloud/services/ses/resource_tc_ses_domain.go` (schema, create, read operations), `tencentcloud/services/ses/service_tencentcloud_ses.go` (DescribeSesDomain to return additional fields), `tencentcloud/services/ses/resource_tc_ses_domain_test.go` (test updates).
+- **Affected docs**: `tencentcloud/services/ses/resource_tc_ses_domain.md` (example usage update).
+- **APIs**: `CreateEmailIdentity` (new request parameters `DKIMOption`, `TagList`), `GetEmailIdentity` (new response fields `DKIMOption`, `TagList`).
+- **Backward compatibility**: All new parameters are optional; existing configurations remain valid. No breaking changes.

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/proposal.md
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/proposal.md
@@ -5,14 +5,14 @@ The `tencentcloud_ses_domain` resource currently only supports setting the `emai
 ## What Changes
 
 - Add a new optional `dkim_option` parameter (uint64) to the `tencentcloud_ses_domain` resource schema, allowing users to specify the DKIM key length (0: 1024-bit, 1: 2048-bit) at creation time.
-- Add new optional `tag_key` and `tag_value` parameters (string) to the `tencentcloud_ses_domain` resource schema, allowing users to associate a single tag with the domain at creation time.
-- Populate `dkim_option`, `tag_key`, and `tag_value` from the `GetEmailIdentity` response in the resource Read operation so they are reflected in Terraform state.
+- Add a new optional `tag_list` nested block parameter to the `tencentcloud_ses_domain` resource schema, allowing users to associate tags with the domain at creation time. The `tag_list` block contains `tag_key` and `tag_value` string sub-fields and supports multiple tag entries.
+- Populate `dkim_option` and `tag_list` from the `GetEmailIdentity` response in the resource Read operation so they are reflected in Terraform state.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `ses-domain-params`: Adds `dkim_option`, `tag_key`, and `tag_value` parameters to the `tencentcloud_ses_domain` resource, enabling DKIM key length configuration and tag association for SES domains.
+- `ses-domain-params`: Adds `dkim_option` and `tag_list` (with `tag_key` and `tag_value` sub-fields) parameters to the `tencentcloud_ses_domain` resource, enabling DKIM key length configuration and tag association for SES domains.
 
 ### Modified Capabilities
 

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/specs/ses-domain-params/spec.md
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/specs/ses-domain-params/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: SES domain resource supports DKIM option parameter
+
+The `tencentcloud_ses_domain` resource SHALL accept an optional `dkim_option` parameter (integer) that specifies the DKIM key length. Value `0` means 1024-bit and value `1` means 2048-bit. The parameter SHALL be `ForceNew` — changing it requires resource recreation.
+
+#### Scenario: Create domain with DKIM option
+- **WHEN** user creates a `tencentcloud_ses_domain` resource with `dkim_option = 1`
+- **THEN** the provider SHALL call `CreateEmailIdentity` with `DKIMOption` set to `1`
+- **AND** the resource SHALL be recreated if `dkim_option` is changed
+
+#### Scenario: Create domain without DKIM option
+- **WHEN** user creates a `tencentcloud_ses_domain` resource without specifying `dkim_option`
+- **THEN** the provider SHALL call `CreateEmailIdentity` without setting `DKIMOption`
+- **AND** the cloud API SHALL apply its default DKIM option
+
+#### Scenario: Read reflects DKIM option
+- **WHEN** the provider reads an existing SES domain via `GetEmailIdentity`
+- **THEN** the provider SHALL populate `dkim_option` in Terraform state from the response `DKIMOption` field if it is not nil
+
+### Requirement: SES domain resource supports tag parameters
+
+The `tencentcloud_ses_domain` resource SHALL accept optional `tag_key` and `tag_value` parameters (string) that associate a single tag with the domain. Both parameters SHALL be `ForceNew` — changing either requires resource recreation.
+
+#### Scenario: Create domain with tag
+- **WHEN** user creates a `tencentcloud_ses_domain` resource with `tag_key = "env"` and `tag_value = "prod"`
+- **THEN** the provider SHALL call `CreateEmailIdentity` with a `TagList` containing one element with `TagKey = "env"` and `TagValue = "prod"`
+
+#### Scenario: Create domain without tag
+- **WHEN** user creates a `tencentcloud_ses_domain` resource without specifying `tag_key` or `tag_value`
+- **THEN** the provider SHALL call `CreateEmailIdentity` without setting `TagList`
+
+#### Scenario: Read reflects tag
+- **WHEN** the provider reads an existing SES domain via `GetEmailIdentity` and the response `TagList` contains at least one element
+- **THEN** the provider SHALL populate `tag_key` and `tag_value` in Terraform state from the first element of the response `TagList`
+
+#### Scenario: Read with no tag
+- **WHEN** the provider reads an existing SES domain via `GetEmailIdentity` and the response `TagList` is empty or nil
+- **THEN** the provider SHALL NOT set `tag_key` or `tag_value` in Terraform state
+
+### Requirement: Backward compatibility
+
+The addition of `dkim_option`, `tag_key`, and `tag_value` parameters SHALL NOT break existing `tencentcloud_ses_domain` configurations. All new parameters SHALL be optional.
+
+#### Scenario: Existing configuration without new parameters
+- **WHEN** a user applies an existing `tencentcloud_ses_domain` configuration that does not include `dkim_option`, `tag_key`, or `tag_value`
+- **THEN** the provider SHALL create and manage the domain as before, with no behavioral change

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/specs/ses-domain-params/spec.md
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/specs/ses-domain-params/spec.md
@@ -18,30 +18,34 @@ The `tencentcloud_ses_domain` resource SHALL accept an optional `dkim_option` pa
 - **WHEN** the provider reads an existing SES domain via `GetEmailIdentity`
 - **THEN** the provider SHALL populate `dkim_option` in Terraform state from the response `DKIMOption` field if it is not nil
 
-### Requirement: SES domain resource supports tag parameters
+### Requirement: SES domain resource supports tag_list parameter
 
-The `tencentcloud_ses_domain` resource SHALL accept optional `tag_key` and `tag_value` parameters (string) that associate a single tag with the domain. Both parameters SHALL be `ForceNew` — changing either requires resource recreation.
+The `tencentcloud_ses_domain` resource SHALL accept an optional `tag_list` nested block parameter that associates one or more tags with the domain. Each `tag_list` block SHALL contain `tag_key` and `tag_value` string sub-fields. The `tag_list` parameter SHALL be `ForceNew` — changing it requires resource recreation.
 
-#### Scenario: Create domain with tag
-- **WHEN** user creates a `tencentcloud_ses_domain` resource with `tag_key = "env"` and `tag_value = "prod"`
+#### Scenario: Create domain with tags
+- **WHEN** user creates a `tencentcloud_ses_domain` resource with a `tag_list` block containing `tag_key = "env"` and `tag_value = "prod"`
 - **THEN** the provider SHALL call `CreateEmailIdentity` with a `TagList` containing one element with `TagKey = "env"` and `TagValue = "prod"`
 
+#### Scenario: Create domain with multiple tags
+- **WHEN** user creates a `tencentcloud_ses_domain` resource with multiple `tag_list` blocks
+- **THEN** the provider SHALL call `CreateEmailIdentity` with a `TagList` containing one element per block, preserving all tag key/value pairs
+
 #### Scenario: Create domain without tag
-- **WHEN** user creates a `tencentcloud_ses_domain` resource without specifying `tag_key` or `tag_value`
+- **WHEN** user creates a `tencentcloud_ses_domain` resource without specifying `tag_list`
 - **THEN** the provider SHALL call `CreateEmailIdentity` without setting `TagList`
 
-#### Scenario: Read reflects tag
+#### Scenario: Read reflects tags
 - **WHEN** the provider reads an existing SES domain via `GetEmailIdentity` and the response `TagList` contains at least one element
-- **THEN** the provider SHALL populate `tag_key` and `tag_value` in Terraform state from the first element of the response `TagList`
+- **THEN** the provider SHALL populate `tag_list` in Terraform state with one block per element, each containing `tag_key` and `tag_value` from the response
 
 #### Scenario: Read with no tag
 - **WHEN** the provider reads an existing SES domain via `GetEmailIdentity` and the response `TagList` is empty or nil
-- **THEN** the provider SHALL NOT set `tag_key` or `tag_value` in Terraform state
+- **THEN** the provider SHALL NOT set `tag_list` in Terraform state
 
 ### Requirement: Backward compatibility
 
-The addition of `dkim_option`, `tag_key`, and `tag_value` parameters SHALL NOT break existing `tencentcloud_ses_domain` configurations. All new parameters SHALL be optional.
+The addition of `dkim_option` and `tag_list` parameters SHALL NOT break existing `tencentcloud_ses_domain` configurations. All new parameters SHALL be optional.
 
 #### Scenario: Existing configuration without new parameters
-- **WHEN** a user applies an existing `tencentcloud_ses_domain` configuration that does not include `dkim_option`, `tag_key`, or `tag_value`
+- **WHEN** a user applies an existing `tencentcloud_ses_domain` configuration that does not include `dkim_option` or `tag_list`
 - **THEN** the provider SHALL create and manage the domain as before, with no behavioral change

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/tasks.md
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/tasks.md
@@ -1,0 +1,26 @@
+## 1. Schema 定义
+
+- [x] 1.1 在 `tencentcloud/services/ses/resource_tc_ses_domain.go` 的 Schema 中新增 `dkim_option` 字段（TypeInt, Optional, ForceNew, 描述 DKIM 密钥长度 0:1024 1:2048）
+- [x] 1.2 在 Schema 中新增 `tag_key` 字段（TypeString, Optional, ForceNew, 描述标签键）
+- [x] 1.3 在 Schema 中新增 `tag_value` 字段（TypeString, Optional, ForceNew, 描述标签值）
+
+## 2. Service 层修改
+
+- [x] 2.1 修改 `tencentcloud/services/ses/service_tencentcloud_ses.go` 中的 `DescribeSesDomain` 方法，使其返回 `*ses.GetEmailIdentityResponseParams` 而非 `[]*ses.DNSAttributes`，以便 Read 函数可以访问 `DKIMOption` 和 `TagList` 字段
+- [x] 2.2 更新 `DescribeSesDomain` 方法内部的空响应检查逻辑，确保 response 为 nil 或 Response 为 nil 时正确返回
+
+## 3. CRUD 函数修改
+
+- [x] 3.1 修改 `resourceTencentCloudSesDomainCreate` 函数：从 schema 读取 `dkim_option` 并设置到 `request.DKIMOption`（将 int 转换为 uint64）
+- [x] 3.2 修改 `resourceTencentCloudSesDomainCreate` 函数：从 schema 读取 `tag_key` 和 `tag_value`，构造 `[]*ses.TagList` 切片（单元素）并设置到 `request.TagList`
+- [x] 3.3 修改 `resourceTencentCloudSesDomainRead` 函数：适配 `DescribeSesDomain` 新的返回类型，从 `GetEmailIdentityResponseParams` 中读取 `Attributes`、`DKIMOption`、`TagList`
+- [x] 3.4 修改 `resourceTencentCloudSesDomainRead` 函数：当 `DKIMOption` 不为 nil 时，调用 `d.Set("dkim_option", *response.DKIMOption)` 设置状态
+- [x] 3.5 修改 `resourceTencentCloudSesDomainRead` 函数：当 `TagList` 非空时，从第一个元素读取 `TagKey` 和 `TagValue` 并设置到 state；为空时不设置
+
+## 4. 测试更新
+
+- [x] 4.1 更新 `tencentcloud/services/ses/resource_tc_ses_domain_test.go`，在测试用例中补充 `dkim_option`、`tag_key`、`tag_value` 参数的测试覆盖
+
+## 5. 文档更新
+
+- [x] 5.1 更新 `tencentcloud/services/ses/resource_tc_ses_domain.md` 的 Example Usage，补充 `dkim_option`、`tag_key`、`tag_value` 参数示例

--- a/openspec/changes/archive/2026-09-01-add-ses-domain-params/tasks.md
+++ b/openspec/changes/archive/2026-09-01-add-ses-domain-params/tasks.md
@@ -1,8 +1,7 @@
 ## 1. Schema 定义
 
 - [x] 1.1 在 `tencentcloud/services/ses/resource_tc_ses_domain.go` 的 Schema 中新增 `dkim_option` 字段（TypeInt, Optional, ForceNew, 描述 DKIM 密钥长度 0:1024 1:2048）
-- [x] 1.2 在 Schema 中新增 `tag_key` 字段（TypeString, Optional, ForceNew, 描述标签键）
-- [x] 1.3 在 Schema 中新增 `tag_value` 字段（TypeString, Optional, ForceNew, 描述标签值）
+- [x] 1.2 在 Schema 中新增 `tag_list` 嵌套块字段（TypeList, Optional, ForceNew），其子字段为 `tag_key`（TypeString, Required, 描述标签键）和 `tag_value`（TypeString, Required, 描述标签值），支持多个标签
 
 ## 2. Service 层修改
 
@@ -12,15 +11,15 @@
 ## 3. CRUD 函数修改
 
 - [x] 3.1 修改 `resourceTencentCloudSesDomainCreate` 函数：从 schema 读取 `dkim_option` 并设置到 `request.DKIMOption`（将 int 转换为 uint64）
-- [x] 3.2 修改 `resourceTencentCloudSesDomainCreate` 函数：从 schema 读取 `tag_key` 和 `tag_value`，构造 `[]*ses.TagList` 切片（单元素）并设置到 `request.TagList`
+- [x] 3.2 修改 `resourceTencentCloudSesDomainCreate` 函数：从 schema 读取 `tag_list` 列表，遍历每个元素的 `tag_key` 和 `tag_value`，构造 `[]*ses.TagList` 切片并设置到 `request.TagList`
 - [x] 3.3 修改 `resourceTencentCloudSesDomainRead` 函数：适配 `DescribeSesDomain` 新的返回类型，从 `GetEmailIdentityResponseParams` 中读取 `Attributes`、`DKIMOption`、`TagList`
 - [x] 3.4 修改 `resourceTencentCloudSesDomainRead` 函数：当 `DKIMOption` 不为 nil 时，调用 `d.Set("dkim_option", *response.DKIMOption)` 设置状态
-- [x] 3.5 修改 `resourceTencentCloudSesDomainRead` 函数：当 `TagList` 非空时，从第一个元素读取 `TagKey` 和 `TagValue` 并设置到 state；为空时不设置
+- [x] 3.5 修改 `resourceTencentCloudSesDomainRead` 函数：当 `TagList` 非空时，遍历每个元素读取 `TagKey` 和 `TagValue` 构造 `tag_list` 列表设置到 state；为空时不设置
 
 ## 4. 测试更新
 
-- [x] 4.1 更新 `tencentcloud/services/ses/resource_tc_ses_domain_test.go`，在测试用例中补充 `dkim_option`、`tag_key`、`tag_value` 参数的测试覆盖
+- [x] 4.1 更新 `tencentcloud/services/ses/resource_tc_ses_domain_test.go`，在测试用例中补充 `dkim_option`、`tag_list`（含 `tag_key`、`tag_value`）参数的测试覆盖
 
 ## 5. 文档更新
 
-- [x] 5.1 更新 `tencentcloud/services/ses/resource_tc_ses_domain.md` 的 Example Usage，补充 `dkim_option`、`tag_key`、`tag_value` 参数示例
+- [x] 5.1 更新 `tencentcloud/services/ses/resource_tc_ses_domain.md` 的 Example Usage，补充 `dkim_option`、`tag_list` 参数示例

--- a/openspec/specs/ses-domain-params/spec.md
+++ b/openspec/specs/ses-domain-params/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: SES domain resource supports DKIM option parameter
+
+The `tencentcloud_ses_domain` resource SHALL accept an optional `dkim_option` parameter (integer) that specifies the DKIM key length. Value `0` means 1024-bit and value `1` means 2048-bit. The parameter SHALL be `ForceNew` — changing it requires resource recreation.
+
+#### Scenario: Create domain with DKIM option
+- **WHEN** user creates a `tencentcloud_ses_domain` resource with `dkim_option = 1`
+- **THEN** the provider SHALL call `CreateEmailIdentity` with `DKIMOption` set to `1`
+- **AND** the resource SHALL be recreated if `dkim_option` is changed
+
+#### Scenario: Create domain without DKIM option
+- **WHEN** user creates a `tencentcloud_ses_domain` resource without specifying `dkim_option`
+- **THEN** the provider SHALL call `CreateEmailIdentity` without setting `DKIMOption`
+- **AND** the cloud API SHALL apply its default DKIM option
+
+#### Scenario: Read reflects DKIM option
+- **WHEN** the provider reads an existing SES domain via `GetEmailIdentity`
+- **THEN** the provider SHALL populate `dkim_option` in Terraform state from the response `DKIMOption` field if it is not nil
+
+### Requirement: SES domain resource supports tag parameters
+
+The `tencentcloud_ses_domain` resource SHALL accept optional `tag_key` and `tag_value` parameters (string) that associate a single tag with the domain. Both parameters SHALL be `ForceNew` — changing either requires resource recreation.
+
+#### Scenario: Create domain with tag
+- **WHEN** user creates a `tencentcloud_ses_domain` resource with `tag_key = "env"` and `tag_value = "prod"`
+- **THEN** the provider SHALL call `CreateEmailIdentity` with a `TagList` containing one element with `TagKey = "env"` and `TagValue = "prod"`
+
+#### Scenario: Create domain without tag
+- **WHEN** user creates a `tencentcloud_ses_domain` resource without specifying `tag_key` or `tag_value`
+- **THEN** the provider SHALL call `CreateEmailIdentity` without setting `TagList`
+
+#### Scenario: Read reflects tag
+- **WHEN** the provider reads an existing SES domain via `GetEmailIdentity` and the response `TagList` contains at least one element
+- **THEN** the provider SHALL populate `tag_key` and `tag_value` in Terraform state from the first element of the response `TagList`
+
+#### Scenario: Read with no tag
+- **WHEN** the provider reads an existing SES domain via `GetEmailIdentity` and the response `TagList` is empty or nil
+- **THEN** the provider SHALL NOT set `tag_key` or `tag_value` in Terraform state
+
+### Requirement: Backward compatibility
+
+The addition of `dkim_option`, `tag_key`, and `tag_value` parameters SHALL NOT break existing `tencentcloud_ses_domain` configurations. All new parameters SHALL be optional.
+
+#### Scenario: Existing configuration without new parameters
+- **WHEN** a user applies an existing `tencentcloud_ses_domain` configuration that does not include `dkim_option`, `tag_key`, or `tag_value`
+- **THEN** the provider SHALL create and manage the domain as before, with no behavioral change

--- a/openspec/specs/ses-domain-params/spec.md
+++ b/openspec/specs/ses-domain-params/spec.md
@@ -18,30 +18,34 @@ The `tencentcloud_ses_domain` resource SHALL accept an optional `dkim_option` pa
 - **WHEN** the provider reads an existing SES domain via `GetEmailIdentity`
 - **THEN** the provider SHALL populate `dkim_option` in Terraform state from the response `DKIMOption` field if it is not nil
 
-### Requirement: SES domain resource supports tag parameters
+### Requirement: SES domain resource supports tag_list parameter
 
-The `tencentcloud_ses_domain` resource SHALL accept optional `tag_key` and `tag_value` parameters (string) that associate a single tag with the domain. Both parameters SHALL be `ForceNew` — changing either requires resource recreation.
+The `tencentcloud_ses_domain` resource SHALL accept an optional `tag_list` nested block parameter that associates one or more tags with the domain. Each `tag_list` block SHALL contain `tag_key` and `tag_value` string sub-fields. The `tag_list` parameter SHALL be `ForceNew` — changing it requires resource recreation.
 
-#### Scenario: Create domain with tag
-- **WHEN** user creates a `tencentcloud_ses_domain` resource with `tag_key = "env"` and `tag_value = "prod"`
+#### Scenario: Create domain with tags
+- **WHEN** user creates a `tencentcloud_ses_domain` resource with a `tag_list` block containing `tag_key = "env"` and `tag_value = "prod"`
 - **THEN** the provider SHALL call `CreateEmailIdentity` with a `TagList` containing one element with `TagKey = "env"` and `TagValue = "prod"`
 
+#### Scenario: Create domain with multiple tags
+- **WHEN** user creates a `tencentcloud_ses_domain` resource with multiple `tag_list` blocks
+- **THEN** the provider SHALL call `CreateEmailIdentity` with a `TagList` containing one element per block, preserving all tag key/value pairs
+
 #### Scenario: Create domain without tag
-- **WHEN** user creates a `tencentcloud_ses_domain` resource without specifying `tag_key` or `tag_value`
+- **WHEN** user creates a `tencentcloud_ses_domain` resource without specifying `tag_list`
 - **THEN** the provider SHALL call `CreateEmailIdentity` without setting `TagList`
 
-#### Scenario: Read reflects tag
+#### Scenario: Read reflects tags
 - **WHEN** the provider reads an existing SES domain via `GetEmailIdentity` and the response `TagList` contains at least one element
-- **THEN** the provider SHALL populate `tag_key` and `tag_value` in Terraform state from the first element of the response `TagList`
+- **THEN** the provider SHALL populate `tag_list` in Terraform state with one block per element, each containing `tag_key` and `tag_value` from the response
 
 #### Scenario: Read with no tag
 - **WHEN** the provider reads an existing SES domain via `GetEmailIdentity` and the response `TagList` is empty or nil
-- **THEN** the provider SHALL NOT set `tag_key` or `tag_value` in Terraform state
+- **THEN** the provider SHALL NOT set `tag_list` in Terraform state
 
 ### Requirement: Backward compatibility
 
-The addition of `dkim_option`, `tag_key`, and `tag_value` parameters SHALL NOT break existing `tencentcloud_ses_domain` configurations. All new parameters SHALL be optional.
+The addition of `dkim_option` and `tag_list` parameters SHALL NOT break existing `tencentcloud_ses_domain` configurations. All new parameters SHALL be optional.
 
 #### Scenario: Existing configuration without new parameters
-- **WHEN** a user applies an existing `tencentcloud_ses_domain` configuration that does not include `dkim_option`, `tag_key`, or `tag_value`
+- **WHEN** a user applies an existing `tencentcloud_ses_domain` configuration that does not include `dkim_option` or `tag_list`
 - **THEN** the provider SHALL create and manage the domain as before, with no behavioral change

--- a/tencentcloud/services/ses/resource_tc_ses_domain.go
+++ b/tencentcloud/services/ses/resource_tc_ses_domain.go
@@ -37,18 +37,25 @@ func ResourceTencentCloudSesDomain() *schema.Resource {
 				Description: "DKIM key length. 0: 1024-bit, 1: 2048-bit.",
 			},
 
-			"tag_key": {
-				Type:        schema.TypeString,
+			"tag_list": {
+				Type:        schema.TypeList,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Tag key.",
-			},
-
-			"tag_value": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Tag value.",
+				Description: "Tag list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag key.",
+						},
+						"tag_value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag value.",
+						},
+					},
+				},
 			},
 
 			"attributes": {
@@ -99,16 +106,20 @@ func resourceTencentCloudSesDomainCreate(d *schema.ResourceData, meta interface{
 		request.DKIMOption = helper.IntUint64(v.(int))
 	}
 
-	if v, ok := d.GetOk("tag_key"); ok {
-		tagKey := v.(string)
-		if v, ok := d.GetOk("tag_value"); ok {
-			tagList := make([]*ses.TagList, 0, 1)
-			tagList = append(tagList, &ses.TagList{
-				TagKey:   helper.String(tagKey),
-				TagValue: helper.String(v.(string)),
-			})
-			request.TagList = tagList
+	if v, ok := d.GetOk("tag_list"); ok {
+		tagList := make([]*ses.TagList, 0, len(v.([]interface{})))
+		for _, item := range v.([]interface{}) {
+			dMap := item.(map[string]interface{})
+			tag := &ses.TagList{}
+			if v, ok := dMap["tag_key"]; ok {
+				tag.TagKey = helper.String(v.(string))
+			}
+			if v, ok := dMap["tag_value"]; ok {
+				tag.TagValue = helper.String(v.(string))
+			}
+			tagList = append(tagList, tag)
 		}
+		request.TagList = tagList
 	}
 
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
@@ -189,12 +200,18 @@ func resourceTencentCloudSesDomainRead(d *schema.ResourceData, meta interface{})
 	}
 
 	if len(response.TagList) > 0 {
-		if response.TagList[0].TagKey != nil {
-			_ = d.Set("tag_key", *response.TagList[0].TagKey)
+		tagListList := make([]interface{}, 0, len(response.TagList))
+		for _, tag := range response.TagList {
+			tagListMap := map[string]interface{}{}
+			if tag.TagKey != nil {
+				tagListMap["tag_key"] = *tag.TagKey
+			}
+			if tag.TagValue != nil {
+				tagListMap["tag_value"] = *tag.TagValue
+			}
+			tagListList = append(tagListList, tagListMap)
 		}
-		if response.TagList[0].TagValue != nil {
-			_ = d.Set("tag_value", *response.TagList[0].TagValue)
-		}
+		_ = d.Set("tag_list", tagListList)
 	}
 
 	return nil

--- a/tencentcloud/services/ses/resource_tc_ses_domain.go
+++ b/tencentcloud/services/ses/resource_tc_ses_domain.go
@@ -33,6 +33,7 @@ func ResourceTencentCloudSesDomain() *schema.Resource {
 			"dkim_option": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "DKIM key length. 0: 1024-bit, 1: 2048-bit.",
 			},
@@ -40,6 +41,7 @@ func ResourceTencentCloudSesDomain() *schema.Resource {
 			"tag_list": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "Tag list.",
 				Elem: &schema.Resource{

--- a/tencentcloud/services/ses/resource_tc_ses_domain.go
+++ b/tencentcloud/services/ses/resource_tc_ses_domain.go
@@ -30,6 +30,27 @@ func ResourceTencentCloudSesDomain() *schema.Resource {
 				Description: "Your sender domain. You are advised to use a third-level domain, for example, mail.qcloud.com.",
 			},
 
+			"dkim_option": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "DKIM key length. 0: 1024-bit, 1: 2048-bit.",
+			},
+
+			"tag_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Tag key.",
+			},
+
+			"tag_value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Tag value.",
+			},
+
 			"attributes": {
 				Computed:    true,
 				Type:        schema.TypeList,
@@ -74,6 +95,22 @@ func resourceTencentCloudSesDomainCreate(d *schema.ResourceData, meta interface{
 		request.EmailIdentity = helper.String(v.(string))
 	}
 
+	if v, ok := d.GetOkExists("dkim_option"); ok {
+		request.DKIMOption = helper.IntUint64(v.(int))
+	}
+
+	if v, ok := d.GetOk("tag_key"); ok {
+		tagKey := v.(string)
+		if v, ok := d.GetOk("tag_value"); ok {
+			tagList := make([]*ses.TagList, 0, 1)
+			tagList = append(tagList, &ses.TagList{
+				TagKey:   helper.String(tagKey),
+				TagValue: helper.String(v.(string)),
+			})
+			request.TagList = tagList
+		}
+	}
+
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseSesClient().CreateEmailIdentity(request)
 		if e != nil {
@@ -82,6 +119,11 @@ func resourceTencentCloudSesDomainCreate(d *schema.ResourceData, meta interface{
 			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
 				logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
 		}
+
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("create ses domain failed, response is nil"))
+		}
+
 		return nil
 	})
 
@@ -105,22 +147,23 @@ func resourceTencentCloudSesDomainRead(d *schema.ResourceData, meta interface{})
 
 	emailIdentity := d.Id()
 
-	attributes, err := service.DescribeSesDomain(ctx, emailIdentity)
+	response, err := service.DescribeSesDomain(ctx, emailIdentity)
 
 	if err != nil {
 		return err
 	}
 
-	if attributes == nil {
+	if response == nil {
+		log.Printf("[CRUD] ses_domain id=%s", d.Id())
 		d.SetId("")
-		return fmt.Errorf("resource `domain` %s does not exist", emailIdentity)
+		return fmt.Errorf("resource `ses_domain` %s does not exist", emailIdentity)
 	}
 
 	_ = d.Set("email_identity", emailIdentity)
 
-	if attributes != nil {
-		attributesList := make([]interface{}, 0, len(attributes))
-		for _, v := range attributes {
+	if response.Attributes != nil {
+		attributesList := make([]interface{}, 0, len(response.Attributes))
+		for _, v := range response.Attributes {
 			attributesMap := map[string]interface{}{}
 
 			if v.Type != nil {
@@ -139,6 +182,19 @@ func resourceTencentCloudSesDomainRead(d *schema.ResourceData, meta interface{})
 		}
 
 		_ = d.Set("attributes", attributesList)
+	}
+
+	if response.DKIMOption != nil {
+		_ = d.Set("dkim_option", *response.DKIMOption)
+	}
+
+	if len(response.TagList) > 0 {
+		if response.TagList[0].TagKey != nil {
+			_ = d.Set("tag_key", *response.TagList[0].TagKey)
+		}
+		if response.TagList[0].TagValue != nil {
+			_ = d.Set("tag_value", *response.TagList[0].TagValue)
+		}
 	}
 
 	return nil

--- a/tencentcloud/services/ses/resource_tc_ses_domain.md
+++ b/tencentcloud/services/ses/resource_tc_ses_domain.md
@@ -6,8 +6,10 @@ Example Usage
 resource "tencentcloud_ses_domain" "domain" {
     email_identity = "iac.cloud"
     dkim_option    = 1
-    tag_key        = "env"
-    tag_value      = "prod"
+    tag_list {
+        tag_key   = "env"
+        tag_value = "prod"
+    }
 }
 
 ```

--- a/tencentcloud/services/ses/resource_tc_ses_domain.md
+++ b/tencentcloud/services/ses/resource_tc_ses_domain.md
@@ -5,6 +5,9 @@ Example Usage
 ```hcl
 resource "tencentcloud_ses_domain" "domain" {
     email_identity = "iac.cloud"
+    dkim_option    = 1
+    tag_key        = "env"
+    tag_value      = "prod"
 }
 
 ```

--- a/tencentcloud/services/ses/resource_tc_ses_domain_test.go
+++ b/tencentcloud/services/ses/resource_tc_ses_domain_test.go
@@ -32,10 +32,48 @@ func TestAccTencentCloudSesDomain_basic(t *testing.T) {
 	})
 }
 
+// go test -i; go test -test.run TestAccTencentCloudSesDomain_dkimTag -v
+func TestAccTencentCloudSesDomain_dkimTag(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { tcacctest.AccPreCheckBusiness(t, tcacctest.ACCOUNT_TYPE_SES) },
+		Providers: tcacctest.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSesDomainDkimTag,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tencentcloud_ses_domain.domain", "id"),
+					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "email_identity", "iac.cloud"),
+					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "dkim_option", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "tag_key", "env"),
+					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "tag_value", "prod"),
+				),
+			},
+			{
+				ResourceName:      "tencentcloud_ses_domain.domain",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 const testAccSesDomain = `
 
 resource "tencentcloud_ses_domain" "domain" {
   email_identity = "iac.cloud"
+}
+
+`
+
+const testAccSesDomainDkimTag = `
+
+resource "tencentcloud_ses_domain" "domain" {
+  email_identity = "iac.cloud"
+  dkim_option    = 1
+  tag_key        = "env"
+  tag_value      = "prod"
 }
 
 `

--- a/tencentcloud/services/ses/resource_tc_ses_domain_test.go
+++ b/tencentcloud/services/ses/resource_tc_ses_domain_test.go
@@ -46,8 +46,8 @@ func TestAccTencentCloudSesDomain_dkimTag(t *testing.T) {
 					resource.TestCheckResourceAttrSet("tencentcloud_ses_domain.domain", "id"),
 					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "email_identity", "iac.cloud"),
 					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "dkim_option", "1"),
-					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "tag_key", "env"),
-					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "tag_value", "prod"),
+					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "tag_list.0.tag_key", "env"),
+					resource.TestCheckResourceAttr("tencentcloud_ses_domain.domain", "tag_list.0.tag_value", "prod"),
 				),
 			},
 			{
@@ -72,8 +72,10 @@ const testAccSesDomainDkimTag = `
 resource "tencentcloud_ses_domain" "domain" {
   email_identity = "iac.cloud"
   dkim_option    = 1
-  tag_key        = "env"
-  tag_value      = "prod"
+  tag_list {
+    tag_key   = "env"
+    tag_value = "prod"
+  }
 }
 
 `

--- a/tencentcloud/services/ses/service_tencentcloud_ses.go
+++ b/tencentcloud/services/ses/service_tencentcloud_ses.go
@@ -194,7 +194,7 @@ func (me *SesService) DeleteSesEmail_addressById(ctx context.Context, emailAddre
 	return
 }
 
-func (me *SesService) DescribeSesDomain(ctx context.Context, emailIdentity string) (attributes []*ses.DNSAttributes, errRet error) {
+func (me *SesService) DescribeSesDomain(ctx context.Context, emailIdentity string) (response *ses.GetEmailIdentityResponseParams, errRet error) {
 	var (
 		logId   = tccommon.GetLogId(ctx)
 		request = ses.NewGetEmailIdentityRequest()
@@ -208,7 +208,7 @@ func (me *SesService) DescribeSesDomain(ctx context.Context, emailIdentity strin
 	}()
 	request.EmailIdentity = &emailIdentity
 
-	response, err := me.client.UseSesClient().GetEmailIdentity(request)
+	result, err := me.client.UseSesClient().GetEmailIdentity(request)
 	if err != nil {
 		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 			logId, request.GetAction(), request.ToJsonString(), err.Error())
@@ -216,11 +216,11 @@ func (me *SesService) DescribeSesDomain(ctx context.Context, emailIdentity strin
 		return
 	}
 	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
-		logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
-	if len(response.Response.Attributes) < 1 {
+		logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+	if result == nil || result.Response == nil {
 		return
 	}
-	attributes = response.Response.Attributes
+	response = result.Response
 	return
 }
 

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses/v20201002/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses/v20201002/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,8 +59,9 @@ func NewBatchSendEmailRequest() (request *BatchSendEmailRequest) {
 func NewBatchSendEmailResponse() (response *BatchSendEmailResponse) {
     response = &BatchSendEmailResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // BatchSendEmail
@@ -107,6 +108,7 @@ func (c *Client) BatchSendEmailWithContext(ctx context.Context, request *BatchSe
     if request == nil {
         request = NewBatchSendEmailRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "BatchSendEmail")
     
     if c.GetCredential() == nil {
         return nil, errors.New("BatchSendEmail require credential")
@@ -115,6 +117,136 @@ func (c *Client) BatchSendEmailWithContext(ctx context.Context, request *BatchSe
     request.SetContext(ctx)
     
     response = NewBatchSendEmailResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateAddressUnsubscribeConfigRequest() (request *CreateAddressUnsubscribeConfigRequest) {
+    request = &CreateAddressUnsubscribeConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "CreateAddressUnsubscribeConfig")
+    
+    
+    return
+}
+
+func NewCreateAddressUnsubscribeConfigResponse() (response *CreateAddressUnsubscribeConfigResponse) {
+    response = &CreateAddressUnsubscribeConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateAddressUnsubscribeConfig
+// 创建地址级退订配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EMAILCONTENTTOOLARGE = "FailedOperation.EmailContentToolarge"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_BEGINTIMEBEFORENOW = "InvalidParameterValue.BeginTimeBeforeNow"
+//  INVALIDPARAMETERVALUE_EMAILCONTENTISWRONG = "InvalidParameterValue.EmailContentIsWrong"
+//  INVALIDPARAMETERVALUE_SUBJECTLENGTHERROR = "InvalidParameterValue.SubjectLengthError"
+//  INVALIDPARAMETERVALUE_TEMPLATEDATAERROR = "InvalidParameterValue.TemplateDataError"
+//  INVALIDPARAMETERVALUE_TEMPLATENOTMATCHDATA = "InvalidParameterValue.TemplateNotMatchData"
+//  MISSINGPARAMETER_CYCLEPARAMNECESSARY = "MissingParameter.CycleParamNecessary"
+//  MISSINGPARAMETER_SENDPARAMNECESSARY = "MissingParameter.SendParamNecessary"
+//  MISSINGPARAMETER_TIMEDPARAMNECESSARY = "MissingParameter.TimedParamNecessary"
+//  OPERATIONDENIED_RECEIVERNOTEXIST = "OperationDenied.ReceiverNotExist"
+//  OPERATIONDENIED_RECEIVERSTATUSERROR = "OperationDenied.ReceiverStatusError"
+//  OPERATIONDENIED_SENDADDRESSSTATUSERROR = "OperationDenied.SendAddressStatusError"
+//  OPERATIONDENIED_TEMPLATESTATUSERROR = "OperationDenied.TemplateStatusError"
+func (c *Client) CreateAddressUnsubscribeConfig(request *CreateAddressUnsubscribeConfigRequest) (response *CreateAddressUnsubscribeConfigResponse, err error) {
+    return c.CreateAddressUnsubscribeConfigWithContext(context.Background(), request)
+}
+
+// CreateAddressUnsubscribeConfig
+// 创建地址级退订配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EMAILCONTENTTOOLARGE = "FailedOperation.EmailContentToolarge"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_BEGINTIMEBEFORENOW = "InvalidParameterValue.BeginTimeBeforeNow"
+//  INVALIDPARAMETERVALUE_EMAILCONTENTISWRONG = "InvalidParameterValue.EmailContentIsWrong"
+//  INVALIDPARAMETERVALUE_SUBJECTLENGTHERROR = "InvalidParameterValue.SubjectLengthError"
+//  INVALIDPARAMETERVALUE_TEMPLATEDATAERROR = "InvalidParameterValue.TemplateDataError"
+//  INVALIDPARAMETERVALUE_TEMPLATENOTMATCHDATA = "InvalidParameterValue.TemplateNotMatchData"
+//  MISSINGPARAMETER_CYCLEPARAMNECESSARY = "MissingParameter.CycleParamNecessary"
+//  MISSINGPARAMETER_SENDPARAMNECESSARY = "MissingParameter.SendParamNecessary"
+//  MISSINGPARAMETER_TIMEDPARAMNECESSARY = "MissingParameter.TimedParamNecessary"
+//  OPERATIONDENIED_RECEIVERNOTEXIST = "OperationDenied.ReceiverNotExist"
+//  OPERATIONDENIED_RECEIVERSTATUSERROR = "OperationDenied.ReceiverStatusError"
+//  OPERATIONDENIED_SENDADDRESSSTATUSERROR = "OperationDenied.SendAddressStatusError"
+//  OPERATIONDENIED_TEMPLATESTATUSERROR = "OperationDenied.TemplateStatusError"
+func (c *Client) CreateAddressUnsubscribeConfigWithContext(ctx context.Context, request *CreateAddressUnsubscribeConfigRequest) (response *CreateAddressUnsubscribeConfigResponse, err error) {
+    if request == nil {
+        request = NewCreateAddressUnsubscribeConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "CreateAddressUnsubscribeConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateAddressUnsubscribeConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateAddressUnsubscribeConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateCustomBlacklistRequest() (request *CreateCustomBlacklistRequest) {
+    request = &CreateCustomBlacklistRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "CreateCustomBlacklist")
+    
+    
+    return
+}
+
+func NewCreateCustomBlacklistResponse() (response *CreateCustomBlacklistResponse) {
+    response = &CreateCustomBlacklistResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateCustomBlacklist
+// 添加自定义黑名单
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_WRONGDATE = "InvalidParameterValue.WrongDate"
+//  LIMITEXCEEDED_RECEIVERDETAILREQUESTLIMIT = "LimitExceeded.ReceiverDetailRequestLimit"
+//  MISSINGPARAMETER_EMAILSNECESSARY = "MissingParameter.EmailsNecessary"
+func (c *Client) CreateCustomBlacklist(request *CreateCustomBlacklistRequest) (response *CreateCustomBlacklistResponse, err error) {
+    return c.CreateCustomBlacklistWithContext(context.Background(), request)
+}
+
+// CreateCustomBlacklist
+// 添加自定义黑名单
+//
+// 可能返回的错误码:
+//  INVALIDPARAMETERVALUE_WRONGDATE = "InvalidParameterValue.WrongDate"
+//  LIMITEXCEEDED_RECEIVERDETAILREQUESTLIMIT = "LimitExceeded.ReceiverDetailRequestLimit"
+//  MISSINGPARAMETER_EMAILSNECESSARY = "MissingParameter.EmailsNecessary"
+func (c *Client) CreateCustomBlacklistWithContext(ctx context.Context, request *CreateCustomBlacklistRequest) (response *CreateCustomBlacklistResponse, err error) {
+    if request == nil {
+        request = NewCreateCustomBlacklistRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "CreateCustomBlacklist")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateCustomBlacklist require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateCustomBlacklistResponse()
     err = c.Send(request, response)
     return
 }
@@ -133,14 +265,16 @@ func NewCreateEmailAddressRequest() (request *CreateEmailAddressRequest) {
 func NewCreateEmailAddressResponse() (response *CreateEmailAddressResponse) {
     response = &CreateEmailAddressResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateEmailAddress
 // 在验证了发信域名之后，您需要一个发信地址来发送邮件。例如发信域名是mail.qcloud.com，那么发信地址可以为 service@mail.qcloud.com。如果您想要收件人在收件箱列表中显示您的别名，例如"腾讯云邮件通知"。那么发信地址为： 别名 空格 尖括号 邮箱地址。请注意中间需要有空格
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -161,6 +295,7 @@ func (c *Client) CreateEmailAddress(request *CreateEmailAddressRequest) (respons
 // 在验证了发信域名之后，您需要一个发信地址来发送邮件。例如发信域名是mail.qcloud.com，那么发信地址可以为 service@mail.qcloud.com。如果您想要收件人在收件箱列表中显示您的别名，例如"腾讯云邮件通知"。那么发信地址为： 别名 空格 尖括号 邮箱地址。请注意中间需要有空格
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -177,6 +312,7 @@ func (c *Client) CreateEmailAddressWithContext(ctx context.Context, request *Cre
     if request == nil {
         request = NewCreateEmailAddressRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "CreateEmailAddress")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateEmailAddress require credential")
@@ -203,14 +339,16 @@ func NewCreateEmailIdentityRequest() (request *CreateEmailIdentityRequest) {
 func NewCreateEmailIdentityResponse() (response *CreateEmailIdentityResponse) {
     response = &CreateEmailIdentityResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateEmailIdentity
 // 在使用身份发送电子邮件之前，您需要有一个电子邮件域名，该域名可以是您的网站或者移动应用的域名。您首先必须进行验证，证明自己是该域名的所有者，并且授权给腾讯云SES发送许可，才可以从该域名发送电子邮件。
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -230,6 +368,7 @@ func (c *Client) CreateEmailIdentity(request *CreateEmailIdentityRequest) (respo
 // 在使用身份发送电子邮件之前，您需要有一个电子邮件域名，该域名可以是您的网站或者移动应用的域名。您首先必须进行验证，证明自己是该域名的所有者，并且授权给腾讯云SES发送许可，才可以从该域名发送电子邮件。
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -245,6 +384,7 @@ func (c *Client) CreateEmailIdentityWithContext(ctx context.Context, request *Cr
     if request == nil {
         request = NewCreateEmailIdentityRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "CreateEmailIdentity")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateEmailIdentity require credential")
@@ -271,8 +411,9 @@ func NewCreateEmailTemplateRequest() (request *CreateEmailTemplateRequest) {
 func NewCreateEmailTemplateResponse() (response *CreateEmailTemplateResponse) {
     response = &CreateEmailTemplateResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateEmailTemplate
@@ -317,6 +458,7 @@ func (c *Client) CreateEmailTemplateWithContext(ctx context.Context, request *Cr
     if request == nil {
         request = NewCreateEmailTemplateRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "CreateEmailTemplate")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateEmailTemplate require credential")
@@ -343,8 +485,9 @@ func NewCreateReceiverRequest() (request *CreateReceiverRequest) {
 func NewCreateReceiverResponse() (response *CreateReceiverResponse) {
     response = &CreateReceiverResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateReceiver
@@ -373,6 +516,7 @@ func (c *Client) CreateReceiverWithContext(ctx context.Context, request *CreateR
     if request == nil {
         request = NewCreateReceiverRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "CreateReceiver")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateReceiver require credential")
@@ -399,8 +543,9 @@ func NewCreateReceiverDetailRequest() (request *CreateReceiverDetailRequest) {
 func NewCreateReceiverDetailResponse() (response *CreateReceiverDetailResponse) {
     response = &CreateReceiverDetailResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateReceiverDetail
@@ -441,6 +586,7 @@ func (c *Client) CreateReceiverDetailWithContext(ctx context.Context, request *C
     if request == nil {
         request = NewCreateReceiverDetailRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "CreateReceiverDetail")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateReceiverDetail require credential")
@@ -467,8 +613,9 @@ func NewCreateReceiverDetailWithDataRequest() (request *CreateReceiverDetailWith
 func NewCreateReceiverDetailWithDataResponse() (response *CreateReceiverDetailWithDataResponse) {
     response = &CreateReceiverDetailWithDataResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // CreateReceiverDetailWithData
@@ -509,6 +656,7 @@ func (c *Client) CreateReceiverDetailWithDataWithContext(ctx context.Context, re
     if request == nil {
         request = NewCreateReceiverDetailWithDataRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "CreateReceiverDetailWithData")
     
     if c.GetCredential() == nil {
         return nil, errors.New("CreateReceiverDetailWithData require credential")
@@ -517,6 +665,76 @@ func (c *Client) CreateReceiverDetailWithDataWithContext(ctx context.Context, re
     request.SetContext(ctx)
     
     response = NewCreateReceiverDetailWithDataResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteAddressUnsubscribeConfigRequest() (request *DeleteAddressUnsubscribeConfigRequest) {
+    request = &DeleteAddressUnsubscribeConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "DeleteAddressUnsubscribeConfig")
+    
+    
+    return
+}
+
+func NewDeleteAddressUnsubscribeConfigResponse() (response *DeleteAddressUnsubscribeConfigResponse) {
+    response = &DeleteAddressUnsubscribeConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteAddressUnsubscribeConfig
+// 删除地址级退订配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_SERVICENOTAVAILABLE = "FailedOperation.ServiceNotAvailable"
+//  INVALIDPARAMETERVALUE_INVALIDTEMPLATEDATA = "InvalidParameterValue.InValidTemplateData"
+//  INVALIDPARAMETERVALUE_RECEIVEREMAILINVALID = "InvalidParameterValue.ReceiverEmailInvalid"
+//  INVALIDPARAMETERVALUE_TEMPLATEDATAERROR = "InvalidParameterValue.TemplateDataError"
+//  INVALIDPARAMETERVALUE_TEMPLATEDATAINCONSISTENT = "InvalidParameterValue.TemplateDataInconsistent"
+//  INVALIDPARAMETERVALUE_TEMPLATEDATALENLIMIT = "InvalidParameterValue.TemplateDataLenLimit"
+//  LIMITEXCEEDED_RECEIVERDETAILCOUNTLIMIT = "LimitExceeded.ReceiverDetailCountLimit"
+//  LIMITEXCEEDED_RECEIVERDETAILREQUESTLIMIT = "LimitExceeded.ReceiverDetailRequestLimit"
+//  MISSINGPARAMETER_EMAILSNECESSARY = "MissingParameter.EmailsNecessary"
+//  OPERATIONDENIED_RECEIVERISOPERATING = "OperationDenied.ReceiverIsOperating"
+//  OPERATIONDENIED_RECEIVERNOTEXIST = "OperationDenied.ReceiverNotExist"
+func (c *Client) DeleteAddressUnsubscribeConfig(request *DeleteAddressUnsubscribeConfigRequest) (response *DeleteAddressUnsubscribeConfigResponse, err error) {
+    return c.DeleteAddressUnsubscribeConfigWithContext(context.Background(), request)
+}
+
+// DeleteAddressUnsubscribeConfig
+// 删除地址级退订配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_SERVICENOTAVAILABLE = "FailedOperation.ServiceNotAvailable"
+//  INVALIDPARAMETERVALUE_INVALIDTEMPLATEDATA = "InvalidParameterValue.InValidTemplateData"
+//  INVALIDPARAMETERVALUE_RECEIVEREMAILINVALID = "InvalidParameterValue.ReceiverEmailInvalid"
+//  INVALIDPARAMETERVALUE_TEMPLATEDATAERROR = "InvalidParameterValue.TemplateDataError"
+//  INVALIDPARAMETERVALUE_TEMPLATEDATAINCONSISTENT = "InvalidParameterValue.TemplateDataInconsistent"
+//  INVALIDPARAMETERVALUE_TEMPLATEDATALENLIMIT = "InvalidParameterValue.TemplateDataLenLimit"
+//  LIMITEXCEEDED_RECEIVERDETAILCOUNTLIMIT = "LimitExceeded.ReceiverDetailCountLimit"
+//  LIMITEXCEEDED_RECEIVERDETAILREQUESTLIMIT = "LimitExceeded.ReceiverDetailRequestLimit"
+//  MISSINGPARAMETER_EMAILSNECESSARY = "MissingParameter.EmailsNecessary"
+//  OPERATIONDENIED_RECEIVERISOPERATING = "OperationDenied.ReceiverIsOperating"
+//  OPERATIONDENIED_RECEIVERNOTEXIST = "OperationDenied.ReceiverNotExist"
+func (c *Client) DeleteAddressUnsubscribeConfigWithContext(ctx context.Context, request *DeleteAddressUnsubscribeConfigRequest) (response *DeleteAddressUnsubscribeConfigResponse, err error) {
+    if request == nil {
+        request = NewDeleteAddressUnsubscribeConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "DeleteAddressUnsubscribeConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteAddressUnsubscribeConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteAddressUnsubscribeConfigResponse()
     err = c.Send(request, response)
     return
 }
@@ -535,8 +753,9 @@ func NewDeleteBlackListRequest() (request *DeleteBlackListRequest) {
 func NewDeleteBlackListResponse() (response *DeleteBlackListResponse) {
     response = &DeleteBlackListResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteBlackList
@@ -563,6 +782,7 @@ func (c *Client) DeleteBlackListWithContext(ctx context.Context, request *Delete
     if request == nil {
         request = NewDeleteBlackListRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "DeleteBlackList")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteBlackList require credential")
@@ -571,6 +791,56 @@ func (c *Client) DeleteBlackListWithContext(ctx context.Context, request *Delete
     request.SetContext(ctx)
     
     response = NewDeleteBlackListResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteCustomBlackListRequest() (request *DeleteCustomBlackListRequest) {
+    request = &DeleteCustomBlackListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "DeleteCustomBlackList")
+    
+    
+    return
+}
+
+func NewDeleteCustomBlackListResponse() (response *DeleteCustomBlackListResponse) {
+    response = &DeleteCustomBlackListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteCustomBlackList
+// 删除自定义黑名单邮箱地址
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+func (c *Client) DeleteCustomBlackList(request *DeleteCustomBlackListRequest) (response *DeleteCustomBlackListResponse, err error) {
+    return c.DeleteCustomBlackListWithContext(context.Background(), request)
+}
+
+// DeleteCustomBlackList
+// 删除自定义黑名单邮箱地址
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+func (c *Client) DeleteCustomBlackListWithContext(ctx context.Context, request *DeleteCustomBlackListRequest) (response *DeleteCustomBlackListResponse, err error) {
+    if request == nil {
+        request = NewDeleteCustomBlackListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "DeleteCustomBlackList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteCustomBlackList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteCustomBlackListResponse()
     err = c.Send(request, response)
     return
 }
@@ -589,14 +859,16 @@ func NewDeleteEmailAddressRequest() (request *DeleteEmailAddressRequest) {
 func NewDeleteEmailAddressResponse() (response *DeleteEmailAddressResponse) {
     response = &DeleteEmailAddressResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteEmailAddress
 // 删除发信人地址
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -613,6 +885,7 @@ func (c *Client) DeleteEmailAddress(request *DeleteEmailAddressRequest) (respons
 // 删除发信人地址
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -625,6 +898,7 @@ func (c *Client) DeleteEmailAddressWithContext(ctx context.Context, request *Del
     if request == nil {
         request = NewDeleteEmailAddressRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "DeleteEmailAddress")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteEmailAddress require credential")
@@ -651,40 +925,52 @@ func NewDeleteEmailIdentityRequest() (request *DeleteEmailIdentityRequest) {
 func NewDeleteEmailIdentityResponse() (response *DeleteEmailIdentityResponse) {
     response = &DeleteEmailIdentityResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteEmailIdentity
+// **发信域名删除接口仅限于企业用户使用**
+//
 // 删除发信域名，删除后，将不可再使用该域名进行发信
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  LIMITEXCEEDED = "LimitExceeded"
 //  MISSINGPARAMETER = "MissingParameter"
 //  OPERATIONDENIED = "OperationDenied"
+//  OPERATIONDENIED_NOTALLOWDELETE = "OperationDenied.NotAllowDelete"
+//  OPERATIONDENIED_SENDERWITHDOMAINISNOTEMPTY = "OperationDenied.SenderWithDomainIsNotEmpty"
 //  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
 func (c *Client) DeleteEmailIdentity(request *DeleteEmailIdentityRequest) (response *DeleteEmailIdentityResponse, err error) {
     return c.DeleteEmailIdentityWithContext(context.Background(), request)
 }
 
 // DeleteEmailIdentity
+// **发信域名删除接口仅限于企业用户使用**
+//
 // 删除发信域名，删除后，将不可再使用该域名进行发信
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
 //  LIMITEXCEEDED = "LimitExceeded"
 //  MISSINGPARAMETER = "MissingParameter"
 //  OPERATIONDENIED = "OperationDenied"
+//  OPERATIONDENIED_NOTALLOWDELETE = "OperationDenied.NotAllowDelete"
+//  OPERATIONDENIED_SENDERWITHDOMAINISNOTEMPTY = "OperationDenied.SenderWithDomainIsNotEmpty"
 //  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
 func (c *Client) DeleteEmailIdentityWithContext(ctx context.Context, request *DeleteEmailIdentityRequest) (response *DeleteEmailIdentityResponse, err error) {
     if request == nil {
         request = NewDeleteEmailIdentityRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "DeleteEmailIdentity")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteEmailIdentity require credential")
@@ -711,8 +997,9 @@ func NewDeleteEmailTemplateRequest() (request *DeleteEmailTemplateRequest) {
 func NewDeleteEmailTemplateResponse() (response *DeleteEmailTemplateResponse) {
     response = &DeleteEmailTemplateResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteEmailTemplate
@@ -745,6 +1032,7 @@ func (c *Client) DeleteEmailTemplateWithContext(ctx context.Context, request *De
     if request == nil {
         request = NewDeleteEmailTemplateRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "DeleteEmailTemplate")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteEmailTemplate require credential")
@@ -771,8 +1059,9 @@ func NewDeleteReceiverRequest() (request *DeleteReceiverRequest) {
 func NewDeleteReceiverResponse() (response *DeleteReceiverResponse) {
     response = &DeleteReceiverResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // DeleteReceiver
@@ -797,6 +1086,7 @@ func (c *Client) DeleteReceiverWithContext(ctx context.Context, request *DeleteR
     if request == nil {
         request = NewDeleteReceiverRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "DeleteReceiver")
     
     if c.GetCredential() == nil {
         return nil, errors.New("DeleteReceiver require credential")
@@ -805,6 +1095,64 @@ func (c *Client) DeleteReceiverWithContext(ctx context.Context, request *DeleteR
     request.SetContext(ctx)
     
     response = NewDeleteReceiverResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewGetAbuseReportRequest() (request *GetAbuseReportRequest) {
+    request = &GetAbuseReportRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "GetAbuseReport")
+    
+    
+    return
+}
+
+func NewGetAbuseReportResponse() (response *GetAbuseReportResponse) {
+    response = &GetAbuseReportResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// GetAbuseReport
+// 获取垃圾投诉数据
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_INVALIDLIMIT = "FailedOperation.InvalidLimit"
+//  INTERNALERROR_QUERYDATABASEFAILED = "InternalError.QueryDataBaseFailed"
+//  INVALIDPARAMETER_APPIDISREQUIRED = "InvalidParameter.AppIdIsRequired"
+//  INVALIDPARAMETER_INVALIDENDTIMEFORMAT = "InvalidParameter.InvalidEndTimeFormat"
+//  INVALIDPARAMETER_INVALIDSTARTTIMEFORMAT = "InvalidParameter.InvalidStartTimeFormat"
+func (c *Client) GetAbuseReport(request *GetAbuseReportRequest) (response *GetAbuseReportResponse, err error) {
+    return c.GetAbuseReportWithContext(context.Background(), request)
+}
+
+// GetAbuseReport
+// 获取垃圾投诉数据
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_INVALIDLIMIT = "FailedOperation.InvalidLimit"
+//  INTERNALERROR_QUERYDATABASEFAILED = "InternalError.QueryDataBaseFailed"
+//  INVALIDPARAMETER_APPIDISREQUIRED = "InvalidParameter.AppIdIsRequired"
+//  INVALIDPARAMETER_INVALIDENDTIMEFORMAT = "InvalidParameter.InvalidEndTimeFormat"
+//  INVALIDPARAMETER_INVALIDSTARTTIMEFORMAT = "InvalidParameter.InvalidStartTimeFormat"
+func (c *Client) GetAbuseReportWithContext(ctx context.Context, request *GetAbuseReportRequest) (response *GetAbuseReportResponse, err error) {
+    if request == nil {
+        request = NewGetAbuseReportRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "GetAbuseReport")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("GetAbuseReport require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewGetAbuseReportResponse()
     err = c.Send(request, response)
     return
 }
@@ -823,14 +1171,16 @@ func NewGetEmailIdentityRequest() (request *GetEmailIdentityRequest) {
 func NewGetEmailIdentityResponse() (response *GetEmailIdentityResponse) {
     response = &GetEmailIdentityResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // GetEmailIdentity
 // 获取某个发信域名的配置详情
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -847,6 +1197,7 @@ func (c *Client) GetEmailIdentity(request *GetEmailIdentityRequest) (response *G
 // 获取某个发信域名的配置详情
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -859,6 +1210,7 @@ func (c *Client) GetEmailIdentityWithContext(ctx context.Context, request *GetEm
     if request == nil {
         request = NewGetEmailIdentityRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "GetEmailIdentity")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetEmailIdentity require credential")
@@ -885,8 +1237,9 @@ func NewGetEmailTemplateRequest() (request *GetEmailTemplateRequest) {
 func NewGetEmailTemplateResponse() (response *GetEmailTemplateResponse) {
     response = &GetEmailTemplateResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // GetEmailTemplate
@@ -921,6 +1274,7 @@ func (c *Client) GetEmailTemplateWithContext(ctx context.Context, request *GetEm
     if request == nil {
         request = NewGetEmailTemplateRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "GetEmailTemplate")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetEmailTemplate require credential")
@@ -947,14 +1301,13 @@ func NewGetSendEmailStatusRequest() (request *GetSendEmailStatusRequest) {
 func NewGetSendEmailStatusResponse() (response *GetSendEmailStatusResponse) {
     response = &GetSendEmailStatusResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // GetSendEmailStatus
 // 获取邮件发送状态。仅支持查询30天之内的数据
-//
-// 默认接口请求频率限制：1次/秒
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION_EMAILADDRINBLACKLIST = "FailedOperation.EmailAddrInBlacklist"
@@ -996,8 +1349,6 @@ func (c *Client) GetSendEmailStatus(request *GetSendEmailStatusRequest) (respons
 // GetSendEmailStatus
 // 获取邮件发送状态。仅支持查询30天之内的数据
 //
-// 默认接口请求频率限制：1次/秒
-//
 // 可能返回的错误码:
 //  FAILEDOPERATION_EMAILADDRINBLACKLIST = "FailedOperation.EmailAddrInBlacklist"
 //  FAILEDOPERATION_EMAILCONTENTTOOLARGE = "FailedOperation.EmailContentToolarge"
@@ -1035,6 +1386,7 @@ func (c *Client) GetSendEmailStatusWithContext(ctx context.Context, request *Get
     if request == nil {
         request = NewGetSendEmailStatusRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "GetSendEmailStatus")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetSendEmailStatus require credential")
@@ -1061,8 +1413,9 @@ func NewGetStatisticsReportRequest() (request *GetStatisticsReportRequest) {
 func NewGetStatisticsReportResponse() (response *GetStatisticsReportResponse) {
     response = &GetStatisticsReportResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // GetStatisticsReport
@@ -1093,6 +1446,7 @@ func (c *Client) GetStatisticsReportWithContext(ctx context.Context, request *Ge
     if request == nil {
         request = NewGetStatisticsReportRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "GetStatisticsReport")
     
     if c.GetCredential() == nil {
         return nil, errors.New("GetStatisticsReport require credential")
@@ -1101,6 +1455,66 @@ func (c *Client) GetStatisticsReportWithContext(ctx context.Context, request *Ge
     request.SetContext(ctx)
     
     response = NewGetStatisticsReportResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListAddressUnsubscribeConfigRequest() (request *ListAddressUnsubscribeConfigRequest) {
+    request = &ListAddressUnsubscribeConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "ListAddressUnsubscribeConfig")
+    
+    
+    return
+}
+
+func NewListAddressUnsubscribeConfigResponse() (response *ListAddressUnsubscribeConfigResponse) {
+    response = &ListAddressUnsubscribeConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListAddressUnsubscribeConfig
+// 获取地址级退订配置列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_WRONGDATE = "InvalidParameterValue.WrongDate"
+//  OPERATIONDENIED = "OperationDenied"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
+func (c *Client) ListAddressUnsubscribeConfig(request *ListAddressUnsubscribeConfigRequest) (response *ListAddressUnsubscribeConfigResponse, err error) {
+    return c.ListAddressUnsubscribeConfigWithContext(context.Background(), request)
+}
+
+// ListAddressUnsubscribeConfig
+// 获取地址级退订配置列表
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_WRONGDATE = "InvalidParameterValue.WrongDate"
+//  OPERATIONDENIED = "OperationDenied"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
+func (c *Client) ListAddressUnsubscribeConfigWithContext(ctx context.Context, request *ListAddressUnsubscribeConfigRequest) (response *ListAddressUnsubscribeConfigResponse, err error) {
+    if request == nil {
+        request = NewListAddressUnsubscribeConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListAddressUnsubscribeConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListAddressUnsubscribeConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListAddressUnsubscribeConfigResponse()
     err = c.Send(request, response)
     return
 }
@@ -1119,8 +1533,9 @@ func NewListBlackEmailAddressRequest() (request *ListBlackEmailAddressRequest) {
 func NewListBlackEmailAddressResponse() (response *ListBlackEmailAddressResponse) {
     response = &ListBlackEmailAddressResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ListBlackEmailAddress
@@ -1151,6 +1566,7 @@ func (c *Client) ListBlackEmailAddressWithContext(ctx context.Context, request *
     if request == nil {
         request = NewListBlackEmailAddressRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListBlackEmailAddress")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListBlackEmailAddress require credential")
@@ -1159,6 +1575,58 @@ func (c *Client) ListBlackEmailAddressWithContext(ctx context.Context, request *
     request.SetContext(ctx)
     
     response = NewListBlackEmailAddressResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListCustomBlacklistRequest() (request *ListCustomBlacklistRequest) {
+    request = &ListCustomBlacklistRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "ListCustomBlacklist")
+    
+    
+    return
+}
+
+func NewListCustomBlacklistResponse() (response *ListCustomBlacklistResponse) {
+    response = &ListCustomBlacklistResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListCustomBlacklist
+// 获取自定义黑名单列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_INVALIDLIMIT = "FailedOperation.InvalidLimit"
+//  INTERNALERROR = "InternalError"
+func (c *Client) ListCustomBlacklist(request *ListCustomBlacklistRequest) (response *ListCustomBlacklistResponse, err error) {
+    return c.ListCustomBlacklistWithContext(context.Background(), request)
+}
+
+// ListCustomBlacklist
+// 获取自定义黑名单列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_INVALIDLIMIT = "FailedOperation.InvalidLimit"
+//  INTERNALERROR = "InternalError"
+func (c *Client) ListCustomBlacklistWithContext(ctx context.Context, request *ListCustomBlacklistRequest) (response *ListCustomBlacklistResponse, err error) {
+    if request == nil {
+        request = NewListCustomBlacklistRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListCustomBlacklist")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListCustomBlacklist require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListCustomBlacklistResponse()
     err = c.Send(request, response)
     return
 }
@@ -1177,8 +1645,9 @@ func NewListEmailAddressRequest() (request *ListEmailAddressRequest) {
 func NewListEmailAddressResponse() (response *ListEmailAddressResponse) {
     response = &ListEmailAddressResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ListEmailAddress
@@ -1211,6 +1680,7 @@ func (c *Client) ListEmailAddressWithContext(ctx context.Context, request *ListE
     if request == nil {
         request = NewListEmailAddressRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListEmailAddress")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListEmailAddress require credential")
@@ -1237,14 +1707,16 @@ func NewListEmailIdentitiesRequest() (request *ListEmailIdentitiesRequest) {
 func NewListEmailIdentitiesResponse() (response *ListEmailIdentitiesResponse) {
     response = &ListEmailIdentitiesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ListEmailIdentities
 // 获取当前发信域名列表，包含已验证通过与未验证的域名
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -1260,6 +1732,7 @@ func (c *Client) ListEmailIdentities(request *ListEmailIdentitiesRequest) (respo
 // 获取当前发信域名列表，包含已验证通过与未验证的域名
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
 //  INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -1271,6 +1744,7 @@ func (c *Client) ListEmailIdentitiesWithContext(ctx context.Context, request *Li
     if request == nil {
         request = NewListEmailIdentitiesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListEmailIdentities")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListEmailIdentities require credential")
@@ -1297,8 +1771,9 @@ func NewListEmailTemplatesRequest() (request *ListEmailTemplatesRequest) {
 func NewListEmailTemplatesResponse() (response *ListEmailTemplatesResponse) {
     response = &ListEmailTemplatesResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ListEmailTemplates
@@ -1331,6 +1806,7 @@ func (c *Client) ListEmailTemplatesWithContext(ctx context.Context, request *Lis
     if request == nil {
         request = NewListEmailTemplatesRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListEmailTemplates")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListEmailTemplates require credential")
@@ -1357,8 +1833,9 @@ func NewListReceiverDetailsRequest() (request *ListReceiverDetailsRequest) {
 func NewListReceiverDetailsResponse() (response *ListReceiverDetailsResponse) {
     response = &ListReceiverDetailsResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ListReceiverDetails
@@ -1383,6 +1860,7 @@ func (c *Client) ListReceiverDetailsWithContext(ctx context.Context, request *Li
     if request == nil {
         request = NewListReceiverDetailsRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListReceiverDetails")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListReceiverDetails require credential")
@@ -1409,8 +1887,9 @@ func NewListReceiversRequest() (request *ListReceiversRequest) {
 func NewListReceiversResponse() (response *ListReceiversResponse) {
     response = &ListReceiversResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ListReceivers
@@ -1433,6 +1912,7 @@ func (c *Client) ListReceiversWithContext(ctx context.Context, request *ListRece
     if request == nil {
         request = NewListReceiversRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListReceivers")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListReceivers require credential")
@@ -1459,8 +1939,9 @@ func NewListSendTasksRequest() (request *ListSendTasksRequest) {
 func NewListSendTasksResponse() (response *ListSendTasksResponse) {
     response = &ListSendTasksResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // ListSendTasks
@@ -1481,6 +1962,7 @@ func (c *Client) ListSendTasksWithContext(ctx context.Context, request *ListSend
     if request == nil {
         request = NewListSendTasksRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "ListSendTasks")
     
     if c.GetCredential() == nil {
         return nil, errors.New("ListSendTasks require credential")
@@ -1507,8 +1989,9 @@ func NewSendEmailRequest() (request *SendEmailRequest) {
 func NewSendEmailResponse() (response *SendEmailResponse) {
     response = &SendEmailResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // SendEmail
@@ -1519,8 +2002,10 @@ func NewSendEmailResponse() (response *SendEmailResponse) {
 //  FAILEDOPERATION_EMAILADDRINBLACKLIST = "FailedOperation.EmailAddrInBlacklist"
 //  FAILEDOPERATION_EMAILCONTENTTOOLARGE = "FailedOperation.EmailContentToolarge"
 //  FAILEDOPERATION_EXCEEDSENDLIMIT = "FailedOperation.ExceedSendLimit"
+//  FAILEDOPERATION_FILEURLNOTEXIST = "FailedOperation.FileURLNotExist"
 //  FAILEDOPERATION_FREQUENCYLIMIT = "FailedOperation.FrequencyLimit"
 //  FAILEDOPERATION_HIGHREJECTIONRATE = "FailedOperation.HighRejectionRate"
+//  FAILEDOPERATION_ILLEGALURL = "FailedOperation.IllegalURL"
 //  FAILEDOPERATION_INCORRECTEMAIL = "FailedOperation.IncorrectEmail"
 //  FAILEDOPERATION_INCORRECTSENDER = "FailedOperation.IncorrectSender"
 //  FAILEDOPERATION_INSUFFICIENTBALANCE = "FailedOperation.InsufficientBalance"
@@ -1537,6 +2022,7 @@ func NewSendEmailResponse() (response *SendEmailResponse) {
 //  FAILEDOPERATION_TEMPORARYBLOCKED = "FailedOperation.TemporaryBlocked"
 //  FAILEDOPERATION_TOOMANYATTACHMENTS = "FailedOperation.TooManyAttachments"
 //  FAILEDOPERATION_TOOMANYRECIPIENTS = "FailedOperation.TooManyRecipients"
+//  FAILEDOPERATION_URLFORBIDDEN = "FailedOperation.URLForbidden"
 //  FAILEDOPERATION_UNSUPPORTMAILTYPE = "FailedOperation.UnsupportMailType"
 //  FAILEDOPERATION_WITHOUTPERMISSION = "FailedOperation.WithOutPermission"
 //  FAILEDOPERATION_WRONGCONTENTJSON = "FailedOperation.WrongContentJson"
@@ -1568,8 +2054,10 @@ func (c *Client) SendEmail(request *SendEmailRequest) (response *SendEmailRespon
 //  FAILEDOPERATION_EMAILADDRINBLACKLIST = "FailedOperation.EmailAddrInBlacklist"
 //  FAILEDOPERATION_EMAILCONTENTTOOLARGE = "FailedOperation.EmailContentToolarge"
 //  FAILEDOPERATION_EXCEEDSENDLIMIT = "FailedOperation.ExceedSendLimit"
+//  FAILEDOPERATION_FILEURLNOTEXIST = "FailedOperation.FileURLNotExist"
 //  FAILEDOPERATION_FREQUENCYLIMIT = "FailedOperation.FrequencyLimit"
 //  FAILEDOPERATION_HIGHREJECTIONRATE = "FailedOperation.HighRejectionRate"
+//  FAILEDOPERATION_ILLEGALURL = "FailedOperation.IllegalURL"
 //  FAILEDOPERATION_INCORRECTEMAIL = "FailedOperation.IncorrectEmail"
 //  FAILEDOPERATION_INCORRECTSENDER = "FailedOperation.IncorrectSender"
 //  FAILEDOPERATION_INSUFFICIENTBALANCE = "FailedOperation.InsufficientBalance"
@@ -1586,6 +2074,7 @@ func (c *Client) SendEmail(request *SendEmailRequest) (response *SendEmailRespon
 //  FAILEDOPERATION_TEMPORARYBLOCKED = "FailedOperation.TemporaryBlocked"
 //  FAILEDOPERATION_TOOMANYATTACHMENTS = "FailedOperation.TooManyAttachments"
 //  FAILEDOPERATION_TOOMANYRECIPIENTS = "FailedOperation.TooManyRecipients"
+//  FAILEDOPERATION_URLFORBIDDEN = "FailedOperation.URLForbidden"
 //  FAILEDOPERATION_UNSUPPORTMAILTYPE = "FailedOperation.UnsupportMailType"
 //  FAILEDOPERATION_WITHOUTPERMISSION = "FailedOperation.WithOutPermission"
 //  FAILEDOPERATION_WRONGCONTENTJSON = "FailedOperation.WrongContentJson"
@@ -1609,6 +2098,7 @@ func (c *Client) SendEmailWithContext(ctx context.Context, request *SendEmailReq
     if request == nil {
         request = NewSendEmailRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "SendEmail")
     
     if c.GetCredential() == nil {
         return nil, errors.New("SendEmail require credential")
@@ -1617,6 +2107,196 @@ func (c *Client) SendEmailWithContext(ctx context.Context, request *SendEmailReq
     request.SetContext(ctx)
     
     response = NewSendEmailResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateAddressUnsubscribeConfigRequest() (request *UpdateAddressUnsubscribeConfigRequest) {
+    request = &UpdateAddressUnsubscribeConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "UpdateAddressUnsubscribeConfig")
+    
+    
+    return
+}
+
+func NewUpdateAddressUnsubscribeConfigResponse() (response *UpdateAddressUnsubscribeConfigResponse) {
+    response = &UpdateAddressUnsubscribeConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateAddressUnsubscribeConfig
+// 用于更新地址级退订配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_ATTACHCONTENTTOOLARGE = "FailedOperation.AttachContentToolarge"
+//  FAILEDOPERATION_EMAILADDRINBLACKLIST = "FailedOperation.EmailAddrInBlacklist"
+//  FAILEDOPERATION_EMAILCONTENTTOOLARGE = "FailedOperation.EmailContentToolarge"
+//  FAILEDOPERATION_EXCEEDSENDLIMIT = "FailedOperation.ExceedSendLimit"
+//  FAILEDOPERATION_FILEURLNOTEXIST = "FailedOperation.FileURLNotExist"
+//  FAILEDOPERATION_FREQUENCYLIMIT = "FailedOperation.FrequencyLimit"
+//  FAILEDOPERATION_HIGHREJECTIONRATE = "FailedOperation.HighRejectionRate"
+//  FAILEDOPERATION_ILLEGALURL = "FailedOperation.IllegalURL"
+//  FAILEDOPERATION_INCORRECTEMAIL = "FailedOperation.IncorrectEmail"
+//  FAILEDOPERATION_INCORRECTSENDER = "FailedOperation.IncorrectSender"
+//  FAILEDOPERATION_INSUFFICIENTBALANCE = "FailedOperation.InsufficientBalance"
+//  FAILEDOPERATION_INSUFFICIENTQUOTA = "FailedOperation.InsufficientQuota"
+//  FAILEDOPERATION_INVALIDATTACHNAME = "FailedOperation.InvalidAttachName"
+//  FAILEDOPERATION_INVALIDTEMPLATEID = "FailedOperation.InvalidTemplateID"
+//  FAILEDOPERATION_MISSINGEMAILCONTENT = "FailedOperation.MissingEmailContent"
+//  FAILEDOPERATION_NOATTACHPERMISSION = "FailedOperation.NoAttachPermission"
+//  FAILEDOPERATION_NOTAUTHENTICATEDSENDER = "FailedOperation.NotAuthenticatedSender"
+//  FAILEDOPERATION_PROTOCOLCHECKERR = "FailedOperation.ProtocolCheckErr"
+//  FAILEDOPERATION_RECEIVERHASUNSUBSCRIBED = "FailedOperation.ReceiverHasUnsubscribed"
+//  FAILEDOPERATION_REJECTEDBYRECIPIENTS = "FailedOperation.RejectedByRecipients"
+//  FAILEDOPERATION_SENDEMAILERR = "FailedOperation.SendEmailErr"
+//  FAILEDOPERATION_TEMPORARYBLOCKED = "FailedOperation.TemporaryBlocked"
+//  FAILEDOPERATION_TOOMANYATTACHMENTS = "FailedOperation.TooManyAttachments"
+//  FAILEDOPERATION_TOOMANYRECIPIENTS = "FailedOperation.TooManyRecipients"
+//  FAILEDOPERATION_URLFORBIDDEN = "FailedOperation.URLForbidden"
+//  FAILEDOPERATION_UNSUPPORTMAILTYPE = "FailedOperation.UnsupportMailType"
+//  FAILEDOPERATION_WITHOUTPERMISSION = "FailedOperation.WithOutPermission"
+//  FAILEDOPERATION_WRONGCONTENTJSON = "FailedOperation.WrongContentJson"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_ATTACHCONTENTISWRONG = "InvalidParameterValue.AttachContentIsWrong"
+//  INVALIDPARAMETERVALUE_EMAILADDRESSISNULL = "InvalidParameterValue.EmailAddressIsNULL"
+//  INVALIDPARAMETERVALUE_EMAILCONTENTISWRONG = "InvalidParameterValue.EmailContentIsWrong"
+//  INVALIDPARAMETERVALUE_INVALIDEMAILIDENTITY = "InvalidParameterValue.InvalidEmailIdentity"
+//  INVALIDPARAMETERVALUE_RECEIVEREMAILINVALID = "InvalidParameterValue.ReceiverEmailInvalid"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  OPERATIONDENIED = "OperationDenied"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
+//  RESOURCEINSUFFICIENT = "ResourceInsufficient"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+//  UNKNOWNPARAMETER = "UnknownParameter"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) UpdateAddressUnsubscribeConfig(request *UpdateAddressUnsubscribeConfigRequest) (response *UpdateAddressUnsubscribeConfigResponse, err error) {
+    return c.UpdateAddressUnsubscribeConfigWithContext(context.Background(), request)
+}
+
+// UpdateAddressUnsubscribeConfig
+// 用于更新地址级退订配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_ATTACHCONTENTTOOLARGE = "FailedOperation.AttachContentToolarge"
+//  FAILEDOPERATION_EMAILADDRINBLACKLIST = "FailedOperation.EmailAddrInBlacklist"
+//  FAILEDOPERATION_EMAILCONTENTTOOLARGE = "FailedOperation.EmailContentToolarge"
+//  FAILEDOPERATION_EXCEEDSENDLIMIT = "FailedOperation.ExceedSendLimit"
+//  FAILEDOPERATION_FILEURLNOTEXIST = "FailedOperation.FileURLNotExist"
+//  FAILEDOPERATION_FREQUENCYLIMIT = "FailedOperation.FrequencyLimit"
+//  FAILEDOPERATION_HIGHREJECTIONRATE = "FailedOperation.HighRejectionRate"
+//  FAILEDOPERATION_ILLEGALURL = "FailedOperation.IllegalURL"
+//  FAILEDOPERATION_INCORRECTEMAIL = "FailedOperation.IncorrectEmail"
+//  FAILEDOPERATION_INCORRECTSENDER = "FailedOperation.IncorrectSender"
+//  FAILEDOPERATION_INSUFFICIENTBALANCE = "FailedOperation.InsufficientBalance"
+//  FAILEDOPERATION_INSUFFICIENTQUOTA = "FailedOperation.InsufficientQuota"
+//  FAILEDOPERATION_INVALIDATTACHNAME = "FailedOperation.InvalidAttachName"
+//  FAILEDOPERATION_INVALIDTEMPLATEID = "FailedOperation.InvalidTemplateID"
+//  FAILEDOPERATION_MISSINGEMAILCONTENT = "FailedOperation.MissingEmailContent"
+//  FAILEDOPERATION_NOATTACHPERMISSION = "FailedOperation.NoAttachPermission"
+//  FAILEDOPERATION_NOTAUTHENTICATEDSENDER = "FailedOperation.NotAuthenticatedSender"
+//  FAILEDOPERATION_PROTOCOLCHECKERR = "FailedOperation.ProtocolCheckErr"
+//  FAILEDOPERATION_RECEIVERHASUNSUBSCRIBED = "FailedOperation.ReceiverHasUnsubscribed"
+//  FAILEDOPERATION_REJECTEDBYRECIPIENTS = "FailedOperation.RejectedByRecipients"
+//  FAILEDOPERATION_SENDEMAILERR = "FailedOperation.SendEmailErr"
+//  FAILEDOPERATION_TEMPORARYBLOCKED = "FailedOperation.TemporaryBlocked"
+//  FAILEDOPERATION_TOOMANYATTACHMENTS = "FailedOperation.TooManyAttachments"
+//  FAILEDOPERATION_TOOMANYRECIPIENTS = "FailedOperation.TooManyRecipients"
+//  FAILEDOPERATION_URLFORBIDDEN = "FailedOperation.URLForbidden"
+//  FAILEDOPERATION_UNSUPPORTMAILTYPE = "FailedOperation.UnsupportMailType"
+//  FAILEDOPERATION_WITHOUTPERMISSION = "FailedOperation.WithOutPermission"
+//  FAILEDOPERATION_WRONGCONTENTJSON = "FailedOperation.WrongContentJson"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+//  INVALIDPARAMETERVALUE_ATTACHCONTENTISWRONG = "InvalidParameterValue.AttachContentIsWrong"
+//  INVALIDPARAMETERVALUE_EMAILADDRESSISNULL = "InvalidParameterValue.EmailAddressIsNULL"
+//  INVALIDPARAMETERVALUE_EMAILCONTENTISWRONG = "InvalidParameterValue.EmailContentIsWrong"
+//  INVALIDPARAMETERVALUE_INVALIDEMAILIDENTITY = "InvalidParameterValue.InvalidEmailIdentity"
+//  INVALIDPARAMETERVALUE_RECEIVEREMAILINVALID = "InvalidParameterValue.ReceiverEmailInvalid"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  MISSINGPARAMETER = "MissingParameter"
+//  OPERATIONDENIED = "OperationDenied"
+//  REQUESTLIMITEXCEEDED = "RequestLimitExceeded"
+//  RESOURCEINSUFFICIENT = "ResourceInsufficient"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+//  UNKNOWNPARAMETER = "UnknownParameter"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) UpdateAddressUnsubscribeConfigWithContext(ctx context.Context, request *UpdateAddressUnsubscribeConfigRequest) (response *UpdateAddressUnsubscribeConfigResponse, err error) {
+    if request == nil {
+        request = NewUpdateAddressUnsubscribeConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "UpdateAddressUnsubscribeConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateAddressUnsubscribeConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateAddressUnsubscribeConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateCustomBlackListRequest() (request *UpdateCustomBlackListRequest) {
+    request = &UpdateCustomBlackListRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("ses", APIVersion, "UpdateCustomBlackList")
+    
+    
+    return
+}
+
+func NewUpdateCustomBlackListResponse() (response *UpdateCustomBlackListResponse) {
+    response = &UpdateCustomBlackListResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateCustomBlackList
+// 更新自定义黑名单
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_ILLEGALEMAILADDRESS = "InvalidParameterValue.IllegalEmailAddress"
+//  INVALIDPARAMETERVALUE_WRONGDATE = "InvalidParameterValue.WrongDate"
+func (c *Client) UpdateCustomBlackList(request *UpdateCustomBlackListRequest) (response *UpdateCustomBlackListResponse, err error) {
+    return c.UpdateCustomBlackListWithContext(context.Background(), request)
+}
+
+// UpdateCustomBlackList
+// 更新自定义黑名单
+//
+// 可能返回的错误码:
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETERVALUE_ILLEGALEMAILADDRESS = "InvalidParameterValue.IllegalEmailAddress"
+//  INVALIDPARAMETERVALUE_WRONGDATE = "InvalidParameterValue.WrongDate"
+func (c *Client) UpdateCustomBlackListWithContext(ctx context.Context, request *UpdateCustomBlackListRequest) (response *UpdateCustomBlackListResponse, err error) {
+    if request == nil {
+        request = NewUpdateCustomBlackListRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "UpdateCustomBlackList")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateCustomBlackList require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateCustomBlackListResponse()
     err = c.Send(request, response)
     return
 }
@@ -1635,14 +2315,17 @@ func NewUpdateEmailIdentityRequest() (request *UpdateEmailIdentityRequest) {
 func NewUpdateEmailIdentityResponse() (response *UpdateEmailIdentityResponse) {
     response = &UpdateEmailIdentityResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // UpdateEmailIdentity
 // 您已经成功配置好了您的DNS，接下来请求腾讯云验证您的DNS配置是否正确
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION_DKIMNOTAPPLIED = "FailedOperation.DKIMNotApplied"
 //  FAILEDOPERATION_SERVICENOTAVAILABLE = "FailedOperation.ServiceNotAvailable"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
@@ -1660,6 +2343,8 @@ func (c *Client) UpdateEmailIdentity(request *UpdateEmailIdentityRequest) (respo
 // 您已经成功配置好了您的DNS，接下来请求腾讯云验证您的DNS配置是否正确
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION_DKIMNOTAPPLIED = "FailedOperation.DKIMNotApplied"
 //  FAILEDOPERATION_SERVICENOTAVAILABLE = "FailedOperation.ServiceNotAvailable"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
@@ -1673,6 +2358,7 @@ func (c *Client) UpdateEmailIdentityWithContext(ctx context.Context, request *Up
     if request == nil {
         request = NewUpdateEmailIdentityRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "UpdateEmailIdentity")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateEmailIdentity require credential")
@@ -1699,14 +2385,16 @@ func NewUpdateEmailSmtpPassWordRequest() (request *UpdateEmailSmtpPassWordReques
 func NewUpdateEmailSmtpPassWordResponse() (response *UpdateEmailSmtpPassWordResponse) {
     response = &UpdateEmailSmtpPassWordResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // UpdateEmailSmtpPassWord
 // 设置邮箱的smtp密码。若要通过smtp发送邮件，必须为邮箱设置smtp密码。初始时，邮箱没有设置smtp密码，不能使用smtp的方式发送邮件。设置smtp密码后，可以修改密码。
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETERVALUE_INVALIDSMTPPASSWORD = "InvalidParameterValue.InvalidSmtpPassWord"
 //  INVALIDPARAMETERVALUE_NOSUCHSENDER = "InvalidParameterValue.NoSuchSender"
@@ -1719,6 +2407,7 @@ func (c *Client) UpdateEmailSmtpPassWord(request *UpdateEmailSmtpPassWordRequest
 // 设置邮箱的smtp密码。若要通过smtp发送邮件，必须为邮箱设置smtp密码。初始时，邮箱没有设置smtp密码，不能使用smtp的方式发送邮件。设置smtp密码后，可以修改密码。
 //
 // 可能返回的错误码:
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETERVALUE_INVALIDSMTPPASSWORD = "InvalidParameterValue.InvalidSmtpPassWord"
 //  INVALIDPARAMETERVALUE_NOSUCHSENDER = "InvalidParameterValue.NoSuchSender"
@@ -1727,6 +2416,7 @@ func (c *Client) UpdateEmailSmtpPassWordWithContext(ctx context.Context, request
     if request == nil {
         request = NewUpdateEmailSmtpPassWordRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "UpdateEmailSmtpPassWord")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateEmailSmtpPassWord require credential")
@@ -1753,8 +2443,9 @@ func NewUpdateEmailTemplateRequest() (request *UpdateEmailTemplateRequest) {
 func NewUpdateEmailTemplateResponse() (response *UpdateEmailTemplateResponse) {
     response = &UpdateEmailTemplateResponse{
         BaseResponse: &tchttp.BaseResponse{},
-    }
+    } 
     return
+
 }
 
 // UpdateEmailTemplate
@@ -1795,6 +2486,7 @@ func (c *Client) UpdateEmailTemplateWithContext(ctx context.Context, request *Up
     if request == nil {
         request = NewUpdateEmailTemplateRequest()
     }
+    c.InitBaseRequest(&request.BaseRequest, "ses", APIVersion, "UpdateEmailTemplate")
     
     if c.GetCredential() == nil {
         return nil, errors.New("UpdateEmailTemplate require credential")

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses/v20201002/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses/v20201002/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,11 +17,17 @@ package v20201002
 const (
 	// 此产品的特有错误码
 
+	// CAM 后台鉴权失败
+	AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+
 	// 操作失败。
 	FAILEDOPERATION = "FailedOperation"
 
 	// 附件太大，请参考单个附件以及附件总量大小限制。
 	FAILEDOPERATION_ATTACHCONTENTTOOLARGE = "FailedOperation.AttachContentToolarge"
+
+	// DKIM没有创建，需要提前创建
+	FAILEDOPERATION_DKIMNOTAPPLIED = "FailedOperation.DKIMNotApplied"
 
 	// 邮件地址在黑名单中。
 	FAILEDOPERATION_EMAILADDRINBLACKLIST = "FailedOperation.EmailAddrInBlacklist"
@@ -35,11 +41,17 @@ const (
 	// 超出最大模板数量限制。
 	FAILEDOPERATION_EXCEEDTEMPLATELIMIT = "FailedOperation.ExceedTemplateLimit"
 
+	// 链接地址无效或者不存在
+	FAILEDOPERATION_FILEURLNOTEXIST = "FailedOperation.FileURLNotExist"
+
 	// 触发频率控制，短时间内对同一地址发送过多邮件。
 	FAILEDOPERATION_FREQUENCYLIMIT = "FailedOperation.FrequencyLimit"
 
 	// 拒信率过高，被临时block。
 	FAILEDOPERATION_HIGHREJECTIONRATE = "FailedOperation.HighRejectionRate"
+
+	// 邮件包含不合规链接
+	FAILEDOPERATION_ILLEGALURL = "FailedOperation.IllegalURL"
 
 	// 邮箱地址错误。
 	FAILEDOPERATION_INCORRECTEMAIL = "FailedOperation.IncorrectEmail"
@@ -101,6 +113,9 @@ const (
 	// 收件人数太多，最多支持同时发送50人。
 	FAILEDOPERATION_TOOMANYRECIPIENTS = "FailedOperation.TooManyRecipients"
 
+	// 禁止到达率低用户在邮件内容中带有URL 网页链接
+	FAILEDOPERATION_URLFORBIDDEN = "FailedOperation.URLForbidden"
+
 	// 不支持的邮箱类型。
 	FAILEDOPERATION_UNSUPPORTMAILTYPE = "FailedOperation.UnsupportMailType"
 
@@ -113,8 +128,20 @@ const (
 	// 内部错误。
 	INTERNALERROR = "InternalError"
 
+	// 查询数据库超时或失败
+	INTERNALERROR_QUERYDATABASEFAILED = "InternalError.QueryDataBaseFailed"
+
 	// 参数错误。
 	INVALIDPARAMETER = "InvalidParameter"
+
+	// AppId不存在
+	INVALIDPARAMETER_APPIDISREQUIRED = "InvalidParameter.AppIdIsRequired"
+
+	// 结束时间格式错误
+	INVALIDPARAMETER_INVALIDENDTIMEFORMAT = "InvalidParameter.InvalidEndTimeFormat"
+
+	// 开始时间格式错误
+	INVALIDPARAMETER_INVALIDSTARTTIMEFORMAT = "InvalidParameter.InvalidStartTimeFormat"
 
 	// 参数取值错误。
 	INVALIDPARAMETERVALUE = "InvalidParameterValue"
@@ -248,6 +275,9 @@ const (
 	// 超出最大发信地址限制。
 	OPERATIONDENIED_EXCEEDSENDERLIMIT = "OperationDenied.ExceedSenderLimit"
 
+	// 不允许删除域名
+	OPERATIONDENIED_NOTALLOWDELETE = "OperationDenied.NotAllowDelete"
+
 	// 收件人列表正在上传中，请稍后操作。
 	OPERATIONDENIED_RECEIVERISOPERATING = "OperationDenied.ReceiverIsOperating"
 
@@ -262,6 +292,9 @@ const (
 
 	// 发信地址不存在或者状态不是通过状态。
 	OPERATIONDENIED_SENDADDRESSSTATUSERROR = "OperationDenied.SendAddressStatusError"
+
+	// 与该域名相关的发信地址不为空
+	OPERATIONDENIED_SENDERWITHDOMAINISNOTEMPTY = "OperationDenied.SenderWithDomainIsNotEmpty"
 
 	// 发信模板不存在或者状态不是审核通过状态。
 	OPERATIONDENIED_TEMPLATESTATUSERROR = "OperationDenied.TemplateStatusError"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses/v20201002/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses/v20201002/models.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 THL A29 Limited, a Tencent company. All Rights Reserved.
+// Copyright (c) 2017-2025 Tencent. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,95 +20,146 @@ import (
     "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/json"
 )
 
+type AbuseReport struct {
+	// <p>发送时间</p>
+	DeliverTime *string `json:"DeliverTime,omitnil,omitempty" name:"DeliverTime"`
+
+	// <p>发信地址</p>
+	OriginalMailFrom *string `json:"OriginalMailFrom,omitnil,omitempty" name:"OriginalMailFrom"`
+
+	// <p>收信地址</p>
+	OriginalRcptTo *string `json:"OriginalRcptTo,omitnil,omitempty" name:"OriginalRcptTo"`
+
+	// <p>发信域名</p>
+	FromDomain *string `json:"FromDomain,omitnil,omitempty" name:"FromDomain"`
+
+	// <p>投诉时间</p>
+	ComplainTime *string `json:"ComplainTime,omitnil,omitempty" name:"ComplainTime"`
+
+	// <p>收信域名</p>
+	Mta *string `json:"Mta,omitnil,omitempty" name:"Mta"`
+
+	// <p>来源ip</p>
+	SourceIp *string `json:"SourceIp,omitnil,omitempty" name:"SourceIp"`
+
+	// <p>数据时间</p>
+	InsertTime *string `json:"InsertTime,omitnil,omitempty" name:"InsertTime"`
+
+	// <p>模板ID</p>
+	TemplateId *string `json:"TemplateId,omitnil,omitempty" name:"TemplateId"`
+
+	// <p>bulkId</p>
+	BulkId *string `json:"BulkId,omitnil,omitempty" name:"BulkId"`
+
+	// <p>邮件Message-Id</p>
+	MessageId *string `json:"MessageId,omitnil,omitempty" name:"MessageId"`
+
+	// <p>投诉时间</p>
+	AbuseTime *string `json:"AbuseTime,omitnil,omitempty" name:"AbuseTime"`
+
+	// <p>邮件主题</p>
+	Subject *string `json:"Subject,omitnil,omitempty" name:"Subject"`
+}
+
+type AddressUnsubscribeConfigData struct {
+	// 发信地址
+	Address *string `json:"Address,omitnil,omitempty" name:"Address"`
+
+	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
+	UnsubscribeConfig *string `json:"UnsubscribeConfig,omitnil,omitempty" name:"UnsubscribeConfig"`
+
+	// 0:关闭，1:开启
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
 type Attachment struct {
 	// 附件名称，最大支持255个字符长度，不支持部分附件类型，详情请参考[附件类型](https://cloud.tencent.com/document/product/1288/51951)。
-	FileName *string `json:"FileName,omitnil" name:"FileName"`
+	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
 
 	// Base64之后的附件内容，您可以发送的附件大小上限为4M。注意：腾讯云接口请求最大支持 8M 的请求包，附件内容经过 Base64 预期扩大1.5倍。应该控制所有附件的总大小最大在 4M 以内，整体请求超出 8M 接口会返回错误。
-	Content *string `json:"Content,omitnil" name:"Content"`
+	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
+
+	// 附件URL。未开放功能，请勿使用。
+	FileURL *string `json:"FileURL,omitnil,omitempty" name:"FileURL"`
 }
 
 // Predefined struct for user
 type BatchSendEmailRequestParams struct {
-	// 发信邮件地址。请填写发件人邮箱地址，例如：noreply@mail.qcloud.com。如需填写发件人说明，请按照
-	// 发信人 &lt;邮件地址&gt; 的方式填写，例如：
-	// 腾讯云团队 &lt;noreply@mail.qcloud.com&gt;
-	FromEmailAddress *string `json:"FromEmailAddress,omitnil" name:"FromEmailAddress"`
+	// <p>发信邮件地址。请填写发件人邮箱地址，例如：noreply@mail.qcloud.com。如需填写发件人说明，请按照<br>发信人 &lt;邮件地址&gt; 的方式填写，例如：<br>腾讯云团队 &lt;noreply@mail.qcloud.com&gt;</p>
+	FromEmailAddress *string `json:"FromEmailAddress,omitnil,omitempty" name:"FromEmailAddress"`
 
-	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	// <p>收件人列表ID</p>
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
-	// 邮件主题
-	Subject *string `json:"Subject,omitnil" name:"Subject"`
+	// <p>邮件主题</p><p>当使用模版发送时，支持使用模版变量参数填充</p>
+	Subject *string `json:"Subject,omitnil,omitempty" name:"Subject"`
 
-	// 任务类型 1: 立即发送 2: 定时发送 3: 周期（频率）发送
-	TaskType *uint64 `json:"TaskType,omitnil" name:"TaskType"`
+	// <p>任务类型 1: 立即发送 2: 定时发送 3: 周期（频率）发送</p>
+	TaskType *uint64 `json:"TaskType,omitnil,omitempty" name:"TaskType"`
 
-	// 邮件的“回复”电子邮件地址。可以填写您能收到邮件的邮箱地址，可以是个人邮箱。如果不填，收件人的回复邮件将会发送失败。
-	ReplyToAddresses *string `json:"ReplyToAddresses,omitnil" name:"ReplyToAddresses"`
+	// <p>邮件的“回复”电子邮件地址。可以填写您能收到邮件的邮箱地址，可以是个人邮箱。如果不填，收件人的回复邮件将会发送失败。</p>
+	ReplyToAddresses *string `json:"ReplyToAddresses,omitnil,omitempty" name:"ReplyToAddresses"`
 
-	// 使用模板发送时，填写的模板相关参数
-	Template *Template `json:"Template,omitnil" name:"Template"`
+	// <p>使用模板发送时，填写的模板相关参数</p><blockquote class="rno-document-tips rno-document-tips-notice">    <div class="rno-document-tips-body">        <i class="rno-document-tip-icon"></i>        <div class="rno-document-tip-title">注意</div>        <div class="rno-document-tip-desc"><p>如您未申请过特殊配置，则该字段为必填</p></div>    </div></blockquote>
+	Template *Template `json:"Template,omitnil,omitempty" name:"Template"`
 
-	// 已废弃
-	Simple *Simple `json:"Simple,omitnil" name:"Simple"`
+	// <p>已废弃<blockquote class="rno-document-tips rno-document-tips-notice">    <div class="rno-document-tips-body">        <i class="rno-document-tip-icon"></i>        <div class="rno-document-tip-title">说明</div>        <div class="rno-document-tip-desc"><p>仅部分历史上申请了特殊配置的客户需要使用。如您未申请过特殊配置，则不存在该字段。</p></div>    </div></blockquote></p>
+	Simple *Simple `json:"Simple,omitnil,omitempty" name:"Simple"`
 
-	// 需要发送附件时，填写附件相关参数（暂未支持）
-	Attachments []*Attachment `json:"Attachments,omitnil" name:"Attachments"`
+	// <p>需要发送附件时，填写附件相关参数（暂未支持）</p>
+	Attachments []*Attachment `json:"Attachments,omitnil,omitempty" name:"Attachments"`
 
-	// 周期发送任务的必要参数
-	CycleParam *CycleEmailParam `json:"CycleParam,omitnil" name:"CycleParam"`
+	// <p>周期发送任务的必要参数</p>
+	CycleParam *CycleEmailParam `json:"CycleParam,omitnil,omitempty" name:"CycleParam"`
 
-	// 定时发送任务的必要参数
-	TimedParam *TimedEmailParam `json:"TimedParam,omitnil" name:"TimedParam"`
+	// <p>定时发送任务的必要参数</p>
+	TimedParam *TimedEmailParam `json:"TimedParam,omitnil,omitempty" name:"TimedParam"`
 
-	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
-	Unsubscribe *string `json:"Unsubscribe,omitnil" name:"Unsubscribe"`
+	// <p>退订链接选项</p><p>枚举值：</p><ul><li>0： 不加入退订链接</li><li>1： 简体中文</li><li>2： 英文</li><li>3： 繁体中文</li><li>4： 西班牙语</li><li>5： 法语</li><li>6： 德语</li><li>7： 日语</li><li>8： 韩语</li><li>9： 阿拉伯语</li><li>10： 泰语</li><li>11： 印尼语</li><li>12： 越南语</li></ul>
+	Unsubscribe *string `json:"Unsubscribe,omitnil,omitempty" name:"Unsubscribe"`
 
-	// 是否添加广告标识 0:不添加 1:添加到subject前面，2:添加到subject后面
-	ADLocation *uint64 `json:"ADLocation,omitnil" name:"ADLocation"`
+	// <p>是否添加广告标识 0:不添加 1:添加到subject前面，2:添加到subject后面</p>
+	ADLocation *uint64 `json:"ADLocation,omitnil,omitempty" name:"ADLocation"`
 }
 
 type BatchSendEmailRequest struct {
 	*tchttp.BaseRequest
 	
-	// 发信邮件地址。请填写发件人邮箱地址，例如：noreply@mail.qcloud.com。如需填写发件人说明，请按照
-	// 发信人 &lt;邮件地址&gt; 的方式填写，例如：
-	// 腾讯云团队 &lt;noreply@mail.qcloud.com&gt;
-	FromEmailAddress *string `json:"FromEmailAddress,omitnil" name:"FromEmailAddress"`
+	// <p>发信邮件地址。请填写发件人邮箱地址，例如：noreply@mail.qcloud.com。如需填写发件人说明，请按照<br>发信人 &lt;邮件地址&gt; 的方式填写，例如：<br>腾讯云团队 &lt;noreply@mail.qcloud.com&gt;</p>
+	FromEmailAddress *string `json:"FromEmailAddress,omitnil,omitempty" name:"FromEmailAddress"`
 
-	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	// <p>收件人列表ID</p>
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
-	// 邮件主题
-	Subject *string `json:"Subject,omitnil" name:"Subject"`
+	// <p>邮件主题</p><p>当使用模版发送时，支持使用模版变量参数填充</p>
+	Subject *string `json:"Subject,omitnil,omitempty" name:"Subject"`
 
-	// 任务类型 1: 立即发送 2: 定时发送 3: 周期（频率）发送
-	TaskType *uint64 `json:"TaskType,omitnil" name:"TaskType"`
+	// <p>任务类型 1: 立即发送 2: 定时发送 3: 周期（频率）发送</p>
+	TaskType *uint64 `json:"TaskType,omitnil,omitempty" name:"TaskType"`
 
-	// 邮件的“回复”电子邮件地址。可以填写您能收到邮件的邮箱地址，可以是个人邮箱。如果不填，收件人的回复邮件将会发送失败。
-	ReplyToAddresses *string `json:"ReplyToAddresses,omitnil" name:"ReplyToAddresses"`
+	// <p>邮件的“回复”电子邮件地址。可以填写您能收到邮件的邮箱地址，可以是个人邮箱。如果不填，收件人的回复邮件将会发送失败。</p>
+	ReplyToAddresses *string `json:"ReplyToAddresses,omitnil,omitempty" name:"ReplyToAddresses"`
 
-	// 使用模板发送时，填写的模板相关参数
-	Template *Template `json:"Template,omitnil" name:"Template"`
+	// <p>使用模板发送时，填写的模板相关参数</p><blockquote class="rno-document-tips rno-document-tips-notice">    <div class="rno-document-tips-body">        <i class="rno-document-tip-icon"></i>        <div class="rno-document-tip-title">注意</div>        <div class="rno-document-tip-desc"><p>如您未申请过特殊配置，则该字段为必填</p></div>    </div></blockquote>
+	Template *Template `json:"Template,omitnil,omitempty" name:"Template"`
 
-	// 已废弃
-	Simple *Simple `json:"Simple,omitnil" name:"Simple"`
+	// <p>已废弃<blockquote class="rno-document-tips rno-document-tips-notice">    <div class="rno-document-tips-body">        <i class="rno-document-tip-icon"></i>        <div class="rno-document-tip-title">说明</div>        <div class="rno-document-tip-desc"><p>仅部分历史上申请了特殊配置的客户需要使用。如您未申请过特殊配置，则不存在该字段。</p></div>    </div></blockquote></p>
+	Simple *Simple `json:"Simple,omitnil,omitempty" name:"Simple"`
 
-	// 需要发送附件时，填写附件相关参数（暂未支持）
-	Attachments []*Attachment `json:"Attachments,omitnil" name:"Attachments"`
+	// <p>需要发送附件时，填写附件相关参数（暂未支持）</p>
+	Attachments []*Attachment `json:"Attachments,omitnil,omitempty" name:"Attachments"`
 
-	// 周期发送任务的必要参数
-	CycleParam *CycleEmailParam `json:"CycleParam,omitnil" name:"CycleParam"`
+	// <p>周期发送任务的必要参数</p>
+	CycleParam *CycleEmailParam `json:"CycleParam,omitnil,omitempty" name:"CycleParam"`
 
-	// 定时发送任务的必要参数
-	TimedParam *TimedEmailParam `json:"TimedParam,omitnil" name:"TimedParam"`
+	// <p>定时发送任务的必要参数</p>
+	TimedParam *TimedEmailParam `json:"TimedParam,omitnil,omitempty" name:"TimedParam"`
 
-	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
-	Unsubscribe *string `json:"Unsubscribe,omitnil" name:"Unsubscribe"`
+	// <p>退订链接选项</p><p>枚举值：</p><ul><li>0： 不加入退订链接</li><li>1： 简体中文</li><li>2： 英文</li><li>3： 繁体中文</li><li>4： 西班牙语</li><li>5： 法语</li><li>6： 德语</li><li>7： 日语</li><li>8： 韩语</li><li>9： 阿拉伯语</li><li>10： 泰语</li><li>11： 印尼语</li><li>12： 越南语</li></ul>
+	Unsubscribe *string `json:"Unsubscribe,omitnil,omitempty" name:"Unsubscribe"`
 
-	// 是否添加广告标识 0:不添加 1:添加到subject前面，2:添加到subject后面
-	ADLocation *uint64 `json:"ADLocation,omitnil" name:"ADLocation"`
+	// <p>是否添加广告标识 0:不添加 1:添加到subject前面，2:添加到subject后面</p>
+	ADLocation *uint64 `json:"ADLocation,omitnil,omitempty" name:"ADLocation"`
 }
 
 func (r *BatchSendEmailRequest) ToJsonString() string {
@@ -143,11 +194,11 @@ func (r *BatchSendEmailRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type BatchSendEmailResponseParams struct {
-	// 发送任务ID
-	TaskId *uint64 `json:"TaskId,omitnil" name:"TaskId"`
+	// <p>发送任务ID</p>
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type BatchSendEmailResponse struct {
@@ -166,35 +217,195 @@ func (r *BatchSendEmailResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type BlackAddressDetail struct {
+	// 黑名单地址id
+	Id *uint64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 邮箱地址
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
+
+	// 创建时间
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 过期时间
+	ExpireDate *string `json:"ExpireDate,omitnil,omitempty" name:"ExpireDate"`
+
+	// 黑名单状态，0:已过期，1:生效中
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
 type BlackEmailAddress struct {
 	// 邮箱被拉黑时间
-	BounceTime *string `json:"BounceTime,omitnil" name:"BounceTime"`
+	BounceTime *string `json:"BounceTime,omitnil,omitempty" name:"BounceTime"`
 
 	// 被拉黑的邮箱地址
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 
 	// 被拉黑的理由
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	IspDesc *string `json:"IspDesc,omitnil" name:"IspDesc"`
+	IspDesc *string `json:"IspDesc,omitnil,omitempty" name:"IspDesc"`
+}
+
+// Predefined struct for user
+type CreateAddressUnsubscribeConfigRequestParams struct {
+	// 发信地址
+	Address *string `json:"Address,omitnil,omitempty" name:"Address"`
+
+	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
+	UnsubscribeConfig *string `json:"UnsubscribeConfig,omitnil,omitempty" name:"UnsubscribeConfig"`
+
+	// 0:关闭，1:打开
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+type CreateAddressUnsubscribeConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 发信地址
+	Address *string `json:"Address,omitnil,omitempty" name:"Address"`
+
+	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
+	UnsubscribeConfig *string `json:"UnsubscribeConfig,omitnil,omitempty" name:"UnsubscribeConfig"`
+
+	// 0:关闭，1:打开
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+func (r *CreateAddressUnsubscribeConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateAddressUnsubscribeConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Address")
+	delete(f, "UnsubscribeConfig")
+	delete(f, "Status")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateAddressUnsubscribeConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateAddressUnsubscribeConfigResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateAddressUnsubscribeConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateAddressUnsubscribeConfigResponseParams `json:"Response"`
+}
+
+func (r *CreateAddressUnsubscribeConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateAddressUnsubscribeConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateCustomBlacklistRequestParams struct {
+	// 添加到黑名单的邮件地址
+	Emails []*string `json:"Emails,omitnil,omitempty" name:"Emails"`
+
+	// 过期日期
+	ExpireDate *string `json:"ExpireDate,omitnil,omitempty" name:"ExpireDate"`
+}
+
+type CreateCustomBlacklistRequest struct {
+	*tchttp.BaseRequest
+	
+	// 添加到黑名单的邮件地址
+	Emails []*string `json:"Emails,omitnil,omitempty" name:"Emails"`
+
+	// 过期日期
+	ExpireDate *string `json:"ExpireDate,omitnil,omitempty" name:"ExpireDate"`
+}
+
+func (r *CreateCustomBlacklistRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateCustomBlacklistRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Emails")
+	delete(f, "ExpireDate")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateCustomBlacklistRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateCustomBlacklistResponseParams struct {
+	// 收件人总数
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 实际上传数量
+	ValidCount *uint64 `json:"ValidCount,omitnil,omitempty" name:"ValidCount"`
+
+	// 数据过长数量
+	TooLongCount *uint64 `json:"TooLongCount,omitnil,omitempty" name:"TooLongCount"`
+
+	// 重复数量
+	RepeatCount *uint64 `json:"RepeatCount,omitnil,omitempty" name:"RepeatCount"`
+
+	// 格式不正确数量
+	InvalidCount *uint64 `json:"InvalidCount,omitnil,omitempty" name:"InvalidCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateCustomBlacklistResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateCustomBlacklistResponseParams `json:"Response"`
+}
+
+func (r *CreateCustomBlacklistResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateCustomBlacklistResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
 type CreateEmailAddressRequestParams struct {
 	// 您的发信地址（发信地址总数上限为10个）
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 
 	// 发件人别名
-	EmailSenderName *string `json:"EmailSenderName,omitnil" name:"EmailSenderName"`
+	EmailSenderName *string `json:"EmailSenderName,omitnil,omitempty" name:"EmailSenderName"`
 }
 
 type CreateEmailAddressRequest struct {
 	*tchttp.BaseRequest
 	
 	// 您的发信地址（发信地址总数上限为10个）
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 
 	// 发件人别名
-	EmailSenderName *string `json:"EmailSenderName,omitnil" name:"EmailSenderName"`
+	EmailSenderName *string `json:"EmailSenderName,omitnil,omitempty" name:"EmailSenderName"`
 }
 
 func (r *CreateEmailAddressRequest) ToJsonString() string {
@@ -219,8 +430,8 @@ func (r *CreateEmailAddressRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateEmailAddressResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateEmailAddressResponse struct {
@@ -241,15 +452,27 @@ func (r *CreateEmailAddressResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateEmailIdentityRequestParams struct {
-	// 您的发信域名，建议使用三级以上域名。例如：mail.qcloud.com。
-	EmailIdentity *string `json:"EmailIdentity,omitnil" name:"EmailIdentity"`
+	// <p>您的发信域名，建议使用三级以上域名。例如：mail.qcloud.com。</p>
+	EmailIdentity *string `json:"EmailIdentity,omitnil,omitempty" name:"EmailIdentity"`
+
+	// <p>生成的dkim密钥长度。0:1024，1:2048</p>
+	DKIMOption *uint64 `json:"DKIMOption,omitnil,omitempty" name:"DKIMOption"`
+
+	// <p>tag 标签</p>
+	TagList []*TagList `json:"TagList,omitnil,omitempty" name:"TagList"`
 }
 
 type CreateEmailIdentityRequest struct {
 	*tchttp.BaseRequest
 	
-	// 您的发信域名，建议使用三级以上域名。例如：mail.qcloud.com。
-	EmailIdentity *string `json:"EmailIdentity,omitnil" name:"EmailIdentity"`
+	// <p>您的发信域名，建议使用三级以上域名。例如：mail.qcloud.com。</p>
+	EmailIdentity *string `json:"EmailIdentity,omitnil,omitempty" name:"EmailIdentity"`
+
+	// <p>生成的dkim密钥长度。0:1024，1:2048</p>
+	DKIMOption *uint64 `json:"DKIMOption,omitnil,omitempty" name:"DKIMOption"`
+
+	// <p>tag 标签</p>
+	TagList []*TagList `json:"TagList,omitnil,omitempty" name:"TagList"`
 }
 
 func (r *CreateEmailIdentityRequest) ToJsonString() string {
@@ -265,6 +488,8 @@ func (r *CreateEmailIdentityRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "EmailIdentity")
+	delete(f, "DKIMOption")
+	delete(f, "TagList")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateEmailIdentityRequest has unknown keys!", "")
 	}
@@ -273,17 +498,20 @@ func (r *CreateEmailIdentityRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateEmailIdentityResponseParams struct {
-	// 验证类型。固定值：DOMAIN
-	IdentityType *string `json:"IdentityType,omitnil" name:"IdentityType"`
+	// <p>验证类型。固定值：DOMAIN</p>
+	IdentityType *string `json:"IdentityType,omitnil,omitempty" name:"IdentityType"`
 
-	// 是否已通过验证
-	VerifiedForSendingStatus *bool `json:"VerifiedForSendingStatus,omitnil" name:"VerifiedForSendingStatus"`
+	// <p>是否已通过验证</p>
+	VerifiedForSendingStatus *bool `json:"VerifiedForSendingStatus,omitnil,omitempty" name:"VerifiedForSendingStatus"`
 
-	// 需要配置的DNS信息
-	Attributes []*DNSAttributes `json:"Attributes,omitnil" name:"Attributes"`
+	// <p>需要配置的DNS信息</p>
+	Attributes []*DNSAttributes `json:"Attributes,omitnil,omitempty" name:"Attributes"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// <p>dkim位数</p><p>枚举值：</p><ul><li>0： 1024</li><li>1： 2048</li><li>2： 双签</li></ul>
+	DKIMOption *uint64 `json:"DKIMOption,omitnil,omitempty" name:"DKIMOption"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateEmailIdentityResponse struct {
@@ -305,20 +533,20 @@ func (r *CreateEmailIdentityResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateEmailTemplateRequestParams struct {
 	// 模板名称
-	TemplateName *string `json:"TemplateName,omitnil" name:"TemplateName"`
+	TemplateName *string `json:"TemplateName,omitnil,omitempty" name:"TemplateName"`
 
 	// 模板内容
-	TemplateContent *TemplateContent `json:"TemplateContent,omitnil" name:"TemplateContent"`
+	TemplateContent *TemplateContent `json:"TemplateContent,omitnil,omitempty" name:"TemplateContent"`
 }
 
 type CreateEmailTemplateRequest struct {
 	*tchttp.BaseRequest
 	
 	// 模板名称
-	TemplateName *string `json:"TemplateName,omitnil" name:"TemplateName"`
+	TemplateName *string `json:"TemplateName,omitnil,omitempty" name:"TemplateName"`
 
 	// 模板内容
-	TemplateContent *TemplateContent `json:"TemplateContent,omitnil" name:"TemplateContent"`
+	TemplateContent *TemplateContent `json:"TemplateContent,omitnil,omitempty" name:"TemplateContent"`
 }
 
 func (r *CreateEmailTemplateRequest) ToJsonString() string {
@@ -344,10 +572,10 @@ func (r *CreateEmailTemplateRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateEmailTemplateResponseParams struct {
 	// 模板id
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateEmailTemplateResponse struct {
@@ -369,20 +597,20 @@ func (r *CreateEmailTemplateResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateReceiverDetailRequestParams struct {
 	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 邮箱
-	Emails []*string `json:"Emails,omitnil" name:"Emails"`
+	Emails []*string `json:"Emails,omitnil,omitempty" name:"Emails"`
 }
 
 type CreateReceiverDetailRequest struct {
 	*tchttp.BaseRequest
 	
 	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 邮箱
-	Emails []*string `json:"Emails,omitnil" name:"Emails"`
+	Emails []*string `json:"Emails,omitnil,omitempty" name:"Emails"`
 }
 
 func (r *CreateReceiverDetailRequest) ToJsonString() string {
@@ -407,8 +635,23 @@ func (r *CreateReceiverDetailRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateReceiverDetailResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 收件人总数
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 实际上传数量
+	ValidCount *uint64 `json:"ValidCount,omitnil,omitempty" name:"ValidCount"`
+
+	// 数据过长数量
+	TooLongCount *uint64 `json:"TooLongCount,omitnil,omitempty" name:"TooLongCount"`
+
+	// 邮件地址为空数量
+	EmptyEmailCount *uint64 `json:"EmptyEmailCount,omitnil,omitempty" name:"EmptyEmailCount"`
+
+	// 重复数量
+	RepeatCount *uint64 `json:"RepeatCount,omitnil,omitempty" name:"RepeatCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateReceiverDetailResponse struct {
@@ -430,20 +673,20 @@ func (r *CreateReceiverDetailResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateReceiverDetailWithDataRequestParams struct {
 	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 收信人邮箱以及模板参数，数组形式。收件人个数限制20000个以内。
-	Datas []*ReceiverInputData `json:"Datas,omitnil" name:"Datas"`
+	Datas []*ReceiverInputData `json:"Datas,omitnil,omitempty" name:"Datas"`
 }
 
 type CreateReceiverDetailWithDataRequest struct {
 	*tchttp.BaseRequest
 	
 	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 收信人邮箱以及模板参数，数组形式。收件人个数限制20000个以内。
-	Datas []*ReceiverInputData `json:"Datas,omitnil" name:"Datas"`
+	Datas []*ReceiverInputData `json:"Datas,omitnil,omitempty" name:"Datas"`
 }
 
 func (r *CreateReceiverDetailWithDataRequest) ToJsonString() string {
@@ -468,8 +711,23 @@ func (r *CreateReceiverDetailWithDataRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateReceiverDetailWithDataResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 收件人总数
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 实际上传数量
+	ValidCount *uint64 `json:"ValidCount,omitnil,omitempty" name:"ValidCount"`
+
+	// 数据过长数量
+	TooLongCount *uint64 `json:"TooLongCount,omitnil,omitempty" name:"TooLongCount"`
+
+	// 邮件地址为空数量
+	EmptyEmailCount *uint64 `json:"EmptyEmailCount,omitnil,omitempty" name:"EmptyEmailCount"`
+
+	// 重复数量
+	RepeatCount *uint64 `json:"RepeatCount,omitnil,omitempty" name:"RepeatCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateReceiverDetailWithDataResponse struct {
@@ -491,20 +749,20 @@ func (r *CreateReceiverDetailWithDataResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateReceiverRequestParams struct {
 	// 收件人列表名称
-	ReceiversName *string `json:"ReceiversName,omitnil" name:"ReceiversName"`
+	ReceiversName *string `json:"ReceiversName,omitnil,omitempty" name:"ReceiversName"`
 
 	// 收件人列表描述
-	Desc *string `json:"Desc,omitnil" name:"Desc"`
+	Desc *string `json:"Desc,omitnil,omitempty" name:"Desc"`
 }
 
 type CreateReceiverRequest struct {
 	*tchttp.BaseRequest
 	
 	// 收件人列表名称
-	ReceiversName *string `json:"ReceiversName,omitnil" name:"ReceiversName"`
+	ReceiversName *string `json:"ReceiversName,omitnil,omitempty" name:"ReceiversName"`
 
 	// 收件人列表描述
-	Desc *string `json:"Desc,omitnil" name:"Desc"`
+	Desc *string `json:"Desc,omitnil,omitempty" name:"Desc"`
 }
 
 func (r *CreateReceiverRequest) ToJsonString() string {
@@ -530,10 +788,10 @@ func (r *CreateReceiverRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type CreateReceiverResponseParams struct {
 	// 收件人列表id，后续根据收件人列表id上传收件人地址
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type CreateReceiverResponse struct {
@@ -554,43 +812,97 @@ func (r *CreateReceiverResponse) FromJsonString(s string) error {
 
 type CycleEmailParam struct {
 	// 任务开始时间
-	BeginTime *string `json:"BeginTime,omitnil" name:"BeginTime"`
+	BeginTime *string `json:"BeginTime,omitnil,omitempty" name:"BeginTime"`
 
 	// 任务周期 小时维度
-	IntervalTime *uint64 `json:"IntervalTime,omitnil" name:"IntervalTime"`
+	IntervalTime *uint64 `json:"IntervalTime,omitnil,omitempty" name:"IntervalTime"`
 
 	// 是否终止周期，用于任务更新 0否1是
-	TermCycle *uint64 `json:"TermCycle,omitnil" name:"TermCycle"`
+	TermCycle *uint64 `json:"TermCycle,omitnil,omitempty" name:"TermCycle"`
 }
 
 type DNSAttributes struct {
 	// 记录类型 CNAME | A | TXT | MX
-	Type *string `json:"Type,omitnil" name:"Type"`
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
 	// 域名
-	SendDomain *string `json:"SendDomain,omitnil" name:"SendDomain"`
+	SendDomain *string `json:"SendDomain,omitnil,omitempty" name:"SendDomain"`
 
 	// 需要配置的值
-	ExpectedValue *string `json:"ExpectedValue,omitnil" name:"ExpectedValue"`
+	ExpectedValue *string `json:"ExpectedValue,omitnil,omitempty" name:"ExpectedValue"`
 
 	// 腾讯云目前检测到的值
-	CurrentValue *string `json:"CurrentValue,omitnil" name:"CurrentValue"`
+	CurrentValue *string `json:"CurrentValue,omitnil,omitempty" name:"CurrentValue"`
 
 	// 检测是否通过，创建时默认为false
-	Status *bool `json:"Status,omitnil" name:"Status"`
+	Status *bool `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+// Predefined struct for user
+type DeleteAddressUnsubscribeConfigRequestParams struct {
+	// 需要操作的发信地址
+	Address *string `json:"Address,omitnil,omitempty" name:"Address"`
+}
+
+type DeleteAddressUnsubscribeConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 需要操作的发信地址
+	Address *string `json:"Address,omitnil,omitempty" name:"Address"`
+}
+
+func (r *DeleteAddressUnsubscribeConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteAddressUnsubscribeConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Address")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteAddressUnsubscribeConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteAddressUnsubscribeConfigResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteAddressUnsubscribeConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteAddressUnsubscribeConfigResponseParams `json:"Response"`
+}
+
+func (r *DeleteAddressUnsubscribeConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteAddressUnsubscribeConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
 type DeleteBlackListRequestParams struct {
 	// 需要清除的黑名单邮箱列表，数组长度至少为1
-	EmailAddressList []*string `json:"EmailAddressList,omitnil" name:"EmailAddressList"`
+	EmailAddressList []*string `json:"EmailAddressList,omitnil,omitempty" name:"EmailAddressList"`
 }
 
 type DeleteBlackListRequest struct {
 	*tchttp.BaseRequest
 	
 	// 需要清除的黑名单邮箱列表，数组长度至少为1
-	EmailAddressList []*string `json:"EmailAddressList,omitnil" name:"EmailAddressList"`
+	EmailAddressList []*string `json:"EmailAddressList,omitnil,omitempty" name:"EmailAddressList"`
 }
 
 func (r *DeleteBlackListRequest) ToJsonString() string {
@@ -614,8 +926,8 @@ func (r *DeleteBlackListRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteBlackListResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteBlackListResponse struct {
@@ -635,16 +947,70 @@ func (r *DeleteBlackListResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DeleteCustomBlackListRequestParams struct {
+	// 需要删除的邮箱地址
+	Emails []*string `json:"Emails,omitnil,omitempty" name:"Emails"`
+}
+
+type DeleteCustomBlackListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 需要删除的邮箱地址
+	Emails []*string `json:"Emails,omitnil,omitempty" name:"Emails"`
+}
+
+func (r *DeleteCustomBlackListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteCustomBlackListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Emails")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteCustomBlackListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteCustomBlackListResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteCustomBlackListResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteCustomBlackListResponseParams `json:"Response"`
+}
+
+func (r *DeleteCustomBlackListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteCustomBlackListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DeleteEmailAddressRequestParams struct {
 	// 发信地址
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 }
 
 type DeleteEmailAddressRequest struct {
 	*tchttp.BaseRequest
 	
 	// 发信地址
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 }
 
 func (r *DeleteEmailAddressRequest) ToJsonString() string {
@@ -668,8 +1034,8 @@ func (r *DeleteEmailAddressRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteEmailAddressResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteEmailAddressResponse struct {
@@ -691,14 +1057,14 @@ func (r *DeleteEmailAddressResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteEmailIdentityRequestParams struct {
 	// 发信域名
-	EmailIdentity *string `json:"EmailIdentity,omitnil" name:"EmailIdentity"`
+	EmailIdentity *string `json:"EmailIdentity,omitnil,omitempty" name:"EmailIdentity"`
 }
 
 type DeleteEmailIdentityRequest struct {
 	*tchttp.BaseRequest
 	
 	// 发信域名
-	EmailIdentity *string `json:"EmailIdentity,omitnil" name:"EmailIdentity"`
+	EmailIdentity *string `json:"EmailIdentity,omitnil,omitempty" name:"EmailIdentity"`
 }
 
 func (r *DeleteEmailIdentityRequest) ToJsonString() string {
@@ -722,8 +1088,8 @@ func (r *DeleteEmailIdentityRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteEmailIdentityResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteEmailIdentityResponse struct {
@@ -745,14 +1111,14 @@ func (r *DeleteEmailIdentityResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteEmailTemplateRequestParams struct {
 	// 模板ID
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 }
 
 type DeleteEmailTemplateRequest struct {
 	*tchttp.BaseRequest
 	
 	// 模板ID
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 }
 
 func (r *DeleteEmailTemplateRequest) ToJsonString() string {
@@ -776,8 +1142,8 @@ func (r *DeleteEmailTemplateRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteEmailTemplateResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteEmailTemplateResponse struct {
@@ -799,14 +1165,14 @@ func (r *DeleteEmailTemplateResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type DeleteReceiverRequestParams struct {
 	// 收件人列表id，创建收件人列表时会返回
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 }
 
 type DeleteReceiverRequest struct {
 	*tchttp.BaseRequest
 	
 	// 收件人列表id，创建收件人列表时会返回
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 }
 
 func (r *DeleteReceiverRequest) ToJsonString() string {
@@ -830,8 +1196,8 @@ func (r *DeleteReceiverRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DeleteReceiverResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type DeleteReceiverResponse struct {
@@ -851,46 +1217,172 @@ func (r *DeleteReceiverResponse) FromJsonString(s string) error {
 }
 
 type EmailIdentity struct {
-	// 发信域名
-	IdentityName *string `json:"IdentityName,omitnil" name:"IdentityName"`
+	// <p>发信域名</p>
+	IdentityName *string `json:"IdentityName,omitnil,omitempty" name:"IdentityName"`
 
-	// 验证类型，固定为DOMAIN
-	IdentityType *string `json:"IdentityType,omitnil" name:"IdentityType"`
+	// <p>验证类型，固定为DOMAIN</p>
+	IdentityType *string `json:"IdentityType,omitnil,omitempty" name:"IdentityType"`
 
-	// 是否已通过验证
-	SendingEnabled *bool `json:"SendingEnabled,omitnil" name:"SendingEnabled"`
+	// <p>是否已通过验证</p>
+	SendingEnabled *bool `json:"SendingEnabled,omitnil,omitempty" name:"SendingEnabled"`
 
-	// 当前信誉等级
-	CurrentReputationLevel *uint64 `json:"CurrentReputationLevel,omitnil" name:"CurrentReputationLevel"`
+	// <p>当前信誉等级</p>
+	CurrentReputationLevel *uint64 `json:"CurrentReputationLevel,omitnil,omitempty" name:"CurrentReputationLevel"`
 
-	// 当日最高发信量
-	DailyQuota *uint64 `json:"DailyQuota,omitnil" name:"DailyQuota"`
+	// <p>当日最高发信量</p>
+	DailyQuota *uint64 `json:"DailyQuota,omitnil,omitempty" name:"DailyQuota"`
+
+	// <p>域名配置的独立ip</p>
+	SendIp []*string `json:"SendIp,omitnil,omitempty" name:"SendIp"`
+
+	// <p>tag 标签</p>
+	TagList []*TagList `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// <p>dkim位数</p><p>枚举值：</p><ul><li>0： 1024</li><li>1： 2048</li><li>2： 双签</li></ul><p>默认值：0</p>
+	DKIMOption *uint64 `json:"DKIMOption,omitnil,omitempty" name:"DKIMOption"`
 }
 
 type EmailSender struct {
 	// 发信地址
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 
 	// 发信人别名
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	EmailSenderName *string `json:"EmailSenderName,omitnil" name:"EmailSenderName"`
+	EmailSenderName *string `json:"EmailSenderName,omitnil,omitempty" name:"EmailSenderName"`
 
 	// 创建时间
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	CreatedTimestamp *uint64 `json:"CreatedTimestamp,omitnil" name:"CreatedTimestamp"`
+	CreatedTimestamp *uint64 `json:"CreatedTimestamp,omitnil,omitempty" name:"CreatedTimestamp"`
+
+	// smtp密码类型,0=没有设置密码,1=已经设置了密码
+	SmtpPwdType *uint64 `json:"SmtpPwdType,omitnil,omitempty" name:"SmtpPwdType"`
+}
+
+// Predefined struct for user
+type GetAbuseReportRequestParams struct {
+	// 起始时间
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 结束时间
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 偏移量
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 限制数量（默认为1000）
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 发信域名
+	FromDomain *string `json:"FromDomain,omitnil,omitempty" name:"FromDomain"`
+
+	// 发信地址
+	FromAddress *string `json:"FromAddress,omitnil,omitempty" name:"FromAddress"`
+
+	// 收信域名
+	Mta *string `json:"Mta,omitnil,omitempty" name:"Mta"`
+
+	// 收信地址
+	ToAddress *string `json:"ToAddress,omitnil,omitempty" name:"ToAddress"`
+
+	// 模版id
+	TemplateId *string `json:"TemplateId,omitnil,omitempty" name:"TemplateId"`
+}
+
+type GetAbuseReportRequest struct {
+	*tchttp.BaseRequest
+	
+	// 起始时间
+	StartTime *string `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// 结束时间
+	EndTime *string `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// 偏移量
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 限制数量（默认为1000）
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 发信域名
+	FromDomain *string `json:"FromDomain,omitnil,omitempty" name:"FromDomain"`
+
+	// 发信地址
+	FromAddress *string `json:"FromAddress,omitnil,omitempty" name:"FromAddress"`
+
+	// 收信域名
+	Mta *string `json:"Mta,omitnil,omitempty" name:"Mta"`
+
+	// 收信地址
+	ToAddress *string `json:"ToAddress,omitnil,omitempty" name:"ToAddress"`
+
+	// 模版id
+	TemplateId *string `json:"TemplateId,omitnil,omitempty" name:"TemplateId"`
+}
+
+func (r *GetAbuseReportRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetAbuseReportRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	delete(f, "FromDomain")
+	delete(f, "FromAddress")
+	delete(f, "Mta")
+	delete(f, "ToAddress")
+	delete(f, "TemplateId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetAbuseReportRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type GetAbuseReportResponseParams struct {
+	// 打开日志数据
+	Data []*AbuseReport `json:"Data,omitnil,omitempty" name:"Data"`
+
+	// 总条数
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type GetAbuseReportResponse struct {
+	*tchttp.BaseResponse
+	Response *GetAbuseReportResponseParams `json:"Response"`
+}
+
+func (r *GetAbuseReportResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *GetAbuseReportResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
 type GetEmailIdentityRequestParams struct {
-	// 发信域名
-	EmailIdentity *string `json:"EmailIdentity,omitnil" name:"EmailIdentity"`
+	// <p>发信域名</p>
+	EmailIdentity *string `json:"EmailIdentity,omitnil,omitempty" name:"EmailIdentity"`
 }
 
 type GetEmailIdentityRequest struct {
 	*tchttp.BaseRequest
 	
-	// 发信域名
-	EmailIdentity *string `json:"EmailIdentity,omitnil" name:"EmailIdentity"`
+	// <p>发信域名</p>
+	EmailIdentity *string `json:"EmailIdentity,omitnil,omitempty" name:"EmailIdentity"`
 }
 
 func (r *GetEmailIdentityRequest) ToJsonString() string {
@@ -914,17 +1406,23 @@ func (r *GetEmailIdentityRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type GetEmailIdentityResponseParams struct {
-	// 验证类型。固定值：DOMAIN
-	IdentityType *string `json:"IdentityType,omitnil" name:"IdentityType"`
+	// <p>验证类型。固定值：DOMAIN</p>
+	IdentityType *string `json:"IdentityType,omitnil,omitempty" name:"IdentityType"`
 
-	// 是否已通过验证
-	VerifiedForSendingStatus *bool `json:"VerifiedForSendingStatus,omitnil" name:"VerifiedForSendingStatus"`
+	// <p>是否已通过验证</p>
+	VerifiedForSendingStatus *bool `json:"VerifiedForSendingStatus,omitnil,omitempty" name:"VerifiedForSendingStatus"`
 
-	// DNS配置详情
-	Attributes []*DNSAttributes `json:"Attributes,omitnil" name:"Attributes"`
+	// <p>DNS配置详情</p>
+	Attributes []*DNSAttributes `json:"Attributes,omitnil,omitempty" name:"Attributes"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// <p>dkim密钥长度</p><p>枚举值：</p><ul><li>0： 1024</li><li>1： 2048</li><li>2： both</li></ul>
+	DKIMOption *uint64 `json:"DKIMOption,omitnil,omitempty" name:"DKIMOption"`
+
+	// <p>tag 标签</p>
+	TagList []*TagList `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetEmailIdentityResponse struct {
@@ -946,14 +1444,14 @@ func (r *GetEmailIdentityResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type GetEmailTemplateRequestParams struct {
 	// 模板ID
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 }
 
 type GetEmailTemplateRequest struct {
 	*tchttp.BaseRequest
 	
 	// 模板ID
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 }
 
 func (r *GetEmailTemplateRequest) ToJsonString() string {
@@ -978,16 +1476,16 @@ func (r *GetEmailTemplateRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type GetEmailTemplateResponseParams struct {
 	// 模板内容数据
-	TemplateContent *TemplateContent `json:"TemplateContent,omitnil" name:"TemplateContent"`
+	TemplateContent *TemplateContent `json:"TemplateContent,omitnil,omitempty" name:"TemplateContent"`
 
 	// 模板状态 0-审核通过 1-待审核 2-审核拒绝
-	TemplateStatus *uint64 `json:"TemplateStatus,omitnil" name:"TemplateStatus"`
+	TemplateStatus *uint64 `json:"TemplateStatus,omitnil,omitempty" name:"TemplateStatus"`
 
 	// 模板名称
-	TemplateName *string `json:"TemplateName,omitnil" name:"TemplateName"`
+	TemplateName *string `json:"TemplateName,omitnil,omitempty" name:"TemplateName"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetEmailTemplateResponse struct {
@@ -1009,38 +1507,38 @@ func (r *GetEmailTemplateResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type GetSendEmailStatusRequestParams struct {
 	// 发送的日期，必填。仅支持查询某个日期，不支持范围查询。
-	RequestDate *string `json:"RequestDate,omitnil" name:"RequestDate"`
+	RequestDate *string `json:"RequestDate,omitnil,omitempty" name:"RequestDate"`
 
 	// 偏移量。默认为0
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 拉取最大条数，最多 100。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// SendMail接口返回的MessageId字段。
-	MessageId *string `json:"MessageId,omitnil" name:"MessageId"`
+	MessageId *string `json:"MessageId,omitnil,omitempty" name:"MessageId"`
 
 	// 收件人邮箱。
-	ToEmailAddress *string `json:"ToEmailAddress,omitnil" name:"ToEmailAddress"`
+	ToEmailAddress *string `json:"ToEmailAddress,omitnil,omitempty" name:"ToEmailAddress"`
 }
 
 type GetSendEmailStatusRequest struct {
 	*tchttp.BaseRequest
 	
 	// 发送的日期，必填。仅支持查询某个日期，不支持范围查询。
-	RequestDate *string `json:"RequestDate,omitnil" name:"RequestDate"`
+	RequestDate *string `json:"RequestDate,omitnil,omitempty" name:"RequestDate"`
 
 	// 偏移量。默认为0
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 拉取最大条数，最多 100。
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// SendMail接口返回的MessageId字段。
-	MessageId *string `json:"MessageId,omitnil" name:"MessageId"`
+	MessageId *string `json:"MessageId,omitnil,omitempty" name:"MessageId"`
 
 	// 收件人邮箱。
-	ToEmailAddress *string `json:"ToEmailAddress,omitnil" name:"ToEmailAddress"`
+	ToEmailAddress *string `json:"ToEmailAddress,omitnil,omitempty" name:"ToEmailAddress"`
 }
 
 func (r *GetSendEmailStatusRequest) ToJsonString() string {
@@ -1069,10 +1567,10 @@ func (r *GetSendEmailStatusRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type GetSendEmailStatusResponseParams struct {
 	// 邮件发送状态列表
-	EmailStatusList []*SendEmailStatus `json:"EmailStatusList,omitnil" name:"EmailStatusList"`
+	EmailStatusList []*SendEmailStatus `json:"EmailStatusList,omitnil,omitempty" name:"EmailStatusList"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetSendEmailStatusResponse struct {
@@ -1094,32 +1592,32 @@ func (r *GetSendEmailStatusResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type GetStatisticsReportRequestParams struct {
 	// 开始日期
-	StartDate *string `json:"StartDate,omitnil" name:"StartDate"`
+	StartDate *string `json:"StartDate,omitnil,omitempty" name:"StartDate"`
 
 	// 结束日期
-	EndDate *string `json:"EndDate,omitnil" name:"EndDate"`
+	EndDate *string `json:"EndDate,omitnil,omitempty" name:"EndDate"`
 
 	// 发信域名
-	Domain *string `json:"Domain,omitnil" name:"Domain"`
+	Domain *string `json:"Domain,omitnil,omitempty" name:"Domain"`
 
 	// 收件方邮箱类型，例如gmail.com
-	ReceivingMailboxType *string `json:"ReceivingMailboxType,omitnil" name:"ReceivingMailboxType"`
+	ReceivingMailboxType *string `json:"ReceivingMailboxType,omitnil,omitempty" name:"ReceivingMailboxType"`
 }
 
 type GetStatisticsReportRequest struct {
 	*tchttp.BaseRequest
 	
 	// 开始日期
-	StartDate *string `json:"StartDate,omitnil" name:"StartDate"`
+	StartDate *string `json:"StartDate,omitnil,omitempty" name:"StartDate"`
 
 	// 结束日期
-	EndDate *string `json:"EndDate,omitnil" name:"EndDate"`
+	EndDate *string `json:"EndDate,omitnil,omitempty" name:"EndDate"`
 
 	// 发信域名
-	Domain *string `json:"Domain,omitnil" name:"Domain"`
+	Domain *string `json:"Domain,omitnil,omitempty" name:"Domain"`
 
 	// 收件方邮箱类型，例如gmail.com
-	ReceivingMailboxType *string `json:"ReceivingMailboxType,omitnil" name:"ReceivingMailboxType"`
+	ReceivingMailboxType *string `json:"ReceivingMailboxType,omitnil,omitempty" name:"ReceivingMailboxType"`
 }
 
 func (r *GetStatisticsReportRequest) ToJsonString() string {
@@ -1147,13 +1645,13 @@ func (r *GetStatisticsReportRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type GetStatisticsReportResponseParams struct {
 	// 发信统计报告，按天
-	DailyVolumes []*Volume `json:"DailyVolumes,omitnil" name:"DailyVolumes"`
+	DailyVolumes []*Volume `json:"DailyVolumes,omitnil,omitempty" name:"DailyVolumes"`
 
 	// 发信统计报告，总览
-	OverallVolume *Volume `json:"OverallVolume,omitnil" name:"OverallVolume"`
+	OverallVolume *Volume `json:"OverallVolume,omitnil,omitempty" name:"OverallVolume"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type GetStatisticsReportResponse struct {
@@ -1173,46 +1671,113 @@ func (r *GetStatisticsReportResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ListAddressUnsubscribeConfigRequestParams struct {
+	// 偏移量
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 拉取最大条数，不超过100
+	Limit *string `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type ListAddressUnsubscribeConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 偏移量
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 拉取最大条数，不超过100
+	Limit *string `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *ListAddressUnsubscribeConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListAddressUnsubscribeConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Offset")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListAddressUnsubscribeConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListAddressUnsubscribeConfigResponseParams struct {
+	// 地址级退订配置
+	AddressUnsubscribeConfigList []*AddressUnsubscribeConfigData `json:"AddressUnsubscribeConfigList,omitnil,omitempty" name:"AddressUnsubscribeConfigList"`
+
+	// 总数
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListAddressUnsubscribeConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *ListAddressUnsubscribeConfigResponseParams `json:"Response"`
+}
+
+func (r *ListAddressUnsubscribeConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListAddressUnsubscribeConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ListBlackEmailAddressRequestParams struct {
 	// 开始日期，格式为YYYY-MM-DD
-	StartDate *string `json:"StartDate,omitnil" name:"StartDate"`
+	StartDate *string `json:"StartDate,omitnil,omitempty" name:"StartDate"`
 
 	// 结束日期，格式为YYYY-MM-DD
-	EndDate *string `json:"EndDate,omitnil" name:"EndDate"`
+	EndDate *string `json:"EndDate,omitnil,omitempty" name:"EndDate"`
 
 	// 规范，配合Offset使用
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 规范，配合Limit使用，Limit最大取值为100
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 可以指定邮箱进行查询
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 
 	// 已废弃
-	TaskID *string `json:"TaskID,omitnil" name:"TaskID"`
+	TaskID *string `json:"TaskID,omitnil,omitempty" name:"TaskID"`
 }
 
 type ListBlackEmailAddressRequest struct {
 	*tchttp.BaseRequest
 	
 	// 开始日期，格式为YYYY-MM-DD
-	StartDate *string `json:"StartDate,omitnil" name:"StartDate"`
+	StartDate *string `json:"StartDate,omitnil,omitempty" name:"StartDate"`
 
 	// 结束日期，格式为YYYY-MM-DD
-	EndDate *string `json:"EndDate,omitnil" name:"EndDate"`
+	EndDate *string `json:"EndDate,omitnil,omitempty" name:"EndDate"`
 
 	// 规范，配合Offset使用
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 规范，配合Limit使用，Limit最大取值为100
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 可以指定邮箱进行查询
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 
 	// 已废弃
-	TaskID *string `json:"TaskID,omitnil" name:"TaskID"`
+	TaskID *string `json:"TaskID,omitnil,omitempty" name:"TaskID"`
 }
 
 func (r *ListBlackEmailAddressRequest) ToJsonString() string {
@@ -1242,13 +1807,13 @@ func (r *ListBlackEmailAddressRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type ListBlackEmailAddressResponseParams struct {
 	// 黑名单列表
-	BlackList []*BlackEmailAddress `json:"BlackList,omitnil" name:"BlackList"`
+	BlackList []*BlackEmailAddress `json:"BlackList,omitnil,omitempty" name:"BlackList"`
 
 	// 黑名单总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ListBlackEmailAddressResponse struct {
@@ -1264,6 +1829,87 @@ func (r *ListBlackEmailAddressResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ListBlackEmailAddressResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListCustomBlacklistRequestParams struct {
+	// 偏移量，整型，从0开始
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 限制数目，整型,不超过100
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 筛选黑名单的状态，0:已过期，1:生效中, 2:全部
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// 黑名单中的邮箱地址
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
+}
+
+type ListCustomBlacklistRequest struct {
+	*tchttp.BaseRequest
+	
+	// 偏移量，整型，从0开始
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// 限制数目，整型,不超过100
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 筛选黑名单的状态，0:已过期，1:生效中, 2:全部
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// 黑名单中的邮箱地址
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
+}
+
+func (r *ListCustomBlacklistRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListCustomBlacklistRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Offset")
+	delete(f, "Limit")
+	delete(f, "Status")
+	delete(f, "Email")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListCustomBlacklistRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListCustomBlacklistResponseParams struct {
+	// 列表总数
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// 黑名单列表详情
+	Data []*BlackAddressDetail `json:"Data,omitnil,omitempty" name:"Data"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListCustomBlacklistResponse struct {
+	*tchttp.BaseResponse
+	Response *ListCustomBlacklistResponseParams `json:"Response"`
+}
+
+func (r *ListCustomBlacklistResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListCustomBlacklistResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -1299,11 +1945,10 @@ func (r *ListEmailAddressRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type ListEmailAddressResponseParams struct {
 	// 发信地址列表详情
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	EmailSenders []*EmailSender `json:"EmailSenders,omitnil" name:"EmailSenders"`
+	EmailSenders []*EmailSender `json:"EmailSenders,omitnil,omitempty" name:"EmailSenders"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ListEmailAddressResponse struct {
@@ -1324,12 +1969,27 @@ func (r *ListEmailAddressResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type ListEmailIdentitiesRequestParams struct {
+	// tag 标签
+	TagList []*TagList `json:"TagList,omitnil,omitempty" name:"TagList"`
 
+	// 分页 limit
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 分页 offset
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 type ListEmailIdentitiesRequest struct {
 	*tchttp.BaseRequest
 	
+	// tag 标签
+	TagList []*TagList `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// 分页 limit
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// 分页 offset
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 func (r *ListEmailIdentitiesRequest) ToJsonString() string {
@@ -1344,7 +2004,9 @@ func (r *ListEmailIdentitiesRequest) FromJsonString(s string) error {
 	if err := json.Unmarshal([]byte(s), &f); err != nil {
 		return err
 	}
-	
+	delete(f, "TagList")
+	delete(f, "Limit")
+	delete(f, "Offset")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListEmailIdentitiesRequest has unknown keys!", "")
 	}
@@ -1354,16 +2016,19 @@ func (r *ListEmailIdentitiesRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type ListEmailIdentitiesResponseParams struct {
 	// 发信域名列表
-	EmailIdentities []*EmailIdentity `json:"EmailIdentities,omitnil" name:"EmailIdentities"`
+	EmailIdentities []*EmailIdentity `json:"EmailIdentities,omitnil,omitempty" name:"EmailIdentities"`
 
 	// 最大信誉等级
-	MaxReputationLevel *uint64 `json:"MaxReputationLevel,omitnil" name:"MaxReputationLevel"`
+	MaxReputationLevel *uint64 `json:"MaxReputationLevel,omitnil,omitempty" name:"MaxReputationLevel"`
 
 	// 单域名最高日发送量
-	MaxDailyQuota *uint64 `json:"MaxDailyQuota,omitnil" name:"MaxDailyQuota"`
+	MaxDailyQuota *uint64 `json:"MaxDailyQuota,omitnil,omitempty" name:"MaxDailyQuota"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 总数
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ListEmailIdentitiesResponse struct {
@@ -1385,20 +2050,20 @@ func (r *ListEmailIdentitiesResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type ListEmailTemplatesRequestParams struct {
 	// 获取模板数据量，用于分页
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 获取模板偏移值，用于分页
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 type ListEmailTemplatesRequest struct {
 	*tchttp.BaseRequest
 	
 	// 获取模板数据量，用于分页
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 获取模板偏移值，用于分页
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 }
 
 func (r *ListEmailTemplatesRequest) ToJsonString() string {
@@ -1424,13 +2089,13 @@ func (r *ListEmailTemplatesRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type ListEmailTemplatesResponseParams struct {
 	// 邮件模板列表
-	TemplatesMetadata []*TemplatesMetadata `json:"TemplatesMetadata,omitnil" name:"TemplatesMetadata"`
+	TemplatesMetadata []*TemplatesMetadata `json:"TemplatesMetadata,omitnil,omitempty" name:"TemplatesMetadata"`
 
 	// 模板总数量
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ListEmailTemplatesResponse struct {
@@ -1452,32 +2117,50 @@ func (r *ListEmailTemplatesResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type ListReceiverDetailsRequestParams struct {
 	// 收件人列表ID,CreateReceiver接口创建收件人列表时会返回该值
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 偏移量，整型，从0开始
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 限制数目，整型,不超过100
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 收件人地址，长度0-50，示例：xxx@te.com，支持模糊查询
-	Email *string `json:"Email,omitnil" name:"Email"`
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
+
+	// 搜索开始时间
+	CreateTimeBegin *string `json:"CreateTimeBegin,omitnil,omitempty" name:"CreateTimeBegin"`
+
+	// 搜索结束时间
+	CreateTimeEnd *string `json:"CreateTimeEnd,omitnil,omitempty" name:"CreateTimeEnd"`
+
+	// 1:有效，2:无效
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 }
 
 type ListReceiverDetailsRequest struct {
 	*tchttp.BaseRequest
 	
 	// 收件人列表ID,CreateReceiver接口创建收件人列表时会返回该值
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 偏移量，整型，从0开始
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 限制数目，整型,不超过100
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 收件人地址，长度0-50，示例：xxx@te.com，支持模糊查询
-	Email *string `json:"Email,omitnil" name:"Email"`
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
+
+	// 搜索开始时间
+	CreateTimeBegin *string `json:"CreateTimeBegin,omitnil,omitempty" name:"CreateTimeBegin"`
+
+	// 搜索结束时间
+	CreateTimeEnd *string `json:"CreateTimeEnd,omitnil,omitempty" name:"CreateTimeEnd"`
+
+	// 1:有效，2:无效
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 }
 
 func (r *ListReceiverDetailsRequest) ToJsonString() string {
@@ -1496,6 +2179,9 @@ func (r *ListReceiverDetailsRequest) FromJsonString(s string) error {
 	delete(f, "Offset")
 	delete(f, "Limit")
 	delete(f, "Email")
+	delete(f, "CreateTimeBegin")
+	delete(f, "CreateTimeEnd")
+	delete(f, "Status")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListReceiverDetailsRequest has unknown keys!", "")
 	}
@@ -1505,13 +2191,19 @@ func (r *ListReceiverDetailsRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type ListReceiverDetailsResponseParams struct {
 	// 总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据记录
-	Data []*ReceiverDetail `json:"Data,omitnil" name:"Data"`
+	Data []*ReceiverDetail `json:"Data,omitnil,omitempty" name:"Data"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 有效邮件地址数
+	ValidCount *uint64 `json:"ValidCount,omitnil,omitempty" name:"ValidCount"`
+
+	// 无效邮件地址数
+	InvalidCount *uint64 `json:"InvalidCount,omitnil,omitempty" name:"InvalidCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ListReceiverDetailsResponse struct {
@@ -1533,32 +2225,32 @@ func (r *ListReceiverDetailsResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type ListReceiversRequestParams struct {
 	// 偏移量，整型，从0开始
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 限制数目，整型，不超过100
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 列表状态(1 待上传 2 上传中  3传完成)，若查询所有就不传这个字段
-	Status *uint64 `json:"Status,omitnil" name:"Status"`
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
 	// 列表名称的关键字，模糊查询
-	KeyWord *string `json:"KeyWord,omitnil" name:"KeyWord"`
+	KeyWord *string `json:"KeyWord,omitnil,omitempty" name:"KeyWord"`
 }
 
 type ListReceiversRequest struct {
 	*tchttp.BaseRequest
 	
 	// 偏移量，整型，从0开始
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 限制数目，整型，不超过100
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 列表状态(1 待上传 2 上传中  3传完成)，若查询所有就不传这个字段
-	Status *uint64 `json:"Status,omitnil" name:"Status"`
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
 	// 列表名称的关键字，模糊查询
-	KeyWord *string `json:"KeyWord,omitnil" name:"KeyWord"`
+	KeyWord *string `json:"KeyWord,omitnil,omitempty" name:"KeyWord"`
 }
 
 func (r *ListReceiversRequest) ToJsonString() string {
@@ -1586,13 +2278,13 @@ func (r *ListReceiversRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type ListReceiversResponseParams struct {
 	// 总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据记录
-	Data []*ReceiverData `json:"Data,omitnil" name:"Data"`
+	Data []*ReceiverData `json:"Data,omitnil,omitempty" name:"Data"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ListReceiversResponse struct {
@@ -1614,38 +2306,38 @@ func (r *ListReceiversResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type ListSendTasksRequestParams struct {
 	// 偏移量，整型，从0开始，0代表跳过0行
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 限制数目，整型,不超过100
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 任务状态 1 待开始 5 发送中 6 今日暂停发送  7 发信异常 10 发送完成。查询所有状态，则不传这个字段
-	Status *uint64 `json:"Status,omitnil" name:"Status"`
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
 	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 任务类型 1即时 2定时 3周期，查询所有类型则不传这个字段
-	TaskType *uint64 `json:"TaskType,omitnil" name:"TaskType"`
+	TaskType *uint64 `json:"TaskType,omitnil,omitempty" name:"TaskType"`
 }
 
 type ListSendTasksRequest struct {
 	*tchttp.BaseRequest
 	
 	// 偏移量，整型，从0开始，0代表跳过0行
-	Offset *uint64 `json:"Offset,omitnil" name:"Offset"`
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
 
 	// 限制数目，整型,不超过100
-	Limit *uint64 `json:"Limit,omitnil" name:"Limit"`
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
 
 	// 任务状态 1 待开始 5 发送中 6 今日暂停发送  7 发信异常 10 发送完成。查询所有状态，则不传这个字段
-	Status *uint64 `json:"Status,omitnil" name:"Status"`
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
 
 	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 任务类型 1即时 2定时 3周期，查询所有类型则不传这个字段
-	TaskType *uint64 `json:"TaskType,omitnil" name:"TaskType"`
+	TaskType *uint64 `json:"TaskType,omitnil,omitempty" name:"TaskType"`
 }
 
 func (r *ListSendTasksRequest) ToJsonString() string {
@@ -1674,13 +2366,13 @@ func (r *ListSendTasksRequest) FromJsonString(s string) error {
 // Predefined struct for user
 type ListSendTasksResponseParams struct {
 	// 总数
-	TotalCount *uint64 `json:"TotalCount,omitnil" name:"TotalCount"`
+	TotalCount *uint64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 
 	// 数据记录
-	Data []*SendTaskData `json:"Data,omitnil" name:"Data"`
+	Data []*SendTaskData `json:"Data,omitnil,omitempty" name:"Data"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type ListSendTasksResponse struct {
@@ -1701,121 +2393,145 @@ func (r *ListSendTasksResponse) FromJsonString(s string) error {
 
 type ReceiverData struct {
 	// 收件人列表ID
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 收件人列表名称
-	ReceiversName *string `json:"ReceiversName,omitnil" name:"ReceiversName"`
+	ReceiversName *string `json:"ReceiversName,omitnil,omitempty" name:"ReceiversName"`
 
 	// 收件人地址总数
-	Count *uint64 `json:"Count,omitnil" name:"Count"`
+	Count *uint64 `json:"Count,omitnil,omitempty" name:"Count"`
 
 	// 收件人列表描述
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Desc *string `json:"Desc,omitnil" name:"Desc"`
+	Desc *string `json:"Desc,omitnil,omitempty" name:"Desc"`
 
 	// 列表状态(1 待上传 2 上传中 3 上传完成)
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ReceiversStatus *uint64 `json:"ReceiversStatus,omitnil" name:"ReceiversStatus"`
+	ReceiversStatus *uint64 `json:"ReceiversStatus,omitnil,omitempty" name:"ReceiversStatus"`
 
 	// 创建时间,如:2021-09-28 16:40:35
-	CreateTime *string `json:"CreateTime,omitnil" name:"CreateTime"`
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// 无效收件人数量
+	InvalidCount *uint64 `json:"InvalidCount,omitnil,omitempty" name:"InvalidCount"`
 }
 
 type ReceiverDetail struct {
 	// 收件人地址
-	Email *string `json:"Email,omitnil" name:"Email"`
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
 
 	// 创建时间
-	CreateTime *string `json:"CreateTime,omitnil" name:"CreateTime"`
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
 	// 模板参数
-	TemplateData *string `json:"TemplateData,omitnil" name:"TemplateData"`
+	TemplateData *string `json:"TemplateData,omitnil,omitempty" name:"TemplateData"`
+
+	// 无效原因
+	Reason *string `json:"Reason,omitnil,omitempty" name:"Reason"`
+
+	// 1:有效，2:无效
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// 收件人地址id
+	EmailId *uint64 `json:"EmailId,omitnil,omitempty" name:"EmailId"`
 }
 
 type ReceiverInputData struct {
 	// 收件人邮箱
-	Email *string `json:"Email,omitnil" name:"Email"`
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
 
 	// 模板中的变量参数，请使用json.dump将json对象格式化为string类型。该对象是一组键值对，每个Key代表模板中的一个变量，模板中的变量使用{{键}}表示，相应的值在发送时会被替换为{{值}}。
 	// 注意：参数值不能是html等复杂类型的数据。TemplateData (整个 JSON 结构) 总长度限制为 800 bytes。
-	TemplateData *string `json:"TemplateData,omitnil" name:"TemplateData"`
+	TemplateData *string `json:"TemplateData,omitnil,omitempty" name:"TemplateData"`
 }
 
 // Predefined struct for user
 type SendEmailRequestParams struct {
-	// 发信邮件地址。请填写发件人邮箱地址，例如：noreply@mail.qcloud.com
-	// 如需填写发件人说明，请按照如下方式： 
-	// 别名 <邮箱地址>
-	FromEmailAddress *string `json:"FromEmailAddress,omitnil" name:"FromEmailAddress"`
+	// <p>发件人邮箱地址。不使用别名时请直接填写发件人邮箱地址，例如：noreply@mail.qcloud.com如需填写发件人别名时，请按照如下方式（注意别名与邮箱地址之间必须使用一个空格隔开）：别名+一个空格+&lt;邮箱地址&gt;，别名中不能带有冒号(:)。</p>
+	FromEmailAddress *string `json:"FromEmailAddress,omitnil,omitempty" name:"FromEmailAddress"`
 
-	// 收信人邮箱地址，最多支持群发50人。注意：邮件内容会显示所有收件人地址，非群发邮件请多次调用API发送。
-	Destination []*string `json:"Destination,omitnil" name:"Destination"`
+	// <p>邮件主题</p><p>当使用模版发送时，支持使用模版变量参数填充</p>
+	Subject *string `json:"Subject,omitnil,omitempty" name:"Subject"`
 
-	// 邮件主题
-	Subject *string `json:"Subject,omitnil" name:"Subject"`
+	// <p>收信人邮箱地址，最多支持群发50人。注意：邮件内容会显示所有收件人地址，非群发邮件请多次调用API发送。<br>Destination/Cc/Bcc三个参数必须至少存在一个。</p>
+	Destination []*string `json:"Destination,omitnil,omitempty" name:"Destination"`
 
-	// 邮件的“回复”电子邮件地址。可以填写您能收到邮件的邮箱地址，可以是个人邮箱。如果不填，收件人的回复邮件将会发送失败。
-	ReplyToAddresses *string `json:"ReplyToAddresses,omitnil" name:"ReplyToAddresses"`
+	// <p>邮件的“回复”电子邮件地址。可以填写您能收到邮件的邮箱地址，可以是个人邮箱。如果不填，收件人的回复邮件将会发送失败。</p>
+	ReplyToAddresses *string `json:"ReplyToAddresses,omitnil,omitempty" name:"ReplyToAddresses"`
 
-	// 抄送人邮箱地址，最多支持抄送20人。
-	Cc []*string `json:"Cc,omitnil" name:"Cc"`
+	// <p>抄送人邮箱地址，最多支持抄送20人。</p>
+	Cc []*string `json:"Cc,omitnil,omitempty" name:"Cc"`
 
-	// 密送人邮箱地址，最多支持抄送20人。
-	Bcc []*string `json:"Bcc,omitnil" name:"Bcc"`
+	// <p>密送人邮箱地址，最多支持抄送20人,Bcc和Destination不能重复。</p>
+	Bcc []*string `json:"Bcc,omitnil,omitempty" name:"Bcc"`
 
-	// 使用模板发送时，填写的模板相关参数。因 Simple 已经废除使用，Template 为必填项
-	Template *Template `json:"Template,omitnil" name:"Template"`
+	// <p>使用模板发送时，填写模板相关参数。</p><blockquote class="rno-document-tips rno-document-tips-notice">    <div class="rno-document-tips-body">        <i class="rno-document-tip-icon"></i>        <div class="rno-document-tip-title">注意</div>        <div class="rno-document-tip-desc"><p>如您未申请过特殊配置，则该字段为必填</p></div>    </div></blockquote>
+	Template *Template `json:"Template,omitnil,omitempty" name:"Template"`
 
-	// 已废弃
-	Simple *Simple `json:"Simple,omitnil" name:"Simple"`
+	// <p>已废弃</p><blockquote class="rno-document-tips rno-document-tips-notice">    <div class="rno-document-tips-body">        <i class="rno-document-tip-icon"></i>        <div class="rno-document-tip-title">说明</div>        <div class="rno-document-tip-desc"><p>仅部分历史上申请了特殊配置的客户需要使用。如您未申请过特殊配置，则不存在该字段。</p></div>    </div></blockquote>
+	Simple *Simple `json:"Simple,omitnil,omitempty" name:"Simple"`
 
-	// 需要发送附件时，填写附件相关参数。腾讯云接口请求最大支持 8M 的请求包，附件内容经过 Base64 预期扩大1.5倍，应该控制所有附件的总大小最大在 4M 以内，整体请求超出 8M 时接口会返回错误
-	Attachments []*Attachment `json:"Attachments,omitnil" name:"Attachments"`
+	// <p>需要发送附件时，填写附件相关参数。腾讯云接口请求最大支持 8M 的请求包，附件内容经过 Base64 预期扩大1.5倍，应该控制所有附件的总大小最大在 4M 以内，整体请求超出 8M 时接口会返回错误</p>
+	Attachments []*Attachment `json:"Attachments,omitnil,omitempty" name:"Attachments"`
 
-	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
-	Unsubscribe *string `json:"Unsubscribe,omitnil" name:"Unsubscribe"`
+	// <p>退订链接选项</p><p>枚举值：</p><ul><li>0： 不加入退订链接</li><li>1： 简体中文</li><li>2： 英文</li><li>3： 繁体中文</li><li>4： 西班牙语</li><li>5： 法语</li><li>6： 德语</li><li>7： 日语</li><li>8： 韩语</li><li>9： 阿拉伯语</li><li>10： 泰语</li><li>11： 印尼语</li><li>12： 越南语</li></ul>
+	Unsubscribe *string `json:"Unsubscribe,omitnil,omitempty" name:"Unsubscribe"`
 
-	// 邮件触发类型 0:非触发类，默认类型，营销类邮件、非即时类邮件等选择此类型  1:触发类，验证码等即时发送类邮件，若邮件超过一定大小，系统会自动选择非触发类型通道
-	TriggerType *uint64 `json:"TriggerType,omitnil" name:"TriggerType"`
+	// <p>邮件触发类型 0:非触发类，默认类型，营销类邮件、非即时类邮件等选择此类型  1:触发类，验证码等即时发送类邮件，若邮件超过一定大小，系统会自动选择非触发类型通道</p>
+	TriggerType *uint64 `json:"TriggerType,omitnil,omitempty" name:"TriggerType"`
+
+	// <p>smtp头中的Message-Id字段</p>
+	SmtpMessageId *string `json:"SmtpMessageId,omitnil,omitempty" name:"SmtpMessageId"`
+
+	// <p>smtp头中可以设置的其它字段</p>
+	SmtpHeaders *string `json:"SmtpHeaders,omitnil,omitempty" name:"SmtpHeaders"`
+
+	// <p>smtp头中的from字段，建议域名与FromEmailAddress保持一致</p>
+	HeaderFrom *string `json:"HeaderFrom,omitnil,omitempty" name:"HeaderFrom"`
 }
 
 type SendEmailRequest struct {
 	*tchttp.BaseRequest
 	
-	// 发信邮件地址。请填写发件人邮箱地址，例如：noreply@mail.qcloud.com
-	// 如需填写发件人说明，请按照如下方式： 
-	// 别名 <邮箱地址>
-	FromEmailAddress *string `json:"FromEmailAddress,omitnil" name:"FromEmailAddress"`
+	// <p>发件人邮箱地址。不使用别名时请直接填写发件人邮箱地址，例如：noreply@mail.qcloud.com如需填写发件人别名时，请按照如下方式（注意别名与邮箱地址之间必须使用一个空格隔开）：别名+一个空格+&lt;邮箱地址&gt;，别名中不能带有冒号(:)。</p>
+	FromEmailAddress *string `json:"FromEmailAddress,omitnil,omitempty" name:"FromEmailAddress"`
 
-	// 收信人邮箱地址，最多支持群发50人。注意：邮件内容会显示所有收件人地址，非群发邮件请多次调用API发送。
-	Destination []*string `json:"Destination,omitnil" name:"Destination"`
+	// <p>邮件主题</p><p>当使用模版发送时，支持使用模版变量参数填充</p>
+	Subject *string `json:"Subject,omitnil,omitempty" name:"Subject"`
 
-	// 邮件主题
-	Subject *string `json:"Subject,omitnil" name:"Subject"`
+	// <p>收信人邮箱地址，最多支持群发50人。注意：邮件内容会显示所有收件人地址，非群发邮件请多次调用API发送。<br>Destination/Cc/Bcc三个参数必须至少存在一个。</p>
+	Destination []*string `json:"Destination,omitnil,omitempty" name:"Destination"`
 
-	// 邮件的“回复”电子邮件地址。可以填写您能收到邮件的邮箱地址，可以是个人邮箱。如果不填，收件人的回复邮件将会发送失败。
-	ReplyToAddresses *string `json:"ReplyToAddresses,omitnil" name:"ReplyToAddresses"`
+	// <p>邮件的“回复”电子邮件地址。可以填写您能收到邮件的邮箱地址，可以是个人邮箱。如果不填，收件人的回复邮件将会发送失败。</p>
+	ReplyToAddresses *string `json:"ReplyToAddresses,omitnil,omitempty" name:"ReplyToAddresses"`
 
-	// 抄送人邮箱地址，最多支持抄送20人。
-	Cc []*string `json:"Cc,omitnil" name:"Cc"`
+	// <p>抄送人邮箱地址，最多支持抄送20人。</p>
+	Cc []*string `json:"Cc,omitnil,omitempty" name:"Cc"`
 
-	// 密送人邮箱地址，最多支持抄送20人。
-	Bcc []*string `json:"Bcc,omitnil" name:"Bcc"`
+	// <p>密送人邮箱地址，最多支持抄送20人,Bcc和Destination不能重复。</p>
+	Bcc []*string `json:"Bcc,omitnil,omitempty" name:"Bcc"`
 
-	// 使用模板发送时，填写的模板相关参数。因 Simple 已经废除使用，Template 为必填项
-	Template *Template `json:"Template,omitnil" name:"Template"`
+	// <p>使用模板发送时，填写模板相关参数。</p><blockquote class="rno-document-tips rno-document-tips-notice">    <div class="rno-document-tips-body">        <i class="rno-document-tip-icon"></i>        <div class="rno-document-tip-title">注意</div>        <div class="rno-document-tip-desc"><p>如您未申请过特殊配置，则该字段为必填</p></div>    </div></blockquote>
+	Template *Template `json:"Template,omitnil,omitempty" name:"Template"`
 
-	// 已废弃
-	Simple *Simple `json:"Simple,omitnil" name:"Simple"`
+	// <p>已废弃</p><blockquote class="rno-document-tips rno-document-tips-notice">    <div class="rno-document-tips-body">        <i class="rno-document-tip-icon"></i>        <div class="rno-document-tip-title">说明</div>        <div class="rno-document-tip-desc"><p>仅部分历史上申请了特殊配置的客户需要使用。如您未申请过特殊配置，则不存在该字段。</p></div>    </div></blockquote>
+	Simple *Simple `json:"Simple,omitnil,omitempty" name:"Simple"`
 
-	// 需要发送附件时，填写附件相关参数。腾讯云接口请求最大支持 8M 的请求包，附件内容经过 Base64 预期扩大1.5倍，应该控制所有附件的总大小最大在 4M 以内，整体请求超出 8M 时接口会返回错误
-	Attachments []*Attachment `json:"Attachments,omitnil" name:"Attachments"`
+	// <p>需要发送附件时，填写附件相关参数。腾讯云接口请求最大支持 8M 的请求包，附件内容经过 Base64 预期扩大1.5倍，应该控制所有附件的总大小最大在 4M 以内，整体请求超出 8M 时接口会返回错误</p>
+	Attachments []*Attachment `json:"Attachments,omitnil,omitempty" name:"Attachments"`
 
-	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
-	Unsubscribe *string `json:"Unsubscribe,omitnil" name:"Unsubscribe"`
+	// <p>退订链接选项</p><p>枚举值：</p><ul><li>0： 不加入退订链接</li><li>1： 简体中文</li><li>2： 英文</li><li>3： 繁体中文</li><li>4： 西班牙语</li><li>5： 法语</li><li>6： 德语</li><li>7： 日语</li><li>8： 韩语</li><li>9： 阿拉伯语</li><li>10： 泰语</li><li>11： 印尼语</li><li>12： 越南语</li></ul>
+	Unsubscribe *string `json:"Unsubscribe,omitnil,omitempty" name:"Unsubscribe"`
 
-	// 邮件触发类型 0:非触发类，默认类型，营销类邮件、非即时类邮件等选择此类型  1:触发类，验证码等即时发送类邮件，若邮件超过一定大小，系统会自动选择非触发类型通道
-	TriggerType *uint64 `json:"TriggerType,omitnil" name:"TriggerType"`
+	// <p>邮件触发类型 0:非触发类，默认类型，营销类邮件、非即时类邮件等选择此类型  1:触发类，验证码等即时发送类邮件，若邮件超过一定大小，系统会自动选择非触发类型通道</p>
+	TriggerType *uint64 `json:"TriggerType,omitnil,omitempty" name:"TriggerType"`
+
+	// <p>smtp头中的Message-Id字段</p>
+	SmtpMessageId *string `json:"SmtpMessageId,omitnil,omitempty" name:"SmtpMessageId"`
+
+	// <p>smtp头中可以设置的其它字段</p>
+	SmtpHeaders *string `json:"SmtpHeaders,omitnil,omitempty" name:"SmtpHeaders"`
+
+	// <p>smtp头中的from字段，建议域名与FromEmailAddress保持一致</p>
+	HeaderFrom *string `json:"HeaderFrom,omitnil,omitempty" name:"HeaderFrom"`
 }
 
 func (r *SendEmailRequest) ToJsonString() string {
@@ -1831,8 +2547,8 @@ func (r *SendEmailRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "FromEmailAddress")
-	delete(f, "Destination")
 	delete(f, "Subject")
+	delete(f, "Destination")
 	delete(f, "ReplyToAddresses")
 	delete(f, "Cc")
 	delete(f, "Bcc")
@@ -1841,6 +2557,9 @@ func (r *SendEmailRequest) FromJsonString(s string) error {
 	delete(f, "Attachments")
 	delete(f, "Unsubscribe")
 	delete(f, "TriggerType")
+	delete(f, "SmtpMessageId")
+	delete(f, "SmtpHeaders")
+	delete(f, "HeaderFrom")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "SendEmailRequest has unknown keys!", "")
 	}
@@ -1849,11 +2568,11 @@ func (r *SendEmailRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type SendEmailResponseParams struct {
-	// 接受消息生成的唯一消息标识符。
-	MessageId *string `json:"MessageId,omitnil" name:"MessageId"`
+	// <p>接受消息生成的唯一消息标识符。</p>
+	MessageId *string `json:"MessageId,omitnil,omitempty" name:"MessageId"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type SendEmailResponse struct {
@@ -1874,13 +2593,13 @@ func (r *SendEmailResponse) FromJsonString(s string) error {
 
 type SendEmailStatus struct {
 	// SendEmail返回的MessageId
-	MessageId *string `json:"MessageId,omitnil" name:"MessageId"`
+	MessageId *string `json:"MessageId,omitnil,omitempty" name:"MessageId"`
 
 	// 收件人邮箱
-	ToEmailAddress *string `json:"ToEmailAddress,omitnil" name:"ToEmailAddress"`
+	ToEmailAddress *string `json:"ToEmailAddress,omitnil,omitempty" name:"ToEmailAddress"`
 
 	// 发件人邮箱
-	FromEmailAddress *string `json:"FromEmailAddress,omitnil" name:"FromEmailAddress"`
+	FromEmailAddress *string `json:"FromEmailAddress,omitnil,omitempty" name:"FromEmailAddress"`
 
 	// 腾讯云处理状态
 	// 0: 处理成功
@@ -1907,7 +2626,7 @@ type SendEmailStatus struct {
 	// 3024: 邮箱地址格式预检查失败
 	// 3030: 退信率过高，临时限制发送
 	// 3033: 余额不足，账号欠费等
-	SendStatus *int64 `json:"SendStatus,omitnil" name:"SendStatus"`
+	SendStatus *int64 `json:"SendStatus,omitnil,omitempty" name:"SendStatus"`
 
 	// 收件方处理状态
 	// 0: 请求成功被腾讯云接受，进入发送队列
@@ -1915,143 +2634,302 @@ type SendEmailStatus struct {
 	// 2: 邮件因某种原因被丢弃，DeliverMessage表示丢弃原因
 	// 3: 收件方ESP拒信，一般原因为邮箱地址不存在，或其它原因
 	// 8: 邮件被ESP因某些原因延迟递送，DeliverMessage表示延迟原因
-	DeliverStatus *int64 `json:"DeliverStatus,omitnil" name:"DeliverStatus"`
+	DeliverStatus *int64 `json:"DeliverStatus,omitnil,omitempty" name:"DeliverStatus"`
 
 	// 收件方处理状态描述
-	DeliverMessage *string `json:"DeliverMessage,omitnil" name:"DeliverMessage"`
+	DeliverMessage *string `json:"DeliverMessage,omitnil,omitempty" name:"DeliverMessage"`
 
 	// 请求到达腾讯云时间戳
-	RequestTime *int64 `json:"RequestTime,omitnil" name:"RequestTime"`
+	RequestTime *int64 `json:"RequestTime,omitnil,omitempty" name:"RequestTime"`
 
 	// 腾讯云执行递送时间戳
-	DeliverTime *int64 `json:"DeliverTime,omitnil" name:"DeliverTime"`
+	DeliverTime *int64 `json:"DeliverTime,omitnil,omitempty" name:"DeliverTime"`
 
 	// 用户是否打开该邮件
-	UserOpened *bool `json:"UserOpened,omitnil" name:"UserOpened"`
+	UserOpened *bool `json:"UserOpened,omitnil,omitempty" name:"UserOpened"`
 
 	// 用户是否点击该邮件中的链接
-	UserClicked *bool `json:"UserClicked,omitnil" name:"UserClicked"`
+	UserClicked *bool `json:"UserClicked,omitnil,omitempty" name:"UserClicked"`
 
 	// 用户是否取消该发送者的订阅
-	UserUnsubscribed *bool `json:"UserUnsubscribed,omitnil" name:"UserUnsubscribed"`
+	UserUnsubscribed *bool `json:"UserUnsubscribed,omitnil,omitempty" name:"UserUnsubscribed"`
 
 	// 用户是否举报该发送者
-	UserComplainted *bool `json:"UserComplainted,omitnil" name:"UserComplainted"`
+	//
+	// Deprecated: UserComplainted is deprecated.
+	UserComplainted *bool `json:"UserComplainted,omitnil,omitempty" name:"UserComplainted"`
+
+	// 用户是否举报该发送者
+	UserComplained *bool `json:"UserComplained,omitnil,omitempty" name:"UserComplained"`
 }
 
 type SendTaskData struct {
 	// 任务id
-	TaskId *uint64 `json:"TaskId,omitnil" name:"TaskId"`
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
 
 	// 发信地址
-	FromEmailAddress *string `json:"FromEmailAddress,omitnil" name:"FromEmailAddress"`
+	FromEmailAddress *string `json:"FromEmailAddress,omitnil,omitempty" name:"FromEmailAddress"`
 
 	// 收件人列表Id
-	ReceiverId *uint64 `json:"ReceiverId,omitnil" name:"ReceiverId"`
+	ReceiverId *uint64 `json:"ReceiverId,omitnil,omitempty" name:"ReceiverId"`
 
 	// 任务状态 1 待开始 5 发送中 6 今日暂停发送  7 发信异常 10 发送完成
-	TaskStatus *uint64 `json:"TaskStatus,omitnil" name:"TaskStatus"`
+	TaskStatus *uint64 `json:"TaskStatus,omitnil,omitempty" name:"TaskStatus"`
 
 	// 任务类型 1 即时 2 定时 3 周期
-	TaskType *uint64 `json:"TaskType,omitnil" name:"TaskType"`
+	TaskType *uint64 `json:"TaskType,omitnil,omitempty" name:"TaskType"`
 
 	// 任务请求发信数量
-	RequestCount *uint64 `json:"RequestCount,omitnil" name:"RequestCount"`
+	RequestCount *uint64 `json:"RequestCount,omitnil,omitempty" name:"RequestCount"`
 
 	// 已经发送数量
-	SendCount *uint64 `json:"SendCount,omitnil" name:"SendCount"`
+	SendCount *uint64 `json:"SendCount,omitnil,omitempty" name:"SendCount"`
 
 	// 缓存数量
-	CacheCount *uint64 `json:"CacheCount,omitnil" name:"CacheCount"`
+	CacheCount *uint64 `json:"CacheCount,omitnil,omitempty" name:"CacheCount"`
 
 	// 任务创建时间
-	CreateTime *string `json:"CreateTime,omitnil" name:"CreateTime"`
+	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
 	// 任务更新时间
-	UpdateTime *string `json:"UpdateTime,omitnil" name:"UpdateTime"`
+	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 
 	// 邮件主题
-	Subject *string `json:"Subject,omitnil" name:"Subject"`
+	Subject *string `json:"Subject,omitnil,omitempty" name:"Subject"`
 
 	// 模板和模板数据
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	Template *Template `json:"Template,omitnil" name:"Template"`
+	Template *Template `json:"Template,omitnil,omitempty" name:"Template"`
 
 	// 周期任务参数
 	// 注意：此字段可能返回 null，表示取不到有效值。
-	CycleParam *CycleEmailParam `json:"CycleParam,omitnil" name:"CycleParam"`
+	CycleParam *CycleEmailParam `json:"CycleParam,omitnil,omitempty" name:"CycleParam"`
 
 	// 定时任务参数
 	// 注意：此字段可能返回 null，表示取不到有效值。
-	TimedParam *TimedEmailParam `json:"TimedParam,omitnil" name:"TimedParam"`
+	TimedParam *TimedEmailParam `json:"TimedParam,omitnil,omitempty" name:"TimedParam"`
 
 	// 任务异常信息
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	ErrMsg *string `json:"ErrMsg,omitnil" name:"ErrMsg"`
+	ErrMsg *string `json:"ErrMsg,omitnil,omitempty" name:"ErrMsg"`
 
 	// 收件人列表名称
-	ReceiversName *string `json:"ReceiversName,omitnil" name:"ReceiversName"`
+	ReceiversName *string `json:"ReceiversName,omitnil,omitempty" name:"ReceiversName"`
 }
 
 type Simple struct {
 	// base64之后的Html代码。需要包含所有的代码信息，不要包含外部css，否则会导致显示格式错乱
-	Html *string `json:"Html,omitnil" name:"Html"`
+	Html *string `json:"Html,omitnil,omitempty" name:"Html"`
 
 	// base64之后的纯文本信息，如果没有Html，邮件中会直接显示纯文本；如果有Html，它代表邮件的纯文本样式
-	Text *string `json:"Text,omitnil" name:"Text"`
+	Text *string `json:"Text,omitnil,omitempty" name:"Text"`
+}
+
+type TagList struct {
+	// 产品
+	TagKey *string `json:"TagKey,omitnil,omitempty" name:"TagKey"`
+
+	// ses
+	TagValue *string `json:"TagValue,omitnil,omitempty" name:"TagValue"`
 }
 
 type Template struct {
 	// 模板ID。如果没有模板，请先新建一个
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 
 	// 模板中的变量参数，请使用json.dump将json对象格式化为string类型。该对象是一组键值对，每个Key代表模板中的一个变量，模板中的变量使用{{键}}表示，相应的值在发送时会被替换为{{值}}。
 	// 注意：参数值不能是html等复杂类型的数据。
 	// 示例：{"name":"xxx","age":"xx"}
-	TemplateData *string `json:"TemplateData,omitnil" name:"TemplateData"`
+	TemplateData *string `json:"TemplateData,omitnil,omitempty" name:"TemplateData"`
 }
 
 type TemplateContent struct {
 	// base64之后的Html代码
-	Html *string `json:"Html,omitnil" name:"Html"`
+	Html *string `json:"Html,omitnil,omitempty" name:"Html"`
 
 	// base64之后的文本内容
-	Text *string `json:"Text,omitnil" name:"Text"`
+	Text *string `json:"Text,omitnil,omitempty" name:"Text"`
 }
 
 type TemplatesMetadata struct {
 	// 创建时间
-	CreatedTimestamp *uint64 `json:"CreatedTimestamp,omitnil" name:"CreatedTimestamp"`
+	CreatedTimestamp *uint64 `json:"CreatedTimestamp,omitnil,omitempty" name:"CreatedTimestamp"`
 
 	// 模板名称
-	TemplateName *string `json:"TemplateName,omitnil" name:"TemplateName"`
+	TemplateName *string `json:"TemplateName,omitnil,omitempty" name:"TemplateName"`
 
 	// 模板状态。1-审核中|0-已通过|2-拒绝|其它-不可用
-	TemplateStatus *int64 `json:"TemplateStatus,omitnil" name:"TemplateStatus"`
+	TemplateStatus *int64 `json:"TemplateStatus,omitnil,omitempty" name:"TemplateStatus"`
 
 	// 模板ID
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 
 	// 审核原因
-	ReviewReason *string `json:"ReviewReason,omitnil" name:"ReviewReason"`
+	ReviewReason *string `json:"ReviewReason,omitnil,omitempty" name:"ReviewReason"`
 }
 
 type TimedEmailParam struct {
 	// 定时发送邮件的开始时间
-	BeginTime *string `json:"BeginTime,omitnil" name:"BeginTime"`
+	BeginTime *string `json:"BeginTime,omitnil,omitempty" name:"BeginTime"`
+}
+
+// Predefined struct for user
+type UpdateAddressUnsubscribeConfigRequestParams struct {
+	// 发信地址
+	Address *string `json:"Address,omitnil,omitempty" name:"Address"`
+
+	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
+	UnsubscribeConfig *string `json:"UnsubscribeConfig,omitnil,omitempty" name:"UnsubscribeConfig"`
+
+	// 0:关闭配置，1:打开配置
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+type UpdateAddressUnsubscribeConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// 发信地址
+	Address *string `json:"Address,omitnil,omitempty" name:"Address"`
+
+	// 退订链接选项 0: 不加入退订链接 1: 简体中文 2: 英文 3: 繁体中文 4: 西班牙语 5: 法语 6: 德语 7: 日语 8: 韩语 9: 阿拉伯语 10: 泰语
+	UnsubscribeConfig *string `json:"UnsubscribeConfig,omitnil,omitempty" name:"UnsubscribeConfig"`
+
+	// 0:关闭配置，1:打开配置
+	Status *uint64 `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+func (r *UpdateAddressUnsubscribeConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateAddressUnsubscribeConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Address")
+	delete(f, "UnsubscribeConfig")
+	delete(f, "Status")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateAddressUnsubscribeConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateAddressUnsubscribeConfigResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateAddressUnsubscribeConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateAddressUnsubscribeConfigResponseParams `json:"Response"`
+}
+
+func (r *UpdateAddressUnsubscribeConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateAddressUnsubscribeConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateCustomBlackListRequestParams struct {
+	// 需要更改的黑名单id
+	Id *uint64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 修改后的邮件地址
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
+
+	// 过期时间，为空则表示永久有效
+	ExpireDate *string `json:"ExpireDate,omitnil,omitempty" name:"ExpireDate"`
+}
+
+type UpdateCustomBlackListRequest struct {
+	*tchttp.BaseRequest
+	
+	// 需要更改的黑名单id
+	Id *uint64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// 修改后的邮件地址
+	Email *string `json:"Email,omitnil,omitempty" name:"Email"`
+
+	// 过期时间，为空则表示永久有效
+	ExpireDate *string `json:"ExpireDate,omitnil,omitempty" name:"ExpireDate"`
+}
+
+func (r *UpdateCustomBlackListRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateCustomBlackListRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Id")
+	delete(f, "Email")
+	delete(f, "ExpireDate")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateCustomBlackListRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateCustomBlackListResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateCustomBlackListResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateCustomBlackListResponseParams `json:"Response"`
+}
+
+func (r *UpdateCustomBlackListResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateCustomBlackListResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
 type UpdateEmailIdentityRequestParams struct {
-	// 请求验证的域名
-	EmailIdentity *string `json:"EmailIdentity,omitnil" name:"EmailIdentity"`
+	// <p>请求验证的域名</p>
+	EmailIdentity *string `json:"EmailIdentity,omitnil,omitempty" name:"EmailIdentity"`
+
+	// <p>匹分控制台新老API</p>
+	NewAPI *bool `json:"NewAPI,omitnil,omitempty" name:"NewAPI"`
+
+	// <p>dkim位数</p><p>枚举值：</p><ul><li>0： 1024</li><li>1： 2048</li><li>2： 双签</li></ul>
+	DKIMOption *uint64 `json:"DKIMOption,omitnil,omitempty" name:"DKIMOption"`
 }
 
 type UpdateEmailIdentityRequest struct {
 	*tchttp.BaseRequest
 	
-	// 请求验证的域名
-	EmailIdentity *string `json:"EmailIdentity,omitnil" name:"EmailIdentity"`
+	// <p>请求验证的域名</p>
+	EmailIdentity *string `json:"EmailIdentity,omitnil,omitempty" name:"EmailIdentity"`
+
+	// <p>匹分控制台新老API</p>
+	NewAPI *bool `json:"NewAPI,omitnil,omitempty" name:"NewAPI"`
+
+	// <p>dkim位数</p><p>枚举值：</p><ul><li>0： 1024</li><li>1： 2048</li><li>2： 双签</li></ul>
+	DKIMOption *uint64 `json:"DKIMOption,omitnil,omitempty" name:"DKIMOption"`
 }
 
 func (r *UpdateEmailIdentityRequest) ToJsonString() string {
@@ -2067,6 +2945,8 @@ func (r *UpdateEmailIdentityRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "EmailIdentity")
+	delete(f, "NewAPI")
+	delete(f, "DKIMOption")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateEmailIdentityRequest has unknown keys!", "")
 	}
@@ -2075,17 +2955,20 @@ func (r *UpdateEmailIdentityRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateEmailIdentityResponseParams struct {
-	// 验证类型。固定值：DOMAIN
-	IdentityType *string `json:"IdentityType,omitnil" name:"IdentityType"`
+	// <p>验证类型。固定值：DOMAIN</p>
+	IdentityType *string `json:"IdentityType,omitnil,omitempty" name:"IdentityType"`
 
-	// 是否已通过验证
-	VerifiedForSendingStatus *bool `json:"VerifiedForSendingStatus,omitnil" name:"VerifiedForSendingStatus"`
+	// <p>是否已通过验证</p>
+	VerifiedForSendingStatus *bool `json:"VerifiedForSendingStatus,omitnil,omitempty" name:"VerifiedForSendingStatus"`
 
-	// 需要配置的DNS信息
-	Attributes []*DNSAttributes `json:"Attributes,omitnil" name:"Attributes"`
+	// <p>需要配置的DNS信息</p>
+	Attributes []*DNSAttributes `json:"Attributes,omitnil,omitempty" name:"Attributes"`
 
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// <p>dkim位数</p><p>枚举值：</p><ul><li>0： 1024</li><li>1： 2048</li><li>2： 双签</li></ul>
+	DKIMOption *uint64 `json:"DKIMOption,omitnil,omitempty" name:"DKIMOption"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateEmailIdentityResponse struct {
@@ -2107,20 +2990,20 @@ func (r *UpdateEmailIdentityResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type UpdateEmailSmtpPassWordRequestParams struct {
 	// smtp密码，长度限制64
-	Password *string `json:"Password,omitnil" name:"Password"`
+	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
 	// 发信邮箱,长度限制128
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 }
 
 type UpdateEmailSmtpPassWordRequest struct {
 	*tchttp.BaseRequest
 	
 	// smtp密码，长度限制64
-	Password *string `json:"Password,omitnil" name:"Password"`
+	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
 
 	// 发信邮箱,长度限制128
-	EmailAddress *string `json:"EmailAddress,omitnil" name:"EmailAddress"`
+	EmailAddress *string `json:"EmailAddress,omitnil,omitempty" name:"EmailAddress"`
 }
 
 func (r *UpdateEmailSmtpPassWordRequest) ToJsonString() string {
@@ -2145,8 +3028,8 @@ func (r *UpdateEmailSmtpPassWordRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateEmailSmtpPassWordResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateEmailSmtpPassWordResponse struct {
@@ -2168,26 +3051,26 @@ func (r *UpdateEmailSmtpPassWordResponse) FromJsonString(s string) error {
 // Predefined struct for user
 type UpdateEmailTemplateRequestParams struct {
 	// 模板内容
-	TemplateContent *TemplateContent `json:"TemplateContent,omitnil" name:"TemplateContent"`
+	TemplateContent *TemplateContent `json:"TemplateContent,omitnil,omitempty" name:"TemplateContent"`
 
 	// 模板ID
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 
 	// 模板名字
-	TemplateName *string `json:"TemplateName,omitnil" name:"TemplateName"`
+	TemplateName *string `json:"TemplateName,omitnil,omitempty" name:"TemplateName"`
 }
 
 type UpdateEmailTemplateRequest struct {
 	*tchttp.BaseRequest
 	
 	// 模板内容
-	TemplateContent *TemplateContent `json:"TemplateContent,omitnil" name:"TemplateContent"`
+	TemplateContent *TemplateContent `json:"TemplateContent,omitnil,omitempty" name:"TemplateContent"`
 
 	// 模板ID
-	TemplateID *uint64 `json:"TemplateID,omitnil" name:"TemplateID"`
+	TemplateID *uint64 `json:"TemplateID,omitnil,omitempty" name:"TemplateID"`
 
 	// 模板名字
-	TemplateName *string `json:"TemplateName,omitnil" name:"TemplateName"`
+	TemplateName *string `json:"TemplateName,omitnil,omitempty" name:"TemplateName"`
 }
 
 func (r *UpdateEmailTemplateRequest) ToJsonString() string {
@@ -2213,8 +3096,8 @@ func (r *UpdateEmailTemplateRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type UpdateEmailTemplateResponseParams struct {
-	// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil" name:"RequestId"`
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
 
 type UpdateEmailTemplateResponse struct {
@@ -2234,29 +3117,27 @@ func (r *UpdateEmailTemplateResponse) FromJsonString(s string) error {
 }
 
 type Volume struct {
-	// 日期
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	SendDate *string `json:"SendDate,omitnil" name:"SendDate"`
+	// <p>日期</p>
+	SendDate *string `json:"SendDate,omitnil,omitempty" name:"SendDate"`
 
-	// 邮件请求数量
-	RequestCount *uint64 `json:"RequestCount,omitnil" name:"RequestCount"`
+	// <p>邮件请求数量</p>
+	RequestCount *uint64 `json:"RequestCount,omitnil,omitempty" name:"RequestCount"`
 
-	// 腾讯云通过数量
-	AcceptedCount *uint64 `json:"AcceptedCount,omitnil" name:"AcceptedCount"`
+	// <p>腾讯云通过数量</p>
+	AcceptedCount *uint64 `json:"AcceptedCount,omitnil,omitempty" name:"AcceptedCount"`
 
-	// 送达数量
-	DeliveredCount *uint64 `json:"DeliveredCount,omitnil" name:"DeliveredCount"`
+	// <p>送达数量</p>
+	DeliveredCount *uint64 `json:"DeliveredCount,omitnil,omitempty" name:"DeliveredCount"`
 
-	// 打开邮件的用户数量，根据收件人去重
-	OpenedCount *uint64 `json:"OpenedCount,omitnil" name:"OpenedCount"`
+	// <p>打开邮件总次数</p>
+	OpenedCount *uint64 `json:"OpenedCount,omitnil,omitempty" name:"OpenedCount"`
 
-	// 点击了邮件中的链接数量用户数量
-	ClickedCount *uint64 `json:"ClickedCount,omitnil" name:"ClickedCount"`
+	// <p>点击了邮件中的链接数量用户数量</p>
+	ClickedCount *uint64 `json:"ClickedCount,omitnil,omitempty" name:"ClickedCount"`
 
-	// 退信数量
-	BounceCount *uint64 `json:"BounceCount,omitnil" name:"BounceCount"`
+	// <p>退信数量</p>
+	BounceCount *uint64 `json:"BounceCount,omitnil,omitempty" name:"BounceCount"`
 
-	// 取消订阅的用户数量
-	// 注意：此字段可能返回 null，表示取不到有效值。
-	UnsubscribeCount *uint64 `json:"UnsubscribeCount,omitnil" name:"UnsubscribeCount"`
+	// <p>取消订阅的用户数量</p>
+	UnsubscribeCount *uint64 `json:"UnsubscribeCount,omitnil,omitempty" name:"UnsubscribeCount"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1397,7 +1397,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/rum/v20210622
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf v1.3.101
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/scf/v20180416
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.0.748
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses v1.3.136
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ses/v20201002
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sms v1.0.486

--- a/website/docs/r/ses_domain.html.markdown
+++ b/website/docs/r/ses_domain.html.markdown
@@ -17,8 +17,10 @@ Provides a resource to create a ses domain
 resource "tencentcloud_ses_domain" "domain" {
   email_identity = "iac.cloud"
   dkim_option    = 1
-  tag_key        = "env"
-  tag_value      = "prod"
+  tag_list {
+    tag_key   = "env"
+    tag_value = "prod"
+  }
 }
 ```
 
@@ -28,8 +30,12 @@ The following arguments are supported:
 
 * `email_identity` - (Required, String, ForceNew) Your sender domain. You are advised to use a third-level domain, for example, mail.qcloud.com.
 * `dkim_option` - (Optional, Int, ForceNew) DKIM key length. 0: 1024-bit, 1: 2048-bit.
-* `tag_key` - (Optional, String, ForceNew) Tag key.
-* `tag_value` - (Optional, String, ForceNew) Tag value.
+* `tag_list` - (Optional, List, ForceNew) Tag list.
+
+The `tag_list` object supports the following:
+
+* `tag_key` - (Required, String) Tag key.
+* `tag_value` - (Required, String) Tag value.
 
 ## Attributes Reference
 

--- a/website/docs/r/ses_domain.html.markdown
+++ b/website/docs/r/ses_domain.html.markdown
@@ -16,6 +16,9 @@ Provides a resource to create a ses domain
 ```hcl
 resource "tencentcloud_ses_domain" "domain" {
   email_identity = "iac.cloud"
+  dkim_option    = 1
+  tag_key        = "env"
+  tag_value      = "prod"
 }
 ```
 
@@ -24,6 +27,9 @@ resource "tencentcloud_ses_domain" "domain" {
 The following arguments are supported:
 
 * `email_identity` - (Required, String, ForceNew) Your sender domain. You are advised to use a third-level domain, for example, mail.qcloud.com.
+* `dkim_option` - (Optional, Int, ForceNew) DKIM key length. 0: 1024-bit, 1: 2048-bit.
+* `tag_key` - (Optional, String, ForceNew) Tag key.
+* `tag_value` - (Optional, String, ForceNew) Tag value.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add new optional parameters (dkim_option, tag_key, tag_value) to the tencentcloud_ses_domain resource, enabling DKIM key length configuration and tag association for SES domains at creation time. The parameters are populated from the GetEmailIdentity response in the Read operation to reflect them in Terraform state. All new parameters are optional and backward compatible.