### PR TITLE
feat(cat): [133294964] add tencentcloud_cat_instant_tasks data source

### DIFF
--- a/.changelog/4479.txt
+++ b/.changelog/4479.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_cat_instant_tasks
+```

--- a/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/design.md
+++ b/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/design.md
@@ -1,0 +1,77 @@
+## Context
+
+云拨测（CAT，Cat）服务已在 Provider 中提供以下资源/数据源：
+- 资源 `tencentcloud_cat_task_set`（基于 `DescribeProbeTasks`/`CreateProbeTasks`/`DeleteProbeTask` 等接口）
+- 数据源 `tencentcloud_cat_node`（拨测节点）
+- 数据源 `tencentcloud_cat_probe_data`（拨测明细数据）
+- 数据源 `tencentcloud_cat_metric_data`（拨测指标数据）
+
+本次新增数据源 `tencentcloud_cat_instant_tasks`，用于查询**历史即时拨测任务**列表。对应云 API 为 `DescribeInstantTasks`（`cat/v20180409`），返回结构为 `response.Response.Tasks`（`[]*SingleInstantTask`）和 `response.Response.Total`（`*uint64`）。
+
+`SingleInstantTask` 结构体字段如下（来自 vendor）：
+- `TaskId *string` —— 任务 ID
+- `TargetAddress *string` —— 任务地址
+- `TaskType *uint64` —— 任务类型
+- `ProbeTime *uint64` —— 测试时间
+- `Status *string` —— 任务状态
+- `SuccessRate *float64` —— 成功率
+- `NodeCount *uint64` —— 节点数量
+- `TaskCategory *uint64` —— 节点类型
+
+请求参数仅有 `Limit` 与 `Offset`（均为 `*uint64`），无其它过滤条件。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提供 `tencentcloud_cat_instant_tasks` 数据源，封装 `DescribeInstantTasks` 接口
+- 将 `SingleInstantTask` 列表字段展开为 Terraform schema 的列表项字段（遵循"列表展开，不额外嵌套一层"的硬约束）
+- 内部自动分页获取全部历史即时拨测任务（不向用户暴露 `limit`/`offset` 参数）
+- 遵循现有 cat 数据源代码风格（参考 `data_source_tc_cat_node.go`、`data_source_tc_cat_metric_data.go`）
+- 提供 `result_output_file` 参数用于导出结果
+- 使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` + `tccommon.RetryError()` 处理临时性错误
+- 在 Read 的 retry 块内对空响应返回 `NonRetryableError`（数据源硬约束），避免清空 id
+
+**Non-Goals:**
+- 不修改任何已有资源/数据源的 schema（纯新增）
+- 不暴露 `limit`/`offset` 参数给用户（遵循 config.yaml 约束）
+- 不实现写操作（数据源仅做查询）
+- 不引入新的外部依赖
+
+## Decisions
+
+### Decision 1: 列表字段展开到 `tasks` 列表项的顶层（不额外嵌套）
+**选择**: 将 `response.Response.Tasks` 映射为 schema 中的 `tasks`（`schema.TypeList`），每个列表元素的 schema 直接平铺 `task_id`/`target_address`/`task_type`/`probe_time`/`status`/`success_rate`/`node_count`/`task_category`，顶层另设 `total` 字段。
+
+**理由**: 项目硬约束明确要求"资源参数 schema 中禁止创建该资源列表型数据这一层 schema"，应将列表展开，使每个字段都可被 Terraform 单独 set/read。参考 `data_source_tc_cat_node.go` 中 `node_define` 列表的处理方式。
+
+**备选方案**: 把所有字段再包一层 `instant_task_set` —— 违反硬约束，已否决。
+
+### Decision 2: service 层方法签名与分页策略
+**选择**: 在 `service_tencentcloud_cat.go` 新增：
+```go
+func (me *CatService) DescribeCatInstantTasksByFilter(ctx context.Context) (tasks []*cat.SingleInstantTask, total *uint64, errRet error)
+```
+内部以固定 `pageSize`（取云 API 支持的最大值）循环分页，累积 `response.Response.Tasks`，直到本页返回数量小于 `pageSize` 即停止；同时返回最后一次响应的 `Total`。
+
+**理由**:
+- 该 API 无任何过滤参数，因此 service 方法无需接收过滤入参。
+- 遵循 config.yaml "数据源分页：不暴露 limit/offset 给用户，内部实现自动分页"。
+- 参考 `DescribeCatTaskSet` 中已有的分页循环写法（offset/pageSize 累加），保持风格一致。
+
+**备选方案**: 在 data source 中直接调用 API 不抽 service 方法 —— 违反项目"通过 service 层调用云 API"的模式，已否决。
+
+### Decision 3: retry 块对空响应返回 NonRetryableError
+**选择**: 在 data source 的 Read 方法 retry 块内，调用 service 方法后判断 `tasks == nil && total == nil`（即 response/Response 均为空），返回 `tccommon.NonRetryableError`；不在此处 `d.SetId("")`。仅当 `len(tasks) == 0`（有响应但列表为空）时视为正常空结果，不返回错误，并打印 `log.Printf("[DATASOURCE] read empty, skip SetId")` 后继续。
+
+**理由**: 遵循 RESOURCE_KIND_DATASOURCE 硬约束——"retry 块内必须检查云 API Read 接口是否返回了空，若返回了空，不要直接 `d.SetId("")`，而是直接返回 `NonRetryableError`"。区别"API 返回 nil 响应（异常）"与"API 返回空列表（正常）"两种情况。
+
+### Decision 4: data source id 使用任务 id 哈希
+**选择**: 收集所有 `task_id` 后使用 `helper.DataResourceIdsHash(ids)` 生成 data source 的 `d.SetId()`，与 `data_source_tc_cat_node.go` 一致。
+
+**理由**: 复用项目通用工具，保持与同类数据源一致。
+
+## Risks / Trade-offs
+
+- **[任务数量极大时全量分页耗时]** → 通过固定较大 pageSize 减少 API 调用次数；并在 service 层 `ratelimit.Check()` 控制速率。历史即时拨测任务总量通常可控，风险较低。
+- **[空响应误判清空 state]** → 已通过 Decision 3 在 retry 块内区分"异常空"与"正常空列表"，避免误清 id。
+- **[字段类型转换]*uint64 → int / *float64 → float64** → Terraform schema 使用 `TypeInt`/`TypeFloat`，读取时 SDK 返回的是指针，需做 nil 判断后再 set，参考现有数据源的 nil 检查模式。

--- a/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/proposal.md
+++ b/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+用户需要通过 Terraform 查询云拨测（CAT，Cat）的历史即时拨测任务列表。当前 Provider 已支持 cat 资源/数据源（`tencentcloud_cat_task_set`、`tencentcloud_cat_node`、`tencentcloud_cat_probe_data`、`tencentcloud_cat_metric_data`），但缺少针对"历史即时拨测任务"的查询数据源。
+
+这会导致用户无法：
+1. 通过 Terraform 查询已有的即时拨测任务信息（任务 ID、目标地址、任务类型、拨测时间、状态、成功率、节点数量、节点类型等）
+2. 在 Terraform 配置中引用即时拨测任务的结果做下游编排或告警关联
+3. 查看即时拨测任务的总量（Total）
+
+## What Changes
+
+- 新增 Data Source: `tencentcloud_cat_instant_tasks`
+- 实现对 CAT API `DescribeInstantTasks` 接口的调用，获取历史即时拨测任务列表
+- 支持内部自动分页获取所有数据（不向用户暴露 limit/offset 参数，遵循 openspec config.yaml 约束）
+- 返回即时拨测任务列表及总量信息，字段映射如下：
+  - `response.Response.Tasks` → `tasks`（列表，展开每个任务的字段到顶层 schema 元素中）
+  - `response.Response.Tasks.TaskId` → `task_id`
+  - `response.Response.Tasks.TargetAddress` → `target_address`
+  - `response.Response.Tasks.TaskType` → `task_type`
+  - `response.Response.Tasks.ProbeTime` → `probe_time`
+  - `response.Response.Tasks.Status` → `status`
+  - `response.Response.Tasks.SuccessRate` → `success_rate`
+  - `response.Response.Tasks.NodeCount` → `node_count`
+  - `response.Response.Tasks.TaskCategory` → `task_category`
+  - `response.Response.Total` → `total`
+
+## Capabilities
+
+### New Capabilities
+- `cat-instant-tasks-datasource`: 查询云拨测（CAT）历史即时拨测任务列表的 Data Source，封装 `DescribeInstantTasks` 接口，支持自动分页、结果导出与字段展开
+
+### Modified Capabilities
+<!-- 无现有 spec 需要修改 -->
+
+## Impact
+
+- **新增能力**: CAT 历史即时拨测任务列表查询
+- **受影响的服务**: CAT (tencentcloud/services/cat)
+- **新增文件**:
+  - `tencentcloud/services/cat/data_source_tc_cat_instant_tasks.go`
+  - `tencentcloud/services/cat/data_source_tc_cat_instant_tasks.md`
+  - `tencentcloud/services/cat/data_source_tc_cat_instant_tasks_test.go`
+- **修改文件**:
+  - `tencentcloud/services/cat/service_tencentcloud_cat.go`（新增 `DescribeCatInstantTasksByFilter` service 方法，内部实现分页）
+  - `tencentcloud/provider.go`（在 `DataSourcesMap` 注册 `tencentcloud_cat_instant_tasks`）
+  - `tencentcloud/provider.md`（在 CAT 部分 Data Source 节添加条目，由 `make doc` 自动生成）
+- **API 依赖**:
+  - CAT API v20180409: `DescribeInstantTasks`（同步接口，无需轮询 Read）
+  - SDK 包: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409`（已在 vendor 中）
+- **兼容性**: 无破坏性变更，纯新增功能

--- a/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/specs/cat-instant-tasks-datasource/spec.md
+++ b/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/specs/cat-instant-tasks-datasource/spec.md
@@ -1,0 +1,150 @@
+## ADDED Requirements
+
+### Requirement: Data Source Schema Definition
+
+`tencentcloud_cat_instant_tasks` 数据源 SHALL 支持以下输出属性，所有列表项字段平铺在 `tasks` 列表元素内（不额外嵌套一层），顶层提供 `total` 与 `result_output_file`：
+
+**Output Attributes:**
+- `tasks` (List): 历史即时拨测任务列表，每个元素包含：
+  - `task_id` (String): 任务 ID（映射 `SingleInstantTask.TaskId`）
+  - `target_address` (String): 任务地址（映射 `SingleInstantTask.TargetAddress`）
+  - `task_type` (Int): 任务类型（映射 `SingleInstantTask.TaskType`）
+  - `probe_time` (Int): 测试时间（映射 `SingleInstantTask.ProbeTime`）
+  - `status` (String): 任务状态（映射 `SingleInstantTask.Status`）
+  - `success_rate` (Float): 成功率（映射 `SingleInstantTask.SuccessRate`）
+  - `node_count` (Int): 节点数量（映射 `SingleInstantTask.NodeCount`）
+  - `task_category` (Int): 节点类型（映射 `SingleInstantTask.TaskCategory`）
+- `total` (Int): 任务总数（映射 `response.Response.Total`）
+- `result_output_file` (String, Optional): 将查询结果导出到指定文件
+
+数据源 SHALL NOT 向用户暴露 `limit`/`offset` 分页参数；分页 SHALL 在 service 层内部自动完成，获取全部历史即时拨测任务。
+
+#### Scenario: Query all instant tasks
+
+```hcl
+data "tencentcloud_cat_instant_tasks" "example" {
+}
+
+output "tasks" {
+  value = data.tencentcloud_cat_instant_tasks.example.tasks
+}
+
+output "total" {
+  value = data.tencentcloud_cat_instant_tasks.example.total
+}
+```
+
+- **WHEN** 用户不带任何参数查询 `tencentcloud_cat_instant_tasks`
+- **THEN** 返回当前账号下全部历史即时拨测任务
+- **AND** `tasks` 列表中每个元素包含 `task_id`/`target_address`/`task_type`/`probe_time`/`status`/`success_rate`/`node_count`/`task_category` 字段
+- **AND** `total` 反映任务总数
+
+#### Scenario: Export query results to file
+
+```hcl
+data "tencentcloud_cat_instant_tasks" "export" {
+  result_output_file = "/tmp/cat_instant_tasks.json"
+}
+```
+
+- **WHEN** 用户指定 `result_output_file`
+- **THEN** 查询结果以 JSON 格式写入指定文件
+- **AND** 文件内容包含完整的任务列表信息
+
+### Requirement: Service Layer Implementation
+
+`service_tencentcloud_cat.go` SHALL 新增方法用于封装 `DescribeInstantTasks` 接口，内部实现自动分页：
+
+```go
+func (me *CatService) DescribeCatInstantTasksByFilter(ctx context.Context) (tasks []*cat.SingleInstantTask, total *uint64, errRet error)
+```
+
+实现约束：
+1. 使用固定 `pageSize`（云 API 支持的最大值）循环分页，累积 `response.Response.Tasks`，直到本页返回数量小于 `pageSize` 即停止
+2. 每次请求前调用 `ratelimit.Check(request.GetAction())`
+3. 每次请求后记录 `[DEBUG]` 级别的请求体与响应体日志
+4. 失败时记录 `[CRITAL]` 级别错误日志并返回错误
+5. 返回累积后的全部 `tasks` 与最后一次响应的 `total`
+
+#### Scenario: Service method handles empty list
+
+- **WHEN** API 返回非 nil 响应但 `response.Response.Tasks` 为空列表
+- **THEN** service 方法返回空（长度为 0）的 `tasks` 切片与对应的 `total`
+- **AND** 不返回错误
+
+#### Scenario: Service method handles API errors
+
+- **WHEN** API 调用返回错误
+- **THEN** service 方法记录 `[CRITAL]` 错误日志（含请求体与错误原因）
+- **AND** 返回该错误，由上层 retry 机制决定是否重试
+
+#### Scenario: Service method paginates all results
+
+- **WHEN** 历史即时拨测任务数量超过单页 `pageSize`
+- **THEN** service 方法循环调用 `DescribeInstantTasks`，逐步累加 `offset`
+- **AND** 返回所有页累积合并后的完整 `tasks` 列表
+
+### Requirement: Read Retry and Empty-Response Handling
+
+Data Source 的 Read 方法 SHALL 使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包裹 service 方法调用，并通过 `tccommon.RetryError(e)` 包装错误。在 retry 块内 SHALL 满足：
+
+1. 若 service 方法返回错误，使用 `tccommon.RetryError(e)` 包装返回，由外层 retry 决定重试
+2. 若云 API 返回空（`response == nil` / `response.Response == nil` 等，表现为 `tasks == nil && total == nil`），SHALL 直接返回 `tccommon.NonRetryableError`，不调用 `d.SetId("")`，保留现场便于排障
+3. 若 API 返回正常但列表为空（`len(tasks) == 0`），SHALL 视为正常空结果，打印 `log.Printf("[DATASOURCE] read empty, skip SetId")` 后继续后续逻辑，不返回错误
+
+#### Scenario: Retry on transient API failure
+
+- **WHEN** `DescribeInstantTasks` 出现临时性错误
+- **THEN** 通过 `resource.Retry` 自动重试，直到成功或达到 `tccommon.ReadRetryTimeout` 超时
+- **AND** 重试耗尽后以"重试耗尽"形式失败，便于人工介入
+
+#### Scenario: Reject clearing id on nil response
+
+- **WHEN** API 返回的响应为 nil（异常情况）
+- **THEN** Read 方法返回 `NonRetryableError`，不执行 `d.SetId("")`
+- **AND** 避免因 API 短暂波动导致本地 state 中的 id 被清空
+
+### Requirement: Provider Registration
+
+`tencentcloud/provider.go` 的 `DataSourcesMap` SHALL 注册新数据源：
+
+```go
+"tencentcloud_cat_instant_tasks": cat.DataSourceTencentCloudCatInstantTasks(),
+```
+
+#### Scenario: Data source is accessible via Terraform
+
+- **WHEN** 用户在 Terraform 配置中使用 `data "tencentcloud_cat_instant_tasks"`
+- **THEN** Provider 能识别该数据源，不报 "provider doesn't support data source" 错误
+
+### Requirement: Documentation
+
+数据源 SHALL 提供文档文件 `data_source_tc_cat_instant_tasks.md`，内容包括：
+1. 一句话描述，须带上所属云产品名称（CAT / 云拨测）
+2. 使用示例（基本查询）
+3. 不手写 `Argument Reference` 与 `Attribute Reference`（由工具自动生成）
+
+`provider.md` 中 CAT 部分的 Data Source 条目 SHALL 通过 `make doc` 自动生成，不手动编辑 `website/` 目录。
+
+#### Scenario: User finds data source in documentation
+
+- **WHEN** 用户查看生成的文档
+- **THEN** 能看到 `tencentcloud_cat_instant_tasks` 的一句话描述与示例
+- **AND** 文档由 `make doc` 自动生成，无需手动维护 `website/docs/`
+
+### Requirement: Testing
+
+数据源 SHALL 提供单元测试文件 `data_source_tc_cat_instant_tasks_test.go`，使用 mock（gomonkey）方式对云 API 进行 mock，只做业务代码逻辑的单元测试（不使用 terraform 测试套件）。测试 SHALL 覆盖：
+1. 正常查询场景（mock 返回非空任务列表，验证字段映射与 `total` 设置）
+2. 空列表场景（mock 返回空列表，验证不报错、正常设置 id）
+3. API 错误场景（mock 返回错误，验证错误被返回）
+
+#### Scenario: Unit test covers normal query
+
+- **WHEN** mock `DescribeInstantTasks` 返回包含若干 `SingleInstantTask` 的响应
+- **THEN** 单元测试验证 `tasks` 列表字段被正确映射、`total` 被正确设置、`d.Id()` 被设置为任务 id 哈希
+
+#### Scenario: Unit test covers empty list
+
+- **WHEN** mock `DescribeInstantTasks` 返回空任务列表
+- **THEN** 单元测试验证 Read 不报错并正常完成

--- a/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/tasks.md
+++ b/openspec/changes/archive/2026-09-02-add-cat-instant-tasks-datasource/tasks.md
@@ -1,0 +1,74 @@
+## 1. Service Layer（service 层）
+
+- [x] 1.1 在 `tencentcloud/services/cat/service_tencentcloud_cat.go` 新增 `DescribeCatInstantTasksByFilter` 方法，封装 `DescribeInstantTasks` 接口
+  - 方法签名：`func (me *CatService) DescribeCatInstantTasksByFilter(ctx context.Context) (tasks []*cat.SingleInstantTask, total *uint64, errRet error)`
+  - 使用固定 `pageSize`（云 API 支持的最大值）循环分页，累积 `response.Response.Tasks`，直到本页返回数量小于 `pageSize` 即停止
+  - 每次请求前调用 `ratelimit.Check(request.GetAction())`
+  - 每次请求后记录 `[DEBUG]` 级别的请求体与响应体日志
+  - 失败时记录 `[CRITAL]` 错误日志（含请求体与错误原因）并返回错误
+  - 返回累积后的全部 `tasks` 与最后一次响应的 `total`
+- [x] 1.2 处理空列表场景：当 API 返回非 nil 响应但 `response.Response.Tasks` 为空列表时，返回空切片与对应的 `total`，不返回错误
+
+## 2. Data Source 实现（schema 定义与 Read 函数）
+
+- [x] 2.1 创建 `tencentcloud/services/cat/data_source_tc_cat_instant_tasks.go`
+  - 声明 `package cat` 与必要的 import（`context`、`log`、`resource`、`schema`、`tccommon`、`cat`、`helper`）
+- [x] 2.2 定义 `DataSourceTencentCloudCatInstantTasks() *schema.Resource` 的 schema：
+  - 输出 `tasks`（`schema.TypeList`，Computed），每个元素 schema 平铺以下字段（均 Computed，遵循列表展开硬约束，不额外嵌套一层）：
+    - `task_id`（TypeString）、`target_address`（TypeString）、`task_type`（TypeInt）、`probe_time`（TypeInt）、`status`（TypeString）、`success_rate`（TypeFloat）、`node_count`（TypeInt）、`task_category`（TypeInt）
+  - 输出 `total`（TypeInt，Computed）
+  - 输入 `result_output_file`（TypeString，Optional）
+  - 不向用户暴露 `limit`/`offset` 参数（遵循 config.yaml 约束）
+- [x] 2.3 实现 `dataSourceTencentCloudCatInstantTasksRead` Read 函数：
+  - `defer tccommon.LogElapsed("data_source.tencentcloud_cat_instant_tasks.read")()`
+  - `defer tccommon.InconsistentCheck(d, meta)()`
+  - 使用 `tccommon.GetLogId(tccommon.ContextNil)` 与 `context.WithValue` 构造 ctx
+  - 调用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包裹 service 方法 `DescribeCatInstantTasksByFilter(ctx)`
+- [x] 2.4 retry 块内错误与空响应处理（遵循数据源硬约束）：
+  - service 方法返回错误时使用 `tccommon.RetryError(e)` 包装返回
+  - 云 API 返回空（`tasks == nil && total == nil`，即 response/Response 均为空）时直接返回 `NonRetryableError`，不调用 `d.SetId("")`
+  - 列表为空（`len(tasks) == 0` 但响应正常）时打印 `log.Printf("[DATASOURCE] read empty, skip SetId")` 后继续，不返回错误
+- [x] 2.5 将 API 响应映射到 Terraform state：
+  - 遍历 `tasks`，为每个 `SingleInstantTask` 构造 map，set 各字段前先做 nil 判断（遵循 Read 方法硬约束）
+  - `task_id`/`target_address`/`status` 为 `*string` → string
+  - `task_type`/`probe_time`/`node_count`/`task_category` 为 `*uint64` → int
+  - `success_rate` 为 `*float64` → float64
+  - 使用 `helper.DataResourceIdsHash(ids)`（收集所有 `task_id`）设置 `d.SetId()`
+  - set `tasks` 列表与 `total` 到 ResourceData
+
+## 3. 结果导出
+
+- [x] 3.1 在 Read 函数末尾处理 `result_output_file`：若用户指定，使用 `tccommon.WriteToFile(output.(string), tasksList)` 导出结果，失败时返回错误
+
+## 4. Provider 注册
+
+- [x] 4.1 在 `tencentcloud/provider.go` 的 `DataSourcesMap` 中添加注册代码：
+  ```go
+  "tencentcloud_cat_instant_tasks": cat.DataSourceTencentCloudCatInstantTasks(),
+  ```
+- [x] 4.2 确认注册命名遵循约定：`tencentcloud_cat_instant_tasks`
+
+## 5. 文档
+
+- [x] 5.1 创建 `tencentcloud/services/cat/data_source_tc_cat_instant_tasks.md`：
+  - 一句话描述，带上所属云产品名称（CAT / 云拨测），格式为 "Use this data source to query ..."
+  - Example Usage 部分提供基本查询示例
+  - 不手写 `Argument Reference` 与 `Attribute Reference`（由工具自动生成）
+  - RESOURCE_KIND_DATASOURCE 类型无需 Import 部分
+- [ ] 5.2 运行 `make doc` 自动生成 `website/docs/` 文档与 `provider.md` 条目（由 tfpacer-finalize 阶段执行）
+
+## 6. 单元测试
+
+- [x] 6.1 创建 `tencentcloud/services/cat/data_source_tc_cat_instant_tasks_test.go`：
+  - 使用 mock（gomonkey）方式对云 API 进行 mock，不使用 terraform 测试套件（遵循新增 terraform 资源测试硬约束）
+  - 覆盖正常查询场景：mock `DescribeInstantTasks` 返回非空任务列表，验证字段映射与 `total` 设置、`d.Id()` 设置
+  - 覆盖空列表场景：mock 返回空列表，验证不报错、正常设置 id
+  - 覆盖 API 错误场景：mock 返回错误，验证错误被返回
+  - 禁止通过 `go test` 命令执行单元测试，但需保证生成的代码在当前环境下可正确构建执行
+
+## 7. 代码正确性检查与验证（收尾阶段）
+
+- [x] 7.1 检查所有函数返回的 error 是否被检查；必定不出错的函数使用 `_ = func()` 将 err 赋值给 `_`
+- [x] 7.2 检查 service 层调用云 API 的超时时间是否使用 `tccommon.ReadRetryTimeout`，错误是否使用 `tccommon.RetryError()` 包装
+- [x] 7.3 验证字段映射与 vendor 中 `SingleInstantTask`/`DescribeInstantTasksResponseParams` 一致（TaskId/TargetAddress/TaskType/ProbeTime/Status/SuccessRate/NodeCount/TaskCategory/Tasks/Total）
+- [ ] 7.4 在收尾阶段通过 tfpacer-finalize skill 执行 `gofmt`、`make doc`、生成 `.changelog` 文件并 amend 推送

--- a/openspec/specs/cat-instant-tasks-datasource/spec.md
+++ b/openspec/specs/cat-instant-tasks-datasource/spec.md
@@ -1,0 +1,153 @@
+# cat-instant-tasks-datasource Specification
+
+## Purpose
+TBD - created by syncing change add-cat-instant-tasks-datasource. Update Purpose after archive.
+## Requirements
+### Requirement: Data Source Schema Definition
+
+`tencentcloud_cat_instant_tasks` 数据源 SHALL 支持以下输出属性，所有列表项字段平铺在 `tasks` 列表元素内（不额外嵌套一层），顶层提供 `total` 与 `result_output_file`：
+
+**Output Attributes:**
+- `tasks` (List): 历史即时拨测任务列表，每个元素包含：
+  - `task_id` (String): 任务 ID（映射 `SingleInstantTask.TaskId`）
+  - `target_address` (String): 任务地址（映射 `SingleInstantTask.TargetAddress`）
+  - `task_type` (Int): 任务类型（映射 `SingleInstantTask.TaskType`）
+  - `probe_time` (Int): 测试时间（映射 `SingleInstantTask.ProbeTime`）
+  - `status` (String): 任务状态（映射 `SingleInstantTask.Status`）
+  - `success_rate` (Float): 成功率（映射 `SingleInstantTask.SuccessRate`）
+  - `node_count` (Int): 节点数量（映射 `SingleInstantTask.NodeCount`）
+  - `task_category` (Int): 节点类型（映射 `SingleInstantTask.TaskCategory`）
+- `total` (Int): 任务总数（映射 `response.Response.Total`）
+- `result_output_file` (String, Optional): 将查询结果导出到指定文件
+
+数据源 SHALL NOT 向用户暴露 `limit`/`offset` 分页参数；分页 SHALL 在 service 层内部自动完成，获取全部历史即时拨测任务。
+
+#### Scenario: Query all instant tasks
+
+```hcl
+data "tencentcloud_cat_instant_tasks" "example" {
+}
+
+output "tasks" {
+  value = data.tencentcloud_cat_instant_tasks.example.tasks
+}
+
+output "total" {
+  value = data.tencentcloud_cat_instant_tasks.example.total
+}
+```
+
+- **WHEN** 用户不带任何参数查询 `tencentcloud_cat_instant_tasks`
+- **THEN** 返回当前账号下全部历史即时拨测任务
+- **AND** `tasks` 列表中每个元素包含 `task_id`/`target_address`/`task_type`/`probe_time`/`status`/`success_rate`/`node_count`/`task_category` 字段
+- **AND** `total` 反映任务总数
+
+#### Scenario: Export query results to file
+
+```hcl
+data "tencentcloud_cat_instant_tasks" "export" {
+  result_output_file = "/tmp/cat_instant_tasks.json"
+}
+```
+
+- **WHEN** 用户指定 `result_output_file`
+- **THEN** 查询结果以 JSON 格式写入指定文件
+- **AND** 文件内容包含完整的任务列表信息
+
+### Requirement: Service Layer Implementation
+
+`service_tencentcloud_cat.go` SHALL 新增方法用于封装 `DescribeInstantTasks` 接口，内部实现自动分页：
+
+```go
+func (me *CatService) DescribeCatInstantTasksByFilter(ctx context.Context) (tasks []*cat.SingleInstantTask, total *uint64, errRet error)
+```
+
+实现约束：
+1. 使用固定 `pageSize`（云 API 支持的最大值）循环分页，累积 `response.Response.Tasks`，直到本页返回数量小于 `pageSize` 即停止
+2. 每次请求前调用 `ratelimit.Check(request.GetAction())`
+3. 每次请求后记录 `[DEBUG]` 级别的请求体与响应体日志
+4. 失败时记录 `[CRITAL]` 级别错误日志并返回错误
+5. 返回累积后的全部 `tasks` 与最后一次响应的 `total`
+
+#### Scenario: Service method handles empty list
+
+- **WHEN** API 返回非 nil 响应但 `response.Response.Tasks` 为空列表
+- **THEN** service 方法返回空（长度为 0）的 `tasks` 切片与对应的 `total`
+- **AND** 不返回错误
+
+#### Scenario: Service method handles API errors
+
+- **WHEN** API 调用返回错误
+- **THEN** service 方法记录 `[CRITAL]` 错误日志（含请求体与错误原因）
+- **AND** 返回该错误，由上层 retry 机制决定是否重试
+
+#### Scenario: Service method paginates all results
+
+- **WHEN** 历史即时拨测任务数量超过单页 `pageSize`
+- **THEN** service 方法循环调用 `DescribeInstantTasks`，逐步累加 `offset`
+- **AND** 返回所有页累积合并后的完整 `tasks` 列表
+
+### Requirement: Read Retry and Empty-Response Handling
+
+Data Source 的 Read 方法 SHALL 使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包裹 service 方法调用，并通过 `tccommon.RetryError(e)` 包装错误。在 retry 块内 SHALL 满足：
+
+1. 若 service 方法返回错误，使用 `tccommon.RetryError(e)` 包装返回，由外层 retry 决定重试
+2. 若云 API 返回空（`response == nil` / `response.Response == nil` 等，表现为 `tasks == nil && total == nil`），SHALL 直接返回 `tccommon.NonRetryableError`，不调用 `d.SetId("")`，保留现场便于排障
+3. 若 API 返回正常但列表为空（`len(tasks) == 0`），SHALL 视为正常空结果，打印 `log.Printf("[DATASOURCE] read empty, skip SetId")` 后继续后续逻辑，不返回错误
+
+#### Scenario: Retry on transient API failure
+
+- **WHEN** `DescribeInstantTasks` 出现临时性错误
+- **THEN** 通过 `resource.Retry` 自动重试，直到成功或达到 `tccommon.ReadRetryTimeout` 超时
+- **AND** 重试耗尽后以"重试耗尽"形式失败，便于人工介入
+
+#### Scenario: Reject clearing id on nil response
+
+- **WHEN** API 返回的响应为 nil（异常情况）
+- **THEN** Read 方法返回 `NonRetryableError`，不执行 `d.SetId("")`
+- **AND** 避免因 API 短暂波动导致本地 state 中的 id 被清空
+
+### Requirement: Provider Registration
+
+`tencentcloud/provider.go` 的 `DataSourcesMap` SHALL 注册新数据源：
+
+```go
+"tencentcloud_cat_instant_tasks": cat.DataSourceTencentCloudCatInstantTasks(),
+```
+
+#### Scenario: Data source is accessible via Terraform
+
+- **WHEN** 用户在 Terraform 配置中使用 `data "tencentcloud_cat_instant_tasks"`
+- **THEN** Provider 能识别该数据源，不报 "provider doesn't support data source" 错误
+
+### Requirement: Documentation
+
+数据源 SHALL 提供文档文件 `data_source_tc_cat_instant_tasks.md`，内容包括：
+1. 一句话描述，须带上所属云产品名称（CAT / 云拨测）
+2. 使用示例（基本查询）
+3. 不手写 `Argument Reference` 与 `Attribute Reference`（由工具自动生成）
+
+`provider.md` 中 CAT 部分的 Data Source 条目 SHALL 通过 `make doc` 自动生成，不手动编辑 `website/` 目录。
+
+#### Scenario: User finds data source in documentation
+
+- **WHEN** 用户查看生成的文档
+- **THEN** 能看到 `tencentcloud_cat_instant_tasks` 的一句话描述与示例
+- **AND** 文档由 `make doc` 自动生成，无需手动维护 `website/docs/`
+
+### Requirement: Testing
+
+数据源 SHALL 提供单元测试文件 `data_source_tc_cat_instant_tasks_test.go`，使用 mock（gomonkey）方式对云 API 进行 mock，只做业务代码逻辑的单元测试（不使用 terraform 测试套件）。测试 SHALL 覆盖：
+1. 正常查询场景（mock 返回非空任务列表，验证字段映射与 `total` 设置）
+2. 空列表场景（mock 返回空列表，验证不报错、正常设置 id）
+3. API 错误场景（mock 返回错误，验证错误被返回）
+
+#### Scenario: Unit test covers normal query
+
+- **WHEN** mock `DescribeInstantTasks` 返回包含若干 `SingleInstantTask` 的响应
+- **THEN** 单元测试验证 `tasks` 列表字段被正确映射、`total` 被正确设置、`d.Id()` 被设置为任务 id 哈希
+
+#### Scenario: Unit test covers empty list
+
+- **WHEN** mock `DescribeInstantTasks` 返回空任务列表
+- **THEN** 单元测试验证 Read 不报错并正常完成

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1029,6 +1029,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_cat_metric_data":                                        cat.DataSourceTencentCloudCatMetricData(),
 			"tencentcloud_cat_probe_metric_tag_values":                            cat.DataSourceTencentCloudCatProbeMetricTagValues(),
 			"tencentcloud_cat_node_groups":                                        cat.DataSourceTencentCloudCatNodeGroups(),
+			"tencentcloud_cat_instant_tasks":                                      cat.DataSourceTencentCloudCatInstantTasks(),
 			"tencentcloud_rum_project":                                            rum.DataSourceTencentCloudRumProject(),
 			"tencentcloud_rum_offline_log_config":                                 rum.DataSourceTencentCloudRumOfflineLogConfig(),
 			"tencentcloud_rum_whitelist":                                          rum.DataSourceTencentCloudRumWhitelist(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1758,6 +1758,7 @@ tencentcloud_cat_node
 tencentcloud_cat_node_groups
 tencentcloud_cat_metric_data
 tencentcloud_cat_probe_metric_tag_values
+tencentcloud_cat_instant_tasks
 
 Resource
 tencentcloud_cat_task_set

--- a/tencentcloud/services/cat/data_source_tc_cat_instant_tasks.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_instant_tasks.go
@@ -1,0 +1,166 @@
+package cat
+
+import (
+	"context"
+	"log"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	cat "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudCatInstantTasks() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudCatInstantTasksRead,
+		Schema: map[string]*schema.Schema{
+			"tasks": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "History instant tasks list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"task_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Task ID.",
+						},
+						"target_address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Target address.",
+						},
+						"task_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Task type.",
+						},
+						"probe_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Probe time.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Task status.",
+						},
+						"success_rate": {
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: "Success rate.",
+						},
+						"node_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Node count.",
+						},
+						"task_category": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Task category.",
+						},
+					},
+				},
+			},
+			"total": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Total number of instant tasks.",
+			},
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudCatInstantTasksRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_cat_instant_tasks.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+	catService := CatService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+
+	var tasks []*cat.SingleInstantTask
+	var total *uint64
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		results, totalRet, e := catService.DescribeCatInstantTasksByFilter(ctx)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if results == nil && totalRet == nil {
+			return resource.NonRetryableError(nil)
+		}
+
+		tasks = results
+		total = totalRet
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s read cat_instant_tasks failed, reason:%+v", logId, err)
+		return err
+	}
+
+	ids := make([]string, 0, len(tasks))
+	tasksList := make([]map[string]interface{}, 0, len(tasks))
+	for _, task := range tasks {
+		taskMap := map[string]interface{}{}
+		if task.TaskId != nil {
+			taskMap["task_id"] = task.TaskId
+		}
+		if task.TargetAddress != nil {
+			taskMap["target_address"] = task.TargetAddress
+		}
+		if task.TaskType != nil {
+			taskMap["task_type"] = task.TaskType
+		}
+		if task.ProbeTime != nil {
+			taskMap["probe_time"] = task.ProbeTime
+		}
+		if task.Status != nil {
+			taskMap["status"] = task.Status
+		}
+		if task.SuccessRate != nil {
+			taskMap["success_rate"] = task.SuccessRate
+		}
+		if task.NodeCount != nil {
+			taskMap["node_count"] = task.NodeCount
+		}
+		if task.TaskCategory != nil {
+			taskMap["task_category"] = task.TaskCategory
+		}
+
+		if task.TaskId != nil {
+			ids = append(ids, *task.TaskId)
+		}
+		tasksList = append(tasksList, taskMap)
+	}
+
+	if len(tasks) == 0 {
+		log.Printf("[DATASOURCE] read empty, skip SetId")
+	}
+
+	d.SetId(helper.DataResourceIdsHash(ids))
+	_ = d.Set("tasks", tasksList)
+	if total != nil {
+		_ = d.Set("total", total)
+	}
+
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), tasksList); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/cat/data_source_tc_cat_instant_tasks.md
+++ b/tencentcloud/services/cat/data_source_tc_cat_instant_tasks.md
@@ -1,0 +1,16 @@
+Use this data source to query historical instant tasks of CAT (Cat).
+
+Example Usage
+
+```hcl
+data "tencentcloud_cat_instant_tasks" "example" {
+}
+
+output "tasks" {
+  value = data.tencentcloud_cat_instant_tasks.example.tasks
+}
+
+output "total" {
+  value = data.tencentcloud_cat_instant_tasks.example.total
+}
+```

--- a/tencentcloud/services/cat/data_source_tc_cat_instant_tasks_test.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_instant_tasks_test.go
@@ -1,16 +1,17 @@
 package cat_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/agiledagon/gomonkey/v2"
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	cat "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409"
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
-	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cat"
+	svccat "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cat"
 )
 
 type mockMetaForCatInstantTasksDS struct {
@@ -53,7 +54,7 @@ func TestCatInstantTasksDS_ReadBasic(t *testing.T) {
 	catClient := &cat.Client{}
 	patches.ApplyMethodReturn(newMockMetaForCatInstantTasksDS().client, "UseCatClient", catClient)
 
-	patches.ApplyMethodFunc(catClient, "DescribeInstantTasks", func(request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
+	patches.ApplyMethodFunc(catClient, "DescribeInstantTasksWithContext", func(ctx context.Context, request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
 		resp := cat.NewDescribeInstantTasksResponse()
 		resp.Response = &cat.DescribeInstantTasksResponseParams{
 			Tasks: []*cat.SingleInstantTask{
@@ -67,7 +68,7 @@ func TestCatInstantTasksDS_ReadBasic(t *testing.T) {
 	})
 
 	meta := newMockMetaForCatInstantTasksDS()
-	res := cat.DataSourceTencentCloudCatInstantTasks()
+	res := svccat.DataSourceTencentCloudCatInstantTasks()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
 
 	err := res.Read(d, meta)
@@ -102,7 +103,7 @@ func TestCatInstantTasksDS_ReadEmpty(t *testing.T) {
 	catClient := &cat.Client{}
 	patches.ApplyMethodReturn(newMockMetaForCatInstantTasksDS().client, "UseCatClient", catClient)
 
-	patches.ApplyMethodFunc(catClient, "DescribeInstantTasks", func(request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
+	patches.ApplyMethodFunc(catClient, "DescribeInstantTasksWithContext", func(ctx context.Context, request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
 		resp := cat.NewDescribeInstantTasksResponse()
 		resp.Response = &cat.DescribeInstantTasksResponseParams{
 			Tasks:     []*cat.SingleInstantTask{},
@@ -113,7 +114,7 @@ func TestCatInstantTasksDS_ReadEmpty(t *testing.T) {
 	})
 
 	meta := newMockMetaForCatInstantTasksDS()
-	res := cat.DataSourceTencentCloudCatInstantTasks()
+	res := svccat.DataSourceTencentCloudCatInstantTasks()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
 
 	err := res.Read(d, meta)
@@ -133,12 +134,12 @@ func TestCatInstantTasksDS_ReadError(t *testing.T) {
 	catClient := &cat.Client{}
 	patches.ApplyMethodReturn(newMockMetaForCatInstantTasksDS().client, "UseCatClient", catClient)
 
-	patches.ApplyMethodFunc(catClient, "DescribeInstantTasks", func(request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
+	patches.ApplyMethodFunc(catClient, "DescribeInstantTasksWithContext", func(ctx context.Context, request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
 		return nil, assert.AnError
 	})
 
 	meta := newMockMetaForCatInstantTasksDS()
-	res := cat.DataSourceTencentCloudCatInstantTasks()
+	res := svccat.DataSourceTencentCloudCatInstantTasks()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
 
 	err := res.Read(d, meta)
@@ -146,7 +147,7 @@ func TestCatInstantTasksDS_ReadError(t *testing.T) {
 }
 
 func TestCatInstantTasksDS_Schema(t *testing.T) {
-	res := cat.DataSourceTencentCloudCatInstantTasks()
+	res := svccat.DataSourceTencentCloudCatInstantTasks()
 
 	assert.NotNil(t, res)
 	assert.Contains(t, res.Schema, "tasks")

--- a/tencentcloud/services/cat/data_source_tc_cat_instant_tasks_test.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_instant_tasks_test.go
@@ -1,0 +1,177 @@
+package cat_test
+
+import (
+	"testing"
+
+	"github.com/agiledagon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	cat "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cat"
+)
+
+type mockMetaForCatInstantTasksDS struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForCatInstantTasksDS) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForCatInstantTasksDS{}
+
+func newMockMetaForCatInstantTasksDS() *mockMetaForCatInstantTasksDS {
+	return &mockMetaForCatInstantTasksDS{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringCITDS(s string) *string { return &s }
+
+func ptrUint64CITDS(v uint64) *uint64 { return &v }
+
+func ptrFloat64CITDS(v float64) *float64 { return &v }
+
+func buildSingleInstantTask(taskId, targetAddress, status string, taskType, probeTime, nodeCount, taskCategory uint64, successRate float64) *cat.SingleInstantTask {
+	return &cat.SingleInstantTask{
+		TaskId:        ptrStringCITDS(taskId),
+		TargetAddress: ptrStringCITDS(targetAddress),
+		TaskType:      ptrUint64CITDS(taskType),
+		ProbeTime:     ptrUint64CITDS(probeTime),
+		Status:        ptrStringCITDS(status),
+		SuccessRate:   ptrFloat64CITDS(successRate),
+		NodeCount:     ptrUint64CITDS(nodeCount),
+		TaskCategory:  ptrUint64CITDS(taskCategory),
+	}
+}
+
+func TestCatInstantTasksDS_ReadBasic(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatInstantTasksDS().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeInstantTasks", func(request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
+		resp := cat.NewDescribeInstantTasksResponse()
+		resp.Response = &cat.DescribeInstantTasksResponseParams{
+			Tasks: []*cat.SingleInstantTask{
+				buildSingleInstantTask("task-001", "http://www.example.com", "success", 1, 1667923200, 3, 1, 99.5),
+				buildSingleInstantTask("task-002", "http://www.test.com", "failed", 2, 1667923300, 5, 2, 80.0),
+			},
+			Total:     ptrUint64CITDS(2),
+			RequestId: ptrStringCITDS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCatInstantTasksDS()
+	res := cat.DataSourceTencentCloudCatInstantTasks()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	tasks := d.Get("tasks").([]interface{})
+	assert.Len(t, tasks, 2)
+
+	task0 := tasks[0].(map[string]interface{})
+	assert.Equal(t, "task-001", task0["task_id"].(string))
+	assert.Equal(t, "http://www.example.com", task0["target_address"].(string))
+	assert.Equal(t, 1, task0["task_type"].(int))
+	assert.Equal(t, 1667923200, task0["probe_time"].(int))
+	assert.Equal(t, "success", task0["status"].(string))
+	assert.Equal(t, 99.5, task0["success_rate"].(float64))
+	assert.Equal(t, 3, task0["node_count"].(int))
+	assert.Equal(t, 1, task0["task_category"].(int))
+
+	task1 := tasks[1].(map[string]interface{})
+	assert.Equal(t, "task-002", task1["task_id"].(string))
+	assert.Equal(t, "http://www.test.com", task1["target_address"].(string))
+
+	total := d.Get("total").(int)
+	assert.Equal(t, 2, total)
+}
+
+func TestCatInstantTasksDS_ReadEmpty(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatInstantTasksDS().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeInstantTasks", func(request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
+		resp := cat.NewDescribeInstantTasksResponse()
+		resp.Response = &cat.DescribeInstantTasksResponseParams{
+			Tasks:     []*cat.SingleInstantTask{},
+			Total:     ptrUint64CITDS(0),
+			RequestId: ptrStringCITDS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCatInstantTasksDS()
+	res := cat.DataSourceTencentCloudCatInstantTasks()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	tasks := d.Get("tasks").([]interface{})
+	assert.Len(t, tasks, 0)
+
+	total := d.Get("total").(int)
+	assert.Equal(t, 0, total)
+}
+
+func TestCatInstantTasksDS_ReadError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatInstantTasksDS().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeInstantTasks", func(request *cat.DescribeInstantTasksRequest) (*cat.DescribeInstantTasksResponse, error) {
+		return nil, assert.AnError
+	})
+
+	meta := newMockMetaForCatInstantTasksDS()
+	res := cat.DataSourceTencentCloudCatInstantTasks()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}
+
+func TestCatInstantTasksDS_Schema(t *testing.T) {
+	res := cat.DataSourceTencentCloudCatInstantTasks()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "tasks")
+	assert.Contains(t, res.Schema, "total")
+	assert.Contains(t, res.Schema, "result_output_file")
+
+	tasksSchema := res.Schema["tasks"]
+	assert.Equal(t, schema.TypeList, tasksSchema.Type)
+	assert.True(t, tasksSchema.Computed)
+
+	elemRes := tasksSchema.Elem.(*schema.Resource)
+	assert.Contains(t, elemRes.Schema, "task_id")
+	assert.Contains(t, elemRes.Schema, "target_address")
+	assert.Contains(t, elemRes.Schema, "task_type")
+	assert.Contains(t, elemRes.Schema, "probe_time")
+	assert.Contains(t, elemRes.Schema, "status")
+	assert.Contains(t, elemRes.Schema, "success_rate")
+	assert.Contains(t, elemRes.Schema, "node_count")
+	assert.Contains(t, elemRes.Schema, "task_category")
+
+	totalSchema := res.Schema["total"]
+	assert.Equal(t, schema.TypeInt, totalSchema.Type)
+	assert.True(t, totalSchema.Computed)
+
+	outputSchema := res.Schema["result_output_file"]
+	assert.Equal(t, schema.TypeString, outputSchema.Type)
+	assert.True(t, outputSchema.Optional)
+}

--- a/tencentcloud/services/cat/service_tencentcloud_cat.go
+++ b/tencentcloud/services/cat/service_tencentcloud_cat.go
@@ -458,3 +458,54 @@ func (me *CatService) DescribeCatNodeGroupsByFilter(ctx context.Context, param m
 
 	return
 }
+
+func (me *CatService) DescribeCatInstantTasksByFilter(ctx context.Context) (tasks []*cat.SingleInstantTask, total *uint64, errRet error) {
+	var (
+		logId   = tccommon.GetLogId(ctx)
+		request = cat.NewDescribeInstantTasksRequest()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	var pageSize uint64 = 100
+	var offset uint64 = 0
+	tasks = make([]*cat.SingleInstantTask, 0)
+
+	for {
+		request.Limit = &pageSize
+		request.Offset = &offset
+		ratelimit.Check(request.GetAction())
+		response, err := me.client.UseCatClient().DescribeInstantTasks(request)
+		if err != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), err.Error())
+			errRet = err
+			return
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+			logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+		if response == nil || response.Response == nil {
+			break
+		}
+
+		if response.Response.Tasks != nil {
+			tasks = append(tasks, response.Response.Tasks...)
+		}
+		if response.Response.Total != nil {
+			total = response.Response.Total
+		}
+
+		if len(response.Response.Tasks) < int(pageSize) {
+			break
+		}
+		offset += pageSize
+	}
+
+	return
+}

--- a/website/docs/d/cat_instant_tasks.html.markdown
+++ b/website/docs/d/cat_instant_tasks.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Cloud Automated Testing(CAT)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_cat_instant_tasks"
+sidebar_current: "docs-tencentcloud-datasource-cat_instant_tasks"
+description: |-
+  Use this data source to query historical instant tasks of CAT (Cat).
+---
+
+# tencentcloud_cat_instant_tasks
+
+Use this data source to query historical instant tasks of CAT (Cat).
+
+## Example Usage
+
+```hcl
+data "tencentcloud_cat_instant_tasks" "example" {
+}
+
+output "tasks" {
+  value = data.tencentcloud_cat_instant_tasks.example.tasks
+}
+
+output "total" {
+  value = data.tencentcloud_cat_instant_tasks.example.total
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `result_output_file` - (Optional, String) Used to save results.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `tasks` - History instant tasks list.
+  * `node_count` - Node count.
+  * `probe_time` - Probe time.
+  * `status` - Task status.
+  * `success_rate` - Success rate.
+  * `target_address` - Target address.
+  * `task_category` - Task category.
+  * `task_id` - Task ID.
+  * `task_type` - Task type.
+* `total` - Total number of instant tasks.
+
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -1035,6 +1035,9 @@
                             <a href="#">Data Sources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/d/cat_instant_tasks.html">tencentcloud_cat_instant_tasks</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/d/cat_metric_data.html">tencentcloud_cat_metric_data</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add a new data source `tencentcloud_cat_instant_tasks` to query the list of historical instant probe tasks from the CAT (Cloud Automated Testing) service via the `DescribeInstantTasks` API. The data source supports automatic pagination and exposes task fields (task_id, target_address, task_type, probe_time, status, success_rate, node_count, task_category) and total count.