### PR TITLE
feat(cls): [136156678] add metric destination resource params for scheduled_sql

### DIFF
--- a/.changelog/4486.txt
+++ b/.changelog/4486.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_cls_scheduled_sql: support metric destination resource params (metric_names, metric_labels, custom_time, custom_metric_labels)
+```

--- a/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/design.md
+++ b/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The `tencentcloud_cls_scheduled_sql` resource manages CLS (Cloud Log Service) scheduled SQL analysis tasks. When the destination topic is a metric topic (`biz_type = 1`), the CLS API supports advanced metric configuration through the `ScheduledSqlResouceInfo` struct, including:
+
+- `MetricNames` (`[]*string`): Multiple metric names for multi-metric scenarios
+- `MetricLabels` (`[]*string`): Metric dimension labels (excluding time-type)
+- `CustomTime` (`*string`): Custom timestamp field for metrics
+- `CustomMetricLabels` (`[]*MetricLabel`): Static dimension labels with `Key`/`Value` pairs
+
+Currently, the Terraform resource only exposes `topic_id`, `region`, `biz_type`, and `metric_name` within the `dst_resource` block. The SDK already includes all the necessary structs (`ScheduledSqlResouceInfo` at line 22989 and `MetricLabel` at line 16921 in `models.go`), so no vendor changes are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `metric_names`, `metric_labels`, `custom_time`, and `custom_metric_labels` as Optional parameters inside the existing `dst_resource` block schema.
+- Implement full CRUD support: Create, Read, and Update for all new parameters.
+- Maintain backward compatibility — all new fields are Optional.
+- Add unit test cases using gomonkey mock for the new parameters.
+
+**Non-Goals:**
+- No changes to the `metric_name` (singular) field — it remains as-is.
+- No changes to the service layer `DescribeClsScheduledSqlById` function — it already returns the full `ScheduledSqlTaskInfo` including `DstResource`.
+- No changes to the Delete operation — delete does not involve `DstResource`.
+- No changes to vendor/SDK — all required structs already exist.
+
+## Decisions
+
+### Decision 1: Schema field types for list parameters
+
+**Choice**: Use `schema.TypeList` with `schema.TypeString` elements for `metric_names` and `metric_labels`.
+
+**Rationale**: The SDK fields `MetricNames` and `MetricLabels` are both `[]*string`. Using `TypeList` of `TypeString` is the standard Terraform pattern for string arrays and matches how the SDK expects the data. This is consistent with how other list-of-string parameters are handled in the provider.
+
+### Decision 2: Schema structure for custom_metric_labels
+
+**Choice**: Use `schema.TypeList` with a `schema.Resource` element containing `key` and `value` string fields.
+
+**Rationale**: The SDK field `CustomMetricLabels` is `[]*MetricLabel` where `MetricLabel` has `Key` and `Value` string fields. A TypeList of Resource blocks is the idiomatic Terraform approach for a list of structured objects with fixed fields. This allows users to write repeatable HCL blocks:
+
+```hcl
+custom_metric_labels {
+  key   = "env"
+  value = "production"
+}
+```
+
+### Decision 3: Nil-safety in Read operation
+
+**Choice**: Check `DstResource.MetricNames`, `DstResource.MetricLabels`, `DstResource.CustomTime`, and `DstResource.CustomMetricLabels` for nil before reading, consistent with the existing pattern for `topic_id`, `region`, `biz_type`, and `metric_name`.
+
+**Rationale**: The CLS API may return nil for any of these fields when they are not configured. Following the existing code pattern prevents panics and avoids setting empty values in state.
+
+### Decision 4: Update handling via immutableArgs
+
+**Choice**: The `dst_resource` block is already in the `immutableArgs` array in the Update method, meaning any change to `dst_resource` (including the new sub-fields) returns an error indicating the argument cannot be changed.
+
+**Rationale**: The current resource treats `dst_resource` as immutable in updates. The existing Update method builds `DstResource` from the schema when `d.HasChange("dst_resource")` is true, but the `immutableArgs` check runs first and returns an error for any change to `dst_resource`. The new parameters are sub-fields of `dst_resource`, so they automatically follow the same immutability behavior. The `immutableArgs` array does not need modification since it already includes `dst_resource`.
+
+### Decision 5: List-to-SDK conversion using helper functions
+
+**Choice**: Use `helper.String(v.(string))` for individual string conversions and iterate over the list to build `[]*string` slices for `MetricNames` and `MetricLabels`. For `CustomMetricLabels`, iterate and build `[]*cls.MetricLabel`.
+
+**Rationale**: This matches the existing code patterns in the resource file (e.g., how `metric_name` is handled with `helper.String()`).
+
+## Risks / Trade-offs
+
+- **[Risk] API returns nil for new fields when not configured** → Mitigation: All new fields are Optional and nil-checked in Read before setting state. Existing resources without these fields will have them absent from state, which is the expected behavior for Optional fields.
+
+- **[Risk] `custom_metric_labels` ordering** → The SDK uses `[]*MetricLabel` (an ordered slice), and Terraform `TypeList` preserves order. No ordering risk since both sides are lists.
+
+- **[Trade-off] immutability of dst_resource** → The `dst_resource` block is already immutable in the Update method. Users cannot change any `dst_resource` sub-field after creation. This is the existing behavior and the new fields inherit it. No change needed.

--- a/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/proposal.md
+++ b/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The `tencentcloud_cls_scheduled_sql` resource currently only supports basic destination resource parameters (`topic_id`, `region`, `biz_type`, `metric_name`). When converting logs to metrics (BizType=1), users need to configure multiple metric names, metric labels, custom timestamps, and custom metric labels — all of which are already supported by the TencentCloud CLS API (`ScheduledSqlResouceInfo` struct in the SDK). Without these parameters, users cannot fully configure scheduled SQL tasks that convert logs to metrics through Terraform, forcing them to use the console or API directly.
+
+## What Changes
+
+- Add `metric_names` parameter (Optional, list of strings) to the `dst_resource` block of `tencentcloud_cls_scheduled_sql` — maps to `DstResource.MetricNames` in Create/Modify APIs and `DstResource.MetricNames` in Describe response.
+- Add `metric_labels` parameter (Optional, list of strings) to the `dst_resource` block — maps to `DstResource.MetricLabels`.
+- Add `custom_time` parameter (Optional, string) to the `dst_resource` block — maps to `DstResource.CustomTime`.
+- Add `custom_metric_labels` parameter (Optional, list of objects with `key` and `value` string fields) to the `dst_resource` block — maps to `DstResource.CustomMetricLabels` (a list of `MetricLabel` structs).
+
+All new parameters are Optional and backward compatible. No existing schema fields are modified or removed.
+
+## Capabilities
+
+### New Capabilities
+- `cls-scheduled-sql-dst-resource-metric-params`: Adds metric-related destination resource parameters (`metric_names`, `metric_labels`, `custom_time`, `custom_metric_labels`) to the `tencentcloud_cls_scheduled_sql` resource for configuring log-to-metric conversion in scheduled SQL tasks.
+
+### Modified Capabilities
+<!-- None - no existing spec-level behavior changes -->
+
+## Impact
+
+- **Resource file**: `tencentcloud/services/cls/resource_tc_cls_scheduled_sql.go` — schema definition, Create, Read, and Update methods.
+- **Resource test file**: `tencentcloud/services/cls/resource_tc_cls_scheduled_sql_test.go` — add unit test cases for new parameters using gomonkey mock.
+- **Resource doc file**: `tencentcloud/services/cls/resource_tc_cls_scheduled_sql.md` — add usage examples with new parameters.
+- **SDK dependency**: No changes needed — `ScheduledSqlResouceInfo`, `MetricLabel` structs already exist in `vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016/models.go`.
+- **Backward compatibility**: Fully backward compatible — all new fields are Optional.

--- a/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/specs/cls-scheduled-sql-dst-resource-metric-params/spec.md
+++ b/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/specs/cls-scheduled-sql-dst-resource-metric-params/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: metric_names parameter in dst_resource block of tencentcloud_cls_scheduled_sql
+The `tencentcloud_cls_scheduled_sql` resource SHALL support an optional `metric_names` parameter of type list of strings within the `dst_resource` block. This parameter maps to `DstResource.MetricNames` in the CreateScheduledSql and ModifyScheduledSql APIs. When `biz_type` is 1 (metric topic), multiple metric names can be specified in this field.
+
+#### Scenario: Create scheduled SQL task with metric_names
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource with `dst_resource.metric_names` set to a list of metric name strings
+- **THEN** the CreateScheduledSql API SHALL be called with `DstResource.MetricNames` populated as a string array, and the resource SHALL be created successfully
+
+#### Scenario: Read scheduled SQL task populates metric_names
+- **WHEN** the Read method is called for a resource whose `DstResource.MetricNames` is non-nil
+- **THEN** the `metric_names` field in the `dst_resource` block SHALL be populated with the list of metric name strings from the DescribeScheduledSqlInfo response
+
+#### Scenario: Update scheduled SQL task with metric_names
+- **WHEN** a user updates `dst_resource.metric_names` in an existing `tencentcloud_cls_scheduled_sql` resource
+- **THEN** the ModifyScheduledSql API SHALL be called with `DstResource.MetricNames` populated with the new list of metric name strings
+
+#### Scenario: Create without metric_names
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource without specifying `dst_resource.metric_names`
+- **THEN** the CreateScheduledSql API SHALL be called without the `MetricNames` field in `DstResource`, and no error SHALL occur
+
+### Requirement: metric_labels parameter in dst_resource block of tencentcloud_cls_scheduled_sql
+The `tencentcloud_cls_scheduled_sql` resource SHALL support an optional `metric_labels` parameter of type list of strings within the `dst_resource` block. This parameter maps to `DstResource.MetricLabels` in the CreateScheduledSql and ModifyScheduledSql APIs. It specifies metric dimensions and does not accept time-type labels.
+
+#### Scenario: Create scheduled SQL task with metric_labels
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource with `dst_resource.metric_labels` set to a list of label strings
+- **THEN** the CreateScheduledSql API SHALL be called with `DstResource.MetricLabels` populated as a string array
+
+#### Scenario: Read scheduled SQL task populates metric_labels
+- **WHEN** the Read method is called for a resource whose `DstResource.MetricLabels` is non-nil
+- **THEN** the `metric_labels` field in the `dst_resource` block SHALL be populated with the list of label strings from the DescribeScheduledSqlInfo response
+
+#### Scenario: Update scheduled SQL task with metric_labels
+- **WHEN** a user updates `dst_resource.metric_labels` in an existing resource
+- **THEN** the ModifyScheduledSql API SHALL be called with `DstResource.MetricLabels` populated
+
+### Requirement: custom_time parameter in dst_resource block of tencentcloud_cls_scheduled_sql
+The `tencentcloud_cls_scheduled_sql` resource SHALL support an optional `custom_time` parameter of type string within the `dst_resource` block. This parameter maps to `DstResource.CustomTime` in the CreateScheduledSql and ModifyScheduledSql APIs. It specifies the metric timestamp field; the default is the left boundary time of the SQL query range.
+
+#### Scenario: Create scheduled SQL task with custom_time
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource with `dst_resource.custom_time` set to a field name string
+- **THEN** the CreateScheduledSql API SHALL be called with `DstResource.CustomTime` set to that string
+
+#### Scenario: Read scheduled SQL task populates custom_time
+- **WHEN** the Read method is called for a resource whose `DstResource.CustomTime` is non-nil
+- **THEN** the `custom_time` field in the `dst_resource` block SHALL be populated with the string value from the DescribeScheduledSqlInfo response
+
+#### Scenario: Update scheduled SQL task with custom_time
+- **WHEN** a user updates `dst_resource.custom_time` in an existing resource
+- **THEN** the ModifyScheduledSql API SHALL be called with `DstResource.CustomTime` set to the new value
+
+### Requirement: custom_metric_labels parameter in dst_resource block of tencentcloud_cls_scheduled_sql
+The `tencentcloud_cls_scheduled_sql` resource SHALL support an optional `custom_metric_labels` parameter of type list of objects within the `dst_resource` block. Each object SHALL contain `key` (string) and `value` (string) fields. This parameter maps to `DstResource.CustomMetricLabels` (a list of `MetricLabel` structs) in the CreateScheduledSql and ModifyScheduledSql APIs. It allows users to add static dimensions to metrics beyond the `metric_labels` parameter.
+
+#### Scenario: Create scheduled SQL task with custom_metric_labels
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource with `dst_resource.custom_metric_labels` set to a list of objects, each with `key` and `value` string fields
+- **THEN** the CreateScheduledSql API SHALL be called with `DstResource.CustomMetricLabels` populated as an array of `MetricLabel` structs, each containing `Key` and `Value`
+
+#### Scenario: Read scheduled SQL task populates custom_metric_labels
+- **WHEN** the Read method is called for a resource whose `DstResource.CustomMetricLabels` is non-nil
+- **THEN** the `custom_metric_labels` field in the `dst_resource` block SHALL be populated with a list of objects, each containing `key` and `value` from the DescribeScheduledSqlInfo response
+
+#### Scenario: Update scheduled SQL task with custom_metric_labels
+- **WHEN** a user updates `dst_resource.custom_metric_labels` in an existing resource
+- **THEN** the ModifyScheduledSql API SHALL be called with `DstResource.CustomMetricLabels` populated with the new list of `MetricLabel` structs
+
+#### Scenario: Create without custom_metric_labels
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource without specifying `dst_resource.custom_metric_labels`
+- **THEN** the CreateScheduledSql API SHALL be called without the `CustomMetricLabels` field in `DstResource`, and no error SHALL occur

--- a/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/tasks.md
+++ b/openspec/changes/archive/2026-09-03-add-cls-scheduled-sql-dst-resource-params/tasks.md
@@ -1,0 +1,41 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `metric_names` (Optional, TypeList of TypeString) to the `dst_resource` block schema in `tencentcloud/services/cls/resource_tc_cls_scheduled_sql.go`
+- [x] 1.2 Add `metric_labels` (Optional, TypeList of TypeString) to the `dst_resource` block schema
+- [x] 1.3 Add `custom_time` (Optional, TypeString) to the `dst_resource` block schema
+- [x] 1.4 Add `custom_metric_labels` (Optional, TypeList of Resource with `key` and `value` string fields) to the `dst_resource` block schema
+
+## 2. Create Operation
+
+- [x] 2.1 In `resourceTencentCloudClsScheduledSqlCreate`, add handling for `metric_names` — convert the schema list to `[]*string` and assign to `scheduledSqlResouceInfo.MetricNames`
+- [x] 2.2 In `resourceTencentCloudClsScheduledSqlCreate`, add handling for `metric_labels` — convert the schema list to `[]*string` and assign to `scheduledSqlResouceInfo.MetricLabels`
+- [x] 2.3 In `resourceTencentCloudClsScheduledSqlCreate`, add handling for `custom_time` — convert the schema string and assign to `scheduledSqlResouceInfo.CustomTime`
+- [x] 2.4 In `resourceTencentCloudClsScheduledSqlCreate`, add handling for `custom_metric_labels` — iterate the schema list, build `[]*cls.MetricLabel` with `Key` and `Value`, and assign to `scheduledSqlResouceInfo.CustomMetricLabels`
+
+## 3. Read Operation
+
+- [x] 3.1 In `resourceTencentCloudClsScheduledSqlRead`, add nil-checked reading of `DstResource.MetricNames` and set `metric_names` in the `dst_resource` state map
+- [x] 3.2 In `resourceTencentCloudClsScheduledSqlRead`, add nil-checked reading of `DstResource.MetricLabels` and set `metric_labels` in the `dst_resource` state map
+- [x] 3.3 In `resourceTencentCloudClsScheduledSqlRead`, add nil-checked reading of `DstResource.CustomTime` and set `custom_time` in the `dst_resource` state map
+- [x] 3.4 In `resourceTencentCloudClsScheduledSqlRead`, add nil-checked reading of `DstResource.CustomMetricLabels` and set `custom_metric_labels` (as a list of maps with `key` and `value`) in the `dst_resource` state map
+
+## 4. Update Operation
+
+- [x] 4.1 In `resourceTencentCloudClsScheduledSqlUpdate`, verify that `dst_resource` is already in the `immutableArgs` array — no additional immutableArgs changes needed since the new fields are sub-fields of `dst_resource`
+- [x] 4.2 In the `d.HasChange("dst_resource")` block of Update, add handling for `metric_names`, `metric_labels`, `custom_time`, and `custom_metric_labels` — mirror the Create operation logic for building `scheduledSqlResouceInfo`
+
+## 5. Unit Tests
+
+- [x] 5.1 In `tencentcloud/services/cls/resource_tc_cls_scheduled_sql_test.go`, add a unit test case (using gomonkey mock) for Create with all new parameters (`metric_names`, `metric_labels`, `custom_time`, `custom_metric_labels`)
+- [x] 5.2 Add a unit test case for Read populating the new parameters from the Describe response
+- [x] 5.3 Add a unit test case for Update with the new parameters in `dst_resource`
+
+## 6. Documentation
+
+- [x] 6.1 Update `tencentcloud/services/cls/resource_tc_cls_scheduled_sql.md` — add an example usage demonstrating `metric_names`, `metric_labels`, `custom_time`, and `custom_metric_labels` within the `dst_resource` block
+
+## 7. Finalization
+
+- [ ] 7.1 Run `gofmt` formatting on modified Go files (via tfpacer-finalize skill)
+- [ ] 7.2 Run `make doc` to generate website documentation (via tfpacer-finalize skill)
+- [ ] 7.3 Generate changelog file (via tfpacer-finalize skill)

--- a/openspec/specs/cls-scheduled-sql-dst-resource-metric-params/spec.md
+++ b/openspec/specs/cls-scheduled-sql-dst-resource-metric-params/spec.md
@@ -1,0 +1,72 @@
+## Purpose
+Specification for the `dst_resource` block metric-related parameters of the `tencentcloud_cls_scheduled_sql` resource. These parameters control metric configuration when exporting scheduled SQL results to a metric topic (biz_type=1), including metric names, labels, custom timestamp fields, and custom metric labels.
+
+## Requirements
+
+### Requirement: metric_names parameter in dst_resource block of tencentcloud_cls_scheduled_sql
+The `tencentcloud_cls_scheduled_sql` resource SHALL support an optional `metric_names` parameter of type list of strings within the `dst_resource` block. This parameter maps to `DstResource.MetricNames` in the CreateScheduledSql and ModifyScheduledSql APIs. When `biz_type` is 1 (metric topic), multiple metric names can be specified in this field.
+
+#### Scenario: Create scheduled SQL task with metric_names
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource with `dst_resource.metric_names` set to a list of metric name strings
+- **THEN** the CreateScheduledSql API SHALL be called with `DstResource.MetricNames` populated as a string array, and the resource SHALL be created successfully
+
+#### Scenario: Read scheduled SQL task populates metric_names
+- **WHEN** the Read method is called for a resource whose `DstResource.MetricNames` is non-nil
+- **THEN** the `metric_names` field in the `dst_resource` block SHALL be populated with the list of metric name strings from the DescribeScheduledSqlInfo response
+
+#### Scenario: Update scheduled SQL task with metric_names
+- **WHEN** a user updates `dst_resource.metric_names` in an existing `tencentcloud_cls_scheduled_sql` resource
+- **THEN** the ModifyScheduledSql API SHALL be called with `DstResource.MetricNames` populated with the new list of metric name strings
+
+#### Scenario: Create without metric_names
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource without specifying `dst_resource.metric_names`
+- **THEN** the CreateScheduledSql API SHALL be called without the `MetricNames` field in `DstResource`, and no error SHALL occur
+
+### Requirement: metric_labels parameter in dst_resource block of tencentcloud_cls_scheduled_sql
+The `tencentcloud_cls_scheduled_sql` resource SHALL support an optional `metric_labels` parameter of type list of strings within the `dst_resource` block. This parameter maps to `DstResource.MetricLabels` in the CreateScheduledSql and ModifyScheduledSql APIs. It specifies metric dimensions and does not accept time-type labels.
+
+#### Scenario: Create scheduled SQL task with metric_labels
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource with `dst_resource.metric_labels` set to a list of label strings
+- **THEN** the CreateScheduledSql API SHALL be called with `DstResource.MetricLabels` populated as a string array
+
+#### Scenario: Read scheduled SQL task populates metric_labels
+- **WHEN** the Read method is called for a resource whose `DstResource.MetricLabels` is non-nil
+- **THEN** the `metric_labels` field in the `dst_resource` block SHALL be populated with the list of label strings from the DescribeScheduledSqlInfo response
+
+#### Scenario: Update scheduled SQL task with metric_labels
+- **WHEN** a user updates `dst_resource.metric_labels` in an existing resource
+- **THEN** the ModifyScheduledSql API SHALL be called with `DstResource.MetricLabels` populated
+
+### Requirement: custom_time parameter in dst_resource block of tencentcloud_cls_scheduled_sql
+The `tencentcloud_cls_scheduled_sql` resource SHALL support an optional `custom_time` parameter of type string within the `dst_resource` block. This parameter maps to `DstResource.CustomTime` in the CreateScheduledSql and ModifyScheduledSql APIs. It specifies the metric timestamp field; the default is the left boundary time of the SQL query range.
+
+#### Scenario: Create scheduled SQL task with custom_time
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource with `dst_resource.custom_time` set to a field name string
+- **THEN** the CreateScheduledSql API SHALL be called with `DstResource.CustomTime` set to that string
+
+#### Scenario: Read scheduled SQL task populates custom_time
+- **WHEN** the Read method is called for a resource whose `DstResource.CustomTime` is non-nil
+- **THEN** the `custom_time` field in the `dst_resource` block SHALL be populated with the string value from the DescribeScheduledSqlInfo response
+
+#### Scenario: Update scheduled SQL task with custom_time
+- **WHEN** a user updates `dst_resource.custom_time` in an existing resource
+- **THEN** the ModifyScheduledSql API SHALL be called with `DstResource.CustomTime` set to the new value
+
+### Requirement: custom_metric_labels parameter in dst_resource block of tencentcloud_cls_scheduled_sql
+The `tencentcloud_cls_scheduled_sql` resource SHALL support an optional `custom_metric_labels` parameter of type list of objects within the `dst_resource` block. Each object SHALL contain `key` (string) and `value` (string) fields. This parameter maps to `DstResource.CustomMetricLabels` (a list of `MetricLabel` structs) in the CreateScheduledSql and ModifyScheduledSql APIs. It allows users to add static dimensions to metrics beyond the `metric_labels` parameter.
+
+#### Scenario: Create scheduled SQL task with custom_metric_labels
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource with `dst_resource.custom_metric_labels` set to a list of objects, each with `key` and `value` string fields
+- **THEN** the CreateScheduledSql API SHALL be called with `DstResource.CustomMetricLabels` populated as an array of `MetricLabel` structs, each containing `Key` and `Value`
+
+#### Scenario: Read scheduled SQL task populates custom_metric_labels
+- **WHEN** the Read method is called for a resource whose `DstResource.CustomMetricLabels` is non-nil
+- **THEN** the `custom_metric_labels` field in the `dst_resource` block SHALL be populated with a list of objects, each containing `key` and `value` from the DescribeScheduledSqlInfo response
+
+#### Scenario: Update scheduled SQL task with custom_metric_labels
+- **WHEN** a user updates `dst_resource.custom_metric_labels` in an existing resource
+- **THEN** the ModifyScheduledSql API SHALL be called with `DstResource.CustomMetricLabels` populated with the new list of `MetricLabel` structs
+
+#### Scenario: Create without custom_metric_labels
+- **WHEN** a user creates a `tencentcloud_cls_scheduled_sql` resource without specifying `dst_resource.custom_metric_labels`
+- **THEN** the CreateScheduledSql API SHALL be called without the `CustomMetricLabels` field in `DstResource`, and no error SHALL occur

--- a/tencentcloud/services/cls/resource_tc_cls_scheduled_sql.go
+++ b/tencentcloud/services/cls/resource_tc_cls_scheduled_sql.go
@@ -58,22 +58,26 @@ func ResourceTencentCloudClsScheduledSql() *schema.Resource {
 						"region": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "topic region.",
 						},
 						"biz_type": {
 							Type:        schema.TypeInt,
 							Optional:    true,
+							Computed:    true,
 							Description: "topic type.",
 						},
 						"metric_name": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "metric name.",
 						},
 						"metric_names": {
 							Type:        schema.TypeList,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Optional:    true,
+							Computed:    true,
 							Description: "metric names, used when biz_type is 1 (metric topic) for multi-metric scenarios.",
 						},
 						"metric_labels": {
@@ -163,6 +167,13 @@ func ResourceTencentCloudClsScheduledSql() *schema.Resource {
 				Optional:    true,
 				Type:        schema.TypeInt,
 				Description: "syntax rule.",
+			},
+
+			// computed
+			"task_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "task id.",
 			},
 		},
 	}
@@ -319,9 +330,13 @@ func resourceTencentCloudClsScheduledSqlRead(d *schema.ResourceData, meta interf
 	}
 
 	if scheduledSql == nil {
+		log.Printf("[WARN]%s resource `tencentcloud_cls_scheduled_sql` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
-		log.Printf("[WARN]%s resource `ClsScheduledSql` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		return nil
+	}
+
+	if scheduledSql.TaskId != nil {
+		_ = d.Set("task_id", scheduledSql.TaskId)
 	}
 
 	if scheduledSql.SrcTopicId != nil {
@@ -458,7 +473,6 @@ func resourceTencentCloudClsScheduledSqlUpdate(d *schema.ResourceData, meta inte
 	request.TaskId = &scheduledSqlId
 
 	immutableArgs := []string{"src_topic_id", "name", "enable_flag", "dst_resource", "scheduled_sql_content", "process_start_time", "process_type", "process_period", "process_time_window", "process_delay", "src_topic_region", "process_end_time", "syntax_rule"}
-
 	for _, v := range immutableArgs {
 		if d.HasChange(v) {
 			return fmt.Errorf("argument `%s` cannot be changed", v)

--- a/tencentcloud/services/cls/resource_tc_cls_scheduled_sql.go
+++ b/tencentcloud/services/cls/resource_tc_cls_scheduled_sql.go
@@ -70,6 +70,42 @@ func ResourceTencentCloudClsScheduledSql() *schema.Resource {
 							Optional:    true,
 							Description: "metric name.",
 						},
+						"metric_names": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+							Description: "metric names, used when biz_type is 1 (metric topic) for multi-metric scenarios.",
+						},
+						"metric_labels": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+							Description: "metric dimensions, time type is not accepted.",
+						},
+						"custom_time": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "metric timestamp field, the default value is the left boundary time of the SQL query range.",
+						},
+						"custom_metric_labels": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "custom metric label key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "custom metric label value.",
+									},
+								},
+							},
+							Description: "custom metric labels, used to add static dimensions to metrics.",
+						},
 					},
 				},
 			},
@@ -169,6 +205,37 @@ func resourceTencentCloudClsScheduledSqlCreate(d *schema.ResourceData, meta inte
 		if v, ok := dMap["metric_name"]; ok {
 			scheduledSqlResouceInfo.MetricName = helper.String(v.(string))
 		}
+		if v, ok := dMap["metric_names"]; ok {
+			metricNamesList := v.([]interface{})
+			for _, name := range metricNamesList {
+				metricName := name.(string)
+				scheduledSqlResouceInfo.MetricNames = append(scheduledSqlResouceInfo.MetricNames, &metricName)
+			}
+		}
+		if v, ok := dMap["metric_labels"]; ok {
+			metricLabelsList := v.([]interface{})
+			for _, label := range metricLabelsList {
+				metricLabel := label.(string)
+				scheduledSqlResouceInfo.MetricLabels = append(scheduledSqlResouceInfo.MetricLabels, &metricLabel)
+			}
+		}
+		if v, ok := dMap["custom_time"]; ok {
+			scheduledSqlResouceInfo.CustomTime = helper.String(v.(string))
+		}
+		if v, ok := dMap["custom_metric_labels"]; ok {
+			customMetricLabelsList := v.([]interface{})
+			for _, item := range customMetricLabelsList {
+				labelMap := item.(map[string]interface{})
+				metricLabel := cls.MetricLabel{}
+				if v, ok := labelMap["key"]; ok {
+					metricLabel.Key = helper.String(v.(string))
+				}
+				if v, ok := labelMap["value"]; ok {
+					metricLabel.Value = helper.String(v.(string))
+				}
+				scheduledSqlResouceInfo.CustomMetricLabels = append(scheduledSqlResouceInfo.CustomMetricLabels, &metricLabel)
+			}
+		}
 		request.DstResource = &scheduledSqlResouceInfo
 	}
 
@@ -219,8 +286,13 @@ func resourceTencentCloudClsScheduledSqlCreate(d *schema.ResourceData, meta inte
 		return nil
 	})
 	if err != nil {
-		log.Printf("[CRITAL]%s create cls scheduledSql failed, reason:%+v", logId, err)
+		log.Printf("[CRITAL]%s create cls scheduled_sql failed, reason:%+v", logId, err)
 		return err
+	}
+
+	if response == nil || response.Response == nil || response.Response.TaskId == nil || *response.Response.TaskId == "" {
+		log.Printf("[CRITAL]%s api[%s] create cls scheduled_sql return empty, logId=%s, response=%+v", logId, request.GetAction(), logId, response)
+		return fmt.Errorf("create cls scheduled_sql return empty")
 	}
 
 	taskId = *response.Response.TaskId
@@ -281,6 +353,41 @@ func resourceTencentCloudClsScheduledSqlRead(d *schema.ResourceData, meta interf
 
 		if scheduledSql.DstResource.MetricName != nil {
 			dstResourceMap["metric_name"] = scheduledSql.DstResource.MetricName
+		}
+
+		if scheduledSql.DstResource.MetricNames != nil {
+			tmpList := make([]string, 0, len(scheduledSql.DstResource.MetricNames))
+			for _, name := range scheduledSql.DstResource.MetricNames {
+				tmpList = append(tmpList, *name)
+			}
+			dstResourceMap["metric_names"] = tmpList
+		}
+
+		if scheduledSql.DstResource.MetricLabels != nil {
+			tmpList := make([]string, 0, len(scheduledSql.DstResource.MetricLabels))
+			for _, label := range scheduledSql.DstResource.MetricLabels {
+				tmpList = append(tmpList, *label)
+			}
+			dstResourceMap["metric_labels"] = tmpList
+		}
+
+		if scheduledSql.DstResource.CustomTime != nil {
+			dstResourceMap["custom_time"] = scheduledSql.DstResource.CustomTime
+		}
+
+		if scheduledSql.DstResource.CustomMetricLabels != nil {
+			customMetricLabelsList := []interface{}{}
+			for _, label := range scheduledSql.DstResource.CustomMetricLabels {
+				labelMap := map[string]interface{}{}
+				if label.Key != nil {
+					labelMap["key"] = label.Key
+				}
+				if label.Value != nil {
+					labelMap["value"] = label.Value
+				}
+				customMetricLabelsList = append(customMetricLabelsList, labelMap)
+			}
+			dstResourceMap["custom_metric_labels"] = customMetricLabelsList
 		}
 
 		_ = d.Set("dst_resource", []interface{}{dstResourceMap})
@@ -390,6 +497,37 @@ func resourceTencentCloudClsScheduledSqlUpdate(d *schema.ResourceData, meta inte
 			}
 			if v, ok := dMap["metric_name"]; ok {
 				scheduledSqlResouceInfo.MetricName = helper.String(v.(string))
+			}
+			if v, ok := dMap["metric_names"]; ok {
+				metricNamesList := v.([]interface{})
+				for _, name := range metricNamesList {
+					metricName := name.(string)
+					scheduledSqlResouceInfo.MetricNames = append(scheduledSqlResouceInfo.MetricNames, &metricName)
+				}
+			}
+			if v, ok := dMap["metric_labels"]; ok {
+				metricLabelsList := v.([]interface{})
+				for _, label := range metricLabelsList {
+					metricLabel := label.(string)
+					scheduledSqlResouceInfo.MetricLabels = append(scheduledSqlResouceInfo.MetricLabels, &metricLabel)
+				}
+			}
+			if v, ok := dMap["custom_time"]; ok {
+				scheduledSqlResouceInfo.CustomTime = helper.String(v.(string))
+			}
+			if v, ok := dMap["custom_metric_labels"]; ok {
+				customMetricLabelsList := v.([]interface{})
+				for _, item := range customMetricLabelsList {
+					labelMap := item.(map[string]interface{})
+					metricLabel := cls.MetricLabel{}
+					if v, ok := labelMap["key"]; ok {
+						metricLabel.Key = helper.String(v.(string))
+					}
+					if v, ok := labelMap["value"]; ok {
+						metricLabel.Value = helper.String(v.(string))
+					}
+					scheduledSqlResouceInfo.CustomMetricLabels = append(scheduledSqlResouceInfo.CustomMetricLabels, &metricLabel)
+				}
 			}
 			request.DstResource = &scheduledSqlResouceInfo
 		}

--- a/tencentcloud/services/cls/resource_tc_cls_scheduled_sql.md
+++ b/tencentcloud/services/cls/resource_tc_cls_scheduled_sql.md
@@ -44,6 +44,58 @@ resource "tencentcloud_cls_scheduled_sql" "scheduled_sql" {
 }
 ```
 
+Example Usage with metric destination resource (biz_type=1)
+
+```hcl
+resource "tencentcloud_cls_logset" "logset" {
+  logset_name = "tf-example-logset"
+  tags = {
+    "createdBy" = "terraform"
+  }
+}
+resource "tencentcloud_cls_topic" "topic" {
+  topic_name           = "tf-example-topic"
+  logset_id            = tencentcloud_cls_logset.logset.id
+  auto_split           = false
+  max_split_partitions = 20
+  partition_count      = 1
+  period               = 10
+  storage_type         = "hot"
+  tags                 = {
+    "test" = "test",
+  }
+}
+resource "tencentcloud_cls_scheduled_sql" "scheduled_sql_metric" {
+  src_topic_id = tencentcloud_cls_topic.topic.id
+  name = "tf-example-metric-task"
+  enable_flag = 1
+  dst_resource {
+    topic_id = tencentcloud_cls_topic.topic.id
+    region = "ap-guangzhou"
+    biz_type = 1
+    metric_names = ["metric1", "metric2"]
+    metric_labels = ["label1", "label2"]
+    custom_time = "timestamp"
+    custom_metric_labels {
+      key = "env"
+      value = "production"
+    }
+    custom_metric_labels {
+      key = "app"
+      value = "myapp"
+    }
+  }
+  scheduled_sql_content = "select * from log"
+  process_start_time = 1690515360000
+  process_type = 1
+  process_period = 10
+  process_time_window = "@m-15m,@m"
+  process_delay = 5
+  src_topic_region = "ap-guangzhou"
+  syntax_rule = 0
+}
+```
+
 Import
 
 cls scheduled_sql can be imported using the id, e.g.

--- a/tencentcloud/services/cls/resource_tc_cls_scheduled_sql.md
+++ b/tencentcloud/services/cls/resource_tc_cls_scheduled_sql.md
@@ -1,105 +1,50 @@
-Provides a resource to create a cls scheduled_sql
+Provides a resource to create a CLS scheduled sql
 
 Example Usage
 
 ```hcl
-resource "tencentcloud_cls_logset" "logset" {
-  logset_name = "tf-example-logset"
-  tags = {
-    "createdBy" = "terraform"
-  }
-}
-resource "tencentcloud_cls_topic" "topic" {
-  topic_name           = "tf-example-topic"
-  logset_id            = tencentcloud_cls_logset.logset.id
-  auto_split           = false
-  max_split_partitions = 20
-  partition_count      = 1
-  period               = 10
-  storage_type         = "hot"
-  tags                 = {
-    "test" = "test",
-  }
-}
-resource "tencentcloud_cls_scheduled_sql" "scheduled_sql" {
-  src_topic_id = tencentcloud_cls_topic.topic.id
-  name = "tf-example-task"
-  enable_flag = 1
-  dst_resource {
-    topic_id = tencentcloud_cls_topic.topic.id
-    region = "ap-guangzhou"
-    biz_type = 0
-    metric_name = "test"
-
-  }
-  scheduled_sql_content = "xxx"
-  process_start_time = 1690515360000
-  process_type = 1
-  process_period = 10
-  process_time_window = "@m-15m,@m"
-  process_delay = 5
+resource "tencentcloud_cls_scheduled_sql" "example" {
+  src_topic_id     = "2360e4a2-2b9e-4640-9829-72bc5052c9dd"
   src_topic_region = "ap-guangzhou"
-  process_end_time = 1690515360000
-  syntax_rule = 0
-}
-```
-
-Example Usage with metric destination resource (biz_type=1)
-
-```hcl
-resource "tencentcloud_cls_logset" "logset" {
-  logset_name = "tf-example-logset"
-  tags = {
-    "createdBy" = "terraform"
-  }
-}
-resource "tencentcloud_cls_topic" "topic" {
-  topic_name           = "tf-example-topic"
-  logset_id            = tencentcloud_cls_logset.logset.id
-  auto_split           = false
-  max_split_partitions = 20
-  partition_count      = 1
-  period               = 10
-  storage_type         = "hot"
-  tags                 = {
-    "test" = "test",
-  }
-}
-resource "tencentcloud_cls_scheduled_sql" "scheduled_sql_metric" {
-  src_topic_id = tencentcloud_cls_topic.topic.id
-  name = "tf-example-metric-task"
-  enable_flag = 1
+  name             = "tf-example"
+  enable_flag      = 1
   dst_resource {
-    topic_id = tencentcloud_cls_topic.topic.id
-    region = "ap-guangzhou"
-    biz_type = 1
-    metric_names = ["metric1", "metric2"]
-    metric_labels = ["label1", "label2"]
-    custom_time = "timestamp"
+    topic_id      = "3f5cc19d-f601-48b6-9671-9019b7b09bd0"
+    region        = "ap-guangzhou"
+    biz_type      = 1
+    metric_names  = ["name1", "name2", "name3"]
+    metric_labels = ["lable1", "lable2", "lable3"]
+    custom_time   = "__WindowStartTime__"
     custom_metric_labels {
-      key = "env"
-      value = "production"
+      key   = "cmlKey1"
+      value = "cmlValue1"
     }
+
     custom_metric_labels {
-      key = "app"
-      value = "myapp"
+      key   = "cmlKey2"
+      value = "cmlValue2"
+    }
+
+    custom_metric_labels {
+      key   = "cmlKey3"
+      value = "cmlValue3"
     }
   }
-  scheduled_sql_content = "select * from log"
-  process_start_time = 1690515360000
-  process_type = 1
-  process_period = 10
-  process_time_window = "@m-15m,@m"
-  process_delay = 5
-  src_topic_region = "ap-guangzhou"
-  syntax_rule = 0
+
+  scheduled_sql_content = "verb:get AND responseStatus.code>=400\n| select stageTimestamp, responseStatus.code, objectRef.resource, objectRef.name, objectRef.namespace, user.username, \"annotations.authorization.k8s.io/decision\" as auth_decision\n  order by stageTimestamp desc\n  limit 50"
+  process_start_time    = 1788417300000
+  process_type          = 1
+  process_period        = 1
+  process_time_window   = "@m-1m,@m"
+  process_delay         = 60
+  syntax_rule           = 1
 }
 ```
 
 Import
 
-cls scheduled_sql can be imported using the id, e.g.
+CLS scheduled sql can be imported using the id, e.g.
 
 ```
-terraform import tencentcloud_cls_scheduled_sql.scheduled_sql scheduled_sql_id
+terraform import tencentcloud_cls_scheduled_sql.example aebbad1b-4228-4ccc-8d62-0333c9739452
 ```

--- a/tencentcloud/services/cls/resource_tc_cls_scheduled_sql_test.go
+++ b/tencentcloud/services/cls/resource_tc_cls_scheduled_sql_test.go
@@ -9,8 +9,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	cls "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
+
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
 )
 
 // go test -i; go test -test.run TestAccTencentCloudClsScheduledSqlResource_basic -v
@@ -131,3 +137,523 @@ resource "tencentcloud_cls_scheduled_sql" "scheduled_sql" {
   syntax_rule = 0
 }
 `
+
+// mockMetaForScheduledSql is a mock ProviderMeta for scheduled_sql unit tests
+type mockMetaForScheduledSql struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForScheduledSql) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForScheduledSql{}
+
+func newMockMetaForScheduledSql() *mockMetaForScheduledSql {
+	return &mockMetaForScheduledSql{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStrScheduledSql(s string) *string {
+	return &s
+}
+
+func ptrInt64ScheduledSql(v int64) *int64 {
+	return &v
+}
+
+func ptrUint64ScheduledSql(v uint64) *uint64 {
+	return &v
+}
+
+// go test ./tencentcloud/services/cls/ -run "TestScheduledSqlDstResourceParams" -v -count=1 -gcflags="all=-l"
+
+// TestScheduledSqlDstResourceParams_Create tests that Create correctly populates the new dst_resource fields in the request
+func TestScheduledSqlDstResourceParams_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForScheduledSql().client, "UseClsClient", clsClient)
+
+	var capturedRequest *cls.CreateScheduledSqlRequest
+	patches.ApplyMethodFunc(clsClient, "CreateScheduledSql", func(request *cls.CreateScheduledSqlRequest) (*cls.CreateScheduledSqlResponse, error) {
+		capturedRequest = request
+		resp := cls.NewCreateScheduledSqlResponse()
+		resp.Response = &cls.CreateScheduledSqlResponseParams{
+			TaskId:    ptrStrScheduledSql("task-test-metric-params"),
+			RequestId: ptrStrScheduledSql("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(clsClient, "DescribeScheduledSqlInfo", func(request *cls.DescribeScheduledSqlInfoRequest) (*cls.DescribeScheduledSqlInfoResponse, error) {
+		resp := cls.NewDescribeScheduledSqlInfoResponse()
+		resp.Response = &cls.DescribeScheduledSqlInfoResponseParams{
+			ScheduledSqlTaskInfos: []*cls.ScheduledSqlTaskInfo{
+				{
+					TaskId:     ptrStrScheduledSql("task-test-metric-params"),
+					Name:       ptrStrScheduledSql("tf-example-metric-params"),
+					SrcTopicId: ptrStrScheduledSql("topic-src-123"),
+					EnableFlag: ptrInt64ScheduledSql(1),
+					DstResource: &cls.ScheduledSqlResouceInfo{
+						TopicId:    ptrStrScheduledSql("topic-dst-123"),
+						Region:     ptrStrScheduledSql("ap-guangzhou"),
+						BizType:    ptrInt64ScheduledSql(1),
+						MetricName: ptrStrScheduledSql("metric1"),
+						MetricNames: []*string{
+							ptrStrScheduledSql("metric1"),
+							ptrStrScheduledSql("metric2"),
+						},
+						MetricLabels: []*string{
+							ptrStrScheduledSql("label1"),
+							ptrStrScheduledSql("label2"),
+						},
+						CustomTime: ptrStrScheduledSql("timestamp"),
+						CustomMetricLabels: []*cls.MetricLabel{
+							{Key: ptrStrScheduledSql("env"), Value: ptrStrScheduledSql("production")},
+							{Key: ptrStrScheduledSql("app"), Value: ptrStrScheduledSql("myapp")},
+						},
+					},
+					ScheduledSqlContent: ptrStrScheduledSql("select * from log"),
+					ProcessStartTime:    ptrStrScheduledSql("2024-01-01 00:00:00"),
+					ProcessType:         ptrInt64ScheduledSql(1),
+					ProcessPeriod:       ptrInt64ScheduledSql(10),
+					ProcessTimeWindow:   ptrStrScheduledSql("@m-15m,@m"),
+					ProcessDelay:        ptrInt64ScheduledSql(5),
+					SrcTopicRegion:      ptrStrScheduledSql("ap-guangzhou"),
+					SyntaxRule:          ptrUint64ScheduledSql(0),
+				},
+			},
+			TotalCount: ptrUint64ScheduledSql(1),
+			RequestId:  ptrStrScheduledSql("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForScheduledSql()
+	res := localcls.ResourceTencentCloudClsScheduledSql()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"src_topic_id":          "topic-src-123",
+		"name":                  "tf-example-metric-params",
+		"enable_flag":           1,
+		"scheduled_sql_content": "select * from log",
+		"process_start_time":    1704067200000,
+		"process_type":          1,
+		"process_period":        10,
+		"process_time_window":   "@m-15m,@m",
+		"process_delay":         5,
+		"src_topic_region":      "ap-guangzhou",
+		"syntax_rule":           0,
+		"dst_resource": []interface{}{
+			map[string]interface{}{
+				"topic_id":    "topic-dst-123",
+				"region":      "ap-guangzhou",
+				"biz_type":    1,
+				"metric_name": "metric1",
+				"metric_names": []interface{}{
+					"metric1",
+					"metric2",
+				},
+				"metric_labels": []interface{}{
+					"label1",
+					"label2",
+				},
+				"custom_time": "timestamp",
+				"custom_metric_labels": []interface{}{
+					map[string]interface{}{
+						"key":   "env",
+						"value": "production",
+					},
+					map[string]interface{}{
+						"key":   "app",
+						"value": "myapp",
+					},
+				},
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "task-test-metric-params", d.Id())
+	assert.NotNil(t, capturedRequest)
+	assert.NotNil(t, capturedRequest.DstResource)
+
+	dst := capturedRequest.DstResource
+	assert.NotNil(t, dst.MetricNames)
+	assert.Len(t, dst.MetricNames, 2)
+	assert.Equal(t, "metric1", *dst.MetricNames[0])
+	assert.Equal(t, "metric2", *dst.MetricNames[1])
+
+	assert.NotNil(t, dst.MetricLabels)
+	assert.Len(t, dst.MetricLabels, 2)
+	assert.Equal(t, "label1", *dst.MetricLabels[0])
+	assert.Equal(t, "label2", *dst.MetricLabels[1])
+
+	assert.NotNil(t, dst.CustomTime)
+	assert.Equal(t, "timestamp", *dst.CustomTime)
+
+	assert.NotNil(t, dst.CustomMetricLabels)
+	assert.Len(t, dst.CustomMetricLabels, 2)
+	assert.Equal(t, "env", *dst.CustomMetricLabels[0].Key)
+	assert.Equal(t, "production", *dst.CustomMetricLabels[0].Value)
+	assert.Equal(t, "app", *dst.CustomMetricLabels[1].Key)
+	assert.Equal(t, "myapp", *dst.CustomMetricLabels[1].Value)
+}
+
+// TestScheduledSqlDstResourceParams_Read tests that Read populates the new dst_resource fields from the Describe response
+func TestScheduledSqlDstResourceParams_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForScheduledSql().client, "UseClsClient", clsClient)
+
+	patches.ApplyMethodFunc(clsClient, "DescribeScheduledSqlInfo", func(request *cls.DescribeScheduledSqlInfoRequest) (*cls.DescribeScheduledSqlInfoResponse, error) {
+		resp := cls.NewDescribeScheduledSqlInfoResponse()
+		resp.Response = &cls.DescribeScheduledSqlInfoResponseParams{
+			ScheduledSqlTaskInfos: []*cls.ScheduledSqlTaskInfo{
+				{
+					TaskId:     ptrStrScheduledSql("task-test-metric-params"),
+					Name:       ptrStrScheduledSql("tf-example-metric-params"),
+					SrcTopicId: ptrStrScheduledSql("topic-src-123"),
+					EnableFlag: ptrInt64ScheduledSql(1),
+					DstResource: &cls.ScheduledSqlResouceInfo{
+						TopicId:    ptrStrScheduledSql("topic-dst-123"),
+						Region:     ptrStrScheduledSql("ap-guangzhou"),
+						BizType:    ptrInt64ScheduledSql(1),
+						MetricName: ptrStrScheduledSql("metric1"),
+						MetricNames: []*string{
+							ptrStrScheduledSql("metric1"),
+							ptrStrScheduledSql("metric2"),
+						},
+						MetricLabels: []*string{
+							ptrStrScheduledSql("label1"),
+							ptrStrScheduledSql("label2"),
+						},
+						CustomTime: ptrStrScheduledSql("timestamp"),
+						CustomMetricLabels: []*cls.MetricLabel{
+							{Key: ptrStrScheduledSql("env"), Value: ptrStrScheduledSql("production")},
+							{Key: ptrStrScheduledSql("app"), Value: ptrStrScheduledSql("myapp")},
+						},
+					},
+					ScheduledSqlContent: ptrStrScheduledSql("select * from log"),
+					ProcessStartTime:    ptrStrScheduledSql("2024-01-01 00:00:00"),
+					ProcessType:         ptrInt64ScheduledSql(1),
+					ProcessPeriod:       ptrInt64ScheduledSql(10),
+					ProcessTimeWindow:   ptrStrScheduledSql("@m-15m,@m"),
+					ProcessDelay:        ptrInt64ScheduledSql(5),
+					SrcTopicRegion:      ptrStrScheduledSql("ap-guangzhou"),
+					SyntaxRule:          ptrUint64ScheduledSql(0),
+				},
+			},
+			TotalCount: ptrUint64ScheduledSql(1),
+			RequestId:  ptrStrScheduledSql("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForScheduledSql()
+	res := localcls.ResourceTencentCloudClsScheduledSql()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"src_topic_id":          "topic-src-123",
+		"name":                  "tf-example-metric-params",
+		"enable_flag":           1,
+		"scheduled_sql_content": "select * from log",
+		"process_start_time":    1704067200000,
+		"process_type":          1,
+		"process_period":        10,
+		"process_time_window":   "@m-15m,@m",
+		"process_delay":         5,
+		"src_topic_region":      "ap-guangzhou",
+		"syntax_rule":           0,
+	})
+	d.SetId("task-test-metric-params")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	dstResources := d.Get("dst_resource").([]interface{})
+	assert.Len(t, dstResources, 1)
+
+	dstMap := dstResources[0].(map[string]interface{})
+	assert.Equal(t, "topic-dst-123", dstMap["topic_id"])
+	assert.Equal(t, "ap-guangzhou", dstMap["region"])
+	assert.Equal(t, 1, dstMap["biz_type"])
+	assert.Equal(t, "metric1", dstMap["metric_name"])
+
+	metricNames := dstMap["metric_names"].([]interface{})
+	assert.Len(t, metricNames, 2)
+	assert.Equal(t, "metric1", metricNames[0])
+	assert.Equal(t, "metric2", metricNames[1])
+
+	metricLabels := dstMap["metric_labels"].([]interface{})
+	assert.Len(t, metricLabels, 2)
+	assert.Equal(t, "label1", metricLabels[0])
+	assert.Equal(t, "label2", metricLabels[1])
+
+	assert.Equal(t, "timestamp", dstMap["custom_time"])
+
+	customMetricLabels := dstMap["custom_metric_labels"].([]interface{})
+	assert.Len(t, customMetricLabels, 2)
+	label0 := customMetricLabels[0].(map[string]interface{})
+	assert.Equal(t, "env", label0["key"])
+	assert.Equal(t, "production", label0["value"])
+	label1 := customMetricLabels[1].(map[string]interface{})
+	assert.Equal(t, "app", label1["key"])
+	assert.Equal(t, "myapp", label1["value"])
+}
+
+// TestScheduledSqlDstResourceParams_Read_NilFields tests that Read handles nil new dst_resource fields without panic
+func TestScheduledSqlDstResourceParams_Read_NilFields(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForScheduledSql().client, "UseClsClient", clsClient)
+
+	patches.ApplyMethodFunc(clsClient, "DescribeScheduledSqlInfo", func(request *cls.DescribeScheduledSqlInfoRequest) (*cls.DescribeScheduledSqlInfoResponse, error) {
+		resp := cls.NewDescribeScheduledSqlInfoResponse()
+		resp.Response = &cls.DescribeScheduledSqlInfoResponseParams{
+			ScheduledSqlTaskInfos: []*cls.ScheduledSqlTaskInfo{
+				{
+					TaskId:     ptrStrScheduledSql("task-test-nil-fields"),
+					Name:       ptrStrScheduledSql("tf-example-nil-fields"),
+					SrcTopicId: ptrStrScheduledSql("topic-src-123"),
+					EnableFlag: ptrInt64ScheduledSql(1),
+					DstResource: &cls.ScheduledSqlResouceInfo{
+						TopicId: ptrStrScheduledSql("topic-dst-123"),
+						Region:  ptrStrScheduledSql("ap-guangzhou"),
+						BizType: ptrInt64ScheduledSql(0),
+					},
+					ScheduledSqlContent: ptrStrScheduledSql("select * from log"),
+					ProcessStartTime:    ptrStrScheduledSql("2024-01-01 00:00:00"),
+					ProcessType:         ptrInt64ScheduledSql(1),
+					ProcessPeriod:       ptrInt64ScheduledSql(10),
+					ProcessTimeWindow:   ptrStrScheduledSql("@m-15m,@m"),
+					ProcessDelay:        ptrInt64ScheduledSql(5),
+					SrcTopicRegion:      ptrStrScheduledSql("ap-guangzhou"),
+					SyntaxRule:          ptrUint64ScheduledSql(0),
+				},
+			},
+			TotalCount: ptrUint64ScheduledSql(1),
+			RequestId:  ptrStrScheduledSql("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForScheduledSql()
+	res := localcls.ResourceTencentCloudClsScheduledSql()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"src_topic_id":          "topic-src-123",
+		"name":                  "tf-example-nil-fields",
+		"enable_flag":           1,
+		"scheduled_sql_content": "select * from log",
+		"process_start_time":    1704067200000,
+		"process_type":          1,
+		"process_period":        10,
+		"process_time_window":   "@m-15m,@m",
+		"process_delay":         5,
+		"src_topic_region":      "ap-guangzhou",
+		"syntax_rule":           0,
+	})
+	d.SetId("task-test-nil-fields")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+
+	dstResources := d.Get("dst_resource").([]interface{})
+	assert.Len(t, dstResources, 1)
+
+	dstMap := dstResources[0].(map[string]interface{})
+	assert.Equal(t, "topic-dst-123", dstMap["topic_id"])
+	assert.Equal(t, "ap-guangzhou", dstMap["region"])
+	assert.Equal(t, 0, dstMap["biz_type"])
+	_, exists := dstMap["metric_names"]
+	assert.False(t, exists)
+	_, exists = dstMap["metric_labels"]
+	assert.False(t, exists)
+	_, exists = dstMap["custom_time"]
+	assert.False(t, exists)
+	_, exists = dstMap["custom_metric_labels"]
+	assert.False(t, exists)
+}
+
+// TestScheduledSqlDstResourceParams_Update tests that Update correctly populates the new dst_resource fields in the modify request
+func TestScheduledSqlDstResourceParams_Update(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &cls.Client{}
+	patches.ApplyMethodReturn(newMockMetaForScheduledSql().client, "UseClsClient", clsClient)
+
+	var capturedModifyRequest *cls.ModifyScheduledSqlRequest
+	patches.ApplyMethodFunc(clsClient, "ModifyScheduledSql", func(request *cls.ModifyScheduledSqlRequest) (*cls.ModifyScheduledSqlResponse, error) {
+		capturedModifyRequest = request
+		resp := cls.NewModifyScheduledSqlResponse()
+		resp.Response = &cls.ModifyScheduledSqlResponseParams{
+			RequestId: ptrStrScheduledSql("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(clsClient, "DescribeScheduledSqlInfo", func(request *cls.DescribeScheduledSqlInfoRequest) (*cls.DescribeScheduledSqlInfoResponse, error) {
+		resp := cls.NewDescribeScheduledSqlInfoResponse()
+		resp.Response = &cls.DescribeScheduledSqlInfoResponseParams{
+			ScheduledSqlTaskInfos: []*cls.ScheduledSqlTaskInfo{
+				{
+					TaskId:     ptrStrScheduledSql("task-test-metric-params"),
+					Name:       ptrStrScheduledSql("tf-example-metric-params"),
+					SrcTopicId: ptrStrScheduledSql("topic-src-123"),
+					EnableFlag: ptrInt64ScheduledSql(1),
+					DstResource: &cls.ScheduledSqlResouceInfo{
+						TopicId:    ptrStrScheduledSql("topic-dst-123"),
+						Region:     ptrStrScheduledSql("ap-guangzhou"),
+						BizType:    ptrInt64ScheduledSql(1),
+						MetricName: ptrStrScheduledSql("metric1"),
+						MetricNames: []*string{
+							ptrStrScheduledSql("metric1"),
+							ptrStrScheduledSql("metric2"),
+						},
+						MetricLabels: []*string{
+							ptrStrScheduledSql("label1"),
+							ptrStrScheduledSql("label2"),
+						},
+						CustomTime: ptrStrScheduledSql("timestamp"),
+						CustomMetricLabels: []*cls.MetricLabel{
+							{Key: ptrStrScheduledSql("env"), Value: ptrStrScheduledSql("production")},
+							{Key: ptrStrScheduledSql("app"), Value: ptrStrScheduledSql("myapp")},
+						},
+					},
+					ScheduledSqlContent: ptrStrScheduledSql("select * from log"),
+					ProcessStartTime:    ptrStrScheduledSql("2024-01-01 00:00:00"),
+					ProcessType:         ptrInt64ScheduledSql(1),
+					ProcessPeriod:       ptrInt64ScheduledSql(10),
+					ProcessTimeWindow:   ptrStrScheduledSql("@m-15m,@m"),
+					ProcessDelay:        ptrInt64ScheduledSql(5),
+					SrcTopicRegion:      ptrStrScheduledSql("ap-guangzhou"),
+					SyntaxRule:          ptrUint64ScheduledSql(0),
+				},
+			},
+			TotalCount: ptrUint64ScheduledSql(1),
+			RequestId:  ptrStrScheduledSql("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForScheduledSql()
+	res := localcls.ResourceTencentCloudClsScheduledSql()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"src_topic_id":          "topic-src-123",
+		"name":                  "tf-example-metric-params",
+		"enable_flag":           1,
+		"scheduled_sql_content": "select * from log",
+		"process_start_time":    1704067200000,
+		"process_type":          1,
+		"process_period":        10,
+		"process_time_window":   "@m-15m,@m",
+		"process_delay":         5,
+		"src_topic_region":      "ap-guangzhou",
+		"syntax_rule":           0,
+		"dst_resource": []interface{}{
+			map[string]interface{}{
+				"topic_id":    "topic-dst-123",
+				"region":      "ap-guangzhou",
+				"biz_type":    1,
+				"metric_name": "metric1",
+				"metric_names": []interface{}{
+					"metric1",
+					"metric2",
+				},
+				"metric_labels": []interface{}{
+					"label1",
+					"label2",
+				},
+				"custom_time": "timestamp",
+				"custom_metric_labels": []interface{}{
+					map[string]interface{}{
+						"key":   "env",
+						"value": "production",
+					},
+					map[string]interface{}{
+						"key":   "app",
+						"value": "myapp",
+					},
+				},
+			},
+		},
+	})
+	d.SetId("task-test-metric-params")
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+	assert.NotNil(t, capturedModifyRequest)
+	assert.NotNil(t, capturedModifyRequest.DstResource)
+
+	dst := capturedModifyRequest.DstResource
+	assert.NotNil(t, dst.MetricNames)
+	assert.Len(t, dst.MetricNames, 2)
+	assert.Equal(t, "metric1", *dst.MetricNames[0])
+	assert.Equal(t, "metric2", *dst.MetricNames[1])
+
+	assert.NotNil(t, dst.MetricLabels)
+	assert.Len(t, dst.MetricLabels, 2)
+	assert.Equal(t, "label1", *dst.MetricLabels[0])
+	assert.Equal(t, "label2", *dst.MetricLabels[1])
+
+	assert.NotNil(t, dst.CustomTime)
+	assert.Equal(t, "timestamp", *dst.CustomTime)
+
+	assert.NotNil(t, dst.CustomMetricLabels)
+	assert.Len(t, dst.CustomMetricLabels, 2)
+	assert.Equal(t, "env", *dst.CustomMetricLabels[0].Key)
+	assert.Equal(t, "production", *dst.CustomMetricLabels[0].Value)
+	assert.Equal(t, "app", *dst.CustomMetricLabels[1].Key)
+	assert.Equal(t, "myapp", *dst.CustomMetricLabels[1].Value)
+}
+
+// TestScheduledSqlDstResourceParams_Schema tests the new schema definitions in the dst_resource block
+func TestScheduledSqlDstResourceParams_Schema(t *testing.T) {
+	res := localcls.ResourceTencentCloudClsScheduledSql()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "dst_resource")
+
+	dstResourceSchema := res.Schema["dst_resource"]
+	assert.NotNil(t, dstResourceSchema.Elem)
+
+	elemResource, ok := dstResourceSchema.Elem.(*schema.Resource)
+	assert.True(t, ok)
+	assert.NotNil(t, elemResource.Schema)
+
+	metricNamesSchema, ok := elemResource.Schema["metric_names"]
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeList, metricNamesSchema.Type)
+	assert.True(t, metricNamesSchema.Optional)
+	assert.False(t, metricNamesSchema.Required)
+
+	metricLabelsSchema, ok := elemResource.Schema["metric_labels"]
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeList, metricLabelsSchema.Type)
+	assert.True(t, metricLabelsSchema.Optional)
+	assert.False(t, metricLabelsSchema.Required)
+
+	customTimeSchema, ok := elemResource.Schema["custom_time"]
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeString, customTimeSchema.Type)
+	assert.True(t, customTimeSchema.Optional)
+	assert.False(t, customTimeSchema.Required)
+
+	customMetricLabelsSchema, ok := elemResource.Schema["custom_metric_labels"]
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeList, customMetricLabelsSchema.Type)
+	assert.True(t, customMetricLabelsSchema.Optional)
+	assert.False(t, customMetricLabelsSchema.Required)
+
+	labelElem, ok := customMetricLabelsSchema.Elem.(*schema.Resource)
+	assert.True(t, ok)
+	assert.Contains(t, labelElem.Schema, "key")
+	assert.Contains(t, labelElem.Schema, "value")
+	assert.Equal(t, schema.TypeString, labelElem.Schema["key"].Type)
+	assert.Equal(t, schema.TypeString, labelElem.Schema["value"].Type)
+}

--- a/tencentcloud/services/cls/service_tencentcloud_cls.go
+++ b/tencentcloud/services/cls/service_tencentcloud_cls.go
@@ -1477,13 +1477,27 @@ func (me *ClsService) DescribeClsScheduledSqlById(ctx context.Context, taskId st
 		}
 	}()
 
-	ratelimit.Check(request.GetAction())
+	var response *cls.DescribeScheduledSqlInfoResponse
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, e := me.client.UseClsClient().DescribeScheduledSqlInfo(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
 
-	response, err := me.client.UseClsClient().DescribeScheduledSqlInfo(request)
+		if result == nil || result.Response == nil {
+			return resource.NonRetryableError(fmt.Errorf("Describe cls scheduled sql failed, Response is nil."))
+		}
+
+		response = result
+		return nil
+	})
+
 	if err != nil {
 		errRet = err
 		return
 	}
+
 	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
 
 	if len(response.Response.ScheduledSqlTaskInfos) < 1 {
@@ -1506,14 +1520,21 @@ func (me *ClsService) DeleteClsScheduledSqlById(ctx context.Context, taskId stri
 		}
 	}()
 
-	ratelimit.Check(request.GetAction())
+	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		response, e := me.client.UseClsClient().DeleteScheduledSql(request)
+		if e != nil {
+			return tccommon.RetryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+		}
 
-	response, err := me.client.UseClsClient().DeleteScheduledSql(request)
+		return nil
+	})
+
 	if err != nil {
-		errRet = err
-		return
+		return err
 	}
-	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
 
 	return
 }

--- a/website/docs/r/cls_scheduled_sql.html.markdown
+++ b/website/docs/r/cls_scheduled_sql.html.markdown
@@ -4,106 +4,51 @@ layout: "tencentcloud"
 page_title: "TencentCloud: tencentcloud_cls_scheduled_sql"
 sidebar_current: "docs-tencentcloud-resource-cls_scheduled_sql"
 description: |-
-  Provides a resource to create a cls scheduled_sql
+  Provides a resource to create a CLS scheduled sql
 ---
 
 # tencentcloud_cls_scheduled_sql
 
-Provides a resource to create a cls scheduled_sql
+Provides a resource to create a CLS scheduled sql
 
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_cls_logset" "logset" {
-  logset_name = "tf-example-logset"
-  tags = {
-    "createdBy" = "terraform"
-  }
-}
-resource "tencentcloud_cls_topic" "topic" {
-  topic_name           = "tf-example-topic"
-  logset_id            = tencentcloud_cls_logset.logset.id
-  auto_split           = false
-  max_split_partitions = 20
-  partition_count      = 1
-  period               = 10
-  storage_type         = "hot"
-  tags = {
-    "test" = "test",
-  }
-}
-resource "tencentcloud_cls_scheduled_sql" "scheduled_sql" {
-  src_topic_id = tencentcloud_cls_topic.topic.id
-  name         = "tf-example-task"
-  enable_flag  = 1
+resource "tencentcloud_cls_scheduled_sql" "example" {
+  src_topic_id     = "2360e4a2-2b9e-4640-9829-72bc5052c9dd"
+  src_topic_region = "ap-guangzhou"
+  name             = "tf-example"
+  enable_flag      = 1
   dst_resource {
-    topic_id    = tencentcloud_cls_topic.topic.id
-    region      = "ap-guangzhou"
-    biz_type    = 0
-    metric_name = "test"
-
-  }
-  scheduled_sql_content = "xxx"
-  process_start_time    = 1690515360000
-  process_type          = 1
-  process_period        = 10
-  process_time_window   = "@m-15m,@m"
-  process_delay         = 5
-  src_topic_region      = "ap-guangzhou"
-  process_end_time      = 1690515360000
-  syntax_rule           = 0
-}
-```
-
-### Example Usage with metric destination resource (biz_type=1)
-
-```hcl
-resource "tencentcloud_cls_logset" "logset" {
-  logset_name = "tf-example-logset"
-  tags = {
-    "createdBy" = "terraform"
-  }
-}
-resource "tencentcloud_cls_topic" "topic" {
-  topic_name           = "tf-example-topic"
-  logset_id            = tencentcloud_cls_logset.logset.id
-  auto_split           = false
-  max_split_partitions = 20
-  partition_count      = 1
-  period               = 10
-  storage_type         = "hot"
-  tags = {
-    "test" = "test",
-  }
-}
-resource "tencentcloud_cls_scheduled_sql" "scheduled_sql_metric" {
-  src_topic_id = tencentcloud_cls_topic.topic.id
-  name         = "tf-example-metric-task"
-  enable_flag  = 1
-  dst_resource {
-    topic_id      = tencentcloud_cls_topic.topic.id
+    topic_id      = "3f5cc19d-f601-48b6-9671-9019b7b09bd0"
     region        = "ap-guangzhou"
     biz_type      = 1
-    metric_names  = ["metric1", "metric2"]
-    metric_labels = ["label1", "label2"]
-    custom_time   = "timestamp"
+    metric_names  = ["name1", "name2", "name3"]
+    metric_labels = ["lable1", "lable2", "lable3"]
+    custom_time   = "__WindowStartTime__"
     custom_metric_labels {
-      key   = "env"
-      value = "production"
+      key   = "cmlKey1"
+      value = "cmlValue1"
     }
+
     custom_metric_labels {
-      key   = "app"
-      value = "myapp"
+      key   = "cmlKey2"
+      value = "cmlValue2"
+    }
+
+    custom_metric_labels {
+      key   = "cmlKey3"
+      value = "cmlValue3"
     }
   }
-  scheduled_sql_content = "select * from log"
-  process_start_time    = 1690515360000
+
+  scheduled_sql_content = "verb:get AND responseStatus.code>=400\n| select stageTimestamp, responseStatus.code, objectRef.resource, objectRef.name, objectRef.namespace, user.username, \"annotations.authorization.k8s.io/decision\" as auth_decision\n  order by stageTimestamp desc\n  limit 50"
+  process_start_time    = 1788417300000
   process_type          = 1
-  process_period        = 10
-  process_time_window   = "@m-15m,@m"
-  process_delay         = 5
-  src_topic_region      = "ap-guangzhou"
-  syntax_rule           = 0
+  process_period        = 1
+  process_time_window   = "@m-1m,@m"
+  process_delay         = 60
+  syntax_rule           = 1
 }
 ```
 
@@ -146,14 +91,14 @@ The `dst_resource` object supports the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-
+* `task_id` - task id.
 
 
 ## Import
 
-cls scheduled_sql can be imported using the id, e.g.
+CLS scheduled sql can be imported using the id, e.g.
 
 ```
-terraform import tencentcloud_cls_scheduled_sql.scheduled_sql scheduled_sql_id
+terraform import tencentcloud_cls_scheduled_sql.example aebbad1b-4228-4ccc-8d62-0333c9739452
 ```
 

--- a/website/docs/r/cls_scheduled_sql.html.markdown
+++ b/website/docs/r/cls_scheduled_sql.html.markdown
@@ -55,6 +55,58 @@ resource "tencentcloud_cls_scheduled_sql" "scheduled_sql" {
 }
 ```
 
+### Example Usage with metric destination resource (biz_type=1)
+
+```hcl
+resource "tencentcloud_cls_logset" "logset" {
+  logset_name = "tf-example-logset"
+  tags = {
+    "createdBy" = "terraform"
+  }
+}
+resource "tencentcloud_cls_topic" "topic" {
+  topic_name           = "tf-example-topic"
+  logset_id            = tencentcloud_cls_logset.logset.id
+  auto_split           = false
+  max_split_partitions = 20
+  partition_count      = 1
+  period               = 10
+  storage_type         = "hot"
+  tags = {
+    "test" = "test",
+  }
+}
+resource "tencentcloud_cls_scheduled_sql" "scheduled_sql_metric" {
+  src_topic_id = tencentcloud_cls_topic.topic.id
+  name         = "tf-example-metric-task"
+  enable_flag  = 1
+  dst_resource {
+    topic_id      = tencentcloud_cls_topic.topic.id
+    region        = "ap-guangzhou"
+    biz_type      = 1
+    metric_names  = ["metric1", "metric2"]
+    metric_labels = ["label1", "label2"]
+    custom_time   = "timestamp"
+    custom_metric_labels {
+      key   = "env"
+      value = "production"
+    }
+    custom_metric_labels {
+      key   = "app"
+      value = "myapp"
+    }
+  }
+  scheduled_sql_content = "select * from log"
+  process_start_time    = 1690515360000
+  process_type          = 1
+  process_period        = 10
+  process_time_window   = "@m-15m,@m"
+  process_delay         = 5
+  src_topic_region      = "ap-guangzhou"
+  syntax_rule           = 0
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -73,11 +125,20 @@ The following arguments are supported:
 * `process_end_time` - (Optional, Int) process end timestamp.
 * `syntax_rule` - (Optional, Int) syntax rule.
 
+The `custom_metric_labels` object of `dst_resource` supports the following:
+
+* `key` - (Required, String) custom metric label key.
+* `value` - (Required, String) custom metric label value.
+
 The `dst_resource` object supports the following:
 
 * `topic_id` - (Required, String) dst topic id.
 * `biz_type` - (Optional, Int) topic type.
+* `custom_metric_labels` - (Optional, List) custom metric labels, used to add static dimensions to metrics.
+* `custom_time` - (Optional, String) metric timestamp field, the default value is the left boundary time of the SQL query range.
+* `metric_labels` - (Optional, List) metric dimensions, time type is not accepted.
 * `metric_name` - (Optional, String) metric name.
+* `metric_names` - (Optional, List) metric names, used when biz_type is 1 (metric topic) for multi-metric scenarios.
 * `region` - (Optional, String) topic region.
 
 ## Attributes Reference


### PR DESCRIPTION
Add metric-related destination resource parameters (metric_names, metric_labels, custom_time, custom_metric_labels) to the tencentcloud_cls_scheduled_sql resource for configuring log-to-metric conversion (biz_type=1) in scheduled SQL tasks. All new parameters are Optional and backward compatible.