### PR TITLE
feat(cam): [136377720]add tencentcloud_cam_accounts data source

### DIFF
--- a/.changelog/4476.txt
+++ b/.changelog/4476.txt
@@ -1,3 +1,3 @@
 ```release-note:new-data-source
-	tencentcloud_cam_accounts
+tencentcloud_cam_accounts
 ```

--- a/.changelog/4476.txt
+++ b/.changelog/4476.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+	tencentcloud_cam_accounts
+```

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/apm v1.3.124
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.3.16
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bi v1.0.824
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.130
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.157
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat v1.3.136
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.3.115
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb v1.3.171

--- a/go.sum
+++ b/go.sum
@@ -889,8 +889,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bi v1.0.824 h1:DVKvZ6h+
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bi v1.0.824/go.mod h1:DvBpDX/qdJG4KKLeULmRvhAjPYiw8za0HeTSu2y/lFw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing v1.3.39 h1:iJFhv4Z/EdTWeJ3INDX+nK7qoP7G5JF8NMsxcCZe7eY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing v1.3.39/go.mod h1:pQUClJeCf2vHSzhWkTM0rhC502Ac65S6G1WDWK/GiJ0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.130 h1:SJZA2P2k7Py8KUI4qGtxNN+ohWsoY3UwH+fBx8dGsOs=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.130/go.mod h1:tIYWmi/i2zzDWUwDBb0Y+Tn72xwefo/ql0c3pJIVxEs=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.157 h1:JriGd3VMiqDlJcZYj2neON+5ReSJxfLmMdxAzKYSnuc=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.157/go.mod h1:pKtW1TdPyIEIP8GOmWknQt9+lTKbqcV/72I7HUaD1NE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat v1.3.136 h1:zo1fD4kOc8z4GZyhbBIrHlfZGVDSFZ/PJETzsxhyDGo=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat v1.3.136/go.mod h1:jh9OYX2hQOqfUOhdY7QFQnOo2S9GQm5gDDKSV59GS2w=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.3.115 h1:0VngBttqkoB8pD4vsBDtDJpSubKSCVPNldKLTf91O4w=

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/design.md
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/design.md
@@ -2,19 +2,19 @@
 
 The Terraform TencentCloud provider already exposes several CAM data sources (`tencentcloud_cam_users`, `tencentcloud_cam_sub_accounts`, `tencentcloud_cam_roles`, etc.), but none of them wraps the `ListAccounts` API. `ListAccounts` differs from `ListUsers` in that it returns **all** account types (Owner, SubUser, CICUser, WechatCorpUser, AgentIdentity, Collaborator, MessageReceiver) in a single call and supports server-side paging via `MaxItems` / `Marker` plus filtering by `UserType`. This makes it the appropriate API for a general-purpose "list all CAM accounts" data source.
 
-The existing `tencentcloud_cam_users` data source uses the older `ListUsers` API and performs client-side filtering, whereas the new `tencentcloud_cam_accounts` will rely on server-side paging/filtering provided by `ListAccounts`.
+The existing `tencentcloud_cam_users` data source uses the older `ListUsers` API and performs client-side filtering, whereas the new `tencentcloud_cam_accounts` uses `ListAccounts` server-side filtering (`UserType`) and relies on automatic pagination implemented in the service layer to collect every page of results.
 
 ## Goals / Non-Goals
 
 **Goals:**
 - Provide a read-only data source `tencentcloud_cam_accounts` that calls the `ListAccounts` API.
-- Expose the optional request parameters `max_items`, `marker`, and `user_type` so users can control paging and filter by account type.
-- Flatten the `Users` response array into a top-level `users` list, with each element's fields spread directly (no extra nesting layer), per provider conventions for RESOURCE_KIND_DATASOURCE.
-- Surface the paging outputs `marker` and `is_truncated` so callers can detect truncation and chain subsequent calls.
+- Expose the optional `user_type` request parameter so users can filter by account type.
+- Implement automatic full pagination in the service layer: `ListAccounts` returns at most 100 records per call (MaxItems range [1, 100]), so the service requests pages of 100 and follows the response `Marker` while `IsTruncated` is true until every page is fetched.
+- Flatten the collected `Users` response array into a top-level `users` list, with each element's fields spread directly (no extra nesting layer), per provider conventions for RESOURCE_KIND_DATASOURCE.
 - Register the data source in `provider.go` and produce docs/tests.
 
 **Non-Goals:**
-- Not implementing automatic full-pagination loop that fetches every page internally. The data source passes `MaxItems` / `Marker` through to the API and returns the single page plus the `marker` / `is_truncated` fields so the caller decides whether to continue. This mirrors the API's design.
+- Not exposing any paging-related parameter in the data source schema (`max_items`, `marker`, `is_truncated` are all omitted) — pagination is an internal service-layer concern and the data source always returns the complete account list.
 - Not replacing the existing `tencentcloud_cam_users` or `tencentcloud_cam_sub_accounts` data sources.
 
 ## Decisions
@@ -22,8 +22,8 @@ The existing `tencentcloud_cam_users` data source uses the older `ListUsers` API
 ### Decision 1: Use `ListAccounts` (not `ListUsers`)
 `ListAccounts` returns all account types and supports `MaxItems`, `Marker`, and `UserType` natively, matching the required parameter mapping. `ListUsers` only returns sub-users and lacks server-side paging. Therefore `ListAccounts` is the correct API.
 
-### Decision 2: Pass paging parameters through instead of auto-paging
-The `ListAccounts` API is explicitly designed around `MaxItems` / `Marker` paging with an `IsTruncated` flag. The requirement maps `request.MaxItems → max_items` and `request.Marker → marker` as optional inputs, and `response.Response.Marker → marker` and `response.Response.IsTruncated → is_truncated` as outputs. This indicates the data source should expose paging control to the user rather than silently looping. We follow the requirement mapping directly.
+### Decision 2: Auto-paginate in the service layer instead of exposing paging parameters
+`ListAccounts` returns at most 100 records per request (`MaxItems` valid range [1, 100]) and reports truncation with `IsTruncated` plus a `Marker` to continue from. Instead of exposing `max_items` / `marker` inputs and `marker` / `is_truncated` outputs in the schema, the service method `DescribeCamAccountsByFilter` loops internally: it sets `MaxItems = 100` per request, appends `response.Response.Users` to the result, and keeps calling the API with `request.Marker = response.Response.Marker` while `IsTruncated` is true (and `Marker` is non-nil), so the data source always receives the complete account list.
 
 ### Decision 3: Flatten `users` list — no extra nesting layer
 Per provider rule: "资源参数 schema 中禁止创建'该资源列表型数据'这一层 schema". The `users` field is a `TypeList` whose `Elem` is a `schema.Resource` containing the per-account fields directly. Each field (`uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, `user_type`) sits inside that resource elem — this is the standard flattened list pattern used by `tencentcloud_igtm_instance_list` and `tencentcloud_cam_sub_accounts`.
@@ -42,21 +42,20 @@ The `ListAccounts` response (`ListAllUser` struct) types:
 - `UserType` *string → schema `user_type` TypeString (the output `UserType` is a string enum in `ListAllUser`, unlike `SubAccountUser` where it is int)
 
 Request parameter types:
-- `max_items` TypeInt (maps to `MaxItems *int64`)
-- `marker` TypeString (maps to `Marker *string`)
 - `user_type` TypeString (maps to `UserType *string`; no validate func — per user requirement, the enum range is not enforced in schema)
+- No `max_items` / `marker` / `is_truncated` schema fields — pagination is handled entirely inside the service layer.
 
 ### Decision 5: Service-layer method
-Add `DescribeCamAccountsByFilter(ctx, paramMap)` to `service_tencentcloud_cam.go`. It builds a `ListAccountsRequest` from `paramMap`, calls `me.client.UseCamClient().ListAccounts(request)`, and returns `([]*cam.ListAllUser, marker string, isTruncated bool, error)`. The data source read handler wraps the call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`.
+Add `DescribeCamAccountsByFilter(ctx, paramMap)` to `service_tencentcloud_cam.go`. It builds a `ListAccountsRequest` from `paramMap["UserType"]`, sets `MaxItems = 100` per page, and loops: each iteration calls `me.client.UseCamClient().ListAccounts(request)`, appends `response.Response.Users`, and continues with `request.Marker = response.Response.Marker` while `response.Response.IsTruncated` is true and `Marker` is non-nil. It returns `([]*cam.ListAllUser, error)`. The data source read handler wraps the call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`.
 
 ### Decision 6: DATASOURCE empty-response handling
-Per provider rule for RESOURCE_KIND_DATASOURCE: inside the retry block, if the response is nil / `response.Response` is nil / `len(Users) == 0`, return `NonRetryableError` (do **not** `d.SetId("")`). On the outer retry-exhausted path, log `[DATASOURCE] read empty, skip SetId`.
+Consistent with the existing CAM data sources (`tencentcloud_cam_users`, `tencentcloud_cam_sub_accounts`), the read handler does not special-case an empty `Users` list: the retry block assigns the result and the handler proceeds, producing an empty `users` list and a `SetId` computed from the (empty) ids. On the retry-exhausted path the handler logs `[DATASOURCE] read empty, skip SetId` and returns the error.
 
 ### Decision 7: SetId
 Use `helper.DataResourceIdsHash(ids)` where `ids` is the list of `uin` strings, consistent with `tencentcloud_cam_users`.
 
 ## Risks / Trade-offs
 
-- **[Risk] `marker` is both an input and an output field** → The same schema key `marker` is Optional (input) and also set from the response. Terraform allows a field to be both Optional and Computed, which is the correct approach here so the user can supply an initial marker and read back the next marker.
-- **[Risk] Paging is not automatic** → Users who have more accounts than `MaxItems` must issue multiple data source blocks with chained markers. This is a conscious trade-off to honor the API's native paging design and the required parameter mapping. Mitigated by exposing `is_truncated` so users know when to stop.
+- **[Risk] Auto-pagination issues multiple API calls** → Accounts with more than 100 entries trigger several sequential `ListAccounts` requests (100 per page) on every refresh. Accepted because the data source must return the complete account list; `ratelimit.Check` throttles each call.
+- **[Risk] No paging control for users** → Users cannot limit the result size or resume from a marker via the data source. Accepted per requirement: the schema must not expose paging parameters; the service fetches everything using `IsTruncated`.
 - **[Risk] `ConsoleLogin` int vs bool** → Kept as int to match the raw `ListAllUser` struct (`*int64`) and avoid a lossy conversion. Documented in the field description.

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/design.md
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The Terraform TencentCloud provider already exposes several CAM data sources (`tencentcloud_cam_users`, `tencentcloud_cam_sub_accounts`, `tencentcloud_cam_roles`, etc.), but none of them wraps the `ListAccounts` API. `ListAccounts` differs from `ListUsers` in that it returns **all** account types (Owner, SubUser, CICUser, WechatCorpUser, AgentIdentity, Collaborator, MessageReceiver) in a single call and supports server-side paging via `MaxItems` / `Marker` plus filtering by `UserType`. This makes it the appropriate API for a general-purpose "list all CAM accounts" data source.
+
+The existing `tencentcloud_cam_users` data source uses the older `ListUsers` API and performs client-side filtering, whereas the new `tencentcloud_cam_accounts` will rely on server-side paging/filtering provided by `ListAccounts`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a read-only data source `tencentcloud_cam_accounts` that calls the `ListAccounts` API.
+- Expose the optional request parameters `max_items`, `marker`, and `user_type` so users can control paging and filter by account type.
+- Flatten the `Users` response array into a top-level `users` list, with each element's fields spread directly (no extra nesting layer), per provider conventions for RESOURCE_KIND_DATASOURCE.
+- Surface the paging outputs `marker` and `is_truncated` so callers can detect truncation and chain subsequent calls.
+- Register the data source in `provider.go` and produce docs/tests.
+
+**Non-Goals:**
+- Not implementing automatic full-pagination loop that fetches every page internally. The data source passes `MaxItems` / `Marker` through to the API and returns the single page plus the `marker` / `is_truncated` fields so the caller decides whether to continue. This mirrors the API's design.
+- Not replacing the existing `tencentcloud_cam_users` or `tencentcloud_cam_sub_accounts` data sources.
+
+## Decisions
+
+### Decision 1: Use `ListAccounts` (not `ListUsers`)
+`ListAccounts` returns all account types and supports `MaxItems`, `Marker`, and `UserType` natively, matching the required parameter mapping. `ListUsers` only returns sub-users and lacks server-side paging. Therefore `ListAccounts` is the correct API.
+
+### Decision 2: Pass paging parameters through instead of auto-paging
+The `ListAccounts` API is explicitly designed around `MaxItems` / `Marker` paging with an `IsTruncated` flag. The requirement maps `request.MaxItems → max_items` and `request.Marker → marker` as optional inputs, and `response.Response.Marker → marker` and `response.Response.IsTruncated → is_truncated` as outputs. This indicates the data source should expose paging control to the user rather than silently looping. We follow the requirement mapping directly.
+
+### Decision 3: Flatten `users` list — no extra nesting layer
+Per provider rule: "资源参数 schema 中禁止创建'该资源列表型数据'这一层 schema". The `users` field is a `TypeList` whose `Elem` is a `schema.Resource` containing the per-account fields directly. Each field (`uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, `user_type`) sits inside that resource elem — this is the standard flattened list pattern used by `tencentcloud_igtm_instance_list` and `tencentcloud_cam_sub_accounts`.
+
+### Decision 4: Field types match the SDK
+The `ListAccounts` response (`ListAllUser` struct) types:
+- `Uin` *int64 → schema `uin` TypeInt
+- `Name` *string → schema `name` TypeString
+- `Uid` *int64 → schema `uid` TypeInt
+- `Remark` *string → schema `remark` TypeString
+- `ConsoleLogin` *int64 → schema `console_login` TypeInt (keep as int, matching the raw API; do not convert to bool to avoid ambiguity)
+- `PhoneNum` *string → schema `phone_num` TypeString
+- `CountryCode` *string → schema `country_code` TypeString
+- `Email` *string → schema `email` TypeString
+- `CreateTime` *string → schema `create_time` TypeString
+- `UserType` *string → schema `user_type` TypeString (the output `UserType` is a string enum in `ListAllUser`, unlike `SubAccountUser` where it is int)
+
+Request parameter types:
+- `max_items` TypeInt (maps to `MaxItems *int64`)
+- `marker` TypeString (maps to `Marker *string`)
+- `user_type` TypeString (maps to `UserType *string`; no validate func — per user requirement, the enum range is not enforced in schema)
+
+### Decision 5: Service-layer method
+Add `DescribeCamAccountsByFilter(ctx, paramMap)` to `service_tencentcloud_cam.go`. It builds a `ListAccountsRequest` from `paramMap`, calls `me.client.UseCamClient().ListAccounts(request)`, and returns `([]*cam.ListAllUser, marker string, isTruncated bool, error)`. The data source read handler wraps the call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`.
+
+### Decision 6: DATASOURCE empty-response handling
+Per provider rule for RESOURCE_KIND_DATASOURCE: inside the retry block, if the response is nil / `response.Response` is nil / `len(Users) == 0`, return `NonRetryableError` (do **not** `d.SetId("")`). On the outer retry-exhausted path, log `[DATASOURCE] read empty, skip SetId`.
+
+### Decision 7: SetId
+Use `helper.DataResourceIdsHash(ids)` where `ids` is the list of `uin` strings, consistent with `tencentcloud_cam_users`.
+
+## Risks / Trade-offs
+
+- **[Risk] `marker` is both an input and an output field** → The same schema key `marker` is Optional (input) and also set from the response. Terraform allows a field to be both Optional and Computed, which is the correct approach here so the user can supply an initial marker and read back the next marker.
+- **[Risk] Paging is not automatic** → Users who have more accounts than `MaxItems` must issue multiple data source blocks with chained markers. This is a conscious trade-off to honor the API's native paging design and the required parameter mapping. Mitigated by exposing `is_truncated` so users know when to stop.
+- **[Risk] `ConsoleLogin` int vs bool** → Kept as int to match the raw `ListAllUser` struct (`*int64`) and avoid a lossy conversion. Documented in the field description.

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/proposal.md
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Terraform users managing TencentCloud CAM (Cloud Access Management) need a way to query the full list of CAM accounts (including sub-users, collaborators, message receivers, etc.) so that downstream resources can reference account attributes such as Uin, Uid, Name, and UserType. Currently there is no datasource that exposes the `ListAccounts` API, forcing users to hard-code account identifiers.
+
+## What Changes
+
+- Add a new Terraform data source `tencentcloud_cam_accounts` (RESOURCE_KIND_DATASOURCE) that wraps the CAM `ListAccounts` API.
+- The data source exposes optional query parameters `max_items`, `marker`, and `user_type` to control paging and filtering.
+- The data source flattens the response `Users` array into a top-level `users` list with per-account fields (`uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, `user_type`) and also surfaces the paging-related outputs `marker` and `is_truncated`.
+
+## Capabilities
+
+### New Capabilities
+- `cam-accounts-datasource`: Query the list of CAM accounts via the `ListAccounts` API and expose the results as a Terraform data source.
+
+### Modified Capabilities
+<!-- None -->
+
+## Impact
+
+- **New files:**
+  - `tencentcloud/services/cam/data_source_tc_cam_accounts.go`
+  - `tencentcloud/services/cam/data_source_tc_cam_accounts.md`
+  - `tencentcloud/services/cam/data_source_tc_cam_accounts_test.go`
+- **Modified files:**
+  - `tencentcloud/services/cam/service_tencentcloud_cam.go` — append a `DescribeCamAccountsByFilter` method wrapping `ListAccounts`.
+  - `tencentcloud/provider.go` — register the new `tencentcloud_cam_accounts` data source.
+- **API dependency:** `ListAccounts` from `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116` (already vendored).
+- No breaking changes; this is purely additive.

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/proposal.md
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/proposal.md
@@ -5,8 +5,8 @@ Terraform users managing TencentCloud CAM (Cloud Access Management) need a way t
 ## What Changes
 
 - Add a new Terraform data source `tencentcloud_cam_accounts` (RESOURCE_KIND_DATASOURCE) that wraps the CAM `ListAccounts` API.
-- The data source exposes optional query parameters `max_items`, `marker`, and `user_type` to control paging and filtering.
-- The data source flattens the response `Users` array into a top-level `users` list with per-account fields (`uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, `user_type`) and also surfaces the paging-related outputs `marker` and `is_truncated`.
+- The data source exposes the optional query parameter `user_type` to filter accounts by type. Pagination is handled automatically in the service layer: `ListAccounts` returns at most 100 records per call, so the service loops using the response's `IsTruncated` field (and the returned `Marker`) until all pages are fetched. No paging-related parameters (`max_items`, `marker`, `is_truncated`) are exposed in the data source schema.
+- The data source flattens the collected `Users` array into a top-level `users` list with per-account fields (`uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, `user_type`).
 
 ## Capabilities
 
@@ -23,7 +23,7 @@ Terraform users managing TencentCloud CAM (Cloud Access Management) need a way t
   - `tencentcloud/services/cam/data_source_tc_cam_accounts.md`
   - `tencentcloud/services/cam/data_source_tc_cam_accounts_test.go`
 - **Modified files:**
-  - `tencentcloud/services/cam/service_tencentcloud_cam.go` — append a `DescribeCamAccountsByFilter` method wrapping `ListAccounts`.
+  - `tencentcloud/services/cam/service_tencentcloud_cam.go` — append a `DescribeCamAccountsByFilter` method wrapping `ListAccounts` with automatic pagination (up to 100 records per request, looping on `IsTruncated`/`Marker` until all pages are fetched).
   - `tencentcloud/provider.go` — register the new `tencentcloud_cam_accounts` data source.
 - **API dependency:** `ListAccounts` from `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116` (already vendored).
 - No breaking changes; this is purely additive.

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/specs/cam-accounts-datasource/spec.md
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/specs/cam-accounts-datasource/spec.md
@@ -5,15 +5,26 @@ The `tencentcloud_cam_accounts` data source SHALL call the CAM `ListAccounts` AP
 
 #### Scenario: Query all accounts with no filters
 - **WHEN** a user declares `data "tencentcloud_cam_accounts" "all"` with no optional arguments
-- **THEN** the provider calls `ListAccounts` with no `MaxItems`, `Marker`, or `UserType` set and flattens `response.Response.Users` into the `users` list
+- **THEN** the provider calls `ListAccounts` without a `UserType` filter (each page requested with `MaxItems = 100`) and flattens the collected `response.Response.Users` into the `users` list
 
 #### Scenario: Query accounts filtered by user type
 - **WHEN** a user sets `user_type = "SubUser"`
 - **THEN** the provider sets `request.UserType = "SubUser"` so the API returns only sub-users
 
-#### Scenario: Query accounts with paging
-- **WHEN** a user sets `max_items = 50` and `marker = "<previous-marker>"`
-- **THEN** the provider sets `request.MaxItems = 50` and `request.Marker = "<previous-marker>"`, and the data source outputs the updated `marker` and `is_truncated` values from the response
+### Requirement: Pagination SHALL be handled automatically in the service layer and SHALL NOT be exposed in the schema
+The service method `DescribeCamAccountsByFilter` SHALL fetch all pages: it SHALL request at most 100 records per call (the `ListAccounts` `MaxItems` upper bound) and, based on the response's `IsTruncated` field, continue calling the API with the returned `Marker` until `IsTruncated` is false. The data source schema SHALL NOT expose any paging-related parameters (`max_items`, `marker`, or `is_truncated`).
+
+#### Scenario: Truncated response triggers a follow-up request
+- **WHEN** a `ListAccounts` call returns `IsTruncated = true` with `Marker = "abc"`
+- **THEN** the service issues another `ListAccounts` request with `request.Marker = "abc"`, appends the new `Users` to the result, and repeats until `IsTruncated = false`
+
+#### Scenario: Non-truncated response ends the loop
+- **WHEN** a `ListAccounts` call returns `IsTruncated = false`
+- **THEN** the service stops looping and returns the accumulated account list
+
+#### Scenario: Schema exposes no paging parameters
+- **WHEN** the data source schema is inspected
+- **THEN** it contains only `user_type`, `users`, and `result_output_file` (plus the `users` element fields), and does not contain `max_items`, `marker`, or `is_truncated`
 
 ### Requirement: The users list SHALL flatten each account's fields without an extra nesting layer
 The `users` schema SHALL be a `TypeList` whose element is a `schema.Resource` containing `uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, and `user_type` fields directly — there SHALL NOT be an intermediate wrapper block.
@@ -29,23 +40,16 @@ Before calling `d.Set(...)` / building the map for each `users` element, the pro
 - **WHEN** the API returns a user whose `Remark` field is nil
 - **THEN** the `remark` attribute is not set in that element's map
 
-### Requirement: Paging outputs marker and is_truncated SHALL be exposed
-The data source SHALL expose `marker` (string, Optional + Computed) and `is_truncated` (bool, Computed) reflecting `response.Response.Marker` and `response.Response.IsTruncated`.
+### Requirement: The read handler SHALL retry on transient errors
+The read handler SHALL wrap the `DescribeCamAccountsByFilter` call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. An empty `Users` list SHALL NOT be treated as an error: the handler proceeds and produces an empty `users` list, consistent with the existing CAM data sources.
 
-#### Scenario: Truncated result reports next marker
-- **WHEN** the API returns `IsTruncated = true` and `Marker = "abc"`
-- **THEN** the data source outputs `is_truncated = true` and `marker = "abc"`
+#### Scenario: Transient API error triggers retry
+- **WHEN** the `ListAccounts` call fails with a transient error
+- **THEN** the retry block retries the call until it succeeds or `tccommon.ReadRetryTimeout` is exhausted, and the provider logs `[DATASOURCE] read empty, skip SetId` before returning the error
 
-#### Scenario: Non-truncated result
-- **WHEN** the API returns `IsTruncated = false` and no `Marker`
-- **THEN** the data source outputs `is_truncated = false` and `marker` remains empty
-
-### Requirement: The read handler SHALL retry on transient errors and not clear the id on empty response
-The read handler SHALL wrap the `ListAccounts` call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. Inside the retry block, if the response or `Users` list is empty, the handler SHALL return `NonRetryableError` instead of clearing the Terraform id, so transient API blips do not wipe local state.
-
-#### Scenario: Transient empty response triggers retry
-- **WHEN** the `ListAccounts` call returns an empty `Users` list due to a transient API issue
-- **THEN** the retry block returns `NonRetryableError`, causing the outer retry to keep retrying until the timeout is exhausted, and the provider logs `[DATASOURCE] read empty, skip SetId` rather than clearing the id
+#### Scenario: Empty account list completes normally
+- **WHEN** the API returns no users
+- **THEN** the read handler completes without error and the data source reports an empty `users` list
 
 ### Requirement: The data source SHALL be registered in the provider
 The provider SHALL register `tencentcloud_cam_accounts` mapped to `cam.DataSourceTencentCloudCamAccounts()` in `provider.go`.

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/specs/cam-accounts-datasource/spec.md
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/specs/cam-accounts-datasource/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: CAM accounts data source SHALL query accounts via ListAccounts
+The `tencentcloud_cam_accounts` data source SHALL call the CAM `ListAccounts` API and expose the returned account list to Terraform.
+
+#### Scenario: Query all accounts with no filters
+- **WHEN** a user declares `data "tencentcloud_cam_accounts" "all"` with no optional arguments
+- **THEN** the provider calls `ListAccounts` with no `MaxItems`, `Marker`, or `UserType` set and flattens `response.Response.Users` into the `users` list
+
+#### Scenario: Query accounts filtered by user type
+- **WHEN** a user sets `user_type = "SubUser"`
+- **THEN** the provider sets `request.UserType = "SubUser"` so the API returns only sub-users
+
+#### Scenario: Query accounts with paging
+- **WHEN** a user sets `max_items = 50` and `marker = "<previous-marker>"`
+- **THEN** the provider sets `request.MaxItems = 50` and `request.Marker = "<previous-marker>"`, and the data source outputs the updated `marker` and `is_truncated` values from the response
+
+### Requirement: The users list SHALL flatten each account's fields without an extra nesting layer
+The `users` schema SHALL be a `TypeList` whose element is a `schema.Resource` containing `uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, and `user_type` fields directly — there SHALL NOT be an intermediate wrapper block.
+
+#### Scenario: Flattened account fields
+- **WHEN** the API returns a user with `Uin=123`, `Name="alice"`, `Uid=456`
+- **THEN** the `users` list element contains `uin = 123`, `name = "alice"`, `uid = 456` as top-level attributes of the element
+
+### Requirement: Each account field SHALL be set only when the API response value is non-nil
+Before calling `d.Set(...)` / building the map for each `users` element, the provider SHALL check whether the corresponding `ListAllUser` field is nil and skip setting it when nil.
+
+#### Scenario: Nil remark is skipped
+- **WHEN** the API returns a user whose `Remark` field is nil
+- **THEN** the `remark` attribute is not set in that element's map
+
+### Requirement: Paging outputs marker and is_truncated SHALL be exposed
+The data source SHALL expose `marker` (string, Optional + Computed) and `is_truncated` (bool, Computed) reflecting `response.Response.Marker` and `response.Response.IsTruncated`.
+
+#### Scenario: Truncated result reports next marker
+- **WHEN** the API returns `IsTruncated = true` and `Marker = "abc"`
+- **THEN** the data source outputs `is_truncated = true` and `marker = "abc"`
+
+#### Scenario: Non-truncated result
+- **WHEN** the API returns `IsTruncated = false` and no `Marker`
+- **THEN** the data source outputs `is_truncated = false` and `marker` remains empty
+
+### Requirement: The read handler SHALL retry on transient errors and not clear the id on empty response
+The read handler SHALL wrap the `ListAccounts` call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. Inside the retry block, if the response or `Users` list is empty, the handler SHALL return `NonRetryableError` instead of clearing the Terraform id, so transient API blips do not wipe local state.
+
+#### Scenario: Transient empty response triggers retry
+- **WHEN** the `ListAccounts` call returns an empty `Users` list due to a transient API issue
+- **THEN** the retry block returns `NonRetryableError`, causing the outer retry to keep retrying until the timeout is exhausted, and the provider logs `[DATASOURCE] read empty, skip SetId` rather than clearing the id
+
+### Requirement: The data source SHALL be registered in the provider
+The provider SHALL register `tencentcloud_cam_accounts` mapped to `cam.DataSourceTencentCloudCamAccounts()` in `provider.go`.
+
+#### Scenario: Provider registration
+- **WHEN** the provider is initialized
+- **THEN** `tencentcloud_cam_accounts` is available as a data source
+
+### Requirement: Optional input parameters SHALL NOT enforce SDK enum ranges as validate funcs
+The `user_type` input parameter SHALL be a plain `schema.TypeString` with no `ValidateFunc`. The provider SHALL pass the user-supplied value directly to the SDK without validating it against the documented enum range.
+
+#### Scenario: User supplies a user_type value
+- **WHEN** a user sets `user_type = "Collaborator"`
+- **THEN** the provider forwards `"Collaborator"` to `request.UserType` without schema-level validation

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/tasks.md
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Service Layer
 
-- [x] 1.1 Append `DescribeCamAccountsByFilter(ctx, paramMap)` to `tencentcloud/services/cam/service_tencentcloud_cam.go` — build `cam.NewListAccountsRequest()` from `paramMap["MaxItems"]`, `paramMap["Marker"]`, `paramMap["UserType"]`, call `me.client.UseCamClient().ListAccounts(request)`, return `([]*cam.ListAllUser, marker string, isTruncated bool, error)`
+- [x] 1.1 Append `DescribeCamAccountsByFilter(ctx, paramMap)` to `tencentcloud/services/cam/service_tencentcloud_cam.go` — build `cam.NewListAccountsRequest()` from `paramMap["UserType"]`, set `MaxItems = 100` per page (the API returns at most 100 records per call), and loop: call `me.client.UseCamClient().ListAccounts(request)`, append `response.Response.Users`, and continue with `request.Marker = response.Response.Marker` while the response's `IsTruncated` is true and `Marker` is non-nil; return `([]*cam.ListAllUser, error)`
 
 ## 2. Data Source Implementation
 
-- [x] 2.1 Create `tencentcloud/services/cam/data_source_tc_cam_accounts.go` with `DataSourceTencentCloudCamAccounts()` schema: optional inputs `max_items` (TypeInt), `marker` (TypeString, Optional+Computed), `user_type` (TypeString, no ValidateFunc); flattened `users` TypeList whose Elem schema.Resource contains `uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, `user_type`; computed outputs `marker` and `is_truncated`; optional `result_output_file`
-- [x] 2.2 Implement `dataSourceTencentCloudCamAccountsRead` — build paramMap from optional inputs, wrap `DescribeCamAccountsByFilter` in `resource.Retry(tccommon.ReadRetryTimeout, ...)`; inside retry return `NonRetryableError` on empty response (do NOT `d.SetId("")`); flatten `Users` into `users` list setting each field only when non-nil; set `marker` and `is_truncated`; on retry-exhausted path log `[DATASOURCE] read empty, skip SetId`; SetId via `helper.DataResourceIdsHash(ids)`
+- [x] 2.1 Create `tencentcloud/services/cam/data_source_tc_cam_accounts.go` with `DataSourceTencentCloudCamAccounts()` schema: optional input `user_type` (TypeString, no ValidateFunc); flattened `users` TypeList whose Elem schema.Resource contains `uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, `user_type`; optional `result_output_file`. No paging-related parameters (`max_items`, `marker`, `is_truncated`) are exposed — pagination is automatic in the service layer
+- [x] 2.2 Implement `dataSourceTencentCloudCamAccountsRead` — build paramMap from `user_type`, wrap `DescribeCamAccountsByFilter` in `resource.Retry(tccommon.ReadRetryTimeout, ...)`; log `[DATASOURCE] read empty, skip SetId` on the retry-exhausted path; an empty `Users` list is not an error (consistent with `tencentcloud_cam_users`); flatten `Users` into `users` list setting each field only when non-nil; SetId via `helper.DataResourceIdsHash(ids)`
 - [x] 2.3 Verify all returned errors are checked; functions that cannot fail use `_ = func()` for the err
 
 ## 3. Provider Registration
@@ -14,5 +14,5 @@
 
 ## 4. Documentation & Tests
 
-- [x] 4.1 Create `tencentcloud/services/cam/data_source_tc_cam_accounts.md` with one-line description ("Use this data source to query ..."), Example Usage (including paging example using `max_items`/`marker`/`user_type`), no Argument/Attribute Reference sections (auto-generated), no Import section
-- [x] 4.2 Create `tencentcloud/services/cam/data_source_tc_cam_accounts_test.go` using gomonkey mocks (no Terraform test suite) — mock `DescribeCamAccountsByFilter` to return sample `ListAllUser` data and verify the read handler flattens fields correctly
+- [x] 4.1 Create `tencentcloud/services/cam/data_source_tc_cam_accounts.md` with one-line description ("Use this data source to query ..."), Example Usage (querying all accounts and filtering by `user_type`), no Argument/Attribute Reference sections (auto-generated), no Import section
+- [x] 4.2 Create `tencentcloud/services/cam/data_source_tc_cam_accounts_test.go` using gomonkey mocks (no Terraform test suite) — mock `DescribeCamAccountsByFilter` (returning `([]*cam.ListAllUser, error)`) with sample `ListAllUser` data and verify the read handler flattens fields correctly, handles nil fields and empty responses, and the schema exposes no paging parameters

--- a/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/tasks.md
+++ b/openspec/changes/archive/2026-09-02-add-cam-accounts-datasource/tasks.md
@@ -1,0 +1,18 @@
+## 1. Service Layer
+
+- [x] 1.1 Append `DescribeCamAccountsByFilter(ctx, paramMap)` to `tencentcloud/services/cam/service_tencentcloud_cam.go` — build `cam.NewListAccountsRequest()` from `paramMap["MaxItems"]`, `paramMap["Marker"]`, `paramMap["UserType"]`, call `me.client.UseCamClient().ListAccounts(request)`, return `([]*cam.ListAllUser, marker string, isTruncated bool, error)`
+
+## 2. Data Source Implementation
+
+- [x] 2.1 Create `tencentcloud/services/cam/data_source_tc_cam_accounts.go` with `DataSourceTencentCloudCamAccounts()` schema: optional inputs `max_items` (TypeInt), `marker` (TypeString, Optional+Computed), `user_type` (TypeString, no ValidateFunc); flattened `users` TypeList whose Elem schema.Resource contains `uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, `user_type`; computed outputs `marker` and `is_truncated`; optional `result_output_file`
+- [x] 2.2 Implement `dataSourceTencentCloudCamAccountsRead` — build paramMap from optional inputs, wrap `DescribeCamAccountsByFilter` in `resource.Retry(tccommon.ReadRetryTimeout, ...)`; inside retry return `NonRetryableError` on empty response (do NOT `d.SetId("")`); flatten `Users` into `users` list setting each field only when non-nil; set `marker` and `is_truncated`; on retry-exhausted path log `[DATASOURCE] read empty, skip SetId`; SetId via `helper.DataResourceIdsHash(ids)`
+- [x] 2.3 Verify all returned errors are checked; functions that cannot fail use `_ = func()` for the err
+
+## 3. Provider Registration
+
+- [x] 3.1 Register `tencentcloud_cam_accounts` → `cam.DataSourceTencentCloudCamAccounts()` in the data source map of `tencentcloud/provider.go`
+
+## 4. Documentation & Tests
+
+- [x] 4.1 Create `tencentcloud/services/cam/data_source_tc_cam_accounts.md` with one-line description ("Use this data source to query ..."), Example Usage (including paging example using `max_items`/`marker`/`user_type`), no Argument/Attribute Reference sections (auto-generated), no Import section
+- [x] 4.2 Create `tencentcloud/services/cam/data_source_tc_cam_accounts_test.go` using gomonkey mocks (no Terraform test suite) — mock `DescribeCamAccountsByFilter` to return sample `ListAllUser` data and verify the read handler flattens fields correctly

--- a/openspec/specs/cam-accounts-datasource/spec.md
+++ b/openspec/specs/cam-accounts-datasource/spec.md
@@ -1,22 +1,33 @@
 # cam-accounts-datasource Specification
 
 ## Purpose
-TBD - created by archiving change add-cam-accounts-datasource. Update Purpose after archive.
+Provides a Terraform data source `tencentcloud_cam_accounts` that queries the full list of CAM accounts (Owner, SubUser, CICUser, WechatCorpUser, AgentIdentity, Collaborator, MessageReceiver) via the CAM `ListAccounts` API. Pagination is handled automatically in the service layer (up to 100 records per call, looping on the response's `IsTruncated` field and `Marker` until all pages are fetched), and no paging-related parameters are exposed in the schema.
 ## Requirements
 ### Requirement: CAM accounts data source SHALL query accounts via ListAccounts
 The `tencentcloud_cam_accounts` data source SHALL call the CAM `ListAccounts` API and expose the returned account list to Terraform.
 
 #### Scenario: Query all accounts with no filters
 - **WHEN** a user declares `data "tencentcloud_cam_accounts" "all"` with no optional arguments
-- **THEN** the provider calls `ListAccounts` with no `MaxItems`, `Marker`, or `UserType` set and flattens `response.Response.Users` into the `users` list
+- **THEN** the provider calls `ListAccounts` without a `UserType` filter (each page requested with `MaxItems = 100`) and flattens the collected `response.Response.Users` into the `users` list
 
 #### Scenario: Query accounts filtered by user type
 - **WHEN** a user sets `user_type = "SubUser"`
 - **THEN** the provider sets `request.UserType = "SubUser"` so the API returns only sub-users
 
-#### Scenario: Query accounts with paging
-- **WHEN** a user sets `max_items = 50` and `marker = "<previous-marker>"`
-- **THEN** the provider sets `request.MaxItems = 50` and `request.Marker = "<previous-marker>"`, and the data source outputs the updated `marker` and `is_truncated` values from the response
+### Requirement: Pagination SHALL be handled automatically in the service layer and SHALL NOT be exposed in the schema
+The service method `DescribeCamAccountsByFilter` SHALL fetch all pages: it SHALL request at most 100 records per call (the `ListAccounts` `MaxItems` upper bound) and, based on the response's `IsTruncated` field, continue calling the API with the returned `Marker` until `IsTruncated` is false. The data source schema SHALL NOT expose any paging-related parameters (`max_items`, `marker`, or `is_truncated`).
+
+#### Scenario: Truncated response triggers a follow-up request
+- **WHEN** a `ListAccounts` call returns `IsTruncated = true` with `Marker = "abc"`
+- **THEN** the service issues another `ListAccounts` request with `request.Marker = "abc"`, appends the new `Users` to the result, and repeats until `IsTruncated = false`
+
+#### Scenario: Non-truncated response ends the loop
+- **WHEN** a `ListAccounts` call returns `IsTruncated = false`
+- **THEN** the service stops looping and returns the accumulated account list
+
+#### Scenario: Schema exposes no paging parameters
+- **WHEN** the data source schema is inspected
+- **THEN** it contains only `user_type`, `users`, and `result_output_file` (plus the `users` element fields), and does not contain `max_items`, `marker`, or `is_truncated`
 
 ### Requirement: The users list SHALL flatten each account's fields without an extra nesting layer
 The `users` schema SHALL be a `TypeList` whose element is a `schema.Resource` containing `uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, and `user_type` fields directly — there SHALL NOT be an intermediate wrapper block.
@@ -32,23 +43,16 @@ Before calling `d.Set(...)` / building the map for each `users` element, the pro
 - **WHEN** the API returns a user whose `Remark` field is nil
 - **THEN** the `remark` attribute is not set in that element's map
 
-### Requirement: Paging outputs marker and is_truncated SHALL be exposed
-The data source SHALL expose `marker` (string, Optional + Computed) and `is_truncated` (bool, Computed) reflecting `response.Response.Marker` and `response.Response.IsTruncated`.
+### Requirement: The read handler SHALL retry on transient errors
+The read handler SHALL wrap the `DescribeCamAccountsByFilter` call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. An empty `Users` list SHALL NOT be treated as an error: the handler proceeds and produces an empty `users` list, consistent with the existing CAM data sources.
 
-#### Scenario: Truncated result reports next marker
-- **WHEN** the API returns `IsTruncated = true` and `Marker = "abc"`
-- **THEN** the data source outputs `is_truncated = true` and `marker = "abc"`
+#### Scenario: Transient API error triggers retry
+- **WHEN** the `ListAccounts` call fails with a transient error
+- **THEN** the retry block retries the call until it succeeds or `tccommon.ReadRetryTimeout` is exhausted, and the provider logs `[DATASOURCE] read empty, skip SetId` before returning the error
 
-#### Scenario: Non-truncated result
-- **WHEN** the API returns `IsTruncated = false` and no `Marker`
-- **THEN** the data source outputs `is_truncated = false` and `marker` remains empty
-
-### Requirement: The read handler SHALL retry on transient errors and not clear the id on empty response
-The read handler SHALL wrap the `ListAccounts` call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. Inside the retry block, if the response or `Users` list is empty, the handler SHALL return `NonRetryableError` instead of clearing the Terraform id, so transient API blips do not wipe local state.
-
-#### Scenario: Transient empty response triggers retry
-- **WHEN** the `ListAccounts` call returns an empty `Users` list due to a transient API issue
-- **THEN** the retry block returns `NonRetryableError`, causing the outer retry to keep retrying until the timeout is exhausted, and the provider logs `[DATASOURCE] read empty, skip SetId` rather than clearing the id
+#### Scenario: Empty account list completes normally
+- **WHEN** the API returns no users
+- **THEN** the read handler completes without error and the data source reports an empty `users` list
 
 ### Requirement: The data source SHALL be registered in the provider
 The provider SHALL register `tencentcloud_cam_accounts` mapped to `cam.DataSourceTencentCloudCamAccounts()` in `provider.go`.
@@ -63,4 +67,3 @@ The `user_type` input parameter SHALL be a plain `schema.TypeString` with no `Va
 #### Scenario: User supplies a user_type value
 - **WHEN** a user sets `user_type = "Collaborator"`
 - **THEN** the provider forwards `"Collaborator"` to `request.UserType` without schema-level validation
-

--- a/openspec/specs/cam-accounts-datasource/spec.md
+++ b/openspec/specs/cam-accounts-datasource/spec.md
@@ -1,0 +1,66 @@
+# cam-accounts-datasource Specification
+
+## Purpose
+TBD - created by archiving change add-cam-accounts-datasource. Update Purpose after archive.
+## Requirements
+### Requirement: CAM accounts data source SHALL query accounts via ListAccounts
+The `tencentcloud_cam_accounts` data source SHALL call the CAM `ListAccounts` API and expose the returned account list to Terraform.
+
+#### Scenario: Query all accounts with no filters
+- **WHEN** a user declares `data "tencentcloud_cam_accounts" "all"` with no optional arguments
+- **THEN** the provider calls `ListAccounts` with no `MaxItems`, `Marker`, or `UserType` set and flattens `response.Response.Users` into the `users` list
+
+#### Scenario: Query accounts filtered by user type
+- **WHEN** a user sets `user_type = "SubUser"`
+- **THEN** the provider sets `request.UserType = "SubUser"` so the API returns only sub-users
+
+#### Scenario: Query accounts with paging
+- **WHEN** a user sets `max_items = 50` and `marker = "<previous-marker>"`
+- **THEN** the provider sets `request.MaxItems = 50` and `request.Marker = "<previous-marker>"`, and the data source outputs the updated `marker` and `is_truncated` values from the response
+
+### Requirement: The users list SHALL flatten each account's fields without an extra nesting layer
+The `users` schema SHALL be a `TypeList` whose element is a `schema.Resource` containing `uin`, `name`, `uid`, `remark`, `console_login`, `phone_num`, `country_code`, `email`, `create_time`, and `user_type` fields directly — there SHALL NOT be an intermediate wrapper block.
+
+#### Scenario: Flattened account fields
+- **WHEN** the API returns a user with `Uin=123`, `Name="alice"`, `Uid=456`
+- **THEN** the `users` list element contains `uin = 123`, `name = "alice"`, `uid = 456` as top-level attributes of the element
+
+### Requirement: Each account field SHALL be set only when the API response value is non-nil
+Before calling `d.Set(...)` / building the map for each `users` element, the provider SHALL check whether the corresponding `ListAllUser` field is nil and skip setting it when nil.
+
+#### Scenario: Nil remark is skipped
+- **WHEN** the API returns a user whose `Remark` field is nil
+- **THEN** the `remark` attribute is not set in that element's map
+
+### Requirement: Paging outputs marker and is_truncated SHALL be exposed
+The data source SHALL expose `marker` (string, Optional + Computed) and `is_truncated` (bool, Computed) reflecting `response.Response.Marker` and `response.Response.IsTruncated`.
+
+#### Scenario: Truncated result reports next marker
+- **WHEN** the API returns `IsTruncated = true` and `Marker = "abc"`
+- **THEN** the data source outputs `is_truncated = true` and `marker = "abc"`
+
+#### Scenario: Non-truncated result
+- **WHEN** the API returns `IsTruncated = false` and no `Marker`
+- **THEN** the data source outputs `is_truncated = false` and `marker` remains empty
+
+### Requirement: The read handler SHALL retry on transient errors and not clear the id on empty response
+The read handler SHALL wrap the `ListAccounts` call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. Inside the retry block, if the response or `Users` list is empty, the handler SHALL return `NonRetryableError` instead of clearing the Terraform id, so transient API blips do not wipe local state.
+
+#### Scenario: Transient empty response triggers retry
+- **WHEN** the `ListAccounts` call returns an empty `Users` list due to a transient API issue
+- **THEN** the retry block returns `NonRetryableError`, causing the outer retry to keep retrying until the timeout is exhausted, and the provider logs `[DATASOURCE] read empty, skip SetId` rather than clearing the id
+
+### Requirement: The data source SHALL be registered in the provider
+The provider SHALL register `tencentcloud_cam_accounts` mapped to `cam.DataSourceTencentCloudCamAccounts()` in `provider.go`.
+
+#### Scenario: Provider registration
+- **WHEN** the provider is initialized
+- **THEN** `tencentcloud_cam_accounts` is available as a data source
+
+### Requirement: Optional input parameters SHALL NOT enforce SDK enum ranges as validate funcs
+The `user_type` input parameter SHALL be a plain `schema.TypeString` with no `ValidateFunc`. The provider SHALL pass the user-supplied value directly to the SDK without validating it against the documented enum range.
+
+#### Scenario: User supplies a user_type value
+- **WHEN** a user sets `user_type = "Collaborator"`
+- **THEN** the provider forwards `"Collaborator"` to `request.UserType` without schema-level validation
+

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -785,6 +785,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_cam_oidc_config":                                        cam.DataSourceTencentCloudCamOidcConfig(),
 			"tencentcloud_user_info":                                              cam.DataSourceTencentCloudUserInfo(),
 			"tencentcloud_cam_sub_accounts":                                       cam.DataSourceTencentCloudCamSubAccounts(),
+			"tencentcloud_cam_accounts":                                           cam.DataSourceTencentCloudCamAccounts(),
 			"tencentcloud_cam_role_detail":                                        cam.DataSourceTencentCloudCamRoleDetail(),
 			"tencentcloud_cam_policy_detail":                                      cam.DataSourceTencentCloudCamPolicyDetail(),
 			"tencentcloud_cdn_domains":                                            cdn.DataSourceTencentCloudCdnDomains(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -264,6 +264,7 @@ tencentcloud_cam_policy_granting_service_access
 tencentcloud_cam_oidc_config
 tencentcloud_cam_group_user_account
 tencentcloud_cam_sub_accounts
+tencentcloud_cam_accounts
 tencentcloud_cam_role_detail
 tencentcloud_cam_policy_detail
 

--- a/tencentcloud/services/cam/data_source_tc_cam_accounts.go
+++ b/tencentcloud/services/cam/data_source_tc_cam_accounts.go
@@ -16,17 +16,6 @@ func DataSourceTencentCloudCamAccounts() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceTencentCloudCamAccountsRead,
 		Schema: map[string]*schema.Schema{
-			"max_items": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "Maximum number of accounts to return per request. Valid range: [1, 100]. When the returned result is truncated due to reaching MaxItems, the output `is_truncated` will be true.",
-			},
-			"marker": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "When the returned result is truncated, use Marker to fetch the content after the current truncation position. Output `marker` carries the next page marker when `is_truncated` is true.",
-			},
 			"user_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -91,11 +80,6 @@ func DataSourceTencentCloudCamAccounts() *schema.Resource {
 					},
 				},
 			},
-			"is_truncated": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "Whether the returned result is truncated.",
-			},
 			"result_output_file": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -116,30 +100,18 @@ func dataSourceTencentCloudCamAccountsRead(d *schema.ResourceData, meta interfac
 	)
 
 	paramMap := make(map[string]interface{})
-	if v, ok := d.GetOk("max_items"); ok {
-		paramMap["MaxItems"] = helper.IntInt64(v.(int))
-	}
-	if v, ok := d.GetOk("marker"); ok {
-		paramMap["Marker"] = helper.String(v.(string))
-	}
 	if v, ok := d.GetOk("user_type"); ok {
 		paramMap["UserType"] = helper.String(v.(string))
 	}
 
-	var (
-		respData    []*cam.ListAllUser
-		respMarker  string
-		isTruncated bool
-	)
+	var respData []*cam.ListAllUser
 	reqErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
-		users, marker, truncated, e := service.DescribeCamAccountsByFilter(ctx, paramMap)
+		users, e := service.DescribeCamAccountsByFilter(ctx, paramMap)
 		if e != nil {
 			return tccommon.RetryError(e)
 		}
 
 		respData = users
-		respMarker = marker
-		isTruncated = truncated
 		return nil
 	})
 
@@ -188,8 +160,6 @@ func dataSourceTencentCloudCamAccountsRead(d *schema.ResourceData, meta interfac
 
 	d.SetId(helper.DataResourceIdsHash(ids))
 	_ = d.Set("users", usersList)
-	_ = d.Set("marker", respMarker)
-	_ = d.Set("is_truncated", isTruncated)
 
 	output, ok := d.GetOk("result_output_file")
 	if ok && output.(string) != "" {

--- a/tencentcloud/services/cam/data_source_tc_cam_accounts.go
+++ b/tencentcloud/services/cam/data_source_tc_cam_accounts.go
@@ -1,0 +1,207 @@
+package cam
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	cam "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudCamAccounts() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudCamAccountsRead,
+		Schema: map[string]*schema.Schema{
+			"max_items": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Maximum number of accounts to return per request. Valid range: [1, 100]. When the returned result is truncated due to reaching MaxItems, the output `is_truncated` will be true.",
+			},
+			"marker": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "When the returned result is truncated, use Marker to fetch the content after the current truncation position. Output `marker` carries the next page marker when `is_truncated` is true.",
+			},
+			"user_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Account type to filter by. Valid values: `Owner` (master account), `SubUser` (sub user), `CICUser` (CIC sub user), `WechatCorpUser` (WeCom sub user), `AgentIdentity` (AgentIdentity sub user), `Collaborator` (collaborator), `MessageReceiver` (message receiver).",
+			},
+			"users": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of CAM accounts. Each element contains the following attributes:",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uin": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Account ID (Uin).",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Account name.",
+						},
+						"uid": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Account UID.",
+						},
+						"remark": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Account remark.",
+						},
+						"console_login": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Whether the account can log in to the console. Returned as the raw int value from the API.",
+						},
+						"phone_num": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Phone number.",
+						},
+						"country_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Country code.",
+						},
+						"email": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Email.",
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Creation time. Format: YYYY-MM-DD hh:mm:ss.",
+						},
+						"user_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Account type. Valid values: `Owner`, `SubUser`, `CICUser`, `WechatCorpUser`, `AgentIdentity`, `Collaborator`, `MessageReceiver`, `Unknown`.",
+						},
+					},
+				},
+			},
+			"is_truncated": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the returned result is truncated.",
+			},
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudCamAccountsRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_cam_accounts.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	var (
+		logId   = tccommon.GetLogId(nil)
+		ctx     = tccommon.NewResourceLifeCycleHandleFuncContext(context.Background(), logId, d, meta)
+		service = CamService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+	)
+
+	paramMap := make(map[string]interface{})
+	if v, ok := d.GetOk("max_items"); ok {
+		paramMap["MaxItems"] = helper.IntInt64(v.(int))
+	}
+	if v, ok := d.GetOk("marker"); ok {
+		paramMap["Marker"] = helper.String(v.(string))
+	}
+	if v, ok := d.GetOk("user_type"); ok {
+		paramMap["UserType"] = helper.String(v.(string))
+	}
+
+	var (
+		respData    []*cam.ListAllUser
+		respMarker  string
+		isTruncated bool
+	)
+	reqErr := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		users, marker, truncated, e := service.DescribeCamAccountsByFilter(ctx, paramMap)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if len(users) == 0 {
+			return resource.NonRetryableError(fmt.Errorf("cam accounts is empty"))
+		}
+
+		respData = users
+		respMarker = marker
+		isTruncated = truncated
+		return nil
+	})
+
+	if reqErr != nil {
+		log.Printf("[DATASOURCE] read empty, skip SetId, cam_accounts id=%s", d.Id())
+		return reqErr
+	}
+
+	ids := make([]string, 0, len(respData))
+	usersList := make([]map[string]interface{}, 0, len(respData))
+	for _, user := range respData {
+		userMap := map[string]interface{}{}
+		if user.Uin != nil {
+			userMap["uin"] = user.Uin
+			ids = append(ids, helper.Int64ToStr(*user.Uin))
+		}
+		if user.Name != nil {
+			userMap["name"] = user.Name
+		}
+		if user.Uid != nil {
+			userMap["uid"] = user.Uid
+		}
+		if user.Remark != nil {
+			userMap["remark"] = user.Remark
+		}
+		if user.ConsoleLogin != nil {
+			userMap["console_login"] = user.ConsoleLogin
+		}
+		if user.PhoneNum != nil {
+			userMap["phone_num"] = user.PhoneNum
+		}
+		if user.CountryCode != nil {
+			userMap["country_code"] = user.CountryCode
+		}
+		if user.Email != nil {
+			userMap["email"] = user.Email
+		}
+		if user.CreateTime != nil {
+			userMap["create_time"] = user.CreateTime
+		}
+		if user.UserType != nil {
+			userMap["user_type"] = user.UserType
+		}
+		usersList = append(usersList, userMap)
+	}
+
+	d.SetId(helper.DataResourceIdsHash(ids))
+	_ = d.Set("users", usersList)
+	_ = d.Set("marker", respMarker)
+	_ = d.Set("is_truncated", isTruncated)
+
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), usersList); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/cam/data_source_tc_cam_accounts.go
+++ b/tencentcloud/services/cam/data_source_tc_cam_accounts.go
@@ -2,7 +2,6 @@ package cam
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -136,10 +135,6 @@ func dataSourceTencentCloudCamAccountsRead(d *schema.ResourceData, meta interfac
 		users, marker, truncated, e := service.DescribeCamAccountsByFilter(ctx, paramMap)
 		if e != nil {
 			return tccommon.RetryError(e)
-		}
-
-		if len(users) == 0 {
-			return resource.NonRetryableError(fmt.Errorf("cam accounts is empty"))
 		}
 
 		respData = users

--- a/tencentcloud/services/cam/data_source_tc_cam_accounts.md
+++ b/tencentcloud/services/cam/data_source_tc_cam_accounts.md
@@ -1,4 +1,4 @@
-Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types.
+Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types. All pages are fetched automatically, so the `users` list contains every account visible to the credentials.
 
 Example Usage
 
@@ -10,11 +10,5 @@ data "tencentcloud_cam_accounts" "all" {
 # query accounts filtered by user type
 data "tencentcloud_cam_accounts" "sub_users" {
   user_type = "SubUser"
-}
-
-# query accounts with paging
-data "tencentcloud_cam_accounts" "page" {
-  max_items = 50
-  marker    = "previous-marker"
 }
 ```

--- a/tencentcloud/services/cam/data_source_tc_cam_accounts.md
+++ b/tencentcloud/services/cam/data_source_tc_cam_accounts.md
@@ -1,0 +1,20 @@
+Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types.
+
+Example Usage
+
+```hcl
+# query all CAM accounts
+data "tencentcloud_cam_accounts" "all" {
+}
+
+# query accounts filtered by user type
+data "tencentcloud_cam_accounts" "sub_users" {
+  user_type = "SubUser"
+}
+
+# query accounts with paging
+data "tencentcloud_cam_accounts" "page" {
+  max_items = 50
+  marker    = "previous-marker"
+}
+```

--- a/tencentcloud/services/cam/data_source_tc_cam_accounts.md
+++ b/tencentcloud/services/cam/data_source_tc_cam_accounts.md
@@ -4,8 +4,7 @@ Example Usage
 
 ```hcl
 # query all CAM accounts
-data "tencentcloud_cam_accounts" "all" {
-}
+data "tencentcloud_cam_accounts" "all" {}
 
 # query accounts filtered by user type
 data "tencentcloud_cam_accounts" "sub_users" {

--- a/tencentcloud/services/cam/data_source_tc_cam_accounts_test.go
+++ b/tencentcloud/services/cam/data_source_tc_cam_accounts_test.go
@@ -1,0 +1,220 @@
+package cam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	camv20190116 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cam"
+)
+
+type mockMetaForCamAccountsDS struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForCamAccountsDS) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForCamAccountsDS{}
+
+func newMockMetaForCamAccountsDS() *mockMetaForCamAccountsDS {
+	return &mockMetaForCamAccountsDS{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrCamAccountsDS(s string) *string { return &s }
+func ptrInt64CamAccountsDS(v int64) *int64 { return &v }
+
+// go test ./tencentcloud/services/cam/ -run "TestCamAccountsDataSource" -v -count=1 -gcflags="all=-l"
+
+// TestCamAccountsDataSource_ReadBasic tests that the read handler flattens a populated
+// ListAccounts response into the users list and surfaces marker / is_truncated correctly.
+func TestCamAccountsDataSource_ReadBasic(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, string, bool, error) {
+		return []*camv20190116.ListAllUser{
+			{
+				Uin:          ptrInt64CamAccountsDS(100037718139),
+				Name:         ptrStrCamAccountsDS("alice"),
+				Uid:          ptrInt64CamAccountsDS(1034),
+				Remark:       ptrStrCamAccountsDS("operator"),
+				ConsoleLogin: ptrInt64CamAccountsDS(1),
+				PhoneNum:     ptrStrCamAccountsDS("13800000000"),
+				CountryCode:  ptrStrCamAccountsDS("86"),
+				Email:        ptrStrCamAccountsDS("alice@example.com"),
+				CreateTime:   ptrStrCamAccountsDS("2024-01-01 10:00:00"),
+				UserType:     ptrStrCamAccountsDS("SubUser"),
+			},
+			{
+				Uin:          ptrInt64CamAccountsDS(100037718140),
+				Name:         ptrStrCamAccountsDS("bob"),
+				Uid:          ptrInt64CamAccountsDS(1035),
+				Remark:       ptrStrCamAccountsDS("collaborator"),
+				ConsoleLogin: ptrInt64CamAccountsDS(0),
+				PhoneNum:     ptrStrCamAccountsDS("13900000000"),
+				CountryCode:  ptrStrCamAccountsDS("86"),
+				Email:        ptrStrCamAccountsDS("bob@example.com"),
+				CreateTime:   ptrStrCamAccountsDS("2024-02-02 11:00:00"),
+				UserType:     ptrStrCamAccountsDS("Collaborator"),
+			},
+		}, "next-page-marker", true, nil
+	})
+
+	meta := newMockMetaForCamAccountsDS()
+	res := cam.DataSourceTencentCloudCamAccounts()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	users := d.Get("users").([]interface{})
+	assert.Len(t, users, 2)
+
+	user0 := users[0].(map[string]interface{})
+	assert.Equal(t, 100037718139, user0["uin"].(int))
+	assert.Equal(t, "alice", user0["name"].(string))
+	assert.Equal(t, 1034, user0["uid"].(int))
+	assert.Equal(t, "operator", user0["remark"].(string))
+	assert.Equal(t, 1, user0["console_login"].(int))
+	assert.Equal(t, "13800000000", user0["phone_num"].(string))
+	assert.Equal(t, "86", user0["country_code"].(string))
+	assert.Equal(t, "alice@example.com", user0["email"].(string))
+	assert.Equal(t, "2024-01-01 10:00:00", user0["create_time"].(string))
+	assert.Equal(t, "SubUser", user0["user_type"].(string))
+
+	user1 := users[1].(map[string]interface{})
+	assert.Equal(t, 100037718140, user1["uin"].(int))
+	assert.Equal(t, "bob", user1["name"].(string))
+	assert.Equal(t, "Collaborator", user1["user_type"].(string))
+	assert.Equal(t, 0, user1["console_login"].(int))
+
+	assert.Equal(t, "next-page-marker", d.Get("marker").(string))
+	assert.Equal(t, true, d.Get("is_truncated").(bool))
+}
+
+// TestCamAccountsDataSource_ReadWithNilFields tests that nil fields in the API response
+// are safely skipped without panicking.
+func TestCamAccountsDataSource_ReadWithNilFields(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, string, bool, error) {
+		return []*camv20190116.ListAllUser{
+			{
+				Uin:        ptrInt64CamAccountsDS(100037718141),
+				Name:       ptrStrCamAccountsDS("charlie"),
+				Uid:        nil,
+				Remark:     nil,
+				PhoneNum:   nil,
+				UserType:   ptrStrCamAccountsDS("MessageReceiver"),
+				CreateTime: ptrStrCamAccountsDS("2024-03-03 12:00:00"),
+			},
+		}, "", false, nil
+	})
+
+	meta := newMockMetaForCamAccountsDS()
+	res := cam.DataSourceTencentCloudCamAccounts()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	users := d.Get("users").([]interface{})
+	assert.Len(t, users, 1)
+
+	user0 := users[0].(map[string]interface{})
+	assert.Equal(t, 100037718141, user0["uin"].(int))
+	assert.Equal(t, "charlie", user0["name"].(string))
+	assert.Equal(t, "MessageReceiver", user0["user_type"].(string))
+	assert.Equal(t, "2024-03-03 12:00:00", user0["create_time"].(string))
+	// nil fields default to zero values
+	assert.Equal(t, 0, user0["uid"].(int))
+	assert.Equal(t, "", user0["remark"].(string))
+	assert.Equal(t, "", user0["phone_num"].(string))
+
+	assert.Equal(t, "", d.Get("marker").(string))
+	assert.Equal(t, false, d.Get("is_truncated").(bool))
+}
+
+// TestCamAccountsDataSource_ReadEmptyResponse tests that an empty Users list returns an
+// error (NonRetryableError inside retry) and does not clear the id.
+func TestCamAccountsDataSource_ReadEmptyResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, string, bool, error) {
+		return []*camv20190116.ListAllUser{}, "", false, nil
+	})
+
+	meta := newMockMetaForCamAccountsDS()
+	res := cam.DataSourceTencentCloudCamAccounts()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}
+
+// TestCamAccountsDataSource_Schema tests the schema definition includes the expected fields.
+func TestCamAccountsDataSource_Schema(t *testing.T) {
+	res := cam.DataSourceTencentCloudCamAccounts()
+
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Read)
+
+	assert.Contains(t, res.Schema, "max_items")
+	assert.Contains(t, res.Schema, "marker")
+	assert.Contains(t, res.Schema, "user_type")
+	assert.Contains(t, res.Schema, "users")
+	assert.Contains(t, res.Schema, "is_truncated")
+	assert.Contains(t, res.Schema, "result_output_file")
+
+	maxItemsSchema := res.Schema["max_items"]
+	assert.Equal(t, schema.TypeInt, maxItemsSchema.Type)
+	assert.True(t, maxItemsSchema.Optional)
+
+	markerSchema := res.Schema["marker"]
+	assert.Equal(t, schema.TypeString, markerSchema.Type)
+	assert.True(t, markerSchema.Optional)
+	assert.True(t, markerSchema.Computed)
+
+	userTypeSchema := res.Schema["user_type"]
+	assert.Equal(t, schema.TypeString, userTypeSchema.Type)
+	assert.True(t, userTypeSchema.Optional)
+	assert.Nil(t, userTypeSchema.ValidateFunc)
+
+	usersSchema := res.Schema["users"]
+	assert.Equal(t, schema.TypeList, usersSchema.Type)
+	assert.True(t, usersSchema.Computed)
+
+	elemRes := usersSchema.Elem.(*schema.Resource)
+	assert.Contains(t, elemRes.Schema, "uin")
+	assert.Contains(t, elemRes.Schema, "name")
+	assert.Contains(t, elemRes.Schema, "uid")
+	assert.Contains(t, elemRes.Schema, "remark")
+	assert.Contains(t, elemRes.Schema, "console_login")
+	assert.Contains(t, elemRes.Schema, "phone_num")
+	assert.Contains(t, elemRes.Schema, "country_code")
+	assert.Contains(t, elemRes.Schema, "email")
+	assert.Contains(t, elemRes.Schema, "create_time")
+	assert.Contains(t, elemRes.Schema, "user_type")
+
+	consoleLoginSchema := elemRes.Schema["console_login"]
+	assert.Equal(t, schema.TypeInt, consoleLoginSchema.Type)
+
+	uinSchema := elemRes.Schema["uin"]
+	assert.Equal(t, schema.TypeInt, uinSchema.Type)
+
+	isTruncatedSchema := res.Schema["is_truncated"]
+	assert.Equal(t, schema.TypeBool, isTruncatedSchema.Type)
+	assert.True(t, isTruncatedSchema.Computed)
+}

--- a/tencentcloud/services/cam/data_source_tc_cam_accounts_test.go
+++ b/tencentcloud/services/cam/data_source_tc_cam_accounts_test.go
@@ -34,12 +34,12 @@ func ptrInt64CamAccountsDS(v int64) *int64 { return &v }
 // go test ./tencentcloud/services/cam/ -run "TestCamAccountsDataSource" -v -count=1 -gcflags="all=-l"
 
 // TestCamAccountsDataSource_ReadBasic tests that the read handler flattens a populated
-// ListAccounts response into the users list and surfaces marker / is_truncated correctly.
+// ListAccounts response into the users list.
 func TestCamAccountsDataSource_ReadBasic(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, string, bool, error) {
+	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, error) {
 		return []*camv20190116.ListAllUser{
 			{
 				Uin:          ptrInt64CamAccountsDS(100037718139),
@@ -65,7 +65,7 @@ func TestCamAccountsDataSource_ReadBasic(t *testing.T) {
 				CreateTime:   ptrStrCamAccountsDS("2024-02-02 11:00:00"),
 				UserType:     ptrStrCamAccountsDS("Collaborator"),
 			},
-		}, "next-page-marker", true, nil
+		}, nil
 	})
 
 	meta := newMockMetaForCamAccountsDS()
@@ -96,9 +96,6 @@ func TestCamAccountsDataSource_ReadBasic(t *testing.T) {
 	assert.Equal(t, "bob", user1["name"].(string))
 	assert.Equal(t, "Collaborator", user1["user_type"].(string))
 	assert.Equal(t, 0, user1["console_login"].(int))
-
-	assert.Equal(t, "next-page-marker", d.Get("marker").(string))
-	assert.Equal(t, true, d.Get("is_truncated").(bool))
 }
 
 // TestCamAccountsDataSource_ReadWithNilFields tests that nil fields in the API response
@@ -107,7 +104,7 @@ func TestCamAccountsDataSource_ReadWithNilFields(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, string, bool, error) {
+	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, error) {
 		return []*camv20190116.ListAllUser{
 			{
 				Uin:        ptrInt64CamAccountsDS(100037718141),
@@ -118,7 +115,7 @@ func TestCamAccountsDataSource_ReadWithNilFields(t *testing.T) {
 				UserType:   ptrStrCamAccountsDS("MessageReceiver"),
 				CreateTime: ptrStrCamAccountsDS("2024-03-03 12:00:00"),
 			},
-		}, "", false, nil
+		}, nil
 	})
 
 	meta := newMockMetaForCamAccountsDS()
@@ -141,19 +138,16 @@ func TestCamAccountsDataSource_ReadWithNilFields(t *testing.T) {
 	assert.Equal(t, 0, user0["uid"].(int))
 	assert.Equal(t, "", user0["remark"].(string))
 	assert.Equal(t, "", user0["phone_num"].(string))
-
-	assert.Equal(t, "", d.Get("marker").(string))
-	assert.Equal(t, false, d.Get("is_truncated").(bool))
 }
 
-// TestCamAccountsDataSource_ReadEmptyResponse tests that an empty Users list returns an
-// error (NonRetryableError inside retry) and does not clear the id.
+// TestCamAccountsDataSource_ReadEmptyResponse tests that an empty Users list does not
+// produce an error and the read handler still completes.
 func TestCamAccountsDataSource_ReadEmptyResponse(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, string, bool, error) {
-		return []*camv20190116.ListAllUser{}, "", false, nil
+	patches.ApplyMethodFunc(&cam.CamService{}, "DescribeCamAccountsByFilter", func(_ context.Context, _ map[string]interface{}) ([]*camv20190116.ListAllUser, error) {
+		return []*camv20190116.ListAllUser{}, nil
 	})
 
 	meta := newMockMetaForCamAccountsDS()
@@ -161,7 +155,8 @@ func TestCamAccountsDataSource_ReadEmptyResponse(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
 
 	err := res.Read(d, meta)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	assert.Empty(t, d.Get("users").([]interface{}))
 }
 
 // TestCamAccountsDataSource_Schema tests the schema definition includes the expected fields.
@@ -171,21 +166,13 @@ func TestCamAccountsDataSource_Schema(t *testing.T) {
 	assert.NotNil(t, res)
 	assert.NotNil(t, res.Read)
 
-	assert.Contains(t, res.Schema, "max_items")
-	assert.Contains(t, res.Schema, "marker")
 	assert.Contains(t, res.Schema, "user_type")
 	assert.Contains(t, res.Schema, "users")
-	assert.Contains(t, res.Schema, "is_truncated")
 	assert.Contains(t, res.Schema, "result_output_file")
-
-	maxItemsSchema := res.Schema["max_items"]
-	assert.Equal(t, schema.TypeInt, maxItemsSchema.Type)
-	assert.True(t, maxItemsSchema.Optional)
-
-	markerSchema := res.Schema["marker"]
-	assert.Equal(t, schema.TypeString, markerSchema.Type)
-	assert.True(t, markerSchema.Optional)
-	assert.True(t, markerSchema.Computed)
+	// pagination is handled automatically in the service layer and must not be exposed
+	assert.NotContains(t, res.Schema, "max_items")
+	assert.NotContains(t, res.Schema, "marker")
+	assert.NotContains(t, res.Schema, "is_truncated")
 
 	userTypeSchema := res.Schema["user_type"]
 	assert.Equal(t, schema.TypeString, userTypeSchema.Type)
@@ -213,8 +200,4 @@ func TestCamAccountsDataSource_Schema(t *testing.T) {
 
 	uinSchema := elemRes.Schema["uin"]
 	assert.Equal(t, schema.TypeInt, uinSchema.Type)
-
-	isTruncatedSchema := res.Schema["is_truncated"]
-	assert.Equal(t, schema.TypeBool, isTruncatedSchema.Type)
-	assert.True(t, isTruncatedSchema.Computed)
 }

--- a/tencentcloud/services/cam/service_tencentcloud_cam.go
+++ b/tencentcloud/services/cam/service_tencentcloud_cam.go
@@ -2128,3 +2128,48 @@ func (me *CamService) DescribeCamPolicyDetailByFilter(ctx context.Context, param
 	result = response.Response
 	return
 }
+
+func (me *CamService) DescribeCamAccountsByFilter(ctx context.Context, paramMap map[string]interface{}) (users []*cam.ListAllUser, marker string, isTruncated bool, errRet error) {
+	var (
+		logId   = tccommon.GetLogId(ctx)
+		request = cam.NewListAccountsRequest()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	if v, ok := paramMap["MaxItems"]; ok {
+		request.MaxItems = v.(*int64)
+	}
+	if v, ok := paramMap["Marker"]; ok {
+		request.Marker = v.(*string)
+	}
+	if v, ok := paramMap["UserType"]; ok {
+		request.UserType = v.(*string)
+	}
+
+	ratelimit.Check(request.GetAction())
+
+	response, err := me.client.UseCamClient().ListAccounts(request)
+	if err != nil {
+		errRet = err
+		return
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+	if response == nil || response.Response == nil {
+		return
+	}
+
+	users = response.Response.Users
+	if response.Response.Marker != nil {
+		marker = *response.Response.Marker
+	}
+	if response.Response.IsTruncated != nil {
+		isTruncated = *response.Response.IsTruncated
+	}
+	return
+}

--- a/tencentcloud/services/cam/service_tencentcloud_cam.go
+++ b/tencentcloud/services/cam/service_tencentcloud_cam.go
@@ -2129,7 +2129,11 @@ func (me *CamService) DescribeCamPolicyDetailByFilter(ctx context.Context, param
 	return
 }
 
-func (me *CamService) DescribeCamAccountsByFilter(ctx context.Context, paramMap map[string]interface{}) (users []*cam.ListAllUser, marker string, isTruncated bool, errRet error) {
+// DescribeCamAccountsByFilter queries all CAM accounts via the ListAccounts API with
+// automatic pagination. The API returns at most 100 records per request; the loop keeps
+// requesting with the returned Marker until IsTruncated is false, so the full account
+// list is fetched and returned.
+func (me *CamService) DescribeCamAccountsByFilter(ctx context.Context, paramMap map[string]interface{}) (users []*cam.ListAllUser, errRet error) {
 	var (
 		logId   = tccommon.GetLogId(ctx)
 		request = cam.NewListAccountsRequest()
@@ -2141,35 +2145,35 @@ func (me *CamService) DescribeCamAccountsByFilter(ctx context.Context, paramMap 
 		}
 	}()
 
-	if v, ok := paramMap["MaxItems"]; ok {
-		request.MaxItems = v.(*int64)
-	}
-	if v, ok := paramMap["Marker"]; ok {
-		request.Marker = v.(*string)
-	}
 	if v, ok := paramMap["UserType"]; ok {
 		request.UserType = v.(*string)
 	}
 
-	ratelimit.Check(request.GetAction())
+	// The ListAccounts API returns at most 100 records per request, so request the
+	// maximum page size and follow the returned Marker while IsTruncated is true.
+	maxItems := int64(100)
+	users = make([]*cam.ListAllUser, 0)
+	for {
+		request.MaxItems = &maxItems
+		ratelimit.Check(request.GetAction())
 
-	response, err := me.client.UseCamClient().ListAccounts(request)
-	if err != nil {
-		errRet = err
-		return
-	}
-	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+		response, err := me.client.UseCamClient().ListAccounts(request)
+		if err != nil {
+			errRet = err
+			return
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
 
-	if response == nil || response.Response == nil {
-		return
-	}
+		if response == nil || response.Response == nil {
+			return
+		}
 
-	users = response.Response.Users
-	if response.Response.Marker != nil {
-		marker = *response.Response.Marker
-	}
-	if response.Response.IsTruncated != nil {
-		isTruncated = *response.Response.IsTruncated
+		users = append(users, response.Response.Users...)
+		if response.Response.IsTruncated == nil || !*response.Response.IsTruncated || response.Response.Marker == nil {
+			break
+		}
+
+		request.Marker = response.Response.Marker
 	}
 	return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116/models.go
@@ -5589,26 +5589,29 @@ type LoginActionFlag struct {
 }
 
 type LoginActionFlagIntl struct {
-	// 手机
+	// <p>手机</p>
 	Phone *uint64 `json:"Phone,omitnil,omitempty" name:"Phone"`
 
-	// 硬token
+	// <p>硬token</p>
 	Token *uint64 `json:"Token,omitnil,omitempty" name:"Token"`
 
-	// 软token
+	// <p>软token</p>
 	Stoken *uint64 `json:"Stoken,omitnil,omitempty" name:"Stoken"`
 
-	// 微信
+	// <p>微信</p>
 	Wechat *uint64 `json:"Wechat,omitnil,omitempty" name:"Wechat"`
 
-	// 自定义
+	// <p>自定义</p>
 	Custom *uint64 `json:"Custom,omitnil,omitempty" name:"Custom"`
 
-	// 邮件
+	// <p>邮件</p>
 	Mail *uint64 `json:"Mail,omitnil,omitempty" name:"Mail"`
 
-	// u2f硬件token
+	// <p>u2f硬件token</p>
 	U2FToken *uint64 `json:"U2FToken,omitnil,omitempty" name:"U2FToken"`
+
+	// <p>passkey通行密钥</p>
+	Passkey *uint64 `json:"Passkey,omitnil,omitempty" name:"Passkey"`
 }
 
 type LoginActionMfaFlag struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1211,7 +1211,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/bi/v20220105
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing v1.3.39
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing/v20180709
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.130
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.3.157
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat v1.3.136

--- a/website/docs/d/cam_accounts.html.markdown
+++ b/website/docs/d/cam_accounts.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Cloud Access Management(CAM)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_cam_accounts"
+sidebar_current: "docs-tencentcloud-datasource-cam_accounts"
+description: |-
+  Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types.
+---
+
+# tencentcloud_cam_accounts
+
+Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types.
+
+## Example Usage
+
+```hcl
+# query all CAM accounts
+data "tencentcloud_cam_accounts" "all" {
+}
+
+# query accounts filtered by user type
+data "tencentcloud_cam_accounts" "sub_users" {
+  user_type = "SubUser"
+}
+
+# query accounts with paging
+data "tencentcloud_cam_accounts" "page" {
+  max_items = 50
+  marker    = "previous-marker"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `marker` - (Optional, String) When the returned result is truncated, use Marker to fetch the content after the current truncation position. Output `marker` carries the next page marker when `is_truncated` is true.
+* `max_items` - (Optional, Int) Maximum number of accounts to return per request. Valid range: [1, 100]. When the returned result is truncated due to reaching MaxItems, the output `is_truncated` will be true.
+* `result_output_file` - (Optional, String) Used to save results.
+* `user_type` - (Optional, String) Account type to filter by. Valid values: `Owner` (master account), `SubUser` (sub user), `CICUser` (CIC sub user), `WechatCorpUser` (WeCom sub user), `AgentIdentity` (AgentIdentity sub user), `Collaborator` (collaborator), `MessageReceiver` (message receiver).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `is_truncated` - Whether the returned result is truncated.
+* `users` - A list of CAM accounts. Each element contains the following attributes:
+  * `console_login` - Whether the account can log in to the console. Returned as the raw int value from the API.
+  * `country_code` - Country code.
+  * `create_time` - Creation time. Format: YYYY-MM-DD hh:mm:ss.
+  * `email` - Email.
+  * `name` - Account name.
+  * `phone_num` - Phone number.
+  * `remark` - Account remark.
+  * `uid` - Account UID.
+  * `uin` - Account ID (Uin).
+  * `user_type` - Account type. Valid values: `Owner`, `SubUser`, `CICUser`, `WechatCorpUser`, `AgentIdentity`, `Collaborator`, `MessageReceiver`, `Unknown`.
+
+

--- a/website/docs/d/cam_accounts.html.markdown
+++ b/website/docs/d/cam_accounts.html.markdown
@@ -15,8 +15,7 @@ Use this data source to query the list of CAM accounts via the CAM `ListAccounts
 
 ```hcl
 # query all CAM accounts
-data "tencentcloud_cam_accounts" "all" {
-}
+data "tencentcloud_cam_accounts" "all" {}
 
 # query accounts filtered by user type
 data "tencentcloud_cam_accounts" "sub_users" {

--- a/website/docs/d/cam_accounts.html.markdown
+++ b/website/docs/d/cam_accounts.html.markdown
@@ -4,12 +4,12 @@ layout: "tencentcloud"
 page_title: "TencentCloud: tencentcloud_cam_accounts"
 sidebar_current: "docs-tencentcloud-datasource-cam_accounts"
 description: |-
-  Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types.
+  Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types. All pages are fetched automatically, so the `users` list contains every account visible to the credentials.
 ---
 
 # tencentcloud_cam_accounts
 
-Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types.
+Use this data source to query the list of CAM accounts via the CAM `ListAccounts` API, including sub users, collaborators, message receivers and other account types. All pages are fetched automatically, so the `users` list contains every account visible to the credentials.
 
 ## Example Usage
 
@@ -22,20 +22,12 @@ data "tencentcloud_cam_accounts" "all" {
 data "tencentcloud_cam_accounts" "sub_users" {
   user_type = "SubUser"
 }
-
-# query accounts with paging
-data "tencentcloud_cam_accounts" "page" {
-  max_items = 50
-  marker    = "previous-marker"
-}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `marker` - (Optional, String) When the returned result is truncated, use Marker to fetch the content after the current truncation position. Output `marker` carries the next page marker when `is_truncated` is true.
-* `max_items` - (Optional, Int) Maximum number of accounts to return per request. Valid range: [1, 100]. When the returned result is truncated due to reaching MaxItems, the output `is_truncated` will be true.
 * `result_output_file` - (Optional, String) Used to save results.
 * `user_type` - (Optional, String) Account type to filter by. Valid values: `Owner` (master account), `SubUser` (sub user), `CICUser` (CIC sub user), `WechatCorpUser` (WeCom sub user), `AgentIdentity` (AgentIdentity sub user), `Collaborator` (collaborator), `MessageReceiver` (message receiver).
 
@@ -43,7 +35,6 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `is_truncated` - Whether the returned result is truncated.
 * `users` - A list of CAM accounts. Each element contains the following attributes:
   * `console_login` - Whether the account can log in to the console. Returned as the raw int value from the API.
   * `country_code` - Country code.

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -861,6 +861,9 @@
                                     <a href="/docs/providers/tencentcloud/d/cam_account_summary.html">tencentcloud_cam_account_summary</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/d/cam_accounts.html">tencentcloud_cam_accounts</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/d/cam_group_memberships.html">tencentcloud_cam_group_memberships</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add a new Terraform data source tencentcloud_cam_accounts that wraps the CAM ListAccounts API. It exposes optional query parameters (max_items, marker, user_type) and flattens the Users array into a top-level users list with per-account fields (uin, name, uid, remark, console_login, phone_num, country_code, email, create_time, user_type) plus paging outputs (marker, is_truncated).