### PR TITLE
feat(cat): [133294964] add tencentcloud_cat_probe_tasks data source

### DIFF
--- a/.changelog/4487.txt
+++ b/.changelog/4487.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+tencentcloud_cat_probe_tasks
+```

--- a/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/design.md
+++ b/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/design.md
@@ -1,0 +1,101 @@
+## Context
+
+CAT（云拨测）服务当前已在 Provider 中支持拨测任务的创建与管理（`tencentcloud_cat_task_set` 资源，对应 `DescribeProbeTasks` / `DeleteProbeTask` 等接口）。但缺少一个面向列表查询的 Data Source，用户无法在 Terraform 中按条件读取已有拨测任务信息。
+
+现有 cat service 层已封装了 `DescribeCatTaskSet`（按单个 taskId 查询）方法，但它仅返回单条任务，无法满足按多条件过滤、分页获取完整列表的需求。本次新增 Data Source `tencentcloud_cat_probe_tasks` 复用同一 `DescribeProbeTasks` 云 API，但需要一个新的 service 层方法支持所有可选过滤参数并将全部页数据累积返回。
+
+云 API `DescribeProbeTasks` 入参包含 `Offset`/`Limit`（最大值 100），且支持 `TaskIDs`/`TaskName`/`TargetAddress`/`TaskStatus`/`PayMode`/`OrderState`/`TaskType`/`TaskCategory`/`OrderBy`/`Ascend`/`TagFilters` 等过滤参数；出参为 `TaskSet`（`[]*ProbeTask`）与 `Total`。其中 `TaskStatus`/`TaskType`/`TaskCategory` 在入参中为 `[]*int64`（数组），而在出参 `ProbeTask` 中为 `*int64`（单值）。`TagFilters` 入参为 `[]*KeyValuePair`（Key/Value）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 新增 Data Source `tencentcloud_cat_probe_tasks`，支持所有 `DescribeProbeTasks` 入参作为可选过滤条件
+- service 层新增 `DescribeCatProbeTasksByFilter` 方法，内部自动分页（pageSize 取云 API 最大值 100），累积全部任务返回
+- 字段映射严格遵循接口与参数映射关系，列表项字段平铺在 `task_set` 列表元素内（嵌套的 `tag_info_list` 作为子列表）
+- Read 方法使用 retry 包裹并对空响应做安全处理（nil 响应返回 NonRetryableError，空列表正常返回）
+- 提供基于 gomonkey 的 mock 单元测试
+
+**Non-Goals:**
+- 不修改现有 `tencentcloud_cat_task_set` 资源及其 service 方法
+- 不向用户暴露 `limit`/`offset` 分页参数
+- 不新增异步接口轮询逻辑（`DescribeProbeTasks` 为同步查询接口）
+
+## Decisions
+
+### 1. Service 层方法签名与分页策略
+
+新增方法：
+```go
+func (me *CatService) DescribeCatProbeTasksByFilter(ctx context.Context, param map[string]interface{}) (tasks []*cat.ProbeTask, total *int64, errRet error)
+```
+
+- 采用固定 `pageSize = 100`（云 API 注释标注的最大值）循环分页，累积 `response.Response.TaskSet`，直到本页返回数量小于 `pageSize` 即停止。
+- 不向用户暴露 `limit`/`offset`，分页在 service 层内部完成，与现有 `DescribeCatInstantTasksByFilter` / `DescribeCatTaskSet` 保持一致风格。
+- 参数通过 `param map[string]interface{}` 传入，在方法内按 key 赋值到 request 字段，便于扩展。
+
+**理由**: 复用现有 cat service 的分页模式，保持代码风格一致；map 传参与 igtm 等现有数据源一致。
+
+### 2. 入参类型处理
+
+| Terraform Schema 字段 | Schema 类型 | 云 API 字段 | 云 API 类型 | 转换说明 |
+|---|---|---|---|---|
+| `task_i_ds` | TypeList(string) | `TaskIDs` | `[]*string` | 列表转指针切片 |
+| `task_name` | TypeString | `TaskName` | `*string` | 直接转换 |
+| `target_address` | TypeString | `TargetAddress` | `*string` | 直接转换 |
+| `task_status` | TypeList(int) | `TaskStatus` | `[]*int64` | 列表转指针切片 |
+| `pay_mode` | TypeInt | `PayMode` | `*int64` | 直接转换 |
+| `order_state` | TypeInt | `OrderState` | `*int64` | 直接转换 |
+| `task_type` | TypeList(int) | `TaskType` | `[]*int64` | 列表转指针切片 |
+| `task_category` | TypeList(int) | `TaskCategory` | `[]*int64` | 列表转指针切片 |
+| `order_by` | TypeString | `OrderBy` | `*string` | 直接转换 |
+| `ascend` | TypeBool | `Ascend` | `*bool` | 直接转换 |
+| `tag_filters` | TypeList(block) | `TagFilters` | `[]*KeyValuePair` | 块含 key/value 转 KeyValuePair 切片 |
+
+`task_status`/`task_type`/`task_category` 入参为切片类型（支持多值过滤），因此 schema 使用 TypeList(int)。`tag_filters` 为含 `key`/`value`（均必填）的 block 列表，映射到 `KeyValuePair`。
+
+### 3. 出参字段映射（task_set 列表元素）
+
+`task_set` 为 TypeList，每个元素为 Resource，字段平铺（不额外嵌套"列表型数据"一层），嵌套的 `tag_info_list` 作为子 TypeList：
+
+| Terraform 字段 | Schema 类型 | 云 API 字段(ProbeTask) |
+|---|---|---|
+| `name` | TypeString | `Name` |
+| `task_id` | TypeString | `TaskId` |
+| `task_type` | TypeInt | `TaskType` |
+| `nodes` | TypeList(string) | `Nodes` |
+| `node_ip_type` | TypeInt | `NodeIpType` |
+| `interval` | TypeInt | `Interval` |
+| `parameters` | TypeString | `Parameters` |
+| `status` | TypeInt | `Status` |
+| `target_address` | TypeString | `TargetAddress` |
+| `pay_mode` | TypeInt | `PayMode` |
+| `order_state` | TypeInt | `OrderState` |
+| `task_category` | TypeInt | `TaskCategory` |
+| `created_at` | TypeString | `CreatedAt` |
+| `cron` | TypeString | `Cron` |
+| `cron_state` | TypeInt | `CronState` |
+| `tag_info_list` | TypeList(block: key/value) | `TagInfoList` ([]*KeyValuePair) |
+| `sub_sync_flag` | TypeInt | `SubSyncFlag` |
+
+`total` 为顶层 TypeInt（映射 `response.Response.Total`）。
+
+### 4. Read 方法 retry 与空响应处理
+
+遵循数据源规范：
+- retry 块内若 service 返回错误，用 `tccommon.RetryError(e)` 包装
+- 若云 API 返回空（`response == nil` / `response.Response == nil`，表现为 `tasks == nil && total == nil`），直接返回 `NonRetryableError`，不调用 `d.SetId("")`，保留现场
+- 若返回正常但列表为空（`len(tasks) == 0`），打印 `log.Printf("[DATASOURCE] read empty, skip SetId")` 后继续，不报错
+- `d.SetId(helper.BuildToken())` 设置 id（与 igtm 数据源一致）
+
+### 5. 测试策略
+
+使用 gomonkey mock `DescribeProbeTasksWithContext`，不使用 terraform 测试套件，覆盖：
+- 正常查询（mock 返回非空任务列表，验证字段映射与 total 设置）
+- 空列表场景（mock 返回空列表，验证不报错、正常设置 id）
+- API 错误场景（mock 返回错误，验证错误被返回）
+
+## Risks / Trade-offs
+
+- **[入参切片字段语义差异]** → `TaskStatus`/`TaskType`/`TaskCategory` 入参为切片（多值过滤）但出参为单值，schema 中分别用 TypeList(int) 入参与 TypeInt 出参，由于 Terraform 数据源 Read 不回写入参（入参由用户配置），二者互不干扰，无冲突。
+- **[TagFilters Key/Value 必填]** → 映射要求 `tag_filters` 块内 `key`/`value` 必填，与云 API `KeyValuePair` 结构一致；若用户不传 `tag_filters` 则不设置该 request 字段。
+- **[分页累积性能]** → 当任务数量极大时全量累积可能较慢，但符合数据源"不暴露分页给用户"的约定，且 `Limit` 最大值 100 已尽量减少请求次数。

--- a/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/proposal.md
+++ b/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+用户需要通过 Terraform 查询 CAT（云拨测）拨测任务列表。当前 Provider 已支持拨测任务资源的创建和管理（`tencentcloud_cat_task_set`），但缺少对应的 Data Source 来按条件查询现有拨测任务列表，导致用户无法在 Terraform 配置中引用已有的拨测任务信息，也无法根据任务名、目标地址、状态、标签等条件过滤查询拨测任务。
+
+## What Changes
+
+- 新增 Data Source: `tencentcloud_cat_probe_tasks`
+- 实现对 CAT API `DescribeProbeTasks` 接口的调用（分页查询拨测任务列表）
+- 支持通过多种过滤条件查询拨测任务列表：
+  - `task_i_ds`: 按任务 ID 列表过滤
+  - `task_name`: 按任务名过滤
+  - `target_address`: 按拨测目标地址过滤
+  - `task_status`: 按任务状态过滤
+  - `pay_mode`: 按付费模式过滤
+  - `order_state`: 按订单状态过滤
+  - `task_type`: 按拨测类型过滤
+  - `task_category`: 按节点类型过滤
+  - `order_by`: 排序列
+  - `ascend`: 是否正序
+  - `tag_filters`: 按标签过滤（Key/Value）
+  - `result_output_file`: 输出结果到文件
+- 返回拨测任务列表 `task_set`（字段平铺到每个列表元素内）及任务总数 `total`
+
+## Capabilities
+
+### New Capabilities
+- `cat-probe-tasks-datasource`: CAT 拨测任务列表数据源，通过 `DescribeProbeTasks` 接口按条件查询拨测任务列表并返回任务详情与总数
+
+### Modified Capabilities
+<!-- 无需修改现有 capability -->
+
+## Impact
+
+- **新增能力**: CAT 拨测任务列表查询
+- **受影响的服务**: CAT (tencentcloud/services/cat)
+- **新增文件**:
+  - `tencentcloud/services/cat/data_source_tc_cat_probe_tasks.go`
+  - `tencentcloud/services/cat/data_source_tc_cat_probe_tasks.md`
+  - `tencentcloud/services/cat/data_source_tc_cat_probe_tasks_test.go`
+  - Provider 注册代码需要添加此 data source
+  - provider.md 需要添加此 data source 的声明（通过 make doc 生成）
+- **API 依赖**:
+  - CAT API v20180409: `DescribeProbeTasks`
+- **兼容性**: 无破坏性变更，纯新增功能

--- a/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/specs/cat-probe-tasks-datasource/spec.md
+++ b/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/specs/cat-probe-tasks-datasource/spec.md
@@ -1,0 +1,202 @@
+## ADDED Requirements
+
+### Requirement: Data Source Schema Definition
+
+`tencentcloud_cat_probe_tasks` 数据源 SHALL 支持以下可选输入参数用于过滤拨测任务列表，所有列表项字段平铺在 `task_set` 列表元素内（不额外嵌套一层），顶层提供 `total` 与 `result_output_file`：
+
+**Input Parameters (All Optional):**
+- `task_i_ds` (List of String): 按任务 ID 列表过滤（映射 `request.TaskIDs`）
+- `task_name` (String): 按任务名过滤（映射 `request.TaskName`）
+- `target_address` (String): 按拨测目标地址过滤（映射 `request.TargetAddress`）
+- `task_status` (List of Int): 按任务状态过滤（映射 `request.TaskStatus`，云 API 入参为整型数组）
+- `pay_mode` (Int): 按付费模式过滤（映射 `request.PayMode`）
+- `order_state` (Int): 按订单状态过滤（映射 `request.OrderState`）
+- `task_type` (List of Int): 按拨测类型过滤（映射 `request.TaskType`，云 API 入参为整型数组）
+- `task_category` (List of Int): 按节点类型过滤（映射 `request.TaskCategory`，云 API 入参为整型数组）
+- `order_by` (String): 排序列（映射 `request.OrderBy`）
+- `ascend` (Bool): 是否正序（映射 `request.Ascend`）
+- `tag_filters` (List of Block): 按标签过滤（映射 `request.TagFilters`），每个块包含：
+  - `key` (String, Required): 标签键（映射 `TagFilters.Key`）
+  - `value` (String, Required): 标签值（映射 `TagFilters.Value`）
+- `result_output_file` (String, Optional): 将查询结果导出到指定文件
+
+**Output Attributes:**
+- `task_set` (List): 拨测任务列表，每个元素包含以下字段（映射 `response.Response.TaskSet` 中 `ProbeTask` 的对应字段）：
+  - `name` (String): 任务名
+  - `task_id` (String): 任务 ID
+  - `task_type` (Int): 拨测类型
+  - `nodes` (List of String): 拨测节点列表
+  - `node_ip_type` (Int): 拨测点 IP 类型
+  - `interval` (Int): 拨测间隔（分钟）
+  - `parameters` (String): 拨测参数
+  - `status` (Int): 任务状态
+  - `target_address` (String): 目标地址
+  - `pay_mode` (Int): 付费模式
+  - `order_state` (Int): 订单状态
+  - `task_category` (Int): 任务分类
+  - `created_at` (String): 创建时间
+  - `cron` (String): 定时任务 cron 表达式
+  - `cron_state` (Int): 定时任务启动状态
+  - `tag_info_list` (List of Block): 任务当前绑定的标签，每个块包含 `key` (String) 与 `value` (String)
+  - `sub_sync_flag` (Int): 是否为同步账号
+- `total` (Int): 任务总数（映射 `response.Response.Total`）
+
+数据源 SHALL NOT 向用户暴露 `limit`/`offset` 分页参数；分页 SHALL 在 service 层内部自动完成，获取全部拨测任务。
+
+#### Scenario: Query all probe tasks
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "example" {
+}
+
+output "task_set" {
+  value = data.tencentcloud_cat_probe_tasks.example.task_set
+}
+
+output "total" {
+  value = data.tencentcloud_cat_probe_tasks.example.total
+}
+```
+
+- **WHEN** 用户不带任何参数查询 `tencentcloud_cat_probe_tasks`
+- **THEN** 返回当前账号下全部拨测任务
+- **AND** `task_set` 列表中每个元素包含完整的任务字段
+- **AND** `total` 反映任务总数
+
+#### Scenario: Query probe tasks by name and target address
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "by_name" {
+  task_name      = "my-probe-task"
+  target_address = "http://www.example.com"
+}
+```
+
+- **WHEN** 用户指定 `task_name` 与 `target_address`
+- **THEN** 仅返回匹配任务名与目标地址的拨测任务
+
+#### Scenario: Query probe tasks by tag filters
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "by_tags" {
+  tag_filters {
+    key   = "Environment"
+    value = "Production"
+  }
+}
+```
+
+- **WHEN** 用户指定 `tag_filters` 块（含必填的 `key`/`value`）
+- **THEN** 仅返回包含指定标签键值对的拨测任务
+
+#### Scenario: Export query results to file
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "export" {
+  task_name          = "prod"
+  result_output_file = "/tmp/cat_probe_tasks.json"
+}
+```
+
+- **WHEN** 用户指定 `result_output_file`
+- **THEN** 查询结果以 JSON 格式写入指定文件
+- **AND** 文件内容包含完整的任务列表信息
+
+### Requirement: Service Layer Implementation
+
+`service_tencentcloud_cat.go` SHALL 新增方法用于封装 `DescribeProbeTasks` 接口，内部实现自动分页：
+
+```go
+func (me *CatService) DescribeCatProbeTasksByFilter(ctx context.Context, param map[string]interface{}) (tasks []*cat.ProbeTask, total *int64, errRet error)
+```
+
+实现约束：
+1. 使用固定 `pageSize`（云 API 支持的最大值 100）循环分页，累积 `response.Response.TaskSet`，直到本页返回数量小于 `pageSize` 即停止
+2. 每次请求前调用 `ratelimit.Check(request.GetAction())`
+3. 从 `param` 中按 key 读取并设置 request 字段：`TaskIDs`/`TaskName`/`TargetAddress`/`TaskStatus`/`PayMode`/`OrderState`/`TaskType`/`TaskCategory`/`OrderBy`/`Ascend`/`TagFilters`
+4. 每次请求后记录 `[DEBUG]` 级别的请求体与响应体日志
+5. 失败时记录 `[CRITAL]` 级别错误日志并返回错误
+6. 返回累积后的全部 `tasks` 与最后一次响应的 `total`
+
+#### Scenario: Service method handles empty list
+
+- **WHEN** API 返回非 nil 响应但 `response.Response.TaskSet` 为空列表
+- **THEN** service 方法返回空（长度为 0）的 `tasks` 切片与对应的 `total`
+- **AND** 不返回错误
+
+#### Scenario: Service method handles API errors
+
+- **WHEN** API 调用返回错误
+- **THEN** service 方法记录 `[CRITAL]` 错误日志（含请求体与错误原因）
+- **AND** 返回该错误，由上层 retry 机制决定是否重试
+
+#### Scenario: Service method paginates all results
+
+- **WHEN** 拨测任务数量超过单页 `pageSize`
+- **THEN** service 方法循环调用 `DescribeProbeTasks`，逐步累加 `offset`
+- **AND** 返回所有页累积合并后的完整 `tasks` 列表
+
+### Requirement: Read Retry and Empty-Response Handling
+
+Data Source 的 Read 方法 SHALL 使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包裹 service 方法调用，并通过 `tccommon.RetryError(e)` 包装错误。在 retry 块内 SHALL 满足：
+
+1. 若 service 方法返回错误，使用 `tccommon.RetryError(e)` 包装返回，由外层 retry 决定重试
+2. 若云 API 返回空（`response == nil` / `response.Response == nil` 等，表现为 `tasks == nil && total == nil`），SHALL 直接返回 `tccommon.NonRetryableError`，不调用 `d.SetId("")`，保留现场便于排障
+3. 若 API 返回正常但列表为空（`len(tasks) == 0`），SHALL 视为正常空结果，打印 `log.Printf("[DATASOURCE] read empty, skip SetId")` 后继续后续逻辑，不返回错误
+
+#### Scenario: Retry on transient API failure
+
+- **WHEN** `DescribeProbeTasks` 出现临时性错误
+- **THEN** 通过 `resource.Retry` 自动重试，直到成功或达到 `tccommon.ReadRetryTimeout` 超时
+- **AND** 重试耗尽后以"重试耗尽"形式失败，便于人工介入
+
+#### Scenario: Reject clearing id on nil response
+
+- **WHEN** API 返回的响应为 nil（异常情况）
+- **THEN** Read 方法返回 `NonRetryableError`，不执行 `d.SetId("")`
+- **AND** 避免因 API 短暂波动导致本地 state 中的 id 被清空
+
+### Requirement: Provider Registration
+
+`tencentcloud/provider.go` 的 `DataSourcesMap` SHALL 注册新数据源：
+
+```go
+"tencentcloud_cat_probe_tasks": cat.DataSourceTencentCloudCatProbeTasks(),
+```
+
+#### Scenario: Data source is accessible via Terraform
+
+- **WHEN** 用户在 Terraform 配置中使用 `data "tencentcloud_cat_probe_tasks"`
+- **THEN** Provider 能识别该数据源，不报 "provider doesn't support data source" 错误
+
+### Requirement: Documentation
+
+数据源 SHALL 提供文档文件 `data_source_tc_cat_probe_tasks.md`，内容包括：
+1. 一句话描述，须带上所属云产品名称（CAT / 云拨测）
+2. 使用示例（基本查询、按条件过滤查询）
+3. 不手写 `Argument Reference` 与 `Attribute Reference`（由工具自动生成）
+
+`provider.md` 中 CAT 部分的 Data Source 条目 SHALL 通过 `make doc` 自动生成，不手动编辑 `website/` 目录。
+
+#### Scenario: User finds data source in documentation
+
+- **WHEN** 用户查看生成的文档
+- **THEN** 能看到 `tencentcloud_cat_probe_tasks` 的一句话描述与示例
+- **AND** 文档由 `make doc` 自动生成，无需手动维护 `website/docs/`
+
+### Requirement: Testing
+
+数据源 SHALL 提供单元测试文件 `data_source_tc_cat_probe_tasks_test.go`，使用 mock（gomonkey）方式对云 API 进行 mock，只做业务代码逻辑的单元测试（不使用 terraform 测试套件）。测试 SHALL 覆盖：
+1. 正常查询场景（mock 返回非空任务列表，验证字段映射与 `total` 设置）
+2. 空列表场景（mock 返回空列表，验证不报错、正常设置 id）
+3. API 错误场景（mock 返回错误，验证错误被返回）
+
+#### Scenario: Unit test covers normal query
+
+- **WHEN** mock `DescribeProbeTasks` 返回包含若干 `ProbeTask` 的响应
+- **THEN** 单元测试验证 `task_set` 列表字段被正确映射、`total` 被正确设置、`d.Id()` 被设置
+
+#### Scenario: Unit test covers empty list
+
+- **WHEN** mock `DescribeProbeTasks` 返回空任务列表
+- **THEN** 单元测试验证 Read 不报错并正常完成

--- a/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/tasks.md
+++ b/openspec/changes/archive/2026-09-03-add-cat-probe-tasks-datasource/tasks.md
@@ -1,0 +1,42 @@
+## 1. Preparation
+
+- [x] 1.1 确认 SDK 已支持 `DescribeProbeTasks` 接口（vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409，已存在 `DescribeProbeTasksRequest`/`DescribeProbeTasksResponse`/`ProbeTask`/`KeyValuePair` 结构）
+- [x] 1.2 确认 cat service 目录已存在（tencentcloud/services/cat/），参考现有 `data_source_tc_cat_instant_tasks.go` 与 `service_tencentcloud_cat.go` 代码风格
+
+## 2. Service Layer
+
+- [x] 2.1 在 `tencentcloud/services/cat/service_tencentcloud_cat.go` 中新增方法 `DescribeCatProbeTasksByFilter(ctx context.Context, param map[string]interface{}) (tasks []*cat.ProbeTask, total *int64, errRet error)`
+- [x] 2.2 实现自动分页：固定 `pageSize=100`（云 API 最大值），循环累加 `response.Response.TaskSet`，直到本页数量小于 pageSize 停止
+- [x] 2.3 从 `param` 读取并设置 request 字段：TaskIDs/TaskName/TargetAddress/TaskStatus/PayMode/OrderState/TaskType/TaskCategory/OrderBy/Ascend/TagFilters
+- [x] 2.4 每次请求前 `ratelimit.Check(request.GetAction())`，请求后记录 [DEBUG] 日志，失败记录 [CRITAL] 日志并返回错误
+
+## 3. Data Source Schema & Read
+
+- [x] 3.1 创建 `tencentcloud/services/cat/data_source_tc_cat_probe_tasks.go`，定义 `DataSourceTencentCloudCatProbeTasks()` schema
+- [x] 3.2 定义可选入参 schema：task_i_ds(List string)、task_name(string)、target_address(string)、task_status(List int)、pay_mode(int)、order_state(int)、task_type(List int)、task_category(List int)、order_by(string)、ascend(bool)、tag_filters(List block: key/value 必填)、result_output_file(string)
+- [x] 3.3 定义出参 schema：task_set(List block，字段平铺 name/task_id/task_type/nodes/node_ip_type/interval/parameters/status/target_address/pay_mode/order_state/task_category/created_at/cron/cron_state/tag_info_list(List block: key/value)/sub_sync_flag)、total(int)
+- [x] 3.4 实现 `dataSourceTencentCloudCatProbeTasksRead`：使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包裹 service 调用，错误用 `tccommon.RetryError(e)` 包装
+- [x] 3.5 retry 块内：nil 响应（tasks==nil && total==nil）返回 NonRetryableError 不清 id；空列表（len==0）打印 `[DATASOURCE] read empty, skip SetId` 后继续
+- [x] 3.6 遍历 tasks 构造 task_set 列表 map，设置每个字段前判断 nil；设置 total；`d.SetId(helper.BuildToken())`；处理 result_output_file 导出
+
+## 4. Provider Registration
+
+- [x] 4.1 在 `tencentcloud/provider.go` 的 DataSourcesMap 中添加 `"tencentcloud_cat_probe_tasks": cat.DataSourceTencentCloudCatProbeTasks()`
+
+## 5. Documentation
+
+- [x] 5.1 创建 `tencentcloud/services/cat/data_source_tc_cat_probe_tasks.md`：一句话描述（带 CAT/云拨测产品名）、Example Usage（基本查询、按条件过滤查询），不手写 Argument/Attribute Reference
+- [x] 5.2 后续通过 `make doc` 自动生成 `website/docs/` 与 provider.md 条目（不在本步骤手动编辑 website/）
+
+## 6. Testing
+
+- [x] 6.1 创建 `tencentcloud/services/cat/data_source_tc_cat_probe_tasks_test.go`，使用 gomonkey mock `DescribeProbeTasksWithContext`（不使用 terraform 测试套件）
+- [x] 6.2 测试正常查询场景：mock 返回非空 ProbeTask 列表，验证 task_set 字段映射与 total 设置
+- [x] 6.3 测试空列表场景：mock 返回空列表，验证不报错、正常设置 id
+- [x] 6.4 测试 API 错误场景：mock 返回错误，验证错误被返回
+
+## 7. Validation
+
+- [x] 7.1 检查所有函数返回的 error 均被处理（无未使用变量；必定不出错的用 `_ =` 赋值）
+- [x] 7.2 确认生成的代码可正确构建执行（不执行 go build/vet/lint，由其他流程验证）
+- [x] 7.3 运行 `openspec validate add-cat-probe-tasks-datasource --strict` 验证提案

--- a/openspec/specs/cat-probe-tasks-datasource/spec.md
+++ b/openspec/specs/cat-probe-tasks-datasource/spec.md
@@ -1,0 +1,205 @@
+# cat-probe-tasks-datasource Specification
+
+## Purpose
+TBD - created by syncing change add-cat-probe-tasks-datasource. Update Purpose after archive.
+## Requirements
+### Requirement: Data Source Schema Definition
+
+`tencentcloud_cat_probe_tasks` 数据源 SHALL 支持以下可选输入参数用于过滤拨测任务列表，所有列表项字段平铺在 `task_set` 列表元素内（不额外嵌套一层），顶层提供 `total` 与 `result_output_file`：
+
+**Input Parameters (All Optional):**
+- `task_i_ds` (List of String): 按任务 ID 列表过滤（映射 `request.TaskIDs`）
+- `task_name` (String): 按任务名过滤（映射 `request.TaskName`）
+- `target_address` (String): 按拨测目标地址过滤（映射 `request.TargetAddress`）
+- `task_status` (List of Int): 按任务状态过滤（映射 `request.TaskStatus`，云 API 入参为整型数组）
+- `pay_mode` (Int): 按付费模式过滤（映射 `request.PayMode`）
+- `order_state` (Int): 按订单状态过滤（映射 `request.OrderState`）
+- `task_type` (List of Int): 按拨测类型过滤（映射 `request.TaskType`，云 API 入参为整型数组）
+- `task_category` (List of Int): 按节点类型过滤（映射 `request.TaskCategory`，云 API 入参为整型数组）
+- `order_by` (String): 排序列（映射 `request.OrderBy`）
+- `ascend` (Bool): 是否正序（映射 `request.Ascend`）
+- `tag_filters` (List of Block): 按标签过滤（映射 `request.TagFilters`），每个块包含：
+  - `key` (String, Required): 标签键（映射 `TagFilters.Key`）
+  - `value` (String, Required): 标签值（映射 `TagFilters.Value`）
+- `result_output_file` (String, Optional): 将查询结果导出到指定文件
+
+**Output Attributes:**
+- `task_set` (List): 拨测任务列表，每个元素包含以下字段（映射 `response.Response.TaskSet` 中 `ProbeTask` 的对应字段）：
+  - `name` (String): 任务名
+  - `task_id` (String): 任务 ID
+  - `task_type` (Int): 拨测类型
+  - `nodes` (List of String): 拨测节点列表
+  - `node_ip_type` (Int): 拨测点 IP 类型
+  - `interval` (Int): 拨测间隔（分钟）
+  - `parameters` (String): 拨测参数
+  - `status` (Int): 任务状态
+  - `target_address` (String): 目标地址
+  - `pay_mode` (Int): 付费模式
+  - `order_state` (Int): 订单状态
+  - `task_category` (Int): 任务分类
+  - `created_at` (String): 创建时间
+  - `cron` (String): 定时任务 cron 表达式
+  - `cron_state` (Int): 定时任务启动状态
+  - `tag_info_list` (List of Block): 任务当前绑定的标签，每个块包含 `key` (String) 与 `value` (String)
+  - `sub_sync_flag` (Int): 是否为同步账号
+- `total` (Int): 任务总数（映射 `response.Response.Total`）
+
+数据源 SHALL NOT 向用户暴露 `limit`/`offset` 分页参数；分页 SHALL 在 service 层内部自动完成，获取全部拨测任务。
+
+#### Scenario: Query all probe tasks
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "example" {
+}
+
+output "task_set" {
+  value = data.tencentcloud_cat_probe_tasks.example.task_set
+}
+
+output "total" {
+  value = data.tencentcloud_cat_probe_tasks.example.total
+}
+```
+
+- **WHEN** 用户不带任何参数查询 `tencentcloud_cat_probe_tasks`
+- **THEN** 返回当前账号下全部拨测任务
+- **AND** `task_set` 列表中每个元素包含完整的任务字段
+- **AND** `total` 反映任务总数
+
+#### Scenario: Query probe tasks by name and target address
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "by_name" {
+  task_name      = "my-probe-task"
+  target_address = "http://www.example.com"
+}
+```
+
+- **WHEN** 用户指定 `task_name` 与 `target_address`
+- **THEN** 仅返回匹配任务名与目标地址的拨测任务
+
+#### Scenario: Query probe tasks by tag filters
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "by_tags" {
+  tag_filters {
+    key   = "Environment"
+    value = "Production"
+  }
+}
+```
+
+- **WHEN** 用户指定 `tag_filters` 块（含必填的 `key`/`value`）
+- **THEN** 仅返回包含指定标签键值对的拨测任务
+
+#### Scenario: Export query results to file
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "export" {
+  task_name          = "prod"
+  result_output_file = "/tmp/cat_probe_tasks.json"
+}
+```
+
+- **WHEN** 用户指定 `result_output_file`
+- **THEN** 查询结果以 JSON 格式写入指定文件
+- **AND** 文件内容包含完整的任务列表信息
+
+### Requirement: Service Layer Implementation
+
+`service_tencentcloud_cat.go` SHALL 新增方法用于封装 `DescribeProbeTasks` 接口，内部实现自动分页：
+
+```go
+func (me *CatService) DescribeCatProbeTasksByFilter(ctx context.Context, param map[string]interface{}) (tasks []*cat.ProbeTask, total *int64, errRet error)
+```
+
+实现约束：
+1. 使用固定 `pageSize`（云 API 支持的最大值 100）循环分页，累积 `response.Response.TaskSet`，直到本页返回数量小于 `pageSize` 即停止
+2. 每次请求前调用 `ratelimit.Check(request.GetAction())`
+3. 从 `param` 中按 key 读取并设置 request 字段：`TaskIDs`/`TaskName`/`TargetAddress`/`TaskStatus`/`PayMode`/`OrderState`/`TaskType`/`TaskCategory`/`OrderBy`/`Ascend`/`TagFilters`
+4. 每次请求后记录 `[DEBUG]` 级别的请求体与响应体日志
+5. 失败时记录 `[CRITAL]` 级别错误日志并返回错误
+6. 返回累积后的全部 `tasks` 与最后一次响应的 `total`
+
+#### Scenario: Service method handles empty list
+
+- **WHEN** API 返回非 nil 响应但 `response.Response.TaskSet` 为空列表
+- **THEN** service 方法返回空（长度为 0）的 `tasks` 切片与对应的 `total`
+- **AND** 不返回错误
+
+#### Scenario: Service method handles API errors
+
+- **WHEN** API 调用返回错误
+- **THEN** service 方法记录 `[CRITAL]` 错误日志（含请求体与错误原因）
+- **AND** 返回该错误，由上层 retry 机制决定是否重试
+
+#### Scenario: Service method paginates all results
+
+- **WHEN** 拨测任务数量超过单页 `pageSize`
+- **THEN** service 方法循环调用 `DescribeProbeTasks`，逐步累加 `offset`
+- **AND** 返回所有页累积合并后的完整 `tasks` 列表
+
+### Requirement: Read Retry and Empty-Response Handling
+
+Data Source 的 Read 方法 SHALL 使用 `resource.Retry(tccommon.ReadRetryTimeout, ...)` 包裹 service 方法调用，并通过 `tccommon.RetryError(e)` 包装错误。在 retry 块内 SHALL 满足：
+
+1. 若 service 方法返回错误，使用 `tccommon.RetryError(e)` 包装返回，由外层 retry 决定重试
+2. 若云 API 返回空（`response == nil` / `response.Response == nil` 等，表现为 `tasks == nil && total == nil`），SHALL 直接返回 `tccommon.NonRetryableError`，不调用 `d.SetId("")`，保留现场便于排障
+3. 若 API 返回正常但列表为空（`len(tasks) == 0`），SHALL 视为正常空结果，打印 `log.Printf("[DATASOURCE] read empty, skip SetId")` 后继续后续逻辑，不返回错误
+
+#### Scenario: Retry on transient API failure
+
+- **WHEN** `DescribeProbeTasks` 出现临时性错误
+- **THEN** 通过 `resource.Retry` 自动重试，直到成功或达到 `tccommon.ReadRetryTimeout` 超时
+- **AND** 重试耗尽后以"重试耗尽"形式失败，便于人工介入
+
+#### Scenario: Reject clearing id on nil response
+
+- **WHEN** API 返回的响应为 nil（异常情况）
+- **THEN** Read 方法返回 `NonRetryableError`，不执行 `d.SetId("")`
+- **AND** 避免因 API 短暂波动导致本地 state 中的 id 被清空
+
+### Requirement: Provider Registration
+
+`tencentcloud/provider.go` 的 `DataSourcesMap` SHALL 注册新数据源：
+
+```go
+"tencentcloud_cat_probe_tasks": cat.DataSourceTencentCloudCatProbeTasks(),
+```
+
+#### Scenario: Data source is accessible via Terraform
+
+- **WHEN** 用户在 Terraform 配置中使用 `data "tencentcloud_cat_probe_tasks"`
+- **THEN** Provider 能识别该数据源，不报 "provider doesn't support data source" 错误
+
+### Requirement: Documentation
+
+数据源 SHALL 提供文档文件 `data_source_tc_cat_probe_tasks.md`，内容包括：
+1. 一句话描述，须带上所属云产品名称（CAT / 云拨测）
+2. 使用示例（基本查询、按条件过滤查询）
+3. 不手写 `Argument Reference` 与 `Attribute Reference`（由工具自动生成）
+
+`provider.md` 中 CAT 部分的 Data Source 条目 SHALL 通过 `make doc` 自动生成，不手动编辑 `website/` 目录。
+
+#### Scenario: User finds data source in documentation
+
+- **WHEN** 用户查看生成的文档
+- **THEN** 能看到 `tencentcloud_cat_probe_tasks` 的一句话描述与示例
+- **AND** 文档由 `make doc` 自动生成，无需手动维护 `website/docs/`
+
+### Requirement: Testing
+
+数据源 SHALL 提供单元测试文件 `data_source_tc_cat_probe_tasks_test.go`，使用 mock（gomonkey）方式对云 API 进行 mock，只做业务代码逻辑的单元测试（不使用 terraform 测试套件）。测试 SHALL 覆盖：
+1. 正常查询场景（mock 返回非空任务列表，验证字段映射与 `total` 设置）
+2. 空列表场景（mock 返回空列表，验证不报错、正常设置 id）
+3. API 错误场景（mock 返回错误，验证错误被返回）
+
+#### Scenario: Unit test covers normal query
+
+- **WHEN** mock `DescribeProbeTasks` 返回包含若干 `ProbeTask` 的响应
+- **THEN** 单元测试验证 `task_set` 列表字段被正确映射、`total` 被正确设置、`d.Id()` 被设置
+
+#### Scenario: Unit test covers empty list
+
+- **WHEN** mock `DescribeProbeTasks` 返回空任务列表
+- **THEN** 单元测试验证 Read 不报错并正常完成

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -1031,6 +1031,7 @@ func Provider() *schema.Provider {
 			"tencentcloud_cat_probe_metric_tag_values":                            cat.DataSourceTencentCloudCatProbeMetricTagValues(),
 			"tencentcloud_cat_node_groups":                                        cat.DataSourceTencentCloudCatNodeGroups(),
 			"tencentcloud_cat_instant_tasks":                                      cat.DataSourceTencentCloudCatInstantTasks(),
+			"tencentcloud_cat_probe_tasks":                                        cat.DataSourceTencentCloudCatProbeTasks(),
 			"tencentcloud_rum_project":                                            rum.DataSourceTencentCloudRumProject(),
 			"tencentcloud_rum_offline_log_config":                                 rum.DataSourceTencentCloudRumOfflineLogConfig(),
 			"tencentcloud_rum_whitelist":                                          rum.DataSourceTencentCloudRumWhitelist(),

--- a/tencentcloud/provider.md
+++ b/tencentcloud/provider.md
@@ -1760,6 +1760,7 @@ tencentcloud_cat_node_groups
 tencentcloud_cat_metric_data
 tencentcloud_cat_probe_metric_tag_values
 tencentcloud_cat_instant_tasks
+tencentcloud_cat_probe_tasks
 
 Resource
 tencentcloud_cat_task_set

--- a/tencentcloud/services/cat/data_source_tc_cat_probe_tasks.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_probe_tasks.go
@@ -1,0 +1,416 @@
+package cat
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	cat "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
+)
+
+func DataSourceTencentCloudCatProbeTasks() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTencentCloudCatProbeTasksRead,
+		Schema: map[string]*schema.Schema{
+			"task_i_ds": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Task ID list.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Task name.",
+			},
+			"target_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Target address.",
+			},
+			"task_status": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Task status list.",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+			"pay_mode": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Pay mode.",
+			},
+			"order_state": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Order state.",
+			},
+			"task_type": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Task type list.",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+			"task_category": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Task category list.",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+			"order_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Order by column.",
+			},
+			"ascend": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to sort in ascending order.",
+			},
+			"tag_filters": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Tag filters.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag key.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Tag value.",
+						},
+					},
+				},
+			},
+			"task_set": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Probe task list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Task name.",
+						},
+						"task_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Task ID.",
+						},
+						"task_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Task type.",
+						},
+						"nodes": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Probe node list.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"node_ip_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Probe node IP type.",
+						},
+						"interval": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Probe interval in minutes.",
+						},
+						"parameters": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Probe parameters.",
+						},
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Task status.",
+						},
+						"target_address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Target address.",
+						},
+						"pay_mode": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Pay mode.",
+						},
+						"order_state": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Order state.",
+						},
+						"task_category": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Task category.",
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Created time.",
+						},
+						"cron": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Cron expression for scheduled task.",
+						},
+						"cron_state": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Scheduled task start status.",
+						},
+						"tag_info_list": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Tag info list.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Tag key.",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Tag value.",
+									},
+								},
+							},
+						},
+						"sub_sync_flag": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Whether it is a sync account.",
+						},
+					},
+				},
+			},
+			"total": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Total number of probe tasks.",
+			},
+			"result_output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Used to save results.",
+			},
+		},
+	}
+}
+
+func dataSourceTencentCloudCatProbeTasksRead(d *schema.ResourceData, meta interface{}) error {
+	defer tccommon.LogElapsed("data_source.tencentcloud_cat_probe_tasks.read")()
+	defer tccommon.InconsistentCheck(d, meta)()
+
+	logId := tccommon.GetLogId(tccommon.ContextNil)
+	ctx := context.WithValue(context.TODO(), tccommon.LogIdKey, logId)
+
+	catService := CatService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+
+	paramMap := make(map[string]interface{})
+	if v, ok := d.GetOk("task_i_ds"); ok {
+		taskIDs := v.([]interface{})
+		tmpList := make([]*string, 0, len(taskIDs))
+		for _, item := range taskIDs {
+			tmpList = append(tmpList, helper.String(item.(string)))
+		}
+		paramMap["task_i_ds"] = tmpList
+	}
+	if v, ok := d.GetOk("task_name"); ok {
+		paramMap["task_name"] = helper.String(v.(string))
+	}
+	if v, ok := d.GetOk("target_address"); ok {
+		paramMap["target_address"] = helper.String(v.(string))
+	}
+	if v, ok := d.GetOk("task_status"); ok {
+		taskStatus := v.([]interface{})
+		tmpList := make([]*int64, 0, len(taskStatus))
+		for _, item := range taskStatus {
+			tmpList = append(tmpList, helper.Int64(int64(item.(int))))
+		}
+		paramMap["task_status"] = tmpList
+	}
+	if v, ok := d.GetOk("pay_mode"); ok {
+		paramMap["pay_mode"] = helper.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("order_state"); ok {
+		paramMap["order_state"] = helper.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("task_type"); ok {
+		taskType := v.([]interface{})
+		tmpList := make([]*int64, 0, len(taskType))
+		for _, item := range taskType {
+			tmpList = append(tmpList, helper.Int64(int64(item.(int))))
+		}
+		paramMap["task_type"] = tmpList
+	}
+	if v, ok := d.GetOk("task_category"); ok {
+		taskCategory := v.([]interface{})
+		tmpList := make([]*int64, 0, len(taskCategory))
+		for _, item := range taskCategory {
+			tmpList = append(tmpList, helper.Int64(int64(item.(int))))
+		}
+		paramMap["task_category"] = tmpList
+	}
+	if v, ok := d.GetOk("order_by"); ok {
+		paramMap["order_by"] = helper.String(v.(string))
+	}
+	if v, ok := d.GetOk("ascend"); ok {
+		paramMap["ascend"] = helper.Bool(v.(bool))
+	}
+	if v, ok := d.GetOk("tag_filters"); ok {
+		tagFilters := v.([]interface{})
+		tmpList := make([]*cat.KeyValuePair, 0, len(tagFilters))
+		for _, item := range tagFilters {
+			tagFilterMap := item.(map[string]interface{})
+			keyValuePair := cat.KeyValuePair{}
+			if v, ok := tagFilterMap["key"].(string); ok && v != "" {
+				keyValuePair.Key = helper.String(v)
+			}
+			if v, ok := tagFilterMap["value"].(string); ok && v != "" {
+				keyValuePair.Value = helper.String(v)
+			}
+			tmpList = append(tmpList, &keyValuePair)
+		}
+		paramMap["tag_filters"] = tmpList
+	}
+
+	var tasks []*cat.ProbeTask
+	var total *int64
+	err := resource.Retry(tccommon.ReadRetryTimeout, func() *resource.RetryError {
+		results, totalRet, e := catService.DescribeCatProbeTasksByFilter(ctx, paramMap)
+		if e != nil {
+			return tccommon.RetryError(e)
+		}
+
+		if results == nil && totalRet == nil {
+			return resource.NonRetryableError(nil)
+		}
+
+		tasks = results
+		total = totalRet
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s read cat_probe_tasks failed, reason:%+v", logId, err)
+		return err
+	}
+
+	taskSetList := make([]map[string]interface{}, 0, len(tasks))
+	for _, task := range tasks {
+		taskMap := map[string]interface{}{}
+		if task.Name != nil {
+			taskMap["name"] = task.Name
+		}
+		if task.TaskId != nil {
+			taskMap["task_id"] = task.TaskId
+		}
+		if task.TaskType != nil {
+			taskMap["task_type"] = task.TaskType
+		}
+		if task.Nodes != nil {
+			nodesList := make([]string, 0, len(task.Nodes))
+			for _, node := range task.Nodes {
+				if node != nil {
+					nodesList = append(nodesList, *node)
+				}
+			}
+			taskMap["nodes"] = nodesList
+		}
+		if task.NodeIpType != nil {
+			taskMap["node_ip_type"] = task.NodeIpType
+		}
+		if task.Interval != nil {
+			taskMap["interval"] = task.Interval
+		}
+		if task.Parameters != nil {
+			taskMap["parameters"] = task.Parameters
+		}
+		if task.Status != nil {
+			taskMap["status"] = task.Status
+		}
+		if task.TargetAddress != nil {
+			taskMap["target_address"] = task.TargetAddress
+		}
+		if task.PayMode != nil {
+			taskMap["pay_mode"] = task.PayMode
+		}
+		if task.OrderState != nil {
+			taskMap["order_state"] = task.OrderState
+		}
+		if task.TaskCategory != nil {
+			taskMap["task_category"] = task.TaskCategory
+		}
+		if task.CreatedAt != nil {
+			taskMap["created_at"] = task.CreatedAt
+		}
+		if task.Cron != nil {
+			taskMap["cron"] = task.Cron
+		}
+		if task.CronState != nil {
+			taskMap["cron_state"] = task.CronState
+		}
+		if task.TagInfoList != nil {
+			tagInfoList := make([]map[string]interface{}, 0, len(task.TagInfoList))
+			for _, tagInfo := range task.TagInfoList {
+				tagInfoMap := map[string]interface{}{}
+				if tagInfo.Key != nil {
+					tagInfoMap["key"] = tagInfo.Key
+				}
+				if tagInfo.Value != nil {
+					tagInfoMap["value"] = tagInfo.Value
+				}
+				tagInfoList = append(tagInfoList, tagInfoMap)
+			}
+			taskMap["tag_info_list"] = tagInfoList
+		}
+		if task.SubSyncFlag != nil {
+			taskMap["sub_sync_flag"] = task.SubSyncFlag
+		}
+
+		taskSetList = append(taskSetList, taskMap)
+	}
+
+	if len(tasks) == 0 {
+		log.Printf("[DATASOURCE] read empty, skip SetId")
+	}
+
+	d.SetId(helper.BuildToken())
+	_ = d.Set("task_set", taskSetList)
+	if total != nil {
+		_ = d.Set("total", total)
+	}
+
+	output, ok := d.GetOk("result_output_file")
+	if ok && output.(string) != "" {
+		if e := tccommon.WriteToFile(output.(string), taskSetList); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/services/cat/data_source_tc_cat_probe_tasks.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_probe_tasks.go
@@ -16,7 +16,7 @@ func DataSourceTencentCloudCatProbeTasks() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceTencentCloudCatProbeTasksRead,
 		Schema: map[string]*schema.Schema{
-			"task_i_ds": {
+			"task_ids": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Task ID list.",
@@ -232,13 +232,13 @@ func dataSourceTencentCloudCatProbeTasksRead(d *schema.ResourceData, meta interf
 	catService := CatService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
 
 	paramMap := make(map[string]interface{})
-	if v, ok := d.GetOk("task_i_ds"); ok {
+	if v, ok := d.GetOk("task_ids"); ok {
 		taskIDs := v.([]interface{})
 		tmpList := make([]*string, 0, len(taskIDs))
 		for _, item := range taskIDs {
 			tmpList = append(tmpList, helper.String(item.(string)))
 		}
-		paramMap["task_i_ds"] = tmpList
+		paramMap["task_ids"] = tmpList
 	}
 	if v, ok := d.GetOk("task_name"); ok {
 		paramMap["task_name"] = helper.String(v.(string))

--- a/tencentcloud/services/cat/data_source_tc_cat_probe_tasks.md
+++ b/tencentcloud/services/cat/data_source_tc_cat_probe_tasks.md
@@ -1,0 +1,36 @@
+Use this data source to query the list of probe tasks of CAT (云拨测).
+
+Example Usage
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "example" {
+}
+
+output "task_set" {
+  value = data.tencentcloud_cat_probe_tasks.example.task_set
+}
+
+output "total" {
+  value = data.tencentcloud_cat_probe_tasks.example.total
+}
+```
+
+Query probe tasks by name and target address
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "by_name" {
+  task_name      = "my-probe-task"
+  target_address = "http://www.example.com"
+}
+```
+
+Query probe tasks by tag filters
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "by_tags" {
+  tag_filters {
+    key   = "Environment"
+    value = "Production"
+  }
+}
+```

--- a/tencentcloud/services/cat/data_source_tc_cat_probe_tasks_test.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_probe_tasks_test.go
@@ -1,0 +1,300 @@
+package cat_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	cat "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cat/v20180409"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	svccat "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cat"
+)
+
+type mockMetaForCatProbeTasksDS struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForCatProbeTasksDS) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForCatProbeTasksDS{}
+
+func newMockMetaForCatProbeTasksDS() *mockMetaForCatProbeTasksDS {
+	return &mockMetaForCatProbeTasksDS{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringCPTDS(s string) *string { return &s }
+
+func ptrInt64CPTDS(v int64) *int64 { return &v }
+
+func buildProbeTask(name, taskId, targetAddress, parameters, createdAt, cron string, taskType, nodeIpType, interval, status, payMode, orderState, taskCategory, cronState, subSyncFlag int64) *cat.ProbeTask {
+	return &cat.ProbeTask{
+		Name:          ptrStringCPTDS(name),
+		TaskId:        ptrStringCPTDS(taskId),
+		TaskType:      ptrInt64CPTDS(taskType),
+		Nodes:         []*string{ptrStringCPTDS("node-1"), ptrStringCPTDS("node-2")},
+		NodeIpType:    ptrInt64CPTDS(nodeIpType),
+		Interval:      ptrInt64CPTDS(interval),
+		Parameters:    ptrStringCPTDS(parameters),
+		Status:        ptrInt64CPTDS(status),
+		TargetAddress: ptrStringCPTDS(targetAddress),
+		PayMode:       ptrInt64CPTDS(payMode),
+		OrderState:    ptrInt64CPTDS(orderState),
+		TaskCategory:  ptrInt64CPTDS(taskCategory),
+		CreatedAt:     ptrStringCPTDS(createdAt),
+		Cron:          ptrStringCPTDS(cron),
+		CronState:     ptrInt64CPTDS(cronState),
+		TagInfoList: []*cat.KeyValuePair{
+			{
+				Key:   ptrStringCPTDS("Environment"),
+				Value: ptrStringCPTDS("Production"),
+			},
+		},
+		SubSyncFlag: ptrInt64CPTDS(subSyncFlag),
+	}
+}
+
+// go test ./tencentcloud/services/cat/ -run "TestCatProbeTasksDS" -v -count=1 -gcflags="all=-l"
+
+func TestCatProbeTasksDS_ReadBasic(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatProbeTasksDS().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeProbeTasksWithContext", func(ctx context.Context, request *cat.DescribeProbeTasksRequest) (*cat.DescribeProbeTasksResponse, error) {
+		resp := cat.NewDescribeProbeTasksResponse()
+		resp.Response = &cat.DescribeProbeTasksResponseParams{
+			TaskSet: []*cat.ProbeTask{
+				buildProbeTask("task-001", "probe-task-001", "http://www.example.com", "params", "2024-01-01 00:00:00", "0 0 * * *", 1, 1, 5, 2, 2, 1, 1, 1, 0),
+				buildProbeTask("task-002", "probe-task-002", "http://www.test.com", "params2", "2024-01-02 00:00:00", "0 0 * * *", 5, 0, 10, 6, 1, 1, 2, 2, 1),
+			},
+			Total:     ptrInt64CPTDS(2),
+			RequestId: ptrStringCPTDS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCatProbeTasksDS()
+	res := svccat.DataSourceTencentCloudCatProbeTasks()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	taskSet := d.Get("task_set").([]interface{})
+	assert.Len(t, taskSet, 2)
+
+	task0 := taskSet[0].(map[string]interface{})
+	assert.Equal(t, "task-001", task0["name"].(string))
+	assert.Equal(t, "probe-task-001", task0["task_id"].(string))
+	assert.Equal(t, 1, task0["task_type"].(int))
+	assert.Equal(t, "http://www.example.com", task0["target_address"].(string))
+	assert.Equal(t, 2, task0["status"].(int))
+	assert.Equal(t, 2, task0["pay_mode"].(int))
+	assert.Equal(t, "params", task0["parameters"].(string))
+
+	nodes := task0["nodes"].([]interface{})
+	assert.Len(t, nodes, 2)
+	assert.Equal(t, "node-1", nodes[0].(string))
+
+	tagInfoList := task0["tag_info_list"].([]interface{})
+	assert.Len(t, tagInfoList, 1)
+	tagInfo := tagInfoList[0].(map[string]interface{})
+	assert.Equal(t, "Environment", tagInfo["key"].(string))
+	assert.Equal(t, "Production", tagInfo["value"].(string))
+
+	total := d.Get("total").(int)
+	assert.Equal(t, 2, total)
+}
+
+func TestCatProbeTasksDS_ReadWithFilters(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatProbeTasksDS().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeProbeTasksWithContext", func(ctx context.Context, request *cat.DescribeProbeTasksRequest) (*cat.DescribeProbeTasksResponse, error) {
+		assert.Equal(t, "my-probe-task", *request.TaskName)
+		assert.Equal(t, "http://www.example.com", *request.TargetAddress)
+		assert.Equal(t, int64(2), *request.PayMode)
+		assert.Equal(t, 1, len(request.TaskStatus))
+		assert.Equal(t, int64(2), *request.TaskStatus[0])
+		assert.Equal(t, 1, len(request.TagFilters))
+		assert.Equal(t, "Environment", *request.TagFilters[0].Key)
+		assert.Equal(t, "Production", *request.TagFilters[0].Value)
+
+		resp := cat.NewDescribeProbeTasksResponse()
+		resp.Response = &cat.DescribeProbeTasksResponseParams{
+			TaskSet: []*cat.ProbeTask{
+				buildProbeTask("my-probe-task", "probe-task-001", "http://www.example.com", "params", "2024-01-01 00:00:00", "", 1, 1, 5, 2, 2, 1, 1, 0, 0),
+			},
+			Total:     ptrInt64CPTDS(1),
+			RequestId: ptrStringCPTDS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCatProbeTasksDS()
+	res := svccat.DataSourceTencentCloudCatProbeTasks()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"task_name":      "my-probe-task",
+		"target_address": "http://www.example.com",
+		"pay_mode":       2,
+		"task_status":    []interface{}{2},
+		"tag_filters": []interface{}{
+			map[string]interface{}{
+				"key":   "Environment",
+				"value": "Production",
+			},
+		},
+	})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	taskSet := d.Get("task_set").([]interface{})
+	assert.Len(t, taskSet, 1)
+
+	total := d.Get("total").(int)
+	assert.Equal(t, 1, total)
+}
+
+func TestCatProbeTasksDS_ReadEmpty(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatProbeTasksDS().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeProbeTasksWithContext", func(ctx context.Context, request *cat.DescribeProbeTasksRequest) (*cat.DescribeProbeTasksResponse, error) {
+		resp := cat.NewDescribeProbeTasksResponse()
+		resp.Response = &cat.DescribeProbeTasksResponseParams{
+			TaskSet:   []*cat.ProbeTask{},
+			Total:     ptrInt64CPTDS(0),
+			RequestId: ptrStringCPTDS("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForCatProbeTasksDS()
+	res := svccat.DataSourceTencentCloudCatProbeTasks()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d.Id())
+
+	taskSet := d.Get("task_set").([]interface{})
+	assert.Len(t, taskSet, 0)
+
+	total := d.Get("total").(int)
+	assert.Equal(t, 0, total)
+}
+
+func TestCatProbeTasksDS_ReadError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	catClient := &cat.Client{}
+	patches.ApplyMethodReturn(newMockMetaForCatProbeTasksDS().client, "UseCatClient", catClient)
+
+	patches.ApplyMethodFunc(catClient, "DescribeProbeTasksWithContext", func(ctx context.Context, request *cat.DescribeProbeTasksRequest) (*cat.DescribeProbeTasksResponse, error) {
+		return nil, assert.AnError
+	})
+
+	meta := newMockMetaForCatProbeTasksDS()
+	res := svccat.DataSourceTencentCloudCatProbeTasks()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+	err := res.Read(d, meta)
+	assert.Error(t, err)
+}
+
+func TestCatProbeTasksDS_Schema(t *testing.T) {
+	res := svccat.DataSourceTencentCloudCatProbeTasks()
+
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Schema, "task_i_ds")
+	assert.Contains(t, res.Schema, "task_name")
+	assert.Contains(t, res.Schema, "target_address")
+	assert.Contains(t, res.Schema, "task_status")
+	assert.Contains(t, res.Schema, "pay_mode")
+	assert.Contains(t, res.Schema, "order_state")
+	assert.Contains(t, res.Schema, "task_type")
+	assert.Contains(t, res.Schema, "task_category")
+	assert.Contains(t, res.Schema, "order_by")
+	assert.Contains(t, res.Schema, "ascend")
+	assert.Contains(t, res.Schema, "tag_filters")
+	assert.Contains(t, res.Schema, "task_set")
+	assert.Contains(t, res.Schema, "total")
+	assert.Contains(t, res.Schema, "result_output_file")
+
+	taskIDsSchema := res.Schema["task_i_ds"]
+	assert.Equal(t, schema.TypeList, taskIDsSchema.Type)
+	assert.True(t, taskIDsSchema.Optional)
+
+	taskNameSchema := res.Schema["task_name"]
+	assert.Equal(t, schema.TypeString, taskNameSchema.Type)
+	assert.True(t, taskNameSchema.Optional)
+
+	taskStatusSchema := res.Schema["task_status"]
+	assert.Equal(t, schema.TypeList, taskStatusSchema.Type)
+	assert.True(t, taskStatusSchema.Optional)
+
+	payModeSchema := res.Schema["pay_mode"]
+	assert.Equal(t, schema.TypeInt, payModeSchema.Type)
+	assert.True(t, payModeSchema.Optional)
+
+	ascendSchema := res.Schema["ascend"]
+	assert.Equal(t, schema.TypeBool, ascendSchema.Type)
+	assert.True(t, ascendSchema.Optional)
+
+	tagFiltersSchema := res.Schema["tag_filters"]
+	assert.Equal(t, schema.TypeList, tagFiltersSchema.Type)
+	assert.True(t, tagFiltersSchema.Optional)
+	tagFiltersElemRes := tagFiltersSchema.Elem.(*schema.Resource)
+	assert.Contains(t, tagFiltersElemRes.Schema, "key")
+	assert.Contains(t, tagFiltersElemRes.Schema, "value")
+	assert.True(t, tagFiltersElemRes.Schema["key"].Required)
+	assert.True(t, tagFiltersElemRes.Schema["value"].Required)
+
+	taskSetSchema := res.Schema["task_set"]
+	assert.Equal(t, schema.TypeList, taskSetSchema.Type)
+	assert.True(t, taskSetSchema.Computed)
+	taskSetElemRes := taskSetSchema.Elem.(*schema.Resource)
+	assert.Contains(t, taskSetElemRes.Schema, "name")
+	assert.Contains(t, taskSetElemRes.Schema, "task_id")
+	assert.Contains(t, taskSetElemRes.Schema, "task_type")
+	assert.Contains(t, taskSetElemRes.Schema, "nodes")
+	assert.Contains(t, taskSetElemRes.Schema, "node_ip_type")
+	assert.Contains(t, taskSetElemRes.Schema, "interval")
+	assert.Contains(t, taskSetElemRes.Schema, "parameters")
+	assert.Contains(t, taskSetElemRes.Schema, "status")
+	assert.Contains(t, taskSetElemRes.Schema, "target_address")
+	assert.Contains(t, taskSetElemRes.Schema, "pay_mode")
+	assert.Contains(t, taskSetElemRes.Schema, "order_state")
+	assert.Contains(t, taskSetElemRes.Schema, "task_category")
+	assert.Contains(t, taskSetElemRes.Schema, "created_at")
+	assert.Contains(t, taskSetElemRes.Schema, "cron")
+	assert.Contains(t, taskSetElemRes.Schema, "cron_state")
+	assert.Contains(t, taskSetElemRes.Schema, "tag_info_list")
+	assert.Contains(t, taskSetElemRes.Schema, "sub_sync_flag")
+
+	totalSchema := res.Schema["total"]
+	assert.Equal(t, schema.TypeInt, totalSchema.Type)
+	assert.True(t, totalSchema.Computed)
+
+	outputSchema := res.Schema["result_output_file"]
+	assert.Equal(t, schema.TypeString, outputSchema.Type)
+	assert.True(t, outputSchema.Optional)
+}

--- a/tencentcloud/services/cat/data_source_tc_cat_probe_tasks_test.go
+++ b/tencentcloud/services/cat/data_source_tc_cat_probe_tasks_test.go
@@ -224,7 +224,7 @@ func TestCatProbeTasksDS_Schema(t *testing.T) {
 	res := svccat.DataSourceTencentCloudCatProbeTasks()
 
 	assert.NotNil(t, res)
-	assert.Contains(t, res.Schema, "task_i_ds")
+	assert.Contains(t, res.Schema, "task_ids")
 	assert.Contains(t, res.Schema, "task_name")
 	assert.Contains(t, res.Schema, "target_address")
 	assert.Contains(t, res.Schema, "task_status")
@@ -239,7 +239,7 @@ func TestCatProbeTasksDS_Schema(t *testing.T) {
 	assert.Contains(t, res.Schema, "total")
 	assert.Contains(t, res.Schema, "result_output_file")
 
-	taskIDsSchema := res.Schema["task_i_ds"]
+	taskIDsSchema := res.Schema["task_ids"]
 	assert.Equal(t, schema.TypeList, taskIDsSchema.Type)
 	assert.True(t, taskIDsSchema.Optional)
 

--- a/tencentcloud/services/cat/service_tencentcloud_cat.go
+++ b/tencentcloud/services/cat/service_tencentcloud_cat.go
@@ -459,6 +459,93 @@ func (me *CatService) DescribeCatNodeGroupsByFilter(ctx context.Context, param m
 	return
 }
 
+func (me *CatService) DescribeCatProbeTasksByFilter(ctx context.Context, param map[string]interface{}) (tasks []*cat.ProbeTask, total *int64, errRet error) {
+	var (
+		logId   = tccommon.GetLogId(ctx)
+		request = cat.NewDescribeProbeTasksRequest()
+	)
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), errRet.Error())
+		}
+	}()
+
+	for k, v := range param {
+		if k == "task_i_ds" {
+			request.TaskIDs = v.([]*string)
+		}
+		if k == "task_name" {
+			request.TaskName = v.(*string)
+		}
+		if k == "target_address" {
+			request.TargetAddress = v.(*string)
+		}
+		if k == "task_status" {
+			request.TaskStatus = v.([]*int64)
+		}
+		if k == "pay_mode" {
+			request.PayMode = v.(*int64)
+		}
+		if k == "order_state" {
+			request.OrderState = v.(*int64)
+		}
+		if k == "task_type" {
+			request.TaskType = v.([]*int64)
+		}
+		if k == "task_category" {
+			request.TaskCategory = v.([]*int64)
+		}
+		if k == "order_by" {
+			request.OrderBy = v.(*string)
+		}
+		if k == "ascend" {
+			request.Ascend = v.(*bool)
+		}
+		if k == "tag_filters" {
+			request.TagFilters = v.([]*cat.KeyValuePair)
+		}
+	}
+
+	var offset int64 = 0
+	var pageSize int64 = 100
+	tasks = make([]*cat.ProbeTask, 0)
+
+	for {
+		request.Offset = &offset
+		request.Limit = &pageSize
+		ratelimit.Check(request.GetAction())
+		response, err := me.client.UseCatClient().DescribeProbeTasks(request)
+		if err != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), err.Error())
+			errRet = err
+			return
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+			logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+		if response == nil || response.Response == nil {
+			break
+		}
+
+		if response.Response.TaskSet != nil {
+			tasks = append(tasks, response.Response.TaskSet...)
+		}
+		if response.Response.Total != nil {
+			total = response.Response.Total
+		}
+
+		if len(response.Response.TaskSet) < int(pageSize) {
+			break
+		}
+		offset += pageSize
+	}
+
+	return
+}
+
 func (me *CatService) DescribeCatInstantTasksByFilter(ctx context.Context) (tasks []*cat.SingleInstantTask, total *uint64, errRet error) {
 	var (
 		logId   = tccommon.GetLogId(ctx)

--- a/website/docs/d/cat_probe_tasks.html.markdown
+++ b/website/docs/d/cat_probe_tasks.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 * `tag_filters` - (Optional, List) Tag filters.
 * `target_address` - (Optional, String) Target address.
 * `task_category` - (Optional, List: [`Int`]) Task category list.
-* `task_i_ds` - (Optional, List: [`String`]) Task ID list.
+* `task_ids` - (Optional, List: [`String`]) Task ID list.
 * `task_name` - (Optional, String) Task name.
 * `task_status` - (Optional, List: [`Int`]) Task status list.
 * `task_type` - (Optional, List: [`Int`]) Task type list.

--- a/website/docs/d/cat_probe_tasks.html.markdown
+++ b/website/docs/d/cat_probe_tasks.html.markdown
@@ -1,0 +1,97 @@
+---
+subcategory: "Cloud Automated Testing(CAT)"
+layout: "tencentcloud"
+page_title: "TencentCloud: tencentcloud_cat_probe_tasks"
+sidebar_current: "docs-tencentcloud-datasource-cat_probe_tasks"
+description: |-
+  Use this data source to query the list of probe tasks of CAT (云拨测).
+---
+
+# tencentcloud_cat_probe_tasks
+
+Use this data source to query the list of probe tasks of CAT (云拨测).
+
+## Example Usage
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "example" {
+}
+
+output "task_set" {
+  value = data.tencentcloud_cat_probe_tasks.example.task_set
+}
+
+output "total" {
+  value = data.tencentcloud_cat_probe_tasks.example.total
+}
+```
+
+### Query probe tasks by name and target address
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "by_name" {
+  task_name      = "my-probe-task"
+  target_address = "http://www.example.com"
+}
+```
+
+### Query probe tasks by tag filters
+
+```hcl
+data "tencentcloud_cat_probe_tasks" "by_tags" {
+  tag_filters {
+    key   = "Environment"
+    value = "Production"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ascend` - (Optional, Bool) Whether to sort in ascending order.
+* `order_by` - (Optional, String) Order by column.
+* `order_state` - (Optional, Int) Order state.
+* `pay_mode` - (Optional, Int) Pay mode.
+* `result_output_file` - (Optional, String) Used to save results.
+* `tag_filters` - (Optional, List) Tag filters.
+* `target_address` - (Optional, String) Target address.
+* `task_category` - (Optional, List: [`Int`]) Task category list.
+* `task_i_ds` - (Optional, List: [`String`]) Task ID list.
+* `task_name` - (Optional, String) Task name.
+* `task_status` - (Optional, List: [`Int`]) Task status list.
+* `task_type` - (Optional, List: [`Int`]) Task type list.
+
+The `tag_filters` object supports the following:
+
+* `key` - (Required, String) Tag key.
+* `value` - (Required, String) Tag value.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `task_set` - Probe task list.
+  * `created_at` - Created time.
+  * `cron_state` - Scheduled task start status.
+  * `cron` - Cron expression for scheduled task.
+  * `interval` - Probe interval in minutes.
+  * `name` - Task name.
+  * `node_ip_type` - Probe node IP type.
+  * `nodes` - Probe node list.
+  * `order_state` - Order state.
+  * `parameters` - Probe parameters.
+  * `pay_mode` - Pay mode.
+  * `status` - Task status.
+  * `sub_sync_flag` - Whether it is a sync account.
+  * `tag_info_list` - Tag info list.
+    * `key` - Tag key.
+    * `value` - Tag value.
+  * `target_address` - Target address.
+  * `task_category` - Task category.
+  * `task_id` - Task ID.
+  * `task_type` - Task type.
+* `total` - Total number of probe tasks.
+
+

--- a/website/tencentcloud.erb
+++ b/website/tencentcloud.erb
@@ -1055,6 +1055,9 @@
                                 <li>
                                     <a href="/docs/providers/tencentcloud/d/cat_probe_metric_tag_values.html">tencentcloud_cat_probe_metric_tag_values</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/tencentcloud/d/cat_probe_tasks.html">tencentcloud_cat_probe_tasks</a>
+                                </li>
                             </ul>
                         </li>
                         <li>


### PR DESCRIPTION
Add a new data source `tencentcloud_cat_probe_tasks` to query the list of CAT (Cat Application Testing) probe tasks via the `DescribeProbeTasks` API. Supports filtering by task IDs, task name, target address, task status, pay mode, order state, task type, task category, order by, ascend, and tag filters. Returns the probe task list and total count.