### PR TITLE
feat(cat): [133294964] add tencentcloud_cat_node_groups data source

### DIFF
--- a/.changelog/4480.txt
+++ b/.changelog/4480.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_cat_node_groups
+```

--- a/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/design.md
+++ b/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The TencentCloud Terraform provider serves the CAT (Cloud Automated Testing / 拨测) product via the SDK package `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409`. Three CAT data sources already exist (`tencentcloud_cat_node`, `tencentcloud_cat_probe_data`, `tencentcloud_cat_metric_data`), implemented in `tencentcloud/services/cat/`.
+
+This change adds a fourth data source, `tencentcloud_cat_node_groups`, backed by the cloud API `DescribeNodeGroups` (获取拨测点组). `DescribeNodeGroups` returns a two-level tree of probe node groups (`NodeList []*NodeTree`), plus reference lists for districts (`DistrictList []*DistinctOrNetServiceInfo`) and ISPs (`NetServiceList []*DistinctOrNetServiceInfo`). The request accepts optional filters (node type, task category, IP type, name, region id, district id, net service id, node group type, task type, probe type).
+
+Key SDK types (already vendored, verified):
+- `DescribeNodeGroupsRequest`: scalar/pointer fields — `NodeType []*int64`, `TaskCategory *int64`, `IPType *int64`, `Name *string`, `RegionID *int64`, `DistrictID *int64`, `NetServiceID *int64`, `NodeGroupType *int64`, `TaskType *int64`, `ProbeType *uint64`.
+- `DescribeNodeGroupsResponse.Response`: `NodeList []*NodeTree`, `DistrictList []*DistinctOrNetServiceInfo`, `NetServiceList []*DistinctOrNetServiceInfo`.
+- `NodeTree`: `ID *string`, `Content *string`, `Children []*NodeLeaf`.
+- `NodeLeaf`: `ID *string`, `Content *string`, `Children []*NodeInfoBase`.
+- `NodeInfoBase`: `ID *string`, `Content *string`.
+- `DistinctOrNetServiceInfo`: `ID *string`, `Name *string`.
+
+`DescribeNodeGroups` is a synchronous API with no pagination parameters (no `Limit`/`Offset`). The response is a complete tree, so no pagination loop is required.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a read-only Terraform data source that exposes all filter inputs of `DescribeNodeGroups` and flattens the complete response (`NodeList` tree, `DistrictList`, `NetServiceList`) into Terraform state.
+- Follow the established CAT data source conventions (`data_source_tc_cat_node.go`) for imports, helper usage, retry wrapping, and `result_output_file` handling.
+- Follow the established list-datasource conventions (`data_source_tc_igtm_instance_list.go`) for the retry-wrapped service call and `NonRetryableError` on a nil response inside the retry block (per project rule: a data source Read MUST NOT clear the id on a transient empty API response).
+- Provide gomonkey-mocked unit tests (no acceptance suite), per the project rule that new data sources use mock-based unit tests for business logic.
+- Remain fully backward compatible (purely additive).
+
+**Non-Goals:**
+- No CRUD resource is created (this is a data source only).
+- No pagination handling (the API does not paginate).
+- No modification of the existing `tencentcloud_cat_node` data source.
+- No changes to the `vendor/` SDK (already vendored via go.mod).
+
+## Decisions
+
+### Decision 1: No pagination loop in the service layer
+`DescribeNodeGroups` has no `Limit`/`Offset` parameters and returns the complete node-group tree in a single call. We therefore do NOT implement an internal pagination loop (unlike `DescribeIgtmInstanceListByFilter`). The service method makes a single SDK call inside one `resource.Retry(tccommon.ReadRetryTimeout, ...)` block.
+
+**Alternative considered:** Add a defensive pagination loop for future-proofing. **Rejected** because there are no pagination parameters on the request/response and inventing them would cause SDK errors.
+
+### Decision 2: Nil-response handling returns `NonRetryableError` inside the retry block
+Per the project rule for `RESOURCE_KIND_DATASOURCE`, the Read retry block MUST check whether the API returned an empty/nil response and return `resource.NonRetryableError` (NOT clear `d.SetId("")`). This prevents a transient API hiccup from wiping the local state id. The check covers `result == nil`, `result.Response == nil`, and `result.Response.NodeList == nil && result.Response.DistrictList == nil && result.Response.NetServiceList == nil`. An empty-but-non-nil response (all three lists empty) is treated as a valid result and does NOT error — it simply yields empty computed lists.
+
+### Decision 3: Schema flattening matches the JsonPath mapping exactly
+The output schema follows the documented JsonPath → SchemaName mapping:
+- `node_list` (`TypeList`) — top-level `NodeTree` items, each with `id`, `content`, and nested `children`.
+  - `children` (`TypeList`) — `NodeLeaf` items, each with `id`, `content`, and nested `children`.
+    - inner `children` (`TypeList`) — `NodeInfoBase` items, each with `id`, `content` (no further nesting).
+- `district_list` (`TypeList`) — `DistinctOrNetServiceInfo` items, each with `id`, `name`.
+- `net_service_list` (`TypeList`) — `DistinctOrNetServiceInfo` items, each with `id`, `name`.
+
+The same base name `children` is reused at two nesting levels (per the mapping), and `id`/`content` are reused at each level. Each `id` field is a `TypeString` (the SDK types are `*string`).
+
+### Decision 4: `node_type` is a `TypeList` of `TypeInt`
+The cloud API `NodeType` is `[]*int64` (a slice), while every other input filter is a scalar pointer. To faithfully represent the API, `node_type` is declared as `schema.TypeList` with `Elem: &schema.Schema{Type: schema.TypeInt}`. All other inputs are scalar `TypeInt`/`TypeString` matching their SDK pointer types. When building the request, `node_type` is converted from `[]interface{}` (Terraform) to `[]*int64` (SDK) via `helper.IntPtr` per element.
+
+### Decision 5: Data source id uses `helper.DataResourceIdsHash`
+Following the existing `tencentcloud_cat_node` data source convention, the id is computed as `helper.DataResourceIdsHash(ids)` where `ids` are the top-level `NodeTree.ID` values. This gives a deterministic, content-derived id (preferred over `helper.BuildToken()`'s random token for CAT data sources, and consistent with the sibling `cat_node` data source).
+
+### Decision 6: `result_output_file` writes the flattened lists
+Following `tencentcloud_cat_node`, `result_output_file` (if set) writes the flattened `nodeListTmp` (the node list maps) to the file. This keeps the CAT data sources internally consistent.
+
+### Decision 7: `node_type` request field — single-value convenience
+Because `DescribeNodeGroups.NodeType` is a list but the most common usage is a single value, we accept a Terraform list and convert each element to `*int64`. Users may pass one or more node types; the API takes the union.
+
+## Risks / Trade-offs
+
+- **[Risk] Nested schema depth (three levels of `children`) is verbose.** → **Mitigation:** The nesting is fixed by the cloud API response shape (`NodeTree` → `NodeLeaf` → `NodeInfoBase`); we mirror it exactly so flattening is mechanical and each level has only `id`/`content` (+ optional `children`). No deeper nesting exists in the SDK.
+- **[Risk] Empty response could be confused with API error.** → **Mitigation:** We distinguish nil/empty: a structurally nil response (`result == nil`, `Response == nil`, or all three lists nil) raises `NonRetryableError` so the outer retry keeps trying; a non-nil response with empty lists is a valid empty result.
+- **[Risk] `node_type` being a list diverges from the other scalar filters and may surprise users.** → **Mitigation:** This mirrors the cloud API exactly (`NodeType []*int64`). Documented in the schema `Description` and the example `.md`.
+- **[Risk] Forgetting to update `provider.go` doc-comment breaks `make doc`.** → **Mitigation:** tasks.md explicitly lists updating both the `DataSourcesMap` entry and the provider.go doc-comment index.
+- **[Trade-off] No deterministic ordering guarantee from the API.** The `node_list`/`district_list`/`net_service_list` order follows whatever `DescribeNodeGroups` returns; we do not re-sort.

--- a/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/proposal.md
+++ b/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The Terraform Provider for TencentCloud currently exposes `tencentcloud_cat_node`, `tencentcloud_cat_probe_data`, and `tencentcloud_cat_metric_data` data sources for the CAT (Cloud Automated Testing / 拨测) product, but there is no way to query the available **probe node groups** (拨测点组). Probe node groups — including availability probe groups, advanced probe groups, and user-defined "my probe groups" — are the top-level organizing unit for selecting dial-test nodes when creating probe tasks. Without a data source for node groups, users must hard-code node group IDs into their Terraform configurations, which is fragile and not portable across accounts or regions. Adding a `tencentcloud_cat_node_groups` data source lets users dynamically discover probe node groups (filtered by node type, task category, IP type, region, district, ISP, etc.) and feed them into probe task resources.
+
+## What Changes
+
+- Add a new data source `tencentcloud_cat_node_groups` backed by the cloud API `DescribeNodeGroups` (package `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409`).
+- Expose 10 optional filter arguments: `node_type`, `task_category`, `ip_type`, `name`, `region_id`, `district_id`, `net_service_id`, `node_group_type`, `task_type`, `probe_type`.
+- Expose three computed output collections:
+  - `node_list` — the tree of probe node groups (two-level: `NodeTree` → `Children` (`NodeLeaf`) → `Children` (`NodeInfoBase`)), each level with `id`, `content`, and nested `children`.
+  - `district_list` — province/country list, each with `id` and `name`.
+  - `net_service_list` — ISP list, each with `id` and `name`.
+- Register the new data source in `tencentcloud/provider.go` (`DataSourcesMap`) and update the provider doc-comment index for `make doc`.
+- Add the hand-written example file `tencentcloud/services/cat/data_source_tc_cat_node_groups.md`.
+- Add the service-layer method `DescribeCatNodeGroupsByFilter` to `tencentcloud/services/cat/service_tencentcloud_cat.go` (single API call, no pagination — `DescribeNodeGroups` returns the full tree).
+- Add the data source file `tencentcloud/services/cat/data_source_tc_cat_node_groups.go`.
+- Add gomonkey-based unit tests in `tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go` (mock the SDK client; no Terraform acceptance suite).
+
+## Capabilities
+
+### New Capabilities
+
+- `cat-node-groups-datasource`: A data source that queries CAT probe node groups via `DescribeNodeGroups`, supports filter arguments (node type, task category, IP type, name, region, district, ISP, node group type, task type, probe type), and flattens the returned `node_list` tree plus `district_list` and `net_service_list` into Terraform state.
+
+### Modified Capabilities
+
+<!-- None — this is a purely additive data source. No existing spec-level behavior changes. -->
+
+## Impact
+
+- **New files**:
+  - `tencentcloud/services/cat/data_source_tc_cat_node_groups.go`
+  - `tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go`
+  - `tencentcloud/services/cat/data_source_tc_cat_node_groups.md`
+- **Modified files**:
+  - `tencentcloud/services/cat/service_tencentcloud_cat.go` — add `DescribeCatNodeGroupsByFilter` method.
+  - `tencentcloud/provider.go` — register `tencentcloud_cat_node_groups` in `DataSourcesMap` and update the doc-comment index.
+- **Cloud API dependency**: `DescribeNodeGroups` in `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409` (already vendored).
+- **Documentation**: `make doc` will generate `website/docs/d/cat_node_groups.html.markdown` and update `website/tencentcloud.erb`.
+- **Backward compatibility**: Fully additive; no existing resources or data sources are modified. No breaking changes.

--- a/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/specs/cat-node-groups-datasource/spec.md
+++ b/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/specs/cat-node-groups-datasource/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Data source `tencentcloud_cat_node_groups` SHALL exist and expose `DescribeNodeGroups` filters
+The provider SHALL register a data source named `tencentcloud_cat_node_groups` whose Read operation calls the cloud API `DescribeNodeGroups` (package `cat.v20180409`). The data source SHALL expose the following optional filter arguments, each mapped to the corresponding cloud API request field: `node_type` (`NodeType`, list of int), `task_category` (`TaskCategory`, int), `ip_type` (`IPType`, int), `name` (`Name`, string), `region_id` (`RegionID`, int), `district_id` (`DistrictID`, int), `net_service_id` (`NetServiceID`, int), `node_group_type` (`NodeGroupType`, int), `task_type` (`TaskType`, int), `probe_type` (`ProbeType`, int). Only arguments provided by the user SHALL be set on the request; unset arguments SHALL NOT be sent (relying on API defaults).
+
+#### Scenario: All filter arguments optional
+- **WHEN** a user declares `data "tencentcloud_cat_node_groups" "groups" {}` with no filter arguments
+- **THEN** the Read function SHALL build a `DescribeNodeGroupsRequest` with no filter fields set and the API SHALL return the default (unfiltered) node-group tree
+
+#### Scenario: Single filter applied
+- **WHEN** a user sets `node_type = [1]` and `ip_type = 1`
+- **THEN** the Read function SHALL set `request.NodeType = []*int64{int64Ptr(1)}` and `request.IPType = int64Ptr(1)`, and SHALL leave all other request fields unset
+
+#### Scenario: node_type accepts multiple values
+- **WHEN** a user sets `node_type = [1, 2]`
+- **THEN** the Read function SHALL convert each element to `*int64` and assign the resulting slice to `request.NodeType`
+
+### Requirement: The data source SHALL flatten `DescribeNodeGroups` response into computed attributes
+The Read function SHALL flatten the `DescribeNodeGroupsResponse.Response` into three computed `TypeList` attributes:
+- `node_list`: one entry per `NodeList` item (`NodeTree`). Each entry SHALL expose `id` (`NodeTree.ID`, string), `content` (`NodeTree.Content`, string), and `children` (a `TypeList`).
+  - Each `children` entry (`NodeLeaf`) SHALL expose `id` (`NodeLeaf.ID`), `content` (`NodeLeaf.Content`), and `children` (a `TypeList`).
+    - Each inner `children` entry (`NodeInfoBase`) SHALL expose `id` (`NodeInfoBase.ID`) and `content` (`NodeInfoBase.Content`).
+- `district_list`: one entry per `DistrictList` item (`DistinctOrNetServiceInfo`), exposing `id` (`ID`) and `name` (`Name`).
+- `net_service_list`: one entry per `NetServiceList` item (`DistinctOrNetServiceInfo`), exposing `id` (`ID`) and `name` (`Name`).
+
+Before calling `d.Set` for any field, the Read function SHALL skip fields whose underlying pointer is `nil`. Empty but non-nil lists SHALL be flattened to empty Terraform lists (not an error).
+
+#### Scenario: Fully populated response
+- **WHEN** `DescribeNodeGroups` returns a `NodeList` with two `NodeTree` entries, each having `Children`, plus non-empty `DistrictList` and `NetServiceList`
+- **THEN** `node_list` SHALL contain two entries with nested `children`, `district_list` and `net_service_list` SHALL each contain their respective entries, and every `id`/`content`/`name` value SHALL be populated from the response
+
+#### Scenario: Nil pointer fields skipped
+- **WHEN** a `NodeTree` entry has a non-nil `ID` but a nil `Content`
+- **THEN** the flattened map SHALL include `id` but SHALL omit the `content` key
+
+### Requirement: The Read function SHALL treat a nil API response as retryable, not as state-clearing
+The Read function SHALL wrap the service call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. Inside the retry block, if the response is structurally nil (`result == nil`, `result.Response == nil`, or all of `NodeList`, `DistrictList`, and `NetServiceList` are nil), the function SHALL return `resource.NonRetryableError(...)` so the outer retry continues — it SHALL NOT call `d.SetId("")`. On the retry failure path it SHALL log `[DATASOURCE] read empty, skip SetId` for diagnostics.
+
+#### Scenario: Transient nil response
+- **WHEN** `DescribeNodeGroups` returns a nil response or `Response == nil`
+- **THEN** the retry block SHALL return a `NonRetryableError`, the id SHALL NOT be cleared, and the overall Read SHALL eventually fail with a retry-exhausted error
+
+#### Scenario: Empty-but-valid response
+- **WHEN** `DescribeNodeGroups` returns a non-nil `Response` where `NodeList`, `DistrictList`, and `NetServiceList` are all empty (non-nil, length 0)
+- **THEN** the Read SHALL succeed, set empty `node_list`/`district_list`/`net_service_list`, and set a valid id — SHALL NOT error
+
+### Requirement: The data source id SHALL be deterministic
+After a successful read, the Read function SHALL set the data source id to `helper.DataResourceIdsHash(ids)` where `ids` is the slice of top-level `NodeTree.ID` values from the response. This keeps the id deterministic and consistent with the sibling `tencentcloud_cat_node` data source.
+
+#### Scenario: Id derived from node list
+- **WHEN** the response `NodeList` contains entries with IDs `"A"` and `"B"`
+- **THEN** `d.Id()` SHALL equal `helper.DataResourceIdsHash([]string{"A", "B"})`
+
+### Requirement: `result_output_file` SHALL write the flattened node list
+The data source SHALL accept an optional `result_output_file` argument (string). When set to a non-empty path, after a successful read the Read function SHALL write the flattened `node_list` list (`[]map[string]interface{}`) to that file via `tccommon.WriteToFile`.
+
+#### Scenario: Output file written
+- **WHEN** `result_output_file = "/tmp/out.json"` and the read succeeds
+- **THEN** the flattened node-list maps SHALL be written to `/tmp/out.json`
+
+### Requirement: The provider SHALL register the data source and docs SHALL be generated
+The provider entry `tencentcloud/provider.go` SHALL add `"tencentcloud_cat_node_groups": cat.DataSourceTencentCloudCatNodeGroups()` to `DataSourcesMap`, and the provider.go doc-comment index SHALL list the new data source under the CAT product so that `make doc` regenerates `website/docs/d/cat_node_groups.html.markdown` and updates `website/tencentcloud.erb`. A hand-written example file `tencentcloud/services/cat/data_source_tc_cat_node_groups.md` SHALL be created with a one-line description (mentioning CAT) and an `Example Usage` HCL block.
+
+#### Scenario: Provider registration
+- **WHEN** the provider is initialized
+- **THEN** `DataSourcesMap["tencentcloud_cat_node_groups"]` SHALL be non-nil
+
+#### Scenario: Documentation example file
+- **WHEN** `make doc` runs
+- **THEN** it SHALL generate `website/docs/d/cat_node_groups.html.markdown` from the example `.md` file and the schema `Description` fields
+
+### Requirement: Unit tests SHALL mock the SDK with gomonkey
+The test file `tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go` SHALL use gomonkey to mock the CAT SDK client (NOT a Terraform acceptance test suite). Tests SHALL cover: (a) a successful read that flattens a populated `DescribeNodeGroups` response and asserts the `node_list`/`district_list`/`net_service_list` values and a non-empty id; (b) a nil/empty response path; (c) schema field existence and types. The mocked provider meta SHALL implement `tccommon.ProviderMeta`.
+
+#### Scenario: Successful read mocked
+- **WHEN** the gomonkey-patched `DescribeNodeGroups` returns a response with one `NodeTree` (with one `NodeLeaf` child having one `NodeInfoBase` grandchild), one district, and one ISP
+- **THEN** calling `res.Read(d, meta)` SHALL succeed, `d.Id()` SHALL be non-empty, and `d.Get("node_list")` SHALL contain one entry whose nested `children` contains one entry whose nested `children` contains one entry
+
+#### Scenario: Schema correctness
+- **WHEN** the data source schema is inspected
+- **THEN** it SHALL contain `node_list`, `district_list`, `net_service_list`, `result_output_file`, and all filter arguments with the correct types

--- a/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/tasks.md
+++ b/openspec/changes/archive/2026-09-02-add-cat-node-groups-datasource/tasks.md
@@ -1,0 +1,96 @@
+# Implementation Tasks: Add CAT Node Groups Data Source
+
+## 1. Service Layer
+
+- [x] 1.1 Add `DescribeCatNodeGroupsByFilter` method to `CatService`
+  - Location: `tencentcloud/services/cat/service_tencentcloud_cat.go`
+  - Build a `cat.NewDescribeNodeGroupsRequest()` from the `paramMap`
+  - Map filter keys to request fields: `node_type` → `NodeType` (`[]*int64`), `task_category` → `TaskCategory`, `ip_type` → `IPType`, `name` → `Name`, `region_id` → `RegionID`, `district_id` → `DistrictID`, `net_service_id` → `NetServiceID`, `node_group_type` → `NodeGroupType`, `task_type` → `TaskType`, `probe_type` → `ProbeType`
+  - Call `ratelimit.Check(request.GetAction())` before the API call
+  - Wrap the SDK call `me.client.UseCatClient().DescribeNodeGroups(request)` in a single `resource.Retry(tccommon.ReadRetryTimeout, ...)` block (no pagination — `DescribeNodeGroups` returns the full tree)
+  - Inside the retry block, if `result == nil || result.Response == nil || (result.Response.NodeList == nil && result.Response.DistrictList == nil && result.Response.NetServiceList == nil)` return `resource.NonRetryableError(...)`
+  - Return `(nodeList []*cat.NodeTree, districtList []*cat.DistinctOrNetServiceInfo, netServiceList []*cat.DistinctOrNetServiceInfo, errRet error)`
+  - Add deferred error logging with `log.Printf("[CRITAL]%s api[%s] fail, ...")` matching existing cat service methods
+
+## 2. Data Source Schema & Read
+
+- [x] 2.1 Create `tencentcloud/services/cat/data_source_tc_cat_node_groups.go`
+  - Package `cat`, imports: `context`, `log`, `tccommon`, `helper`, `schema`, `resource`, `cat` SDK
+  - Implement `DataSourceTencentCloudCatNodeGroups() *schema.Resource` returning Read function + schema
+
+- [x] 2.2 Define filter (input) schema arguments (all Optional)
+  - `node_type`: `schema.TypeList`, `Elem: &schema.Schema{Type: schema.TypeInt}` (maps to `NodeType []*int64`)
+  - `task_category`: `schema.TypeInt` (`TaskCategory *int64`)
+  - `ip_type`: `schema.TypeInt` (`IPType *int64`)
+  - `name`: `schema.TypeString` (`Name *string`)
+  - `region_id`: `schema.TypeInt` (`RegionID *int64`)
+  - `district_id`: `schema.TypeInt` (`DistrictID *int64`)
+  - `net_service_id`: `schema.TypeInt` (`NetServiceID *int64`)
+  - `node_group_type`: `schema.TypeInt` (`NodeGroupType *int64`)
+  - `task_type`: `schema.TypeInt` (`TaskType *int64`)
+  - `probe_type`: `schema.TypeInt` (`ProbeType *uint64`)
+  - `result_output_file`: `schema.TypeString`, Optional
+
+- [x] 2.3 Define computed output `node_list` (TypeList) nested schema
+  - Top-level `NodeTree`: `id` (TypeString), `content` (TypeString), `children` (TypeList)
+    - `NodeLeaf`: `id` (TypeString), `content` (TypeString), `children` (TypeList)
+      - `NodeInfoBase`: `id` (TypeString), `content` (TypeString)
+  - Each nested `children` uses `Elem: &schema.Resource{Schema: ...}`
+
+- [x] 2.4 Define computed output `district_list` and `net_service_list` (TypeList) schemas
+  - `district_list`: each entry `id` (TypeString), `name` (TypeString) — `DistinctOrNetServiceInfo`
+  - `net_service_list`: each entry `id` (TypeString), `name` (TypeString) — `DistinctOrNetServiceInfo`
+
+- [x] 2.5 Implement `dataSourceTencentCloudCatNodeGroupsRead` function
+  - Add `defer tccommon.LogElapsed("data_source.tencentcloud_cat_node_groups.read")()` and `defer tccommon.InconsistentCheck(d, meta)()`
+  - Create `logId`/`ctx` with `tccommon.GetLogId(tccommon.ContextNil)` / `context.WithValue(context.TODO(), tccommon.LogIdKey, logId)`
+  - Build `paramMap` from provided filter arguments only (skip unset args); convert `node_type` list to `[]*int64` via `helper.IntInt64` per element; scalar ints via `helper.IntInt64`; string via `helper.String`
+  - Call `catService.DescribeCatNodeGroupsByFilter(ctx, paramMap)` inside `resource.Retry(tccommon.ReadRetryTimeout, ...)`; on error `return tccommon.RetryError(e)`; assign returned slices
+  - On retry failure path, log `log.Printf("[DATASOURCE] read empty, skip SetId")` before returning the error
+
+- [x] 2.6 Flatten response into state with nil-pointer checks
+  - Flatten `nodeList` into `nodeListTmp []map[string]interface{}`: for each `NodeTree`, add `id`/`content` only if non-nil; flatten `Children` (`NodeLeaf`) into `children`; for each `NodeLeaf` flatten `Children` (`NodeInfoBase`) into inner `children`
+  - Collect top-level `NodeTree.ID` values into `ids []string`
+  - Set `d.SetId(helper.DataResourceIdsHash(ids))`
+  - Flatten `districtList` → `districtListTmp` (`id`, `name`), `netServiceList` → `netServiceListTmp` (`id`, `name`), with nil checks
+  - `_ = d.Set("node_list", nodeListTmp)`, `_ = d.Set("district_list", districtListTmp)`, `_ = d.Set("net_service_list", netServiceListTmp)`
+
+- [x] 2.7 Handle `result_output_file`
+  - If `result_output_file` is set and non-empty, write `nodeListTmp` via `tccommon.WriteToFile(output.(string), nodeListTmp)`; return error on failure
+
+## 3. Provider Registration
+
+- [x] 3.1 Register data source in `tencentcloud/provider.go`
+  - Add `"tencentcloud_cat_node_groups": cat.DataSourceTencentCloudCatNodeGroups()` to `DataSourcesMap` (alphabetically after `tencentcloud_cat_node` and before `tencentcloud_cat_probe_data`)
+
+- [x] 3.2 Update provider.go doc-comment index
+  - Add the new data source entry under the CAT product's `Data Source` subsection in the provider.go comment block so `make doc` updates `website/tencentcloud.erb`
+
+## 4. Documentation Example File
+
+- [x] 4.1 Create `tencentcloud/services/cat/data_source_tc_cat_node_groups.md`
+  - One-line description mentioning CAT: `Use this data source to query detailed information of cat node groups`
+  - `Example Usage` HCL block demonstrating filter usage (e.g. `node_type = [1]`, `ip_type = 1`)
+  - No `Argument Reference` / `Attribute Reference` sections (auto-generated by `make doc`)
+
+## 5. Unit Tests (gomonkey mock)
+
+- [x] 5.1 Create `tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go`
+  - Package `cat_test`, imports: `testing`, `gomonkey/v2`, `schema`, `stretchr/testify/assert`, `cat` SDK, `tccommon`, `connectivity`, `services/cat`
+  - Implement a mock `ProviderMeta` returning `*connectivity.TencentCloudClient`
+
+- [x] 5.2 Test successful read flattening
+  - Mock `UseCatClient` to return a `cat.Client{}`; mock `DescribeNodeGroups` to return a response with one `NodeTree` (one `NodeLeaf` child with one `NodeInfoBase` grandchild), one district, one ISP
+  - Call `res.Read(d, meta)`; assert no error, non-empty `d.Id()`, and `node_list`/`district_list`/`net_service_list` values with nested `children` populated
+
+- [x] 5.3 Test nil/empty response path
+  - Mock `DescribeNodeGroups` returning nil response → assert `res.Read` returns an error (NonRetryableError surfaces) and `d.SetId("")` is NOT called prematurely
+
+- [x] 5.4 Test schema correctness
+  - Assert `res.Schema` contains `node_list`, `district_list`, `net_service_list`, `result_output_file`, and all filter arguments with correct types
+
+## 6. Validation
+
+- [x] 6.1 Verify code compiles (gofmt in finalize phase only)
+- [x] 6.2 Verify `make doc` regenerates `website/docs/d/cat_node_groups.html.markdown` and updates `website/tencentcloud.erb`
+- [x] 6.3 Confirm no existing CAT data sources are broken (additive change only)

--- a/openspec/specs/cat-node-groups-datasource/spec.md
+++ b/openspec/specs/cat-node-groups-datasource/spec.md
@@ -1,0 +1,87 @@
+# Specification: CAT Node Groups Data Source
+
+## Purpose
+
+Defines the `tencentcloud_cat_node_groups` data source that wraps the CAT `DescribeNodeGroups` cloud API, exposing its filter arguments and flattening the node-group tree, district list, and ISP list into computed Terraform attributes.
+
+## Requirements
+
+### Requirement: Data source `tencentcloud_cat_node_groups` SHALL exist and expose `DescribeNodeGroups` filters
+The provider SHALL register a data source named `tencentcloud_cat_node_groups` whose Read operation calls the cloud API `DescribeNodeGroups` (package `cat.v20180409`). The data source SHALL expose the following optional filter arguments, each mapped to the corresponding cloud API request field: `node_type` (`NodeType`, list of int), `task_category` (`TaskCategory`, int), `ip_type` (`IPType`, int), `name` (`Name`, string), `region_id` (`RegionID`, int), `district_id` (`DistrictID`, int), `net_service_id` (`NetServiceID`, int), `node_group_type` (`NodeGroupType`, int), `task_type` (`TaskType`, int), `probe_type` (`ProbeType`, int). Only arguments provided by the user SHALL be set on the request; unset arguments SHALL NOT be sent (relying on API defaults).
+
+#### Scenario: All filter arguments optional
+- **WHEN** a user declares `data "tencentcloud_cat_node_groups" "groups" {}` with no filter arguments
+- **THEN** the Read function SHALL build a `DescribeNodeGroupsRequest` with no filter fields set and the API SHALL return the default (unfiltered) node-group tree
+
+#### Scenario: Single filter applied
+- **WHEN** a user sets `node_type = [1]` and `ip_type = 1`
+- **THEN** the Read function SHALL set `request.NodeType = []*int64{int64Ptr(1)}` and `request.IPType = int64Ptr(1)`, and SHALL leave all other request fields unset
+
+#### Scenario: node_type accepts multiple values
+- **WHEN** a user sets `node_type = [1, 2]`
+- **THEN** the Read function SHALL convert each element to `*int64` and assign the resulting slice to `request.NodeType`
+
+### Requirement: The data source SHALL flatten `DescribeNodeGroups` response into computed attributes
+The Read function SHALL flatten the `DescribeNodeGroupsResponse.Response` into three computed `TypeList` attributes:
+- `node_list`: one entry per `NodeList` item (`NodeTree`). Each entry SHALL expose `id` (`NodeTree.ID`, string), `content` (`NodeTree.Content`, string), and `children` (a `TypeList`).
+  - Each `children` entry (`NodeLeaf`) SHALL expose `id` (`NodeLeaf.ID`), `content` (`NodeLeaf.Content`), and `children` (a `TypeList`).
+    - Each inner `children` entry (`NodeInfoBase`) SHALL expose `id` (`NodeInfoBase.ID`) and `content` (`NodeInfoBase.Content`).
+- `district_list`: one entry per `DistrictList` item (`DistinctOrNetServiceInfo`), exposing `id` (`ID`) and `name` (`Name`).
+- `net_service_list`: one entry per `NetServiceList` item (`DistinctOrNetServiceInfo`), exposing `id` (`ID`) and `name` (`Name`).
+
+Before calling `d.Set` for any field, the Read function SHALL skip fields whose underlying pointer is `nil`. Empty but non-nil lists SHALL be flattened to empty Terraform lists (not an error).
+
+#### Scenario: Fully populated response
+- **WHEN** `DescribeNodeGroups` returns a `NodeList` with two `NodeTree` entries, each having `Children`, plus non-empty `DistrictList` and `NetServiceList`
+- **THEN** `node_list` SHALL contain two entries with nested `children`, `district_list` and `net_service_list` SHALL each contain their respective entries, and every `id`/`content`/`name` value SHALL be populated from the response
+
+#### Scenario: Nil pointer fields skipped
+- **WHEN** a `NodeTree` entry has a non-nil `ID` but a nil `Content`
+- **THEN** the flattened map SHALL include `id` but SHALL omit the `content` key
+
+### Requirement: The Read function SHALL treat a nil API response as retryable, not as state-clearing
+The Read function SHALL wrap the service call in `resource.Retry(tccommon.ReadRetryTimeout, ...)`. Inside the retry block, if the response is structurally nil (`result == nil`, `result.Response == nil`, or all of `NodeList`, `DistrictList`, and `NetServiceList` are nil), the function SHALL return `resource.NonRetryableError(...)` so the outer retry continues — it SHALL NOT call `d.SetId("")`. On the retry failure path it SHALL log `[DATASOURCE] read empty, skip SetId` for diagnostics.
+
+#### Scenario: Transient nil response
+- **WHEN** `DescribeNodeGroups` returns a nil response or `Response == nil`
+- **THEN** the retry block SHALL return a `NonRetryableError`, the id SHALL NOT be cleared, and the overall Read SHALL eventually fail with a retry-exhausted error
+
+#### Scenario: Empty-but-valid response
+- **WHEN** `DescribeNodeGroups` returns a non-nil `Response` where `NodeList`, `DistrictList`, and `NetServiceList` are all empty (non-nil, length 0)
+- **THEN** the Read SHALL succeed, set empty `node_list`/`district_list`/`net_service_list`, and set a valid id — SHALL NOT error
+
+### Requirement: The data source id SHALL be deterministic
+After a successful read, the Read function SHALL set the data source id to `helper.DataResourceIdsHash(ids)` where `ids` is the slice of top-level `NodeTree.ID` values from the response. This keeps the id deterministic and consistent with the sibling `tencentcloud_cat_node` data source.
+
+#### Scenario: Id derived from node list
+- **WHEN** the response `NodeList` contains entries with IDs `"A"` and `"B"`
+- **THEN** `d.Id()` SHALL equal `helper.DataResourceIdsHash([]string{"A", "B"})`
+
+### Requirement: `result_output_file` SHALL write the flattened node list
+The data source SHALL accept an optional `result_output_file` argument (string). When set to a non-empty path, after a successful read the Read function SHALL write the flattened `node_list` list (`[]map[string]interface{}`) to that file via `tccommon.WriteToFile`.
+
+#### Scenario: Output file written
+- **WHEN** `result_output_file = "/tmp/out.json"` and the read succeeds
+- **THEN** the flattened node-list maps SHALL be written to `/tmp/out.json`
+
+### Requirement: The provider SHALL register the data source and docs SHALL be generated
+The provider entry `tencentcloud/provider.go` SHALL add `"tencentcloud_cat_node_groups": cat.DataSourceTencentCloudCatNodeGroups()` to `DataSourcesMap`, and the provider.go doc-comment index SHALL list the new data source under the CAT product so that `make doc` regenerates `website/docs/d/cat_node_groups.html.markdown` and updates `website/tencentcloud.erb`. A hand-written example file `tencentcloud/services/cat/data_source_tc_cat_node_groups.md` SHALL be created with a one-line description (mentioning CAT) and an `Example Usage` HCL block.
+
+#### Scenario: Provider registration
+- **WHEN** the provider is initialized
+- **THEN** `DataSourcesMap["tencentcloud_cat_node_groups"]` SHALL be non-nil
+
+#### Scenario: Documentation example file
+- **WHEN** `make doc` runs
+- **THEN** it SHALL generate `website/docs/d/cat_node_groups.html.markdown` from the example `.md` file and the schema `Description` fields
+
+### Requirement: Unit tests SHALL mock the SDK with gomonkey
+The test file `tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go` SHALL use gomonkey to mock the CAT SDK client (NOT a Terraform acceptance test suite). Tests SHALL cover: (a) a successful read that flattens a populated `DescribeNodeGroups` response and asserts the `node_list`/`district_list`/`net_service_list` values and a non-empty id; (b) a nil/empty response path; (c) schema field existence and types. The mocked provider meta SHALL implement `tccommon.ProviderMeta`.
+
+#### Scenario: Successful read mocked
+- **WHEN** the gomonkey-patched `DescribeNodeGroups` returns a response with one `NodeTree` (with one `NodeLeaf` child having one `NodeInfoBase` grandchild), one district, and one ISP
+- **THEN** calling `res.Read(d, meta)` SHALL succeed, `d.Id()` SHALL be non-empty, and `d.Get("node_list")` SHALL contain one entry whose nested `children` contains one entry whose nested `children` contains one entry
+
+#### Scenario: Schema correctness
+- **WHEN** the data source schema is inspected
+- **THEN** it SHALL contain `node_list`, `district_list`, `net_service_list`, `result_output_file`, and all filter arguments with the correct types

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1028,6 +1028,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_cat_node":                                               cat.DataSourceTencentCloudCatNode(),
 			"tencentcloud_cat_metric_data":                                        cat.DataSourceTencentCloudCatMetricData(),
 			"tencentcloud_cat_probe_metric_tag_values":                            cat.DataSourceTencentCloudCatProbeMetricTagValues(),
+			"tencentcloud_cat_node_groups":                                        cat.DataSourceTencentCloudCatNodeGroups(),
 			"tencentcloud_rum_project":                                            rum.DataSourceTencentCloudRumProject(),
 			"tencentcloud_rum_offline_log_config":                                 rum.DataSourceTencentCloudRumOfflineLogConfig(),
 			"tencentcloud_rum_whitelist":                                          rum.DataSourceTencentCloudRumWhitelist(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1755,6 +1755,7 @@ Cloud Automated Testing(CAT)
 Data Source
 tencentcloud_cat_probe_data
 tencentcloud_cat_node
+tencentcloud_cat_node_groups
 tencentcloud_cat_metric_data
 tencentcloud_cat_probe_metric_tag_values
 

--- a/tencentcloud/services/cat/data_source_tc_cat_node_groups.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_node_groups.go
@@ -1,0 +1,363 @@
+package cat
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	cat "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudCatNodeGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudCatNodeGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"node_type": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Node type. 0: all, 1: IDC, 2: LastMile, 3: Mobile. Defaults to 0 if not set.",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+
+			"task_category": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Node category. 0: all, 1: PC, 2: Mobile. Defaults to 0 if not set.",
+			},
+
+			"ip_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "IP type. 0: all, 1: IPv4, 2: IPv6. Defaults to 0 if not set.",
+			},
+
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Probe node description keyword.",
+			},
+
+			"region_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Region ID. 0: selected probe points, 1: Chinese Mainland, 2: Hong Kong, Macao and Taiwan, 3: Asia Pacific, 4: Europe and America, 5: Africa and Oceania. Defaults to 0 if not set.",
+			},
+
+			"district_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Province or country ID. 0 means all. Defaults to 0 if not set.",
+			},
+
+			"net_service_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "ISP ID. 0: all, 1: China Telecom, 2: China Unicom, 3: China Mobile, 99: others. Defaults to 0 if not set.",
+			},
+
+			"node_group_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Node group type. 0: advanced probe group, 1: availability node, 2: my probe group. Defaults to 0 if not set.",
+			},
+
+			"task_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Task type, such as 1, 2, 3, 4, 5, 6, 7. 1-page performance, 2-file upload, 3-file download, 4-port performance, 5-network quality, 6-audio and video experience, 7-domain whois. Defaults to 0 if not set, no filtering by task type.",
+			},
+
+			"probe_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Test type, including scheduled test and instant test. 0-scheduled probe, others mean instant probe.",
+			},
+
+			"node_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Tree node list, two levels in total.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node ID.",
+						},
+						"content": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Node name.",
+						},
+						"children": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Child nodes.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Child node ID.",
+									},
+									"content": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Child node name.",
+									},
+									"children": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "Node list.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"id": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Node code.",
+												},
+												"content": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Node name.",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"district_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Province or country list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Province (international) or ISP ID.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Name.",
+						},
+					},
+				},
+			},
+
+			"net_service_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "ISP list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Province (international) or ISP ID.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Name.",
+						},
+					},
+				},
+			},
+
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudCatNodeGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_cat_node_groups.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+	paramMap := make(map[string]interface{})
+	if v, ok := d.GetOk("node_type"); ok {
+		nodeTypeList := v.([]interface{})
+		nodeTypePtrList := make([]*int64, 0, len(nodeTypeList))
+		for _, item := range nodeTypeList {
+			nodeTypePtrList = append(nodeTypePtrList, helper.IntInt64(item.(int)))
+		}
+		paramMap["node_type"] = nodeTypePtrList
+	}
+
+	if v, _ := d.GetOk("task_category"); v != nil {
+		paramMap["task_category"] = helper.IntInt64(v.(int))
+	}
+
+	if v, _ := d.GetOk("ip_type"); v != nil {
+		paramMap["ip_type"] = helper.IntInt64(v.(int))
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		paramMap["name"] = helper.String(v.(string))
+	}
+
+	if v, _ := d.GetOk("region_id"); v != nil {
+		paramMap["region_id"] = helper.IntInt64(v.(int))
+	}
+
+	if v, _ := d.GetOk("district_id"); v != nil {
+		paramMap["district_id"] = helper.IntInt64(v.(int))
+	}
+
+	if v, _ := d.GetOk("net_service_id"); v != nil {
+		paramMap["net_service_id"] = helper.IntInt64(v.(int))
+	}
+
+	if v, _ := d.GetOk("node_group_type"); v != nil {
+		paramMap["node_group_type"] = helper.IntInt64(v.(int))
+	}
+
+	if v, _ := d.GetOk("task_type"); v != nil {
+		paramMap["task_type"] = helper.IntInt64(v.(int))
+	}
+
+	if v, _ := d.GetOk("probe_type"); v != nil {
+		paramMap["probe_type"] = helper.IntUint64(v.(int))
+	}
+
+	catService := CatService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+
+	var nodeList []*cat.NodeTree
+	var districtList []*cat.DistinctOrNetServiceInfo
+	var netServiceList []*cat.DistinctOrNetServiceInfo
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		resultNodeList, resultDistrictList, resultNetServiceList, e := catService.DescribeCatNodeGroupsByFilter(ctx, paramMap)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if resultNodeList == nil && resultDistrictList == nil && resultNetServiceList == nil {
+			e = logError(logId, "DescribeNodeGroups response is nil")
+			return resource.NonRetryableError(e)
+		}
+
+		nodeList = resultNodeList
+		districtList = resultDistrictList
+		netServiceList = resultNetServiceList
+		return nil
+	})
+	if err != nil {
+		log.Printf("[DATASOURCE] read empty, skip SetId")
+		log.Printf("[CRITAL]%s api[%s] fail, reason[%+v]", logId, "DescribeNodeGroups", err)
+		return err
+	}
+
+	ids := make([]string, 0)
+	nodeListTmp := make([]map[string]interface{}, 0)
+	if nodeList != nil {
+		for _, nodeTree := range nodeList {
+			nodeTreeMap := map[string]interface{}{}
+			if nodeTree.ID != nil {
+				nodeTreeMap["id"] = nodeTree.ID
+				ids = append(ids, *nodeTree.ID)
+			}
+			if nodeTree.Content != nil {
+				nodeTreeMap["content"] = nodeTree.Content
+			}
+
+			childrenTmp := make([]map[string]interface{}, 0)
+			if nodeTree.Children != nil {
+				for _, nodeLeaf := range nodeTree.Children {
+					nodeLeafMap := map[string]interface{}{}
+					if nodeLeaf.ID != nil {
+						nodeLeafMap["id"] = nodeLeaf.ID
+					}
+					if nodeLeaf.Content != nil {
+						nodeLeafMap["content"] = nodeLeaf.Content
+					}
+
+					innerChildrenTmp := make([]map[string]interface{}, 0)
+					if nodeLeaf.Children != nil {
+						for _, nodeInfoBase := range nodeLeaf.Children {
+							nodeInfoBaseMap := map[string]interface{}{}
+							if nodeInfoBase.ID != nil {
+								nodeInfoBaseMap["id"] = nodeInfoBase.ID
+							}
+							if nodeInfoBase.Content != nil {
+								nodeInfoBaseMap["content"] = nodeInfoBase.Content
+							}
+							innerChildrenTmp = append(innerChildrenTmp, nodeInfoBaseMap)
+						}
+					}
+					nodeLeafMap["children"] = innerChildrenTmp
+					childrenTmp = append(childrenTmp, nodeLeafMap)
+				}
+			}
+			nodeTreeMap["children"] = childrenTmp
+			nodeListTmp = append(nodeListTmp, nodeTreeMap)
+		}
+	}
+	d.SetId(helper.DataResourceIdsHash(ids))
+
+	districtListTmp := make([]map[string]interface{}, 0)
+	if districtList != nil {
+		for _, district := range districtList {
+			districtMap := map[string]interface{}{}
+			if district.ID != nil {
+				districtMap["id"] = district.ID
+			}
+			if district.Name != nil {
+				districtMap["name"] = district.Name
+			}
+			districtListTmp = append(districtListTmp, districtMap)
+		}
+	}
+
+	netServiceListTmp := make([]map[string]interface{}, 0)
+	if netServiceList != nil {
+		for _, netService := range netServiceList {
+			netServiceMap := map[string]interface{}{}
+			if netService.ID != nil {
+				netServiceMap["id"] = netService.ID
+			}
+			if netService.Name != nil {
+				netServiceMap["name"] = netService.Name
+			}
+			netServiceListTmp = append(netServiceListTmp, netServiceMap)
+		}
+	}
+
+	_ = d.Set("node_list", nodeListTmp)
+	_ = d.Set("district_list", districtListTmp)
+	_ = d.Set("net_service_list", netServiceListTmp)
+
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), nodeListTmp); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}
+
+func logError(logId, msg string) error {
+	log.Printf("[CRITAL]%s %s", logId, msg)
+	return fmt.Errorf(msg)
+}

--- a/tencentcloud/services/cat/data_source_tc_cat_node_groups.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_node_groups.go
@@ -359,5 +359,5 @@ func dataSourceTencentCloudCatNodeGroupsRead(d *schema.ResourceData, meta interf
 
 func logError(logId, msg string) error {
 	log.Printf("[CRITAL]%s %s", logId, msg)
-	return fmt.Errorf(msg)
+	return fmt.Errorf("%s", msg)
 }

--- a/tencentcloud/services/cat/data_source_tc_cat_node_groups.md
+++ b/tencentcloud/services/cat/data_source_tc_cat_node_groups.md
@@ -1,0 +1,11 @@
+Use this data source to query detailed information of cat node groups
+
+Example Usage
+
+```hcl
+data "tencentcloud_cat_node_groups" "groups" {
+  node_type        = [1]
+  ip_type          = 1
+  node_group_type  = 1
+}
+```

--- a/tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go
@@ -1,6 +1,7 @@
 package cat_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -10,7 +11,7 @@ import (
 
 	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
 	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
-	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cat"
+	svccat "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cat"
 )
 
 type mockMetaForCatNodeGroups struct {
@@ -41,7 +42,7 @@ func TestCatNodeGroups_Read_Success(t *testing.T) {
 	catClient := &cat.Client{}
 	patches.ApplyMethodReturn(newMockMetaForCatNodeGroups().client, "UseCatClient", catClient)
 
-	patches.ApplyMethodFunc(catClient, "DescribeNodeGroups", func(request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
+	patches.ApplyMethodFunc(catClient, "DescribeNodeGroupsWithContext", func(ctx context.Context, request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
 		resp := cat.NewDescribeNodeGroupsResponse()
 		resp.Response = &cat.DescribeNodeGroupsResponseParams{
 			NodeList: []*cat.NodeTree{
@@ -80,7 +81,7 @@ func TestCatNodeGroups_Read_Success(t *testing.T) {
 	})
 
 	meta := newMockMetaForCatNodeGroups()
-	res := cat.DataSourceTencentCloudCatNodeGroups()
+	res := svccat.DataSourceTencentCloudCatNodeGroups()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 		"node_type": []interface{}{1},
 		"ip_type":   1,
@@ -129,14 +130,14 @@ func TestCatNodeGroups_Read_NilResponse(t *testing.T) {
 	catClient := &cat.Client{}
 	patches.ApplyMethodReturn(newMockMetaForCatNodeGroups().client, "UseCatClient", catClient)
 
-	patches.ApplyMethodFunc(catClient, "DescribeNodeGroups", func(request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
+	patches.ApplyMethodFunc(catClient, "DescribeNodeGroupsWithContext", func(ctx context.Context, request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
 		resp := cat.NewDescribeNodeGroupsResponse()
 		resp.Response = nil
 		return resp, nil
 	})
 
 	meta := newMockMetaForCatNodeGroups()
-	res := cat.DataSourceTencentCloudCatNodeGroups()
+	res := svccat.DataSourceTencentCloudCatNodeGroups()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
 
 	err := res.Read(d, meta)
@@ -152,7 +153,7 @@ func TestCatNodeGroups_Read_EmptyResponse(t *testing.T) {
 	catClient := &cat.Client{}
 	patches.ApplyMethodReturn(newMockMetaForCatNodeGroups().client, "UseCatClient", catClient)
 
-	patches.ApplyMethodFunc(catClient, "DescribeNodeGroups", func(request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
+	patches.ApplyMethodFunc(catClient, "DescribeNodeGroupsWithContext", func(ctx context.Context, request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
 		resp := cat.NewDescribeNodeGroupsResponse()
 		resp.Response = &cat.DescribeNodeGroupsResponseParams{
 			NodeList:       []*cat.NodeTree{},
@@ -164,7 +165,7 @@ func TestCatNodeGroups_Read_EmptyResponse(t *testing.T) {
 	})
 
 	meta := newMockMetaForCatNodeGroups()
-	res := cat.DataSourceTencentCloudCatNodeGroups()
+	res := svccat.DataSourceTencentCloudCatNodeGroups()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
 
 	err := res.Read(d, meta)
@@ -187,12 +188,12 @@ func TestCatNodeGroups_Read_APIError(t *testing.T) {
 	catClient := &cat.Client{}
 	patches.ApplyMethodReturn(newMockMetaForCatNodeGroups().client, "UseCatClient", catClient)
 
-	patches.ApplyMethodFunc(catClient, "DescribeNodeGroups", func(request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
+	patches.ApplyMethodFunc(catClient, "DescribeNodeGroupsWithContext", func(ctx context.Context, request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
 		return nil, assert.AnError
 	})
 
 	meta := newMockMetaForCatNodeGroups()
-	res := cat.DataSourceTencentCloudCatNodeGroups()
+	res := svccat.DataSourceTencentCloudCatNodeGroups()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
 
 	err := res.Read(d, meta)
@@ -201,7 +202,7 @@ func TestCatNodeGroups_Read_APIError(t *testing.T) {
 
 // TestCatNodeGroups_Schema tests the schema definition
 func TestCatNodeGroups_Schema(t *testing.T) {
-	res := cat.DataSourceTencentCloudCatNodeGroups()
+	res := svccat.DataSourceTencentCloudCatNodeGroups()
 
 	assert.NotNil(t, res)
 	assert.NotNil(t, res.Read)

--- a/tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_node_groups_test.go
@@ -1,0 +1,227 @@
+package cat_test
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	cat "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cat"
+)
+
+type mockMetaForCatNodeGroups struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForCatNodeGroups) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForCatNodeGroups{}
+
+func newMockMetaForCatNodeGroups() *mockMetaForCatNodeGroups {
+	return &mockMetaForCatNodeGroups{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrCat(s string) *string {
+	return &s
+}
+
+// go test ./tencentcloud/services/cat/ -run "TestCatNodeGroups" -v -count=1 -gcflags="all=-l"
+
+// TestCatNodeGroups_Read_Success tests successful read with a populated response
+func TestCatNodeGroups_Read_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatNodeGroups().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeNodeGroups", func(request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
+		resp := cat.NewDescribeNodeGroupsResponse()
+		resp.Response = &cat.DescribeNodeGroupsResponseParams{
+			NodeList: []*cat.NodeTree{
+				{
+					ID:      ptrStrCat("group-A"),
+					Content: ptrStrCat("Group A"),
+					Children: []*cat.NodeLeaf{
+						{
+							ID:      ptrStrCat("leaf-A1"),
+							Content: ptrStrCat("Leaf A1"),
+							Children: []*cat.NodeInfoBase{
+								{
+									ID:      ptrStrCat("node-A1-1"),
+									Content: ptrStrCat("Node A1-1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			DistrictList: []*cat.DistinctOrNetServiceInfo{
+				{
+					ID:   ptrStrCat("1"),
+					Name: ptrStrCat("Beijing"),
+				},
+			},
+			NetServiceList: []*cat.DistinctOrNetServiceInfo{
+				{
+					ID:   ptrStrCat("1"),
+					Name: ptrStrCat("China Telecom"),
+				},
+			},
+			RequestId: ptrStrCat("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCatNodeGroups()
+	res := cat.DataSourceTencentCloudCatNodeGroups()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"node_type": []interface{}{1},
+		"ip_type":   1,
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	nodeList := d.Get("node_list").([]interface{})
+	assert.Equal(t, 1, len(nodeList))
+	nodeTree := nodeList[0].(map[string]interface{})
+	assert.Equal(t, "group-A", nodeTree["id"])
+	assert.Equal(t, "Group A", nodeTree["content"])
+
+	children := nodeTree["children"].([]interface{})
+	assert.Equal(t, 1, len(children))
+	nodeLeaf := children[0].(map[string]interface{})
+	assert.Equal(t, "leaf-A1", nodeLeaf["id"])
+	assert.Equal(t, "Leaf A1", nodeLeaf["content"])
+
+	innerChildren := nodeLeaf["children"].([]interface{})
+	assert.Equal(t, 1, len(innerChildren))
+	nodeInfoBase := innerChildren[0].(map[string]interface{})
+	assert.Equal(t, "node-A1-1", nodeInfoBase["id"])
+	assert.Equal(t, "Node A1-1", nodeInfoBase["content"])
+
+	districtList := d.Get("district_list").([]interface{})
+	assert.Equal(t, 1, len(districtList))
+	district := districtList[0].(map[string]interface{})
+	assert.Equal(t, "1", district["id"])
+	assert.Equal(t, "Beijing", district["name"])
+
+	netServiceList := d.Get("net_service_list").([]interface{})
+	assert.Equal(t, 1, len(netServiceList))
+	netService := netServiceList[0].(map[string]interface{})
+	assert.Equal(t, "1", netService["id"])
+	assert.Equal(t, "China Telecom", netService["name"])
+}
+
+// TestCatNodeGroups_Read_NilResponse tests read when API returns nil response
+func TestCatNodeGroups_Read_NilResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatNodeGroups().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeNodeGroups", func(request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
+		resp := cat.NewDescribeNodeGroupsResponse()
+		resp.Response = nil
+		return resp, nil
+	})
+
+	meta := newMockMetaForCatNodeGroups()
+	res := cat.DataSourceTencentCloudCatNodeGroups()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+	assert.Empty(t, d.Id())
+}
+
+// TestCatNodeGroups_Read_EmptyResponse tests read when API returns empty but non-nil lists
+func TestCatNodeGroups_Read_EmptyResponse(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatNodeGroups().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeNodeGroups", func(request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
+		resp := cat.NewDescribeNodeGroupsResponse()
+		resp.Response = &cat.DescribeNodeGroupsResponseParams{
+			NodeList:       []*cat.NodeTree{},
+			DistrictList:   []*cat.DistinctOrNetServiceInfo{},
+			NetServiceList: []*cat.DistinctOrNetServiceInfo{},
+			RequestId:      ptrStrCat("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCatNodeGroups()
+	res := cat.DataSourceTencentCloudCatNodeGroups()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	nodeList := d.Get("node_list").([]interface{})
+	assert.Equal(t, 0, len(nodeList))
+	districtList := d.Get("district_list").([]interface{})
+	assert.Equal(t, 0, len(districtList))
+	netServiceList := d.Get("net_service_list").([]interface{})
+	assert.Equal(t, 0, len(netServiceList))
+}
+
+// TestCatNodeGroups_Read_APIError tests read when API returns error
+func TestCatNodeGroups_Read_APIError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatNodeGroups().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeNodeGroups", func(request *cat.DescribeNodeGroupsRequest) (*cat.DescribeNodeGroupsResponse, error) {
+		return nil, assert.AnError
+	})
+
+	meta := newMockMetaForCatNodeGroups()
+	res := cat.DataSourceTencentCloudCatNodeGroups()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}
+
+// TestCatNodeGroups_Schema tests the schema definition
+func TestCatNodeGroups_Schema(t *testing.T) {
+	res := cat.DataSourceTencentCloudCatNodeGroups()
+
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Read)
+
+	// Check optional filter fields
+	assert.True(t, res.Schema["node_type"].Optional)
+	assert.Equal(t, schema.TypeList, res.Schema["node_type"].Type)
+	assert.True(t, res.Schema["task_category"].Optional)
+	assert.True(t, res.Schema["ip_type"].Optional)
+	assert.True(t, res.Schema["name"].Optional)
+	assert.True(t, res.Schema["region_id"].Optional)
+	assert.True(t, res.Schema["district_id"].Optional)
+	assert.True(t, res.Schema["net_service_id"].Optional)
+	assert.True(t, res.Schema["node_group_type"].Optional)
+	assert.True(t, res.Schema["task_type"].Optional)
+	assert.True(t, res.Schema["probe_type"].Optional)
+	assert.True(t, res.Schema["result_output_file"].Optional)
+
+	// Check computed output fields
+	assert.True(t, res.Schema["node_list"].Computed)
+	assert.True(t, res.Schema["district_list"].Computed)
+	assert.True(t, res.Schema["net_service_list"].Computed)
+}

--- a/tencentcloud/services/cat/service_tencentcloud_cat.go
+++ b/tencentcloud/services/cat/service_tencentcloud_cat.go
@@ -390,3 +390,71 @@ func (me *CatService) DescribeCatProbeMetricTagValuesByFilter(ctx context.Contex
 
 	return
 }
+
+func (me *CatService) DescribeCatNodeGroupsByFilter(ctx context.Context, param map[string]interface{}) (nodeList []*cat.NodeTree, districtList []*cat.DistinctOrNetServiceInfo, netServiceList []*cat.DistinctOrNetServiceInfo, errRet error) {
+	var (
+		logId   = tccommon.GetLogId(ctx)
+		request = cat.NewDescribeNodeGroupsRequest()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	for k, v := range param {
+		if k == "node_type" {
+			request.NodeType = v.([]*int64)
+		}
+		if k == "task_category" {
+			request.TaskCategory = v.(*int64)
+		}
+		if k == "ip_type" {
+			request.IPType = v.(*int64)
+		}
+		if k == "name" {
+			request.Name = v.(*string)
+		}
+		if k == "region_id" {
+			request.RegionID = v.(*int64)
+		}
+		if k == "district_id" {
+			request.DistrictID = v.(*int64)
+		}
+		if k == "net_service_id" {
+			request.NetServiceID = v.(*int64)
+		}
+		if k == "node_group_type" {
+			request.NodeGroupType = v.(*int64)
+		}
+		if k == "task_type" {
+			request.TaskType = v.(*int64)
+		}
+		if k == "probe_type" {
+			request.ProbeType = v.(*uint64)
+		}
+	}
+
+	ratelimit.Check(request.GetAction())
+	response, err := me.client.UseCatClient().DescribeNodeGroups(request)
+	if err != nil {
+		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+			logId, request.GetAction(), request.ToJsonString(), err.Error())
+		errRet = err
+		return
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+		logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+	if response == nil || response.Response == nil {
+		return
+	}
+
+	nodeList = response.Response.NodeList
+	districtList = response.Response.DistrictList
+	netServiceList = response.Response.NetServiceList
+
+	return
+}

--- a/website/docs/d/cat_node_groups.html.markdown
+++ b/website/docs/d/cat_node_groups.html.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "Cloud Automated Testing(CAT)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_cat_node_groups"
+sidebar_current: "docs-tencentcloud-datasource-cat_node_groups"
+description: |-
+  Use this data source to query detailed information of cat node groups
+---
+
+# tencentcloud_cat_node_groups
+
+Use this data source to query detailed information of cat node groups
+
+## Example Usage
+
+```hcl
+data "tencentcloud_cat_node_groups" "groups" {
+  node_type       = [1]
+  ip_type         = 1
+  node_group_type = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `district_id` - (Optional, Int) Province or country ID. 0 means all. Defaults to 0 if not set.
+* `ip_type` - (Optional, Int) IP type. 0: all, 1: IPv4, 2: IPv6. Defaults to 0 if not set.
+* `name` - (Optional, String) Probe node description keyword.
+* `net_service_id` - (Optional, Int) ISP ID. 0: all, 1: China Telecom, 2: China Unicom, 3: China Mobile, 99: others. Defaults to 0 if not set.
+* `node_group_type` - (Optional, Int) Node group type. 0: advanced probe group, 1: availability node, 2: my probe group. Defaults to 0 if not set.
+* `node_type` - (Optional, List: [`Int`]) Node type. 0: all, 1: IDC, 2: LastMile, 3: Mobile. Defaults to 0 if not set.
+* `probe_type` - (Optional, Int) Test type, including scheduled test and instant test. 0-scheduled probe, others mean instant probe.
+* `region_id` - (Optional, Int) Region ID. 0: selected probe points, 1: Chinese Mainland, 2: Hong Kong, Macao and Taiwan, 3: Asia Pacific, 4: Europe and America, 5: Africa and Oceania. Defaults to 0 if not set.
+* `result_output_file` - (Optional, String) Used to save results.
+* `task_category` - (Optional, Int) Node category. 0: all, 1: PC, 2: Mobile. Defaults to 0 if not set.
+* `task_type` - (Optional, Int) Task type, such as 1, 2, 3, 4, 5, 6, 7. 1-page performance, 2-file upload, 3-file download, 4-port performance, 5-network quality, 6-audio and video experience, 7-domain whois. Defaults to 0 if not set, no filtering by task type.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `district_list` - Province or country list.
+  * `id` - Province (international) or ISP ID.
+  * `name` - Name.
+* `net_service_list` - ISP list.
+  * `id` - Province (international) or ISP ID.
+  * `name` - Name.
+* `node_list` - Tree node list, two levels in total.
+  * `children` - Child nodes.
+    * `children` - Node list.
+      * `content` - Node name.
+      * `id` - Node code.
+    * `content` - Child node name.
+    * `id` - Child node ID.
+  * `content` - Node name.
+  * `id` - Node ID.
+
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -1041,6 +1041,9 @@
                                     <a href="/docs/providers/tencentcloud/d/cat_node.html">tencentcloud_cat_node</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/tencentcloud/d/cat_node_groups.html">tencentcloud_cat_node_groups</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/tencentcloud/d/cat_probe_data.html">tencentcloud_cat_probe_data</a>
                                 </li>
                                 <li>


### PR DESCRIPTION
Add a new data source `tencentcloud_cat_node_groups` for the CAT (Cloud Application Testing) product to query detailed information of cat node groups, including node list, district list, and net service list.