### PR TITLE
feat(clb): [137885115]add period parameter to tencentcloud_clb_log_topic resource

### DIFF
--- a/.changelog/4488.txt
+++ b/.changelog/4488.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_clb_log_topic: support `period` parameter to configure log retention lifecycle
+```

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/chdfs v1.0.600
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.165
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.173
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173

--- a/go.sum
+++ b/go.sum
@@ -917,8 +917,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695 h1:FGwsF1
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam v1.0.695/go.mod h1:HAasVoWz8ed6kAg7Q/DTg+8uZXiOgW7lmJeAGGrquEQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.165 h1:CpNyChYwEyO/fjM1f0KQY1pWgvDn+XftDdgi2LaXMeg=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.165/go.mod h1:cvbOkDX2rAK1Xcb65kGnWHJZMvLvxcc8i4N7OLEdNlo=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165 h1:sQRHq9cZ2TOPqTl86exaNKZ/B7RKvCEviQRvqgC8cqI=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165/go.mod h1:s88/DboRoSIkZNA9/lmXt1ja4LGDG+A+4ZwbqLrCZMQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.173 h1:0ciQExi8a31QKI3Fth846moJRs2ytDu2HusVyW5hgtY=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.173/go.mod h1:r125DBDoW8wpHUxdS5h8ABpJ7lFQk+2F9tfayyU4EZs=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40 h1:bhPBpfz0w3mdVyEolvXrtELUf+gE00O0WnAYIHZq70s=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40/go.mod h1:taTki0q8SHBIUFhjtnDA5UkiVic/WaPQzTqoXeGH3Ns=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173 h1:XomRXMaHth0qAihsXPdenP6McpwP8Phzic54uBI94kM=

--- a/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/design.md
+++ b/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The `tencentcloud_clb_log_topic` resource (`tencentcloud/services/clb/resource_tc_clb_log_topic.go`) manages CLB log topics. It currently exposes `log_set_id`, `topic_name`, `status`, `tags`, and the computed `create_time`.
+
+The resource is unusual because it spans two Tencent Cloud SDK packages:
+- **CLB SDK** (`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317`) is used for **Create** via `ClbService.CreateTopic`, which wraps `clb.CreateTopicRequest`.
+- **CLS SDK** (`github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016`) is used for **Modify** (`cls.NewModifyTopicRequest()`) and **Read** (via `svccls.ClsService.DescribeClsTopicById`, which calls `DescribeTopics` and returns `*cls.TopicInfo`).
+
+**Current state — API behavior analysis (verified against vendored SDK):**
+
+| API | SDK package | `Period` in request | `Period` in response | Go type |
+|-----|-------------|---------------------|----------------------|---------|
+| `CreateTopic` | `clb/v20180317` | Yes (`CreateTopicRequest.Period`) | N/A | `*uint64` |
+| `ModifyTopic` | `cls/v20201016` | Yes (`ModifyTopicRequest.Period`) | N/A | `*int64` |
+| `DescribeTopics` | `cls/v20201016` | N/A | Yes (`TopicInfo.Period`) | `*int64` |
+
+**SDK constraint — type mismatch:** `Period` is `*uint64` on the CLB `CreateTopicRequest` but `*int64` on the CLS `ModifyTopicRequest` and `TopicInfo`. The Terraform schema will use `TypeInt`; values must be cast to the correct SDK type at each call site (`uint64(period)` for Create, `int64(period)` for Modify).
+
+**API semantics:** `Period` is the log storage lifecycle in days. Standard storage supports 1-3600 days; 3640 means permanent retention. The API applies a default of 30 days when `Period` is not supplied. `Period` is accepted by both Create and Modify, so it is **updatable in-place** (not `ForceNew`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add an optional `period` (TypeInt) parameter to the `tencentcloud_clb_log_topic` resource schema that is not `ForceNew` (updatable in-place).
+- Pass `period` to the `CreateTopic` API (CLB SDK) as `Period *uint64`.
+- Pass `period` to the `ModifyTopic` API (CLS SDK) as `Period *int64` when it changes during Update.
+- Read `period` back from the `DescribeTopics` API response (`TopicInfo.Period *int64`) so state refresh and import populate the field.
+- Update the resource `.md` example with `period` usage.
+- Add mock-based unit tests (gomonkey) for Create, Read, and Update of the `period` parameter.
+- Maintain full backward compatibility (optional field, defaults unset).
+
+**Non-Goals:**
+- Adding validation constraints (range 1-3600/3640) beyond relying on the API as the final authority — the API will reject invalid values and surface a clear error.
+- Changing the existing `status`, `tags`, or `create_time` behavior.
+- Adding `period` to any CLB datasource (out of scope).
+- Splitting the resource into CLB-/CLS-specific resources.
+
+## Decisions
+
+### Decision 1: `period` is updatable (not `ForceNew`)
+**Rationale:** The `ModifyTopic` API (CLS SDK) accepts `Period`, so the value can be changed in-place after creation. Marking it `ForceNew` would unnecessarily destroy and recreate log topics (and their data) on every retention change.
+
+### Decision 2: `period` is `Optional` (not `Computed`)
+**Rationale:** The user explicitly configures retention. We do not mark it `Computed` because doing so would force Terraform to reconcile the API default (30) with an unset value, causing spurious diffs for users who do not set `period`. Keeping it purely `Optional` matches the existing `tags` field pattern on this resource. When unset, the provider does not send `Period` and the API applies its own default.
+
+### Decision 3: Service-layer `CreateTopic` receives `period` via the existing `params` map
+**Rationale:** `ClbService.CreateTopic(ctx, params map[string]interface{})` already accepts a generic params map (used for `topic_name`, `partition_count`, `tags`). Adding `params["period"]` avoids changing the function signature and is consistent with the existing pattern. Inside the service function, `Period` is set on `clb.CreateTopicRequest` as `*uint64` only when present.
+
+### Decision 4: Update flow calls `ModifyTopic` directly (consistent with existing `status`/`tags` handling)
+**Rationale:** The existing Update function already calls `cls.NewModifyTopicRequest()` directly for `status` and `tags` changes (with retry). Adding a `d.HasChange("period")` branch that sets `request.Period = helper.Int64(...)` and reuses the same retry/`ModifyTopic` call is the minimal, consistent approach. To handle the case where only `period` changes (and `status`/`tags` do not), the Update function will build a `ModifyTopic` request whenever any of `status`, `tags`, or `period` changes.
+
+### Decision 5: Type casting at call sites
+**Rationale:** Because the CLB Create SDK uses `*uint64` and the CLS Modify/Describe SDK uses `*int64`, the resource code casts the schema `int` value to `uint64` before Create and to `int64` before Modify/Read-set. This is localized to each call site and avoids introducing a shared type abstraction for a single field.
+
+## Risks / Trade-offs
+
+- **[Risk] Type mismatch between CLB and CLS SDKs could cause silent truncation** → Mitigation: explicit `uint64(period)` for Create and `int64(period)` for Modify; the value range (1-3640) fits comfortably in both types, so no overflow. Read sets `*TopicInfo.Period` (`*int64`) into the `TypeInt` schema directly.
+- **[Risk] Drift between user-configured `period` and API default (30) when unset** → Mitigation: `period` is `Optional` (not `Computed`), so Terraform does not attempt to manage the value when the user leaves it blank. Users who want to pin retention simply set `period` explicitly.
+- **[Risk] Update path must still call `ModifyTopic` even if only `period` changes** → Mitigation: restructure the Update function so a single `ModifyTopic` request is built when any of `status`, `tags`, or `period` changes, preserving existing retry behavior and the `cls.NewModifyTopicRequest()` pattern.

--- a/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/design.md
+++ b/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/design.md
@@ -40,14 +40,14 @@ The resource is unusual because it spans two Tencent Cloud SDK packages:
 ### Decision 1: `period` is updatable (not `ForceNew`)
 **Rationale:** The `ModifyTopic` API (CLS SDK) accepts `Period`, so the value can be changed in-place after creation. Marking it `ForceNew` would unnecessarily destroy and recreate log topics (and their data) on every retention change.
 
-### Decision 2: `period` is `Optional` (not `Computed`)
-**Rationale:** The user explicitly configures retention. We do not mark it `Computed` because doing so would force Terraform to reconcile the API default (30) with an unset value, causing spurious diffs for users who do not set `period`. Keeping it purely `Optional` matches the existing `tags` field pattern on this resource. When unset, the provider does not send `Period` and the API applies its own default.
+### Decision 2: `period` is `Optional` and `Computed`
+**Rationale:** The user can explicitly configure retention; marking it `Computed` as well lets the provider surface the API-applied default (30 days) in state after Read when the user leaves it unset, following the same pattern as the existing `status` field on this resource. When unset, the provider does not send `Period` on Create and the API applies its own default.
 
 ### Decision 3: Service-layer `CreateTopic` receives `period` via the existing `params` map
 **Rationale:** `ClbService.CreateTopic(ctx, params map[string]interface{})` already accepts a generic params map (used for `topic_name`, `partition_count`, `tags`). Adding `params["period"]` avoids changing the function signature and is consistent with the existing pattern. Inside the service function, `Period` is set on `clb.CreateTopicRequest` as `*uint64` only when present.
 
-### Decision 4: Update flow calls `ModifyTopic` directly (consistent with existing `status`/`tags` handling)
-**Rationale:** The existing Update function already calls `cls.NewModifyTopicRequest()` directly for `status` and `tags` changes (with retry). Adding a `d.HasChange("period")` branch that sets `request.Period = helper.Int64(...)` and reuses the same retry/`ModifyTopic` call is the minimal, consistent approach. To handle the case where only `period` changes (and `status`/`tags` do not), the Update function will build a `ModifyTopic` request whenever any of `status`, `tags`, or `period` changes.
+### Decision 4: Update flow builds a single `ModifyTopic` request when any updatable field changes
+**Rationale:** `ModifyTopic` (CLS SDK) accepts `Status`, `Tags`, and `Period` in the same request, so the Update function builds one `cls.NewModifyTopicRequest()` whenever any of `status`, `tags`, or `period` changes, populates only the changed fields, and issues a single retried `ModifyTopic` call for all of them. This reuses one call path for all updatable fields (consistent with the previous `status`/`tags` handling) and avoids redundant API calls when multiple fields change at once.
 
 ### Decision 5: Type casting at call sites
 **Rationale:** Because the CLB Create SDK uses `*uint64` and the CLS Modify/Describe SDK uses `*int64`, the resource code casts the schema `int` value to `uint64` before Create and to `int64` before Modify/Read-set. This is localized to each call site and avoids introducing a shared type abstraction for a single field.

--- a/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/proposal.md
+++ b/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The `tencentcloud_clb_log_topic` resource manages CLB (Cloud Load Balancer) log topics but does not expose the log retention period (`Period`). The underlying cloud APIs (`CreateTopic`, `ModifyTopic`, `DescribeTopics`) all support a `Period` field that controls how long (in days) logs are stored, yet users currently cannot configure log retention through Terraform and must fall back to the console or API. Exposing `period` enables full Infrastructure-as-Code lifecycle management of CLB log topics, including retention policy.
+
+## What Changes
+
+- Add an optional `period` (TypeInt) parameter to the `tencentcloud_clb_log_topic` resource schema. The value represents the log storage lifecycle in days (range 1-3600; 3640 means permanent retention). The parameter is updatable and not `ForceNew`.
+- In the Create flow, pass `period` to the `CreateTopic` API (CLB SDK `clb/v20180317`, `CreateTopicRequest.Period` is `*uint64`).
+- In the Update flow, when `period` changes, call the `ModifyTopic` API (CLS SDK `cls/v20201016`, `ModifyTopicRequest.Period` is `*int64`) with the new value.
+- In the Read flow, read `period` back from the `DescribeTopics` API response (`TopicInfo.Period` is `*int64`) and set it into state so refresh and import work correctly.
+- Update the resource `.md` example file with a `period` usage example.
+- Add unit tests (mock-based, using gomonkey) covering the new `period` parameter in Create, Read, and Update.
+
+## Capabilities
+
+### New Capabilities
+- `clb-log-topic-period`: Enable the optional `period` parameter on the `tencentcloud_clb_log_topic` resource to allow users to configure the log retention lifecycle (in days) when creating and updating CLB log topics.
+
+### Modified Capabilities
+<!-- No existing spec requirements require modification; period is a new, independent parameter on the resource. -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/clb/resource_tc_clb_log_topic.go` — add `period` schema field, wire through Create/Read/Update flows
+  - `tencentcloud/services/clb/service_tencentcloud_clb.go` — extend `CreateTopic` service function to accept and pass `Period` to the CLB `CreateTopic` API request
+  - `tencentcloud/services/clb/resource_tc_clb_log_topic.md` — update documentation example with `period` usage
+  - `tencentcloud/services/clb/resource_tc_clb_log_topic_test.go` — add mock-based unit tests for the `period` parameter
+- **SDK dependency:** No SDK upgrade required. The vendored SDKs already contain `Period` on `CreateTopicRequest` (`clb/v20180317`, `*uint64`), `ModifyTopicRequest` (`cls/v20201016`, `*int64`), and `TopicInfo` (`cls/v20201016`, `*int64`).
+- **Backward compatibility:** Fully backward compatible — `period` is Optional and defaults to not being set, so existing configurations continue to work unchanged. The API applies its own default (30 days) when `period` is not provided.
+- **API constraints:** `Period` is accepted by both `CreateTopic` (CLB SDK) and `ModifyTopic` (CLS SDK), so the parameter is updatable in-place (not `ForceNew`). The Read path uses `DescribeTopics` (via the existing `DescribeClsTopicById` service helper) which returns `TopicInfo.Period`.

--- a/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/specs/clb-log-topic-period/spec.md
+++ b/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/specs/clb-log-topic-period/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Support period parameter on CLB log topic
+
+The `tencentcloud_clb_log_topic` resource SHALL support an optional `period` (TypeInt) parameter that controls the log storage lifecycle in days. The parameter SHALL be updatable in-place (not `ForceNew`). When set, the provider SHALL pass `Period` to the `CreateTopic` API (CLB SDK `clb/v20180317`) on creation and to the `ModifyTopic` API (CLS SDK `cls/v20201016`) on update. When the user does not set `period`, the provider SHALL NOT send `Period` and the cloud API default (30 days) SHALL apply.
+
+**Rationale**: The underlying `CreateTopic`, `ModifyTopic`, and `DescribeTopics` APIs all support a `Period` field, but the Terraform resource does not expose it. Exposing `period` enables users to configure log retention through Infrastructure as Code.
+
+#### Scenario: Create a CLB log topic with period
+
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource with the `period` parameter set (e.g. `period = 30`)
+- **THEN** the provider SHALL pass the value to the `CreateTopic` API request as `Period` (cast to `*uint64`)
+- **AND** a subsequent `terraform plan` shows no changes
+
+#### Scenario: Create a CLB log topic without period
+
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource without specifying the `period` parameter
+- **THEN** the provider SHALL NOT set `Period` in the `CreateTopic` API request
+- **AND** the cloud API default retention (30 days) SHALL apply
+
+#### Scenario: Read period back from the DescribeTopics API
+
+- **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Period` is non-nil
+- **THEN** the provider SHALL set the `period` field in state to the value of `TopicInfo.Period`
+- **AND** state refresh and import SHALL populate `period` correctly
+
+#### Scenario: Read when period is not returned
+
+- **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Period` is nil
+- **THEN** the provider SHALL NOT set the `period` field in state
+- **AND** no error is returned
+
+#### Scenario: Update period on an existing CLB log topic
+
+- **WHEN** a user updates the `period` parameter on an existing `tencentcloud_clb_log_topic` resource
+- **THEN** the provider SHALL call the `ModifyTopic` API with the new value as `Period` (cast to `*int64`)
+- **AND** the updated value SHALL be reflected in state after the subsequent Read
+
+#### Scenario: Update other fields without changing period
+
+- **WHEN** a user updates `status` or `tags` but does not change `period`
+- **THEN** the provider SHALL NOT include `Period` in the `ModifyTopic` request
+- **AND** the existing retention value SHALL remain unchanged

--- a/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/tasks.md
+++ b/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/tasks.md
@@ -1,0 +1,32 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `period` schema field (TypeInt, Optional, not ForceNew, description "Log storage lifecycle in days. Standard storage supports 1-3600; 3640 means permanent retention. Defaults to 30 when unset.") to `ResourceTencentCloudClbLogTopic()` in `tencentcloud/services/clb/resource_tc_clb_log_topic.go`
+
+## 2. Service Layer Changes
+
+- [x] 2.1 In `ClbService.CreateTopic` (`tencentcloud/services/clb/service_tencentcloud_clb.go`), read `params["period"]` and, when present, set `request.Period = common.Uint64Ptr(uint64(period.(int)))` on the `clb.CreateTopicRequest`
+
+## 3. Create Function Changes
+
+- [x] 3.1 In `resourceTencentCloudClbInstanceTopicCreate`, read `period` from schema data (`d.GetOk("period")`) and add it to the `params` map passed to `ClbService.CreateTopic`
+
+## 4. Read Function Changes
+
+- [x] 4.1 In `resourceTencentCloudClbInstanceTopicRead`, after the existing `_ = d.Set(...)` calls, check that `res.Period` is non-nil before setting `period` into state via `_ = d.Set("period", res.Period)`
+
+## 5. Update Function Changes
+
+- [x] 5.1 In `resourceTencentCloudClbInstanceTopicUpdate`, add a `d.HasChange("period")` branch that builds/includes `Period` (cast to `*int64` via `helper.Int64`) on the `cls.NewModifyTopicRequest()` when `period` changes, reusing the existing retry/`ModifyTopic` call pattern
+
+## 6. Documentation
+
+- [x] 6.1 Update `tencentcloud/services/clb/resource_tc_clb_log_topic.md` with a `period` usage example in the Example Usage block
+
+## 7. Testing
+
+- [x] 7.1 Add mock-based unit tests (gomonkey) in `tencentcloud/services/clb/resource_tc_clb_log_topic_test.go` covering Create with `period`, Read populating `period` from `TopicInfo.Period`, and Update changing `period` via `ModifyTopic`
+
+## 8. Validation
+
+- [x] 8.1 Verify the code compiles (no `go build`/`go vet`; ensure generated code is syntactically correct and all returned errors are handled)
+- [x] 8.2 Confirm no lint errors (unused variables handled via `_ =` where a function cannot fail)

--- a/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/tasks.md
+++ b/openspec/changes/archive/2026-09-04-add-clb-log-topic-period/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Schema Definition
 
-- [x] 1.1 Add `period` schema field (TypeInt, Optional, not ForceNew, description "Log storage lifecycle in days. Standard storage supports 1-3600; 3640 means permanent retention. Defaults to 30 when unset.") to `ResourceTencentCloudClbLogTopic()` in `tencentcloud/services/clb/resource_tc_clb_log_topic.go`
+- [x] 1.1 Add `period` schema field (TypeInt, Optional, Computed, not ForceNew, description "Log storage lifecycle in days. Standard storage supports 1-3600; 3640 means permanent retention. Defaults to 30 when unset.") to `ResourceTencentCloudClbLogTopic()` in `tencentcloud/services/clb/resource_tc_clb_log_topic.go`
 
 ## 2. Service Layer Changes
 
@@ -16,7 +16,7 @@
 
 ## 5. Update Function Changes
 
-- [x] 5.1 In `resourceTencentCloudClbInstanceTopicUpdate`, add a `d.HasChange("period")` branch that builds/includes `Period` (cast to `*int64` via `helper.Int64`) on the `cls.NewModifyTopicRequest()` when `period` changes, reusing the existing retry/`ModifyTopic` call pattern
+- [x] 5.1 In `resourceTencentCloudClbInstanceTopicUpdate`, build a single `cls.NewModifyTopicRequest()` when any of `status`, `tags`, or `period` changes, populate `Period` (cast to `*int64` via `helper.Int64`) only when `period` changes, and issue one retried `ModifyTopic` call that updates all changed fields together
 
 ## 6. Documentation
 

--- a/openspec/specs/clb-log-topic-period/spec.md
+++ b/openspec/specs/clb-log-topic-period/spec.md
@@ -1,0 +1,47 @@
+# clb-log-topic-period Specification
+
+## Purpose
+TBD - created by archiving change add-clb-log-topic-period. Update Purpose after archive.
+## Requirements
+### Requirement: Support period parameter on CLB log topic
+
+The `tencentcloud_clb_log_topic` resource SHALL support an optional `period` (TypeInt) parameter that controls the log storage lifecycle in days. The parameter SHALL be updatable in-place (not `ForceNew`). When set, the provider SHALL pass `Period` to the `CreateTopic` API (CLB SDK `clb/v20180317`) on creation and to the `ModifyTopic` API (CLS SDK `cls/v20201016`) on update. When the user does not set `period`, the provider SHALL NOT send `Period` and the cloud API default (30 days) SHALL apply.
+
+**Rationale**: The underlying `CreateTopic`, `ModifyTopic`, and `DescribeTopics` APIs all support a `Period` field, but the Terraform resource does not expose it. Exposing `period` enables users to configure log retention through Infrastructure as Code.
+
+#### Scenario: Create a CLB log topic with period
+
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource with the `period` parameter set (e.g. `period = 30`)
+- **THEN** the provider SHALL pass the value to the `CreateTopic` API request as `Period` (cast to `*uint64`)
+- **AND** a subsequent `terraform plan` shows no changes
+
+#### Scenario: Create a CLB log topic without period
+
+- **WHEN** a user creates a `tencentcloud_clb_log_topic` resource without specifying the `period` parameter
+- **THEN** the provider SHALL NOT set `Period` in the `CreateTopic` API request
+- **AND** the cloud API default retention (30 days) SHALL apply
+
+#### Scenario: Read period back from the DescribeTopics API
+
+- **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Period` is non-nil
+- **THEN** the provider SHALL set the `period` field in state to the value of `TopicInfo.Period`
+- **AND** state refresh and import SHALL populate `period` correctly
+
+#### Scenario: Read when period is not returned
+
+- **WHEN** the `Read` method calls `DescribeTopics` and the response `TopicInfo.Period` is nil
+- **THEN** the provider SHALL NOT set the `period` field in state
+- **AND** no error is returned
+
+#### Scenario: Update period on an existing CLB log topic
+
+- **WHEN** a user updates the `period` parameter on an existing `tencentcloud_clb_log_topic` resource
+- **THEN** the provider SHALL call the `ModifyTopic` API with the new value as `Period` (cast to `*int64`)
+- **AND** the updated value SHALL be reflected in state after the subsequent Read
+
+#### Scenario: Update other fields without changing period
+
+- **WHEN** a user updates `status` or `tags` but does not change `period`
+- **THEN** the provider SHALL NOT include `Period` in the `ModifyTopic` request
+- **AND** the existing retention value SHALL remain unchanged
+

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic.go
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic.go
@@ -53,6 +53,11 @@ func ResourceTencentCloudClbLogTopic() *schema.Resource {
 				Description: "Tags of clb log topic.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"period": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Log storage lifecycle in days. Standard storage supports 1-3600; 3640 means permanent retention. Defaults to 30 when unset.",
+			},
 			//compute
 			"create_time": {
 				Type:        schema.TypeString,
@@ -91,6 +96,9 @@ func resourceTencentCloudClbInstanceTopicCreate(d *schema.ResourceData, meta int
 	}
 	if tags, ok := d.GetOk("tags"); ok {
 		params["tags"] = tags.(map[string]interface{})
+	}
+	if period, ok := d.GetOk("period"); ok {
+		params["period"] = period
 	}
 	resp, err := clbService.CreateTopic(ctx, params)
 	if err != nil {
@@ -155,6 +163,10 @@ func resourceTencentCloudClbInstanceTopicRead(d *schema.ResourceData, meta inter
 	_ = d.Set("create_time", res.CreateTime)
 	_ = d.Set("status", res.Status)
 
+	if res.Period != nil {
+		_ = d.Set("period", res.Period)
+	}
+
 	if res.Tags != nil {
 		tagsMap := make(map[string]string, len(res.Tags))
 		for _, tag := range res.Tags {
@@ -217,6 +229,28 @@ func resourceTencentCloudClbInstanceTopicUpdate(d *schema.ResourceData, meta int
 				}
 				request.Tags = clsTags
 			}
+		}
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().ModifyTopic(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("period") {
+		request := cls.NewModifyTopicRequest()
+		request.TopicId = &topicId
+		if v, ok := d.GetOk("period"); ok {
+			request.Period = helper.Int64(int64(v.(int)))
 		}
 		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().ModifyTopic(request)

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic.go
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic.go
@@ -56,6 +56,7 @@ func ResourceTencentCloudClbLogTopic() *schema.Resource {
 			"period": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "Log storage lifecycle in days. Standard storage supports 1-3600; 3640 means permanent retention. Defaults to 30 when unset.",
 			},
 			//compute
@@ -191,66 +192,35 @@ func resourceTencentCloudClbInstanceTopicUpdate(d *schema.ResourceData, meta int
 		topicId = d.Id()
 	)
 
-	if d.HasChange("status") {
-		if v, ok := d.GetOkExists("status"); ok {
-			request := cls.NewModifyTopicRequest()
-			request.TopicId = &topicId
-			request.Status = helper.Bool(v.(bool))
-			err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-				result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().ModifyTopic(request)
-				if e != nil {
-					return tccommon.RetryError(e)
-				} else {
-					log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
-				}
-
-				return nil
-			})
-
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if d.HasChange("tags") {
+	if d.HasChange("status") || d.HasChange("tags") || d.HasChange("period") {
 		request := cls.NewModifyTopicRequest()
 		request.TopicId = &topicId
-		if v, ok := d.GetOk("tags"); ok {
-			tagsMap := v.(map[string]interface{})
-			if len(tagsMap) > 0 {
-				clsTags := make([]*cls.Tag, 0, len(tagsMap))
-				for key, value := range tagsMap {
-					clsTag := &cls.Tag{
-						Key:   helper.String(key),
-						Value: helper.String(value.(string)),
+
+		if d.HasChange("status") {
+			if v, ok := d.GetOkExists("status"); ok {
+				request.Status = helper.Bool(v.(bool))
+			}
+		}
+		if d.HasChange("tags") {
+			if v, ok := d.GetOk("tags"); ok {
+				tagsMap := v.(map[string]interface{})
+				if len(tagsMap) > 0 {
+					clsTags := make([]*cls.Tag, 0, len(tagsMap))
+					for key, value := range tagsMap {
+						clsTag := &cls.Tag{
+							Key:   helper.String(key),
+							Value: helper.String(value.(string)),
+						}
+						clsTags = append(clsTags, clsTag)
 					}
-					clsTags = append(clsTags, clsTag)
+					request.Tags = clsTags
 				}
-				request.Tags = clsTags
 			}
 		}
-		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().ModifyTopic(request)
-			if e != nil {
-				return tccommon.RetryError(e)
-			} else {
-				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+		if d.HasChange("period") {
+			if v, ok := d.GetOk("period"); ok {
+				request.Period = helper.Int64(int64(v.(int)))
 			}
-
-			return nil
-		})
-
-		if err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("period") {
-		request := cls.NewModifyTopicRequest()
-		request.TopicId = &topicId
-		if v, ok := d.GetOk("period"); ok {
-			request.Period = helper.Int64(int64(v.(int)))
 		}
 		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseClsClient().ModifyTopic(request)

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic.go
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic.go
@@ -98,7 +98,7 @@ func resourceTencentCloudClbInstanceTopicCreate(d *schema.ResourceData, meta int
 	if tags, ok := d.GetOk("tags"); ok {
 		params["tags"] = tags.(map[string]interface{})
 	}
-	if period, ok := d.GetOk("period"); ok {
+	if period, ok := d.GetOkExists("period"); ok {
 		params["period"] = period
 	}
 	resp, err := clbService.CreateTopic(ctx, params)
@@ -218,7 +218,7 @@ func resourceTencentCloudClbInstanceTopicUpdate(d *schema.ResourceData, meta int
 			}
 		}
 		if d.HasChange("period") {
-			if v, ok := d.GetOk("period"); ok {
+			if v, ok := d.GetOkExists("period"); ok {
 				request.Period = helper.Int64(int64(v.(int)))
 			}
 		}

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic.md
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic.md
@@ -7,6 +7,7 @@ resource "tencentcloud_clb_log_topic" "example" {
   log_set_id = "2ed70190-bf06-4777-980d-2d8a327a2554"
   topic_name = "tf-example"
   status     = true
+  period     = 30
   tags = {
     env = "prod"
   }

--- a/tencentcloud/services/clb/resource_tc_clb_log_topic_test.go
+++ b/tencentcloud/services/clb/resource_tc_clb_log_topic_test.go
@@ -1,16 +1,24 @@
 package clb_test
 
 import (
-	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
-	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
-	svccls "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cls"
-
 	"context"
 	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+
+	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	localclb "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/clb"
+	localcls "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/cls"
+
+	clbv20180317 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317"
+	clsv20201016 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
 )
 
 func TestAccTencentCloudClbInstanceTopic(t *testing.T) {
@@ -67,7 +75,7 @@ func testAccCheckClbInstanceTopicExists(n string) resource.TestCheckFunc {
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("[CHECK][CLB topic][Exists] check: CLB topic id is not set")
 		}
-		clsService := svccls.NewClsService(tcacctest.AccProvider.Meta().(tccommon.ProviderMeta).GetAPIV3Conn())
+		clsService := localcls.NewClsService(tcacctest.AccProvider.Meta().(tccommon.ProviderMeta).GetAPIV3Conn())
 		instance, err := clsService.DescribeClsTopicById(ctx, rs.Primary.ID, nil)
 		if err != nil {
 			return err
@@ -118,3 +126,278 @@ resource "tencentcloud_clb_log_topic" "topic" {
     }
 }
 `
+
+// --- gomonkey mock unit tests for period parameter ---
+
+type mockMetaForClbLogTopic struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForClbLogTopic) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForClbLogTopic{}
+
+func newMockMetaForClbLogTopic() *mockMetaForClbLogTopic {
+	return &mockMetaForClbLogTopic{client: &connectivity.TencentCloudClient{}}
+}
+
+func ptrStringCLT(s string) *string { return &s }
+func ptrInt64CLT(i int64) *int64    { return &i }
+func ptrBoolCLT(b bool) *bool       { return &b }
+
+// TestClbLogTopic_Create_WithPeriod verifies that when period is set, the
+// CreateTopic request carries the correct Period value (cast to *uint64).
+func TestClbLogTopic_Create_WithPeriod(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clbClient := &clbv20180317.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClbLogTopic().client, "UseClbClient", clbClient)
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClbLogTopic().client, "UseClsClient", clsClient)
+
+	var capturedRequest *clbv20180317.CreateTopicRequest
+	patches.ApplyMethodFunc(clbClient, "CreateTopic", func(request *clbv20180317.CreateTopicRequest) (*clbv20180317.CreateTopicResponse, error) {
+		capturedRequest = request
+		resp := clbv20180317.NewCreateTopicResponse()
+		resp.Response = &clbv20180317.CreateTopicResponseParams{
+			TopicId:   ptrStringCLT("fake-topic-id"),
+			RequestId: ptrStringCLT("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeClsLogset so log_set_id validation passes
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsLogset", func(_ context.Context, _ string) (*clsv20201016.LogsetInfo, error) {
+		return &clsv20201016.LogsetInfo{
+			LogsetId:   ptrStringCLT("fake-logset-id"),
+			LogsetName: ptrStringCLT("clb_logset"),
+		}, nil
+	})
+
+	// Mock DescribeClsTopicById for the read-back after create
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:   ptrStringCLT("fake-logset-id"),
+		TopicId:    ptrStringCLT("fake-topic-id"),
+		TopicName:  ptrStringCLT("tf-test-topic"),
+		Status:     ptrBoolCLT(true),
+		Period:     ptrInt64CLT(30),
+		CreateTime: ptrStringCLT("2024-01-01 00:00:00"),
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClbLogTopic()
+	res := localclb.ResourceTencentCloudClbLogTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"log_set_id": "fake-logset-id",
+		"topic_name": "tf-test-topic",
+		"period":     30,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "fake-topic-id", d.Id())
+
+	// Verify Period was set on the create request as *uint64
+	assert.NotNil(t, capturedRequest.Period)
+	assert.Equal(t, uint64(30), *capturedRequest.Period)
+
+	// Verify period is read back into state
+	assert.Equal(t, 30, d.Get("period"))
+}
+
+// TestClbLogTopic_Create_WithoutPeriod verifies that when period is not set,
+// the CreateTopic request does not carry Period and the API default applies.
+func TestClbLogTopic_Create_WithoutPeriod(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clbClient := &clbv20180317.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClbLogTopic().client, "UseClbClient", clbClient)
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClbLogTopic().client, "UseClsClient", clsClient)
+
+	var capturedRequest *clbv20180317.CreateTopicRequest
+	patches.ApplyMethodFunc(clbClient, "CreateTopic", func(request *clbv20180317.CreateTopicRequest) (*clbv20180317.CreateTopicResponse, error) {
+		capturedRequest = request
+		resp := clbv20180317.NewCreateTopicResponse()
+		resp.Response = &clbv20180317.CreateTopicResponseParams{
+			TopicId:   ptrStringCLT("fake-topic-id-2"),
+			RequestId: ptrStringCLT("fake-request-id-2"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsLogset", func(_ context.Context, _ string) (*clsv20201016.LogsetInfo, error) {
+		return &clsv20201016.LogsetInfo{
+			LogsetId:   ptrStringCLT("fake-logset-id"),
+			LogsetName: ptrStringCLT("clb_logset"),
+		}, nil
+	})
+
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:   ptrStringCLT("fake-logset-id"),
+		TopicId:    ptrStringCLT("fake-topic-id-2"),
+		TopicName:  ptrStringCLT("tf-test-topic-2"),
+		Status:     ptrBoolCLT(true),
+		Period:     ptrInt64CLT(30),
+		CreateTime: ptrStringCLT("2024-01-01 00:00:00"),
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClbLogTopic()
+	res := localclb.ResourceTencentCloudClbLogTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"log_set_id": "fake-logset-id",
+		"topic_name": "tf-test-topic-2",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "fake-topic-id-2", d.Id())
+
+	// Verify Period was NOT set on the create request (user did not specify it)
+	assert.Nil(t, capturedRequest.Period)
+}
+
+// TestClbLogTopic_Read_PeriodPopulated verifies that period is correctly read
+// from the TopicInfo.Period response and set in resource data.
+func TestClbLogTopic_Read_PeriodPopulated(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClbLogTopic().client, "UseClsClient", clsClient)
+
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:   ptrStringCLT("fake-logset-id"),
+		TopicId:    ptrStringCLT("fake-topic-id"),
+		TopicName:  ptrStringCLT("tf-test-topic"),
+		Status:     ptrBoolCLT(true),
+		Period:     ptrInt64CLT(60),
+		CreateTime: ptrStringCLT("2024-01-01 00:00:00"),
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClbLogTopic()
+	res := localclb.ResourceTencentCloudClbLogTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"log_set_id": "fake-logset-id",
+		"topic_name": "tf-test-topic",
+	})
+	d.SetId("fake-topic-id")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "fake-topic-id", d.Id())
+
+	// Verify period is populated from TopicInfo.Period
+	assert.Equal(t, 60, d.Get("period"))
+}
+
+// TestClbLogTopic_Read_PeriodNil verifies that when Period is nil in the
+// TopicInfo response, period is not set in resource data (no crash).
+func TestClbLogTopic_Read_PeriodNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClbLogTopic().client, "UseClsClient", clsClient)
+
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:   ptrStringCLT("fake-logset-id"),
+		TopicId:    ptrStringCLT("fake-topic-id-nil"),
+		TopicName:  ptrStringCLT("tf-test-topic-nil"),
+		Status:     ptrBoolCLT(true),
+		Period:     nil,
+		CreateTime: ptrStringCLT("2024-01-01 00:00:00"),
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClbLogTopic()
+	res := localclb.ResourceTencentCloudClbLogTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"log_set_id": "fake-logset-id",
+		"topic_name": "tf-test-topic-nil",
+	})
+	d.SetId("fake-topic-id-nil")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "fake-topic-id-nil", d.Id())
+
+	// Verify period defaults to 0 (not set) when TopicInfo.Period is nil
+	assert.Equal(t, 0, d.Get("period"))
+}
+
+// TestClbLogTopic_Update_Period verifies that updating the period parameter
+// calls the ModifyTopic API with the new Period value (cast to *int64).
+func TestClbLogTopic_Update_Period(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	clsClient := &clsv20201016.Client{}
+	patches.ApplyMethodReturn(newMockMetaForClbLogTopic().client, "UseClsClient", clsClient)
+
+	var capturedRequest *clsv20201016.ModifyTopicRequest
+	patches.ApplyMethodFunc(clsClient, "ModifyTopic", func(request *clsv20201016.ModifyTopicRequest) (*clsv20201016.ModifyTopicResponse, error) {
+		capturedRequest = request
+		resp := clsv20201016.NewModifyTopicResponse()
+		resp.Response = &clsv20201016.ModifyTopicResponseParams{
+			RequestId: ptrStringCLT("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Mock DescribeClsTopicById for the read-back after update
+	topicInfo := &clsv20201016.TopicInfo{
+		LogsetId:   ptrStringCLT("fake-logset-id"),
+		TopicId:    ptrStringCLT("fake-topic-id"),
+		TopicName:  ptrStringCLT("tf-test-topic"),
+		Status:     ptrBoolCLT(true),
+		Period:     ptrInt64CLT(60),
+		CreateTime: ptrStringCLT("2024-01-01 00:00:00"),
+	}
+	patches.ApplyMethodFunc(&localcls.ClsService{}, "DescribeClsTopicById", func(_ context.Context, _ string, _ *uint64) (*clsv20201016.TopicInfo, error) {
+		return topicInfo, nil
+	})
+
+	meta := newMockMetaForClbLogTopic()
+	res := localclb.ResourceTencentCloudClbLogTopic()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"log_set_id": "fake-logset-id",
+		"topic_name": "tf-test-topic",
+		"period":     60,
+	})
+	d.SetId("fake-topic-id")
+
+	// Force period to be detected as changed
+	patches.ApplyMethodFunc(d, "HasChange", func(key string) bool {
+		return key == "period"
+	})
+
+	err := res.Update(d, meta)
+	assert.NoError(t, err)
+
+	// Verify ModifyTopic was called with Period as *int64
+	assert.NotNil(t, capturedRequest)
+	assert.NotNil(t, capturedRequest.Period)
+	assert.Equal(t, int64(60), *capturedRequest.Period)
+	assert.NotNil(t, capturedRequest.TopicId)
+	assert.Equal(t, "fake-topic-id", *capturedRequest.TopicId)
+
+	// Verify the updated value is reflected in state after read-back
+	assert.Equal(t, 60, d.Get("period"))
+}

--- a/tencentcloud/services/clb/service_tencentcloud_clb.go
+++ b/tencentcloud/services/clb/service_tencentcloud_clb.go
@@ -1586,6 +1586,10 @@ func (me *ClbService) CreateTopic(ctx context.Context, params map[string]interfa
 		request.PartitionCount = common.Uint64Ptr((uint64)(partitionCount.(int)))
 	}
 
+	if period, ok := params["period"]; ok {
+		request.Period = common.Uint64Ptr((uint64)(period.(int)))
+	}
+
 	if tags, ok := params["tags"].(map[string]interface{}); ok && len(tags) > 0 {
 		tagInfoList := make([]*clb.TagInfo, 0, len(tags))
 		for key, value := range tags {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/client.go
@@ -8523,6 +8523,10 @@ func NewModifyLoadBalancerSlaResponse() (response *ModifyLoadBalancerSlaResponse
 //
 // - 传统型负载均衡实例不支持升级为性能容量型实例。
 //
+// 
+//
+// 本接口为异步接口，本接口返回成功后需以返回的RequestID为入参，调用 [DescribeTaskStatus](https://cloud.tencent.com/document/product/214/30683) 接口查询本次任务是否成功。
+//
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
 //  INTERNALERROR = "InternalError"
@@ -8544,6 +8548,10 @@ func (c *Client) ModifyLoadBalancerSla(request *ModifyLoadBalancerSlaRequest) (r
 // - 共享型升级为性能容量型实例后，不支持再回退到共享型实例。
 //
 // - 传统型负载均衡实例不支持升级为性能容量型实例。
+//
+// 
+//
+// 本接口为异步接口，本接口返回成功后需以返回的RequestID为入参，调用 [DescribeTaskStatus](https://cloud.tencent.com/document/product/214/30683) 接口查询本次任务是否成功。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317/models.go
@@ -152,6 +152,14 @@ func (r *AddModelRewriteResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type ApiBaseItem struct {
+	// <p>后端转发协议</p>
+	Protocol *string `json:"Protocol,omitnil,omitempty" name:"Protocol"`
+
+	// <p>Api Base URL</p>
+	ApiBase *string `json:"ApiBase,omitnil,omitempty" name:"ApiBase"`
+}
+
 // Predefined struct for user
 type AssociateBudgetRequestParams struct {
 	// <p>Budget ID。</p>
@@ -2865,6 +2873,9 @@ type CreateModelRequestParams struct {
 	// <p>API Base URL</p>
 	ApiBase *string `json:"ApiBase,omitnil,omitempty" name:"ApiBase"`
 
+	// <p>多协议 Api Base URL</p>
+	ApiBases []*ApiBaseItem `json:"ApiBases,omitnil,omitempty" name:"ApiBases"`
+
 	// <p>VPC ID</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
@@ -2882,6 +2893,12 @@ type CreateModelRequestParams struct {
 
 	// <p>健康检查配置</p>
 	HealthCheckConfig *ServiceProviderHealthCheckConfigInput `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
+
+	// <p>私网管道 ID</p>
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
+
+	// <p>健康检查配置</p>
+	HealthCheckConfigs []*ServiceProviderHealthCheckConfigItemInput `json:"HealthCheckConfigs,omitnil,omitempty" name:"HealthCheckConfigs"`
 }
 
 type CreateModelRequest struct {
@@ -2911,6 +2928,9 @@ type CreateModelRequest struct {
 	// <p>API Base URL</p>
 	ApiBase *string `json:"ApiBase,omitnil,omitempty" name:"ApiBase"`
 
+	// <p>多协议 Api Base URL</p>
+	ApiBases []*ApiBaseItem `json:"ApiBases,omitnil,omitempty" name:"ApiBases"`
+
 	// <p>VPC ID</p>
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
@@ -2928,6 +2948,12 @@ type CreateModelRequest struct {
 
 	// <p>健康检查配置</p>
 	HealthCheckConfig *ServiceProviderHealthCheckConfigInput `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
+
+	// <p>私网管道 ID</p>
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
+
+	// <p>健康检查配置</p>
+	HealthCheckConfigs []*ServiceProviderHealthCheckConfigItemInput `json:"HealthCheckConfigs,omitnil,omitempty" name:"HealthCheckConfigs"`
 }
 
 func (r *CreateModelRequest) ToJsonString() string {
@@ -2950,12 +2976,15 @@ func (r *CreateModelRequest) FromJsonString(s string) error {
 	delete(f, "ServiceProviderName")
 	delete(f, "Protocol")
 	delete(f, "ApiBase")
+	delete(f, "ApiBases")
 	delete(f, "VpcId")
 	delete(f, "SubnetId")
 	delete(f, "HostHeader")
 	delete(f, "Tags")
 	delete(f, "VerifySSL")
 	delete(f, "HealthCheckConfig")
+	delete(f, "CMRPrivateNetworkTunnelId")
+	delete(f, "HealthCheckConfigs")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateModelRequest has unknown keys!", "")
 	}
@@ -9128,8 +9157,11 @@ type DescribeUpperModelsRequestParams struct {
 	// <p>模型提供商</p>
 	ModelProvider *string `json:"ModelProvider,omitnil,omitempty" name:"ModelProvider"`
 
-	// <p>BYOK 业务 ID，可选</p><p>格式：byok-xxxxxxxx</p>
+	// <p>BYOK 业务 ID，可选</p><p>格式：byok-xxxxxxxx，预留参数</p>
 	ServiceProviderId *string `json:"ServiceProviderId,omitnil,omitempty" name:"ServiceProviderId"`
+
+	// <p>    CMR 私网管道ID </p>
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
 }
 
 type DescribeUpperModelsRequest struct {
@@ -9159,8 +9191,11 @@ type DescribeUpperModelsRequest struct {
 	// <p>模型提供商</p>
 	ModelProvider *string `json:"ModelProvider,omitnil,omitempty" name:"ModelProvider"`
 
-	// <p>BYOK 业务 ID，可选</p><p>格式：byok-xxxxxxxx</p>
+	// <p>BYOK 业务 ID，可选</p><p>格式：byok-xxxxxxxx，预留参数</p>
 	ServiceProviderId *string `json:"ServiceProviderId,omitnil,omitempty" name:"ServiceProviderId"`
+
+	// <p>    CMR 私网管道ID </p>
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
 }
 
 func (r *DescribeUpperModelsRequest) ToJsonString() string {
@@ -9184,6 +9219,7 @@ func (r *DescribeUpperModelsRequest) FromJsonString(s string) error {
 	delete(f, "ModelProtocol")
 	delete(f, "ModelProvider")
 	delete(f, "ServiceProviderId")
+	delete(f, "CMRPrivateNetworkTunnelId")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeUpperModelsRequest has unknown keys!", "")
 	}
@@ -11249,6 +11285,10 @@ type ModelKeyInfoItem struct {
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ApiBase *string `json:"ApiBase,omitnil,omitempty" name:"ApiBase"`
 
+	// <p>多协议 API Base URL</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiBases []*ApiBaseItem `json:"ApiBases,omitnil,omitempty" name:"ApiBases"`
+
 	// <p>模型创建时间（ISO 8601）</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	CreatedAt *string `json:"CreatedAt,omitnil,omitempty" name:"CreatedAt"`
@@ -11301,6 +11341,17 @@ type ModelKeyInfoItem struct {
 
 	// <p>健康检查配置</p>
 	HealthCheckConfig *ServiceProviderHealthCheckConfigOutput `json:"HealthCheckConfig,omitnil,omitempty" name:"HealthCheckConfig"`
+
+	// <p>私网管道 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
+
+	// <p>私网管道名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CMRPrivateNetworkTunnelName *string `json:"CMRPrivateNetworkTunnelName,omitnil,omitempty" name:"CMRPrivateNetworkTunnelName"`
+
+	// <p>健康检查配置</p>
+	HealthCheckConfigs []*ServiceProviderHealthCheckConfigItemOutput `json:"HealthCheckConfigs,omitnil,omitempty" name:"HealthCheckConfigs"`
 }
 
 type ModelNameAggregatedItem struct {
@@ -11410,6 +11461,7 @@ type ModelRouterDetail struct {
 	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
 
 	// <p>带宽</p><p>单位：Mbps</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
 	Bandwidth *uint64 `json:"Bandwidth,omitnil,omitempty" name:"Bandwidth"`
 
 	// <p>弹性公网IP的ID</p>
@@ -13029,8 +13081,11 @@ type ModifyModelAttributesRequestParams struct {
 	// <p>BYOK的ID</p><p>参数格式：byok-kot39u7j</p>
 	ServiceProviderId *string `json:"ServiceProviderId,omitnil,omitempty" name:"ServiceProviderId"`
 
-	// <p>BYOK的自定义名字</p><p>入参限制：1～256个字符</p>
+	// <p>BYOK的自定义名字</p><p>入参限制：1～255个字符</p>
 	ServiceProviderName *string `json:"ServiceProviderName,omitnil,omitempty" name:"ServiceProviderName"`
+
+	// <p>多协议 Api Base URL</p>
+	ApiBases []*ApiBaseItem `json:"ApiBases,omitnil,omitempty" name:"ApiBases"`
 }
 
 type ModifyModelAttributesRequest struct {
@@ -13039,8 +13094,11 @@ type ModifyModelAttributesRequest struct {
 	// <p>BYOK的ID</p><p>参数格式：byok-kot39u7j</p>
 	ServiceProviderId *string `json:"ServiceProviderId,omitnil,omitempty" name:"ServiceProviderId"`
 
-	// <p>BYOK的自定义名字</p><p>入参限制：1～256个字符</p>
+	// <p>BYOK的自定义名字</p><p>入参限制：1～255个字符</p>
 	ServiceProviderName *string `json:"ServiceProviderName,omitnil,omitempty" name:"ServiceProviderName"`
+
+	// <p>多协议 Api Base URL</p>
+	ApiBases []*ApiBaseItem `json:"ApiBases,omitnil,omitempty" name:"ApiBases"`
 }
 
 func (r *ModifyModelAttributesRequest) ToJsonString() string {
@@ -13057,6 +13115,7 @@ func (r *ModifyModelAttributesRequest) FromJsonString(s string) error {
 	}
 	delete(f, "ServiceProviderId")
 	delete(f, "ServiceProviderName")
+	delete(f, "ApiBases")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyModelAttributesRequest has unknown keys!", "")
 	}
@@ -15268,6 +15327,41 @@ type ServiceProviderHealthCheckConfigInput struct {
 	HealthCheckEnabled *bool `json:"HealthCheckEnabled,omitnil,omitempty" name:"HealthCheckEnabled"`
 }
 
+type ServiceProviderHealthCheckConfigItemInput struct {
+	// <p>是否开启健康检查</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul>
+	HealthCheckEnabled *bool `json:"HealthCheckEnabled,omitnil,omitempty" name:"HealthCheckEnabled"`
+
+	// <p>健康检查间隔。支持以300s为步长配置。</p><p>取值范围：[300, 14400]</p><p>单位：s</p><p>默认值：300</p>
+	HealthCheckInterval *uint64 `json:"HealthCheckInterval,omitnil,omitempty" name:"HealthCheckInterval"`
+
+	// <p>不健康阈值。表示当模型连续多少次不健康时认为该模型不健康。</p><p>取值范围：[1, 10]</p>
+	HealthCheckUnhealthyThreshold *uint64 `json:"HealthCheckUnhealthyThreshold,omitnil,omitempty" name:"HealthCheckUnhealthyThreshold"`
+
+	// <p>健康检查使用的最大Token数量。部分模型如gpt系列可能仅支持大于等于16。</p><p>取值范围：[1, 1024]</p><p>默认值：1</p>
+	HealthCheckMaxTokens *uint64 `json:"HealthCheckMaxTokens,omitnil,omitempty" name:"HealthCheckMaxTokens"`
+
+	// <p>健康检查协议</p><p>枚举值：</p><ul><li>chat： 表示/chat/completion协议</li><li>messages： 表示/v1/messages协议</li><li>responses： 表示/v1/messages协议</li></ul>
+	HealthCheckProtocol *string `json:"HealthCheckProtocol,omitnil,omitempty" name:"HealthCheckProtocol"`
+}
+
+type ServiceProviderHealthCheckConfigItemOutput struct {
+	// <p>是否开启健康检查</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul>
+	HealthCheckEnabled *bool `json:"HealthCheckEnabled,omitnil,omitempty" name:"HealthCheckEnabled"`
+
+	// <p>健康检查间隔。支持以300s为步长配置。</p><p>单位：s</p><p>默认值：300</p>
+	HealthCheckInterval *uint64 `json:"HealthCheckInterval,omitnil,omitempty" name:"HealthCheckInterval"`
+
+	// <p>不健康阈值。表示当模型连续多少次不健康时认为该模型不健康。</p><p>取值范围：[1, 10]</p><p>默认值：1</p>
+	HealthCheckUnhealthyThreshold *uint64 `json:"HealthCheckUnhealthyThreshold,omitnil,omitempty" name:"HealthCheckUnhealthyThreshold"`
+
+	// <p>健康检查使用的最大Token数量。部分模型如gpt系列可能仅支持大于等于16。</p><p>默认值：1</p>
+	HealthCheckMaxTokens *uint64 `json:"HealthCheckMaxTokens,omitnil,omitempty" name:"HealthCheckMaxTokens"`
+
+	// <p>健康检查协议</p><p>枚举值：</p><ul><li>chat： 表示/chat/completion协议</li><li>messages： 表示/v1/messages协议</li><li>responses： 表示/v1/messages协议</li></ul>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HealthCheckProtocol *string `json:"HealthCheckProtocol,omitnil,omitempty" name:"HealthCheckProtocol"`
+}
+
 type ServiceProviderHealthCheckConfigOutput struct {
 	// <p>是否开启健康检查</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul>
 	HealthCheckEnabled *bool `json:"HealthCheckEnabled,omitnil,omitempty" name:"HealthCheckEnabled"`
@@ -15837,64 +15931,63 @@ type TargetGroupBackend struct {
 }
 
 type TargetGroupHealthCheck struct {
-	// 是否开启健康检查。
+	// <p>是否开启健康检查。</p>
 	HealthSwitch *bool `json:"HealthSwitch,omitnil,omitempty" name:"HealthSwitch"`
 
-	// 健康检查方式， 其中仅V2新版目标组类型支持该参数， 支持取值 TCP | HTTP | HTTPS | PING | CUSTOM，其中:
-	// <ur><li>当目标组后端转发协议为TCP时， 健康检查方式支持 TCP/HTTP/CUSTOM， 默认为TCP。</li><li>当目标组后端转发协议为UDP时， 健康检查方式支持 PING/CUSTOM，默认为PING。</li><li>当目标组后端转发协议为HTTP时， 健康检查方式支持 HTTP/TCP， 默认为HTTP。</li><li>当目标组后端转发协议为HTTPS时， 健康检查方式支持 HTTPS/TCP， 默认为HTTPS。</li><li>当目标组后端转发协议为GRPC时， 健康检查方式支持GRPC/TCP， 默认为GRPC。</li></ur>
+	// <p>健康检查方式， 其中仅V2新版目标组类型支持该参数， 支持取值 TCP | HTTP | HTTPS | PING | CUSTOM，其中:<br><ur><li>当目标组后端转发协议为TCP时， 健康检查方式支持 TCP/HTTP/CUSTOM， 默认为TCP。</li><li>当目标组后端转发协议为UDP时， 健康检查方式支持 PING/CUSTOM，默认为PING。</li><li>当目标组后端转发协议为HTTP时， 健康检查方式支持 HTTP/TCP， 默认为HTTP。</li><li>当目标组后端转发协议为HTTPS时， 健康检查方式支持 HTTPS/TCP， 默认为HTTPS。</li><li>当目标组后端转发协议为GRPC时， 健康检查方式支持GRPC/TCP， 默认为GRPC。</li></ur></p>
 	Protocol *string `json:"Protocol,omitnil,omitempty" name:"Protocol"`
 
-	// 自定义探测相关参数。健康检查端口，默认为后端服务的端口，除非您希望指定特定端口，否则建议留空。（仅适用于TCP/UDP目标组）。
+	// <p>自定义探测相关参数。健康检查端口，默认为后端服务的端口，除非您希望指定特定端口，否则建议留空。（仅适用于TCP/UDP目标组）。</p>
 	Port *int64 `json:"Port,omitnil,omitempty" name:"Port"`
 
-	// 健康检查超时时间。 默认为2秒。 可配置范围：2 - 30秒。
+	// <p>健康检查超时时间。 </p><p>取值范围：[2, 60]</p><p>单位：秒</p><p>默认值：2</p><p>响应超时时间要小于检查间隔时间。</p>
 	Timeout *int64 `json:"Timeout,omitnil,omitempty" name:"Timeout"`
 
-	// 检测间隔时间。 默认为5秒。 可配置范围：2 - 300秒。
+	// <p>检测间隔时间。</p><p>取值范围：[1, 600]</p><p>单位：秒</p><p>默认值：5</p>
 	GapTime *int64 `json:"GapTime,omitnil,omitempty" name:"GapTime"`
 
-	// 检测健康阈值。 默认为3秒。 可配置范围：2 - 10次。
+	// <p>检测健康阈值。</p><p>取值范围：[2, 10]</p><p>单位：次</p><p>默认值：3</p>
 	GoodLimit *int64 `json:"GoodLimit,omitnil,omitempty" name:"GoodLimit"`
 
-	// 检测不健康阈值。 默认为3秒。 可配置范围：2 - 10次。
+	// <p>检测不健康阈值。</p><p>取值范围：[2, 10]</p><p>单位：次</p><p>默认值：3</p>
 	BadLimit *int64 `json:"BadLimit,omitnil,omitempty" name:"BadLimit"`
 
-	// 目标组下的所有rs的探测包是否开启巨帧。默认开启。仅GWLB类型目标组支持该参数。
+	// <p>目标组下的所有rs的探测包是否开启巨帧。默认开启。仅GWLB类型目标组支持该参数。</p>
 	JumboFrame *bool `json:"JumboFrame,omitnil,omitempty" name:"JumboFrame"`
 
-	// 健康检查状态码（仅适用于HTTP/HTTPS目标组、TCP目标组的HTTP健康检查方式）。可选值：1~31，默认 31，其中：<url> <li>1 表示探测后返回值 1xx 代表健康。</li><li>2 表示返回 2xx 代表健康。</li><li>4 表示返回 3xx 代表健康。</li><li>8 表示返回 4xx 代表健康。</li><li>16 表示返回 5xx 代表健康。</li></url>若希望多种返回码都可代表健康，则将相应的值相加。
+	// <p>健康检查状态码（仅适用于HTTP/HTTPS目标组、TCP目标组的HTTP健康检查方式）。可选值：1~31，默认 31，其中：<url> <li>1 表示探测后返回值 1xx 代表健康。</li><li>2 表示返回 2xx 代表健康。</li><li>4 表示返回 3xx 代表健康。</li><li>8 表示返回 4xx 代表健康。</li><li>16 表示返回 5xx 代表健康。</li></url>若希望多种返回码都可代表健康，则将相应的值相加。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	HttpCode *int64 `json:"HttpCode,omitnil,omitempty" name:"HttpCode"`
 
-	// 健康检查域名， 其中：<ur><li>仅适用于HTTP/HTTPS目标组和TCP目标组的HTTP健康检查方式。</li><li>针对HTTP/HTTPS目标组，当使用HTTP健康检查方式时，该参数为必填项。</li></ur>
+	// <p>健康检查域名， 其中：<ur><li>仅适用于HTTP/HTTPS目标组和TCP目标组的HTTP健康检查方式。</li><li>针对HTTP/HTTPS目标组，当使用HTTP健康检查方式时，该参数为必填项。</li></ur></p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	HttpCheckDomain *string `json:"HttpCheckDomain,omitnil,omitempty" name:"HttpCheckDomain"`
 
-	// 健康检查路径（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式）。
+	// <p>健康检查路径（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式）。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	HttpCheckPath *string `json:"HttpCheckPath,omitnil,omitempty" name:"HttpCheckPath"`
 
-	// 健康检查方法（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式），默认值：HEAD，可选值HEAD或GET。
+	// <p>健康检查方法（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式），默认值：HEAD，可选值HEAD或GET。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	HttpCheckMethod *string `json:"HttpCheckMethod,omitnil,omitempty" name:"HttpCheckMethod"`
 
-	// 健康检查的输入格式，健康检查方式取CUSTOM时，必填此字段，可取值：HEX或TEXT，其中：<ur><li>TEXT：文本格式。</li><li>HEX：十六进制格式， SendContext和RecvContext的字符只能在0123456789ABCDEF中选取且长度必须是偶数位。</li><li>仅适用于TCP/UDP目标组。</li></ur>
+	// <p>健康检查的输入格式，健康检查方式取CUSTOM时，必填此字段，可取值：HEX或TEXT，其中：<ur><li>TEXT：文本格式。</li><li>HEX：十六进制格式， SendContext和RecvContext的字符只能在0123456789ABCDEF中选取且长度必须是偶数位。</li><li>仅适用于TCP/UDP目标组。</li></ur></p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ContextType *string `json:"ContextType,omitnil,omitempty" name:"ContextType"`
 
-	// 自定义探测相关参数。健康检查协议CheckType的值取CUSTOM时，必填此字段，代表健康检查发送的请求内容，只允许ASCII可见字符，最大长度限制500。（仅适用于TCP/UDP目标组）。
+	// <p>自定义探测相关参数。健康检查协议CheckType的值取CUSTOM时，必填此字段，代表健康检查发送的请求内容，只允许ASCII可见字符，最大长度限制500。（仅适用于TCP/UDP目标组）。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	SendContext *string `json:"SendContext,omitnil,omitempty" name:"SendContext"`
 
-	// 自定义探测相关参数。健康检查协议CheckType的值取CUSTOM时，必填此字段，代表健康检查返回的结果，只允许ASCII可见字符，最大长度限制500。（仅适用于TCP/UDP目标组）。
+	// <p>自定义探测相关参数。健康检查协议CheckType的值取CUSTOM时，必填此字段，代表健康检查返回的结果，只允许ASCII可见字符，最大长度限制500。（仅适用于TCP/UDP目标组）。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	RecvContext *string `json:"RecvContext,omitnil,omitempty" name:"RecvContext"`
 
-	// HTTP版本, 其中：<ur><li>健康检查协议CheckType的值取HTTP时，必传此字段。</li><li>支持配置选项：HTTP/1.0, HTTP/1.1。</li><li>仅适用于TCP目标组。</li></ur>
+	// <p>HTTP版本, 其中：<ur><li>健康检查协议CheckType的值取HTTP时，必传此字段。</li><li>支持配置选项：HTTP/1.0, HTTP/1.1。</li><li>仅适用于TCP目标组。</li></ur></p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	HttpVersion *string `json:"HttpVersion,omitnil,omitempty" name:"HttpVersion"`
 
-	// GRPC健康检查状态码（仅适用于后端转发协议为GRPC的目标组）。默认值为 12，可输入值为数值、多个数值、或者范围，例如 20 或 20,25 或 0-99。
+	// <p>GRPC健康检查状态码（仅适用于后端转发协议为GRPC的目标组）。默认值为 12，可输入值为数值、多个数值、或者范围，例如 20 或 20,25 或 0-99。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ExtendedCode *string `json:"ExtendedCode,omitnil,omitempty" name:"ExtendedCode"`
 }
@@ -16086,6 +16179,12 @@ type TestModelInputModalitiesRequestParams struct {
 
 	// <p>是否校验服务提供商的SSL证书</p><p>PublicBYOK时为True且禁止传入；若传入VerifySSL，则优先同步入参逻辑；若传入了ServiceProviderId则同步已创建的Byok实例该Model的逻辑；否则PublicCustom模式下为True，PrivateCustom模式下为False。</p>
 	VerifySSL *bool `json:"VerifySSL,omitnil,omitempty" name:"VerifySSL"`
+
+	// <p>健康检查协议</p><p>枚举值：</p><ul><li>chat： 表示/chat/completion协议</li><li>messages： 表示/v1/messages协议</li><li>responses： 表示/responses协议</li></ul>
+	HealthCheckProtocol *string `json:"HealthCheckProtocol,omitnil,omitempty" name:"HealthCheckProtocol"`
+
+	// <p>CMR私网管道ID</p>
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
 }
 
 type TestModelInputModalitiesRequest struct {
@@ -16120,6 +16219,12 @@ type TestModelInputModalitiesRequest struct {
 
 	// <p>是否校验服务提供商的SSL证书</p><p>PublicBYOK时为True且禁止传入；若传入VerifySSL，则优先同步入参逻辑；若传入了ServiceProviderId则同步已创建的Byok实例该Model的逻辑；否则PublicCustom模式下为True，PrivateCustom模式下为False。</p>
 	VerifySSL *bool `json:"VerifySSL,omitnil,omitempty" name:"VerifySSL"`
+
+	// <p>健康检查协议</p><p>枚举值：</p><ul><li>chat： 表示/chat/completion协议</li><li>messages： 表示/v1/messages协议</li><li>responses： 表示/responses协议</li></ul>
+	HealthCheckProtocol *string `json:"HealthCheckProtocol,omitnil,omitempty" name:"HealthCheckProtocol"`
+
+	// <p>CMR私网管道ID</p>
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
 }
 
 func (r *TestModelInputModalitiesRequest) ToJsonString() string {
@@ -16144,6 +16249,8 @@ func (r *TestModelInputModalitiesRequest) FromJsonString(s string) error {
 	delete(f, "HostHeader")
 	delete(f, "ServiceProviderId")
 	delete(f, "VerifySSL")
+	delete(f, "HealthCheckProtocol")
+	delete(f, "CMRPrivateNetworkTunnelId")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "TestModelInputModalitiesRequest has unknown keys!", "")
 	}
@@ -16212,6 +16319,12 @@ type TestServiceProviderConnectionRequestParams struct {
 
 	// <p>是否校验服务提供商的SSL证书</p><p>默认值：AccessType取值为：</p><ul><li>PublicBYOK时，该参数无效；</li><li>PublicCustom时，该参数默认为true；</li><li>PrivateCustom时，该参数默认为false；</li></ul>
 	VerifySSL *bool `json:"VerifySSL,omitnil,omitempty" name:"VerifySSL"`
+
+	// <p>健康检查协议</p><p>枚举值：</p><ul><li>chat： 表示/chat/completion协议</li><li>messages： 表示/v1/messages协议</li><li>responses： 表示/responses协议</li></ul>
+	HealthCheckProtocol *string `json:"HealthCheckProtocol,omitnil,omitempty" name:"HealthCheckProtocol"`
+
+	// <p>    CMR 私网管道ID </p>
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
 }
 
 type TestServiceProviderConnectionRequest struct {
@@ -16246,6 +16359,12 @@ type TestServiceProviderConnectionRequest struct {
 
 	// <p>是否校验服务提供商的SSL证书</p><p>默认值：AccessType取值为：</p><ul><li>PublicBYOK时，该参数无效；</li><li>PublicCustom时，该参数默认为true；</li><li>PrivateCustom时，该参数默认为false；</li></ul>
 	VerifySSL *bool `json:"VerifySSL,omitnil,omitempty" name:"VerifySSL"`
+
+	// <p>健康检查协议</p><p>枚举值：</p><ul><li>chat： 表示/chat/completion协议</li><li>messages： 表示/v1/messages协议</li><li>responses： 表示/responses协议</li></ul>
+	HealthCheckProtocol *string `json:"HealthCheckProtocol,omitnil,omitempty" name:"HealthCheckProtocol"`
+
+	// <p>    CMR 私网管道ID </p>
+	CMRPrivateNetworkTunnelId *string `json:"CMRPrivateNetworkTunnelId,omitnil,omitempty" name:"CMRPrivateNetworkTunnelId"`
 }
 
 func (r *TestServiceProviderConnectionRequest) ToJsonString() string {
@@ -16270,6 +16389,8 @@ func (r *TestServiceProviderConnectionRequest) FromJsonString(s string) error {
 	delete(f, "HostHeader")
 	delete(f, "ServiceProviderId")
 	delete(f, "VerifySSL")
+	delete(f, "HealthCheckProtocol")
+	delete(f, "CMRPrivateNetworkTunnelId")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "TestServiceProviderConnectionRequest has unknown keys!", "")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1253,7 +1253,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ciam/v20220331
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka v1.3.165
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ckafka/v20190819
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.165
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.173
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40

--- a/website/docs/r/clb_log_topic.html.markdown
+++ b/website/docs/r/clb_log_topic.html.markdown
@@ -18,6 +18,7 @@ resource "tencentcloud_clb_log_topic" "example" {
   log_set_id = "2ed70190-bf06-4777-980d-2d8a327a2554"
   topic_name = "tf-example"
   status     = true
+  period     = 30
   tags = {
     env = "prod"
   }
@@ -30,6 +31,7 @@ The following arguments are supported:
 
 * `log_set_id` - (Required, String, ForceNew) Log topic of CLB instance.
 * `topic_name` - (Required, String, ForceNew) Log topic of CLB instance.
+* `period` - (Optional, Int) Log storage lifecycle in days. Standard storage supports 1-3600; 3640 means permanent retention. Defaults to 30 when unset.
 * `status` - (Optional, Bool) The status of log topic. true: enable; false: disable. Default is true.
 * `tags` - (Optional, Map) Tags of clb log topic.
 


### PR DESCRIPTION
Add an optional `period` (TypeInt) parameter to the `tencentcloud_clb_log_topic` resource to allow users to configure the log retention lifecycle (in days) when creating and updating CLB log topics.

- Add `period` schema field (Optional, not ForceNew) to the resource
- Wire `period` through the Create flow (CLB `CreateTopic` API)
- Wire `period` through the Update flow (CLS `ModifyTopic` API)
- Read `period` back from the `DescribeTopics` API response into state
- Update the resource documentation example with `period` usage
- Add mock-based unit tests (gomonkey) covering Create, Read, and Update for the new `period` parameter