### PR TITLE
feat(dlc): [137991009] add optional re_auth to policy_set in dlc_attach_user_policy_attachment

### DIFF
--- a/.changelog/4491.txt
+++ b/.changelog/4491.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_dlc_attach_user_policy_attachment: support setting `policy_set.re_auth` as an optional input parameter
+```

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.156
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.173
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.0.414
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dts v1.3.153

--- a/go.sum
+++ b/go.sum
@@ -995,7 +995,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.156/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.159/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.162/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1030,8 +1029,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633 h1:Ul5iNhXo
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633/go.mod h1:tc6Hvf03M1cBtMC1IKSa5mlOn3kpxWOwhWU1fRy+KEE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673 h1:YyjGLjvPDKNlpbGt89WLFif7TjId0fHzcrGOaHSQRNQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673/go.mod h1:hXPMop1kJFqAvHj+7TyxxxXS/HGUP4SuKx5gGoAl0Zc=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.156 h1:78OGMhGeGrjml9AAqmeqPfCQXiLz/tM9EjoR3+dVPL0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.156/go.mod h1:/CbfEeeufmoAvXiehDi34baOOE9j/tewKIEq69PxxGY=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.173 h1:wDKILuSdQsTkLXcjDkjv07mIKc7eO+iQLzQSKbqumX0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.173/go.mod h1:K/r4Y/iEF7sH77JKw6FILIC/CBpFsaigcGIvzMpjT2w=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124 h1:atQm8S0BLrr3E+Yn2383KQUEEXpQ6z31MsprAKzMDDE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124/go.mod h1:zxlW9EAn0Hqx6Eub6MMocnHZz/gHundkyI7CdbIhU3o=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.0.414 h1:egwjvOEUKBaxsoRVn/YSEhp2E8qdh77Ous9A/wftDo0=

--- a/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/design.md
+++ b/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/design.md
@@ -1,0 +1,48 @@
+## Context
+
+The `tencentcloud_dlc_attach_user_policy_attachment` resource binds a single DLC authorization policy to a user via the `AttachUserPolicy` API and reads it back via `DescribeUserInfo`. Today the `policy_set.re_auth` schema field is declared `Computed: true` only, so users cannot set it; the value is solely populated from the API response on read. The DLC `Policy` struct in the vendored SDK (`dlc/v20210125/models.go`) defines `ReAuth *bool` with the semantics "whether the grantee is allowed to further grant the permissions (default `false`)". Because `AttachUserPolicyRequest.PolicySet` accepts full `Policy` objects, `ReAuth` is already an accepted input parameter on the create API — the provider simply never forwards it.
+
+This change makes `re_auth` user-settable on create while preserving the read-back behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow users to configure `policy_set.re_auth` (bool) when creating the resource, so the grantee can be allowed to re-grant permissions.
+- Forward the configured `re_auth` value to the `AttachUserPolicy` API request `PolicySet[0].ReAuth`.
+- Keep the field readable from the API response (`DescribeUserInfo`) so state stays accurate.
+- Maintain full backward compatibility: existing configs without `re_auth` continue to work with the API default (`false`).
+
+**Non-Goals:**
+- No in-place Update support is added. The resource remains `RESOURCE_KIND_ATTACHMENT` (Create/Read/Delete only); any change to `re_auth` triggers recreation, consistent with the existing `ForceNew` behavior on `policy_set`.
+- No new API endpoints or SDK upgrades.
+- No changes to other `policy_set` sub-fields.
+
+## Decisions
+
+### Decision 1: Make `re_auth` `Optional: true, Computed: true` rather than `Required`
+
+**Rationale**: The API treats `ReAuth` as optional with a default of `false`. Marking it `Optional` + `Computed` lets users opt in to delegation while keeping existing configurations valid (no `re_auth` → API default applies). `Computed` is retained so the read handler still populates it from the API response, avoiding drift when the API omits or defaults the value.
+
+**Alternatives considered**:
+- `Required`: Would break every existing configuration that does not set `re_auth`. Rejected.
+- `Optional` only (drop `Computed`): Would cause perpetual diffs because the read handler sets the value from the API response but Terraform would treat any non-configured value as "should be zero". Keeping `Computed` preserves the current read-back semantics.
+
+### Decision 2: Forward `re_auth` in the Create handler only
+
+**Rationale**: The resource has no Update handler (it is an attachment resource where any top-level change recreates). The Create handler iterates the `policy_set` list and builds `dlc.Policy` objects; adding a `re_auth` mapping there is the single place that needs to change. The Delete handler (`DetachUserPolicy`) does not take a `Policy` body, and the Read handler already flattens `ReAuth` from the response via `flattenDlcAttachUserPolicyAttachmentPolicySet`, so no change is needed on read.
+
+**Alternatives considered**:
+- Mirror into an Update handler: There is no Update handler, so not applicable.
+
+### Decision 3: Use `d.GetOkExists` semantics via `dMap["re_auth"]` consistent with sibling fields
+
+**Rationale**: The existing Create handler reads each sub-field from the `dMap` (`item.(map[string]interface{})`) using `if v, ok := dMap["<field>"]; ok`. For booleans, Terraform's SDK returns the value through the map regardless of whether it was set (defaults to `false`). To match the existing pattern in this handler and to send an explicit `ReAuth` when the user sets it, the create handler maps `dMap["re_auth"]` to `policy.ReAuth = helper.Bool(v.(bool))`. This is consistent with how other boolean-capable fields are handled across the provider's attachment resources and ensures the user's intent (`true`) is sent. When the user omits it, the SDK default `false` is forwarded, which matches the API default — acceptable and non-breaking.
+
+**Alternatives considered**:
+- Skip sending `ReAuth` when false: Would require distinguishing "unset" from "explicitly false", which Terraform SDK v2 does not expose cleanly via the map for booleans. Given the API default is also `false`, sending `false` is harmless.
+
+## Risks / Trade-offs
+
+- **[Risk] Sending `ReAuth=false` for users who omitted it could differ from API default in edge cases** → Mitigation: The API default is documented as `false`, so sending `false` is equivalent to the default; behavior is unchanged for existing configurations.
+- **[Risk] State drift if API returns a different `ReAuth` than configured** → Mitigation: The field remains `Computed`, so the read handler overrides state from the API response, reconciling any difference. Because `policy_set` is `ForceNew`, a detected difference after read would surface as a recreate on the next plan, which is the existing contract for this attachment resource.
+- **[Trade-off] No in-place update for `re_auth`** → Accepted; consistent with the resource's attachment lifecycle (recreate on change).

--- a/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/proposal.md
+++ b/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The `tencentcloud_dlc_attach_user_policy_attachment` resource currently exposes `policy_set.re_auth` as a `Computed`-only field, meaning users cannot configure whether a grantee is allowed to re-grant (further delegate) the permissions they receive. The DLC `AttachUserPolicy` cloud API accepts `ReAuth` (`*bool`) as an input parameter on each `Policy` in the `PolicySet`, so the API supports letting callers opt into delegation. Exposing this as a user-settable optional field lets users fully control the authorization semantics of the policies they attach, aligning the Terraform provider with the cloud API's capabilities.
+
+## What Changes
+
+- Modify the `policy_set.re_auth` schema field from `Computed: true` to `Optional: true, Computed: true` so users can set it while it is still populated from the API response on read.
+- In the `resourceTencentCloudDlcAttachUserPolicyAttachmentCreate` handler, add mapping of the `re_auth` value from `policy_set` state into the `dlc.Policy.ReAuth` field before calling the `AttachUserPolicy` API.
+- Update the resource documentation (`resource_tc_dlc_attach_user_policy_attachment.md`) to reflect that `re_auth` is now an optional input.
+- Add/update unit test coverage in `resource_tc_dlc_attach_user_policy_attachment_test.go` for the create path that sets `re_auth`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `dlc-attach-user-policy-attachment`: The `policy_set.re_auth` field changes from read-only (`Computed`) to user-settable (`Optional` + `Computed`), and the Create handler now forwards the user-configured `ReAuth` value to the `AttachUserPolicy` API request `PolicySet[*].ReAuth`.
+
+## Impact
+
+- **Code**: `tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.go` (schema + create handler), `tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment_test.go` (unit tests).
+- **Documentation**: `tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.md`.
+- **API**: No new API endpoints; the existing `AttachUserPolicy` (dlc v20210125) already accepts `ReAuth` on each `Policy` in the request `PolicySet`. Verified against the vendored SDK `Policy` struct (`ReAuth *bool`).
+- **Backward compatibility**: Fully backward compatible. The field becomes optional (not required), so existing configurations without `re_auth` continue to work and the API default (`false`) applies. State continues to be populated from the API response on read.
+- **Dependencies**: No new dependencies; uses the already-vendored `tencentcloud-sdk-go/tencentcloud/dlc/v20210125`.

--- a/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/specs/dlc-attach-user-policy-attachment/spec.md
+++ b/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/specs/dlc-attach-user-policy-attachment/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Resource schema SHALL expose binding parameters and limit policy_set to a single policy
+The resource schema SHALL expose `user_id` (Required, ForceNew), `policy_set` (Required, ForceNew, MinItems 1, MaxItems 1), and `account_type` (Optional, ForceNew). The `policy_set` SHALL be a list containing exactly one policy object whose input-eligible fields (`database`, `catalog`, `table`, `operation`, `policy_type`, `function`, `view`, `column`, `data_engine`, `re_auth`, `engine_generation`, `model`, `policy_id`) can be set by the user. The `re_auth` field SHALL be `Optional` and `Computed` (TypeBool): the user MAY set it on create to control whether the grantee can further delegate the permissions, and it SHALL be populated from the cloud API response on read.
+
+#### Scenario: Required arguments are enforced
+- **WHEN** a user omits `user_id` or `policy_set` in the configuration
+- **THEN** Terraform SHALL report a validation error before any API call is made
+
+#### Scenario: policy_set is limited to exactly one policy
+- **WHEN** a user configures `policy_set` with more than one policy block
+- **THEN** Terraform SHALL report a schema validation error (`MaxItems` exceeded) before any API call is made
+- **AND** as a defensive measure, the provider's Create handler SHALL also reject a `PolicySet` whose length is not exactly 1 before calling the DLC API
+
+#### Scenario: account_type is optional
+- **WHEN** a user does not specify `account_type`
+- **THEN** the provider SHALL not set `AccountType` in the API request, allowing the cloud API to apply its default
+
+#### Scenario: re_auth is an optional, computed boolean input
+- **WHEN** a user sets `policy_set.0.re_auth = true` in the configuration
+- **THEN** Terraform SHALL accept the value as a valid boolean input (no validation error)
+- **AND** the provider SHALL forward `ReAuth = true` to the `AttachUserPolicy` API request `PolicySet[0].ReAuth`
+
+#### Scenario: re_auth may be omitted
+- **WHEN** a user does not specify `policy_set.0.re_auth` in the configuration
+- **THEN** Terraform SHALL accept the configuration without error (the field is optional)
+- **AND** the cloud API default (`false`) SHALL apply
+
+#### Scenario: re_auth is populated from the API response on read
+- **WHEN** the provider reads an existing `tencentcloud_dlc_attach_user_policy_attachment` resource
+- **THEN** the provider SHALL set `policy_set.0.re_auth` in Terraform state from the `ReAuth` field of the matched policy in the `DescribeUserInfo` response (when present)
+
+### Requirement: Cloud API calls SHALL use retry and proper error handling
+Create, Read, and Delete SHALL wrap their cloud API calls in `resource.Retry` using `tccommon.WriteRetryTimeout` (for Create/Delete) and `tccommon.ReadRetryTimeout` (for Read). Errors from the cloud API SHALL be wrapped with `tccommon.RetryError`. State mutations (setting the ID and fields) SHALL occur outside the retry block, after successful retry completion. The Create handler SHALL map every user-settable `policy_set` sub-field — including `re_auth` — from Terraform state into the corresponding `dlc.Policy` field of the `AttachUserPolicy` request `PolicySet`.
+
+#### Scenario: Transient API failure is retried
+- **WHEN** a DLC API call fails with a retryable error during Create, Read, or Delete
+- **THEN** the provider SHALL retry the call within the configured timeout and wrap the error with `tccommon.RetryError`
+
+#### Scenario: Create validates the response contains exactly one policy with a non-empty PolicyId
+- **WHEN** the `AttachUserPolicy` API returns a nil response, or a `PolicySet` whose length is not 1, or a policy with an empty `PolicyId`
+- **THEN** the provider SHALL return a `NonRetryableError` rather than writing an empty or invalid id to state
+
+#### Scenario: Create forwards the configured re_auth to the API
+- **WHEN** the Create handler builds the `AttachUserPolicy` request from a configuration that sets `policy_set.0.re_auth`
+- **THEN** the provider SHALL set `PolicySet[0].ReAuth` on the request `dlc.Policy` from the configured `re_auth` value before calling the DLC API

--- a/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/tasks.md
+++ b/openspec/changes/archive/2026-09-07-modify-dlc-attach-user-policy-re-auth/tasks.md
@@ -1,0 +1,23 @@
+## 1. Schema 修改
+
+- [x] 1.1 在 `tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.go` 的 `ResourceTencentCloudDlcAttachUserPolicyAttachment` schema 中，将 `policy_set.re_auth` 字段从 `Computed: true` 修改为 `Optional: true, Computed: true`，保留 `Type: schema.TypeBool` 和现有 `Description`，使该字段变为用户可设置的入参，同时仍从云 API 响应中回填。
+
+## 2. Create 逻辑修改
+
+- [x] 2.1 在 `resourceTencentCloudDlcAttachUserPolicyAttachmentCreate` 函数中，于 `policy_set` 遍历构建 `dlc.Policy` 的逻辑内（与其他子字段并列），增加 `re_auth` 的映射：`if v, ok := dMap["re_auth"]; ok { policy.ReAuth = helper.Bool(v.(bool)) }`，确保用户配置的 `re_auth` 被转发到 `AttachUserPolicy` 请求的 `PolicySet[0].ReAuth`。
+  - 确认：vendored SDK `dlc.Policy` 结构体已包含 `ReAuth *bool` 字段，`AttachUserPolicyRequest.PolicySet` 接受 `[]*Policy`，云 API 支持该入参。
+
+## 3. 文档修改
+
+- [x] 3.1 更新 `tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.md`，在示例用法中补充 `re_auth` 字段的使用示例（如 `re_auth = true`），并确保文档描述反映该字段现为可选入参。
+  - 注意：`website/docs/` 下的文档由 `make doc` 自动生成，本任务仅修改 `tencentcloud/services/dlc/` 下的 `.md` 源文件。
+
+## 4. 单元测试补充
+
+- [x] 4.1 在 `tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment_test.go` 中补充单元测试，覆盖 Create 路径设置 `re_auth` 的场景：在 mock 的 `AttachUserPolicyWithContext` 中捕获请求，断言 `capturedRequest.PolicySet[0].ReAuth` 等于配置值（`true`）；并在 mock 的 `DescribeUserInfoWithContext` 响应中带回 `ReAuth`，断言 state 中 `policy_set.0.re_auth` 被正确回填。
+  - 使用 gomonkey mock 云 API，不使用 terraform 验收测试套件。
+
+## 5. 代码正确性校验
+
+- [x] 5.1 校验 `re_auth` 字段在 schema 中为 `Optional: true, Computed: true`，且 Create 中映射的 `dlc.Policy.ReAuth` 字段名与 vendored SDK 一致；确认 Read 路径（`flattenDlcAttachUserPolicyAttachmentPolicySet`）已处理 `policy.ReAuth` 回填，无需额外修改。
+- [x] 5.2 校验资源仍为 `RESOURCE_KIND_ATTACHMENT`（仅 CRD，无 Update），`policy_set` 保持 `ForceNew`，`re_auth` 作为 `policy_set` 子字段随父级 `ForceNew` 行为变更触发重建，符合现有不可变契约。

--- a/openspec/specs/dlc-attach-user-policy-attachment/spec.md
+++ b/openspec/specs/dlc-attach-user-policy-attachment/spec.md
@@ -53,7 +53,7 @@ Because the DLC `AttachUserPolicy` API is bound to a single policy per call and 
 - **AND** the provider SHALL use `user_id` as the `UserId` request parameter and `policy_id` to identify the target policy (via `PolicyIds` for Delete, or by matching `PolicyId` in the Read response)
 
 ### Requirement: Resource schema SHALL expose binding parameters and limit policy_set to a single policy
-The resource schema SHALL expose `user_id` (Required, ForceNew), `policy_set` (Required, ForceNew, MinItems 1, MaxItems 1), and `account_type` (Optional, ForceNew). The `policy_set` SHALL be a list containing exactly one policy object whose input-eligible fields (`database`, `catalog`, `table`, `operation`, `policy_type`, `function`, `view`, `column`, `data_engine`, `re_auth`, `engine_generation`, `model`, `policy_id`) can be set by the user.
+The resource schema SHALL expose `user_id` (Required, ForceNew), `policy_set` (Required, ForceNew, MinItems 1, MaxItems 1), and `account_type` (Optional, ForceNew). The `policy_set` SHALL be a list containing exactly one policy object whose input-eligible fields (`database`, `catalog`, `table`, `operation`, `policy_type`, `function`, `view`, `column`, `data_engine`, `re_auth`, `engine_generation`, `model`, `policy_id`) can be set by the user. The `re_auth` field SHALL be `Optional` and `Computed` (TypeBool): the user MAY set it on create to control whether the grantee can further delegate the permissions, and it SHALL be populated from the cloud API response on read.
 
 #### Scenario: Required arguments are enforced
 - **WHEN** a user omits `user_id` or `policy_set` in the configuration
@@ -68,6 +68,20 @@ The resource schema SHALL expose `user_id` (Required, ForceNew), `policy_set` (R
 - **WHEN** a user does not specify `account_type`
 - **THEN** the provider SHALL not set `AccountType` in the API request, allowing the cloud API to apply its default
 
+#### Scenario: re_auth is an optional, computed boolean input
+- **WHEN** a user sets `policy_set.0.re_auth = true` in the configuration
+- **THEN** Terraform SHALL accept the value as a valid boolean input (no validation error)
+- **AND** the provider SHALL forward `ReAuth = true` to the `AttachUserPolicy` API request `PolicySet[0].ReAuth`
+
+#### Scenario: re_auth may be omitted
+- **WHEN** a user does not specify `policy_set.0.re_auth` in the configuration
+- **THEN** Terraform SHALL accept the configuration without error (the field is optional)
+- **AND** the cloud API default (`false`) SHALL apply
+
+#### Scenario: re_auth is populated from the API response on read
+- **WHEN** the provider reads an existing `tencentcloud_dlc_attach_user_policy_attachment` resource
+- **THEN** the provider SHALL set `policy_set.0.re_auth` in Terraform state from the `ReAuth` field of the matched policy in the `DescribeUserInfo` response (when present)
+
 ### Requirement: policy_set.operation diff SHALL ignore comma-separated token order
 The `operation` field of `policy_set` accepts a comma-separated list of permission operations (e.g. `MONITOR,USE`). Because the cloud API may return this value with the same set of tokens but in a different order than what was configured, the schema SHALL apply a `DiffSuppressFunc` on `operation` that treats two values as equal when they contain the same comma-separated tokens regardless of order, preventing spurious drift/diffs.
 
@@ -80,7 +94,7 @@ The `operation` field of `policy_set` accepts a comma-separated list of permissi
 - **THEN** Terraform SHALL report a diff for the `operation` field
 
 ### Requirement: Cloud API calls SHALL use retry and proper error handling
-Create, Read, and Delete SHALL wrap their cloud API calls in `resource.Retry` using `tccommon.WriteRetryTimeout` (for Create/Delete) and `tccommon.ReadRetryTimeout` (for Read). Errors from the cloud API SHALL be wrapped with `tccommon.RetryError`. State mutations (setting the ID and fields) SHALL occur outside the retry block, after successful retry completion.
+Create, Read, and Delete SHALL wrap their cloud API calls in `resource.Retry` using `tccommon.WriteRetryTimeout` (for Create/Delete) and `tccommon.ReadRetryTimeout` (for Read). Errors from the cloud API SHALL be wrapped with `tccommon.RetryError`. State mutations (setting the ID and fields) SHALL occur outside the retry block, after successful retry completion. The Create handler SHALL map every user-settable `policy_set` sub-field — including `re_auth` — from Terraform state into the corresponding `dlc.Policy` field of the `AttachUserPolicy` request `PolicySet`.
 
 #### Scenario: Transient API failure is retried
 - **WHEN** a DLC API call fails with a retryable error during Create, Read, or Delete
@@ -89,6 +103,10 @@ Create, Read, and Delete SHALL wrap their cloud API calls in `resource.Retry` us
 #### Scenario: Create validates the response contains exactly one policy with a non-empty PolicyId
 - **WHEN** the `AttachUserPolicy` API returns a nil response, or a `PolicySet` whose length is not 1, or a policy with an empty `PolicyId`
 - **THEN** the provider SHALL return a `NonRetryableError` rather than writing an empty or invalid id to state
+
+#### Scenario: Create forwards the configured re_auth to the API
+- **WHEN** the Create handler builds the `AttachUserPolicy` request from a configuration that sets `policy_set.0.re_auth`
+- **THEN** the provider SHALL set `PolicySet[0].ReAuth` on the request `dlc.Policy` from the configured `re_auth` value before calling the DLC API
 
 ### Requirement: Resource SHALL be registered in the provider
 The provider SHALL register `tencentcloud_dlc_attach_user_policy_attachment` in `tencentcloud/provider.go` and document it in `tencentcloud/provider.md`. A documentation file `resource_tc_dlc_attach_user_policy_attachment.md` SHALL exist under `tencentcloud/services/dlc/`.

--- a/tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.go
@@ -146,6 +146,7 @@ func ResourceTencentCloudDlcAttachUserPolicyAttachment() *schema.Resource {
 						},
 						"re_auth": {
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Computed:    true,
 							Description: "Whether the grantee is allowed to further grant the permissions. Valid values: `false` (default) and `true` (the grantee can grant permissions gained here to other sub-users).",
 						},
@@ -229,6 +230,10 @@ func resourceTencentCloudDlcAttachUserPolicyAttachmentCreate(d *schema.ResourceD
 
 			if v, ok := dMap["model"]; ok {
 				policy.Model = helper.String(v.(string))
+			}
+
+			if v, ok := dMap["re_auth"]; ok {
+				policy.ReAuth = helper.Bool(v.(bool))
 			}
 
 			if v, ok := dMap["source"]; ok {

--- a/tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.go
@@ -108,6 +108,12 @@ func ResourceTencentCloudDlcAttachUserPolicyAttachment() *schema.Resource {
 							Computed:    true,
 							Description: "The grant mode, Valid values: `COMMON` and `SENIOR`.",
 						},
+						"re_auth": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Whether the grantee is allowed to further grant the permissions. Valid values: `false` (default) and `true` (the grantee can grant permissions gained here to other sub-users).",
+						},
 						// computed
 						"policy_id": {
 							Type:        schema.TypeString,
@@ -143,12 +149,6 @@ func ResourceTencentCloudDlcAttachUserPolicyAttachment() *schema.Resource {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Whether the permission source is admin.",
-						},
-						"re_auth": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Computed:    true,
-							Description: "Whether the grantee is allowed to further grant the permissions. Valid values: `false` (default) and `true` (the grantee can grant permissions gained here to other sub-users).",
 						},
 					},
 				},

--- a/tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.md
+++ b/tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment.md
@@ -15,6 +15,7 @@ resource "tencentcloud_dlc_attach_user_policy_attachment" "example" {
     data_engine = "test_engine"
     operation   = "USE,MONITOR"
     source      = "USER"
+    re_auth     = true
   }
 }
 ```

--- a/tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment_test.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_attach_user_policy_attachment_test.go
@@ -144,6 +144,104 @@ func TestDlcAttachUserPolicyAttachment_Create(t *testing.T) {
 	assert.Equal(t, dlcAupaPolicyIdTable, policyMap["policy_id"])
 }
 
+// TestDlcAttachUserPolicyAttachment_Create_WithReAuth verifies that when a user
+// sets `policy_set.0.re_auth = true`, the Create handler forwards `ReAuth = true`
+// to the AttachUserPolicy request `PolicySet[0].ReAuth`, and that the read-back
+// state is populated with `re_auth` from the DescribeUserInfo response.
+func TestDlcAttachUserPolicyAttachment_Create_WithReAuth(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dlcClient := &dlc.Client{}
+	patches.ApplyMethodReturn(newMockMetaDlcAttachUserPolicyAttachment().client, "UseDlcClient", dlcClient)
+
+	var capturedRequest *dlc.AttachUserPolicyRequest
+	patches.ApplyMethodFunc(dlcClient, "AttachUserPolicyWithContext", func(_ context.Context, request *dlc.AttachUserPolicyRequest) (*dlc.AttachUserPolicyResponse, error) {
+		capturedRequest = request
+		resp := dlc.NewAttachUserPolicyResponse()
+		resp.Response = &dlc.AttachUserPolicyResponseParams{
+			RequestId: ptrStrDlcAupa("fake-request-id-create-reauth"),
+			PolicySet: []*dlc.Policy{
+				{
+					Database:   ptrStrDlcAupa("tf_example_db"),
+					Catalog:    ptrStrDlcAupa("DataLakeCatalog"),
+					Table:      ptrStrDlcAupa("tf_example_table"),
+					Operation:  ptrStrDlcAupa("SELECT"),
+					PolicyType: ptrStrDlcAupa("TABLE"),
+					PolicyId:   ptrStrDlcAupa(dlcAupaPolicyIdTable),
+					ReAuth:     ptrBoolDlcAupa(true),
+					Source:     ptrStrDlcAupa("USER"),
+					Mode:       ptrStrDlcAupa("COMMON"),
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(dlcClient, "DescribeUserInfoWithContext", func(_ context.Context, request *dlc.DescribeUserInfoRequest) (*dlc.DescribeUserInfoResponse, error) {
+		totalCount := int64(1)
+		resp := dlc.NewDescribeUserInfoResponse()
+		resp.Response = &dlc.DescribeUserInfoResponseParams{
+			RequestId: ptrStrDlcAupa("fake-request-id-read-reauth"),
+			UserInfo: &dlc.UserDetailInfo{
+				UserId:      ptrStrDlcAupa("100032676511"),
+				Type:        ptrStrDlcAupa("DataAuth"),
+				AccountType: ptrStrDlcAupa("TencentAccount"),
+				DataPolicyInfo: &dlc.Policys{
+					TotalCount: &totalCount,
+					PolicySet: []*dlc.Policy{
+						{
+							Database:   ptrStrDlcAupa("tf_example_db"),
+							Catalog:    ptrStrDlcAupa("DataLakeCatalog"),
+							Table:      ptrStrDlcAupa("tf_example_table"),
+							Operation:  ptrStrDlcAupa("SELECT"),
+							PolicyType: ptrStrDlcAupa("TABLE"),
+							PolicyId:   ptrStrDlcAupa(dlcAupaPolicyIdTable),
+							ReAuth:     ptrBoolDlcAupa(true),
+							Source:     ptrStrDlcAupa("USER"),
+							Mode:       ptrStrDlcAupa("COMMON"),
+						},
+					},
+				},
+			},
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaDlcAttachUserPolicyAttachment()
+	res := svcdlc.ResourceTencentCloudDlcAttachUserPolicyAttachment()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"user_id":      "100032676511",
+		"account_type": "TencentAccount",
+		"policy_set": []interface{}{
+			map[string]interface{}{
+				"database":    "tf_example_db",
+				"catalog":     "DataLakeCatalog",
+				"table":       "tf_example_table",
+				"operation":   "SELECT",
+				"policy_type": "TABLE",
+				"re_auth":     true,
+			},
+		},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("100032676511#%s", dlcAupaPolicyIdTable), d.Id())
+
+	// The configured re_auth must be forwarded to the AttachUserPolicy request.
+	assert.NotNil(t, capturedRequest)
+	assert.Len(t, capturedRequest.PolicySet, 1)
+	assert.NotNil(t, capturedRequest.PolicySet[0].ReAuth)
+	assert.True(t, *capturedRequest.PolicySet[0].ReAuth)
+
+	// The read-back state must reflect the ReAuth value from the API response.
+	policySet := d.Get("policy_set").([]interface{})
+	assert.Len(t, policySet, 1)
+	policyMap := policySet[0].(map[string]interface{})
+	assert.Equal(t, true, policyMap["re_auth"])
+}
+
 func TestDlcAttachUserPolicyAttachment_Create_MultiplePolicies_Error(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/client.go
@@ -101,6 +101,56 @@ func (c *Client) AddDMSPartitionsWithContext(ctx context.Context, request *AddDM
     return
 }
 
+func NewAddDeploymentRequest() (request *AddDeploymentRequest) {
+    request = &AddDeploymentRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "AddDeployment")
+    
+    
+    return
+}
+
+func NewAddDeploymentResponse() (response *AddDeploymentResponse) {
+    response = &AddDeploymentResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// AddDeployment
+// 为已有推理服务新增部署
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) AddDeployment(request *AddDeploymentRequest) (response *AddDeploymentResponse, err error) {
+    return c.AddDeploymentWithContext(context.Background(), request)
+}
+
+// AddDeployment
+// 为已有推理服务新增部署
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) AddDeploymentWithContext(ctx context.Context, request *AddDeploymentRequest) (response *AddDeploymentResponse, err error) {
+    if request == nil {
+        request = NewAddDeploymentRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "AddDeployment")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("AddDeployment require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewAddDeploymentResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewAddOptimizerEnginesRequest() (request *AddOptimizerEnginesRequest) {
     request = &AddOptimizerEnginesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -124,10 +174,7 @@ func NewAddOptimizerEnginesResponse() (response *AddOptimizerEnginesResponse) {
 // 添加数据优化资源
 //
 // 可能返回的错误码:
-//  INTERNALERROR = "InternalError"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  RESOURCENOTFOUND = "ResourceNotFound"
-//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) AddOptimizerEngines(request *AddOptimizerEnginesRequest) (response *AddOptimizerEnginesResponse, err error) {
     return c.AddOptimizerEnginesWithContext(context.Background(), request)
 }
@@ -136,10 +183,7 @@ func (c *Client) AddOptimizerEngines(request *AddOptimizerEnginesRequest) (respo
 // 添加数据优化资源
 //
 // 可能返回的错误码:
-//  INTERNALERROR = "InternalError"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  RESOURCENOTFOUND = "ResourceNotFound"
-//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
 func (c *Client) AddOptimizerEnginesWithContext(ctx context.Context, request *AddOptimizerEnginesRequest) (response *AddOptimizerEnginesResponse, err error) {
     if request == nil {
         request = NewAddOptimizerEnginesRequest()
@@ -791,6 +835,56 @@ func (c *Client) AttachWorkGroupPolicyWithContext(ctx context.Context, request *
     return
 }
 
+func NewBindApiKeyRequest() (request *BindApiKeyRequest) {
+    request = &BindApiKeyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "BindApiKey")
+    
+    
+    return
+}
+
+func NewBindApiKeyResponse() (response *BindApiKeyResponse) {
+    response = &BindApiKeyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// BindApiKey
+// 绑定 API Key 到推理服务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) BindApiKey(request *BindApiKeyRequest) (response *BindApiKeyResponse, err error) {
+    return c.BindApiKeyWithContext(context.Background(), request)
+}
+
+// BindApiKey
+// 绑定 API Key 到推理服务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) BindApiKeyWithContext(ctx context.Context, request *BindApiKeyRequest) (response *BindApiKeyResponse, err error) {
+    if request == nil {
+        request = NewBindApiKeyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "BindApiKey")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("BindApiKey require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewBindApiKeyResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewBindWorkGroupsToUserRequest() (request *BindWorkGroupsToUserRequest) {
     request = &BindWorkGroupsToUserRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1227,6 +1321,116 @@ func (c *Client) CancelTasksWithContext(ctx context.Context, request *CancelTask
     return
 }
 
+func NewCancelTrainingJobInstanceRequest() (request *CancelTrainingJobInstanceRequest) {
+    request = &CancelTrainingJobInstanceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CancelTrainingJobInstance")
+    
+    
+    return
+}
+
+func NewCancelTrainingJobInstanceResponse() (response *CancelTrainingJobInstanceResponse) {
+    response = &CancelTrainingJobInstanceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CancelTrainingJobInstance
+// 暂停（取消）实例
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_INVALIDSQLCONFIGSQL = "InvalidParameter.InvalidSQLConfigSQL"
+//  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  RESOURCENOTFOUND_TASKALREADYFINISHED = "ResourceNotFound.TaskAlreadyFinished"
+func (c *Client) CancelTrainingJobInstance(request *CancelTrainingJobInstanceRequest) (response *CancelTrainingJobInstanceResponse, err error) {
+    return c.CancelTrainingJobInstanceWithContext(context.Background(), request)
+}
+
+// CancelTrainingJobInstance
+// 暂停（取消）实例
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_INVALIDSQLCONFIGSQL = "InvalidParameter.InvalidSQLConfigSQL"
+//  INVALIDPARAMETER_PARAMETERBASE64DECODEFAILED = "InvalidParameter.ParameterBase64DecodeFailed"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  RESOURCENOTFOUND_TASKALREADYFINISHED = "ResourceNotFound.TaskAlreadyFinished"
+func (c *Client) CancelTrainingJobInstanceWithContext(ctx context.Context, request *CancelTrainingJobInstanceRequest) (response *CancelTrainingJobInstanceResponse, err error) {
+    if request == nil {
+        request = NewCancelTrainingJobInstanceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CancelTrainingJobInstance")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CancelTrainingJobInstance require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCancelTrainingJobInstanceResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCheckApiKeyNameRequest() (request *CheckApiKeyNameRequest) {
+    request = &CheckApiKeyNameRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CheckApiKeyName")
+    
+    
+    return
+}
+
+func NewCheckApiKeyNameResponse() (response *CheckApiKeyNameResponse) {
+    response = &CheckApiKeyNameResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CheckApiKeyName
+// 检查 API Key 名称是否重复
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CheckApiKeyName(request *CheckApiKeyNameRequest) (response *CheckApiKeyNameResponse, err error) {
+    return c.CheckApiKeyNameWithContext(context.Background(), request)
+}
+
+// CheckApiKeyName
+// 检查 API Key 名称是否重复
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CheckApiKeyNameWithContext(ctx context.Context, request *CheckApiKeyNameRequest) (response *CheckApiKeyNameResponse, err error) {
+    if request == nil {
+        request = NewCheckApiKeyNameRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CheckApiKeyName")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CheckApiKeyName require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCheckApiKeyNameResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCheckDataEngineConfigPairsValidityRequest() (request *CheckDataEngineConfigPairsValidityRequest) {
     request = &CheckDataEngineConfigPairsValidityRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1463,6 +1667,84 @@ func (c *Client) CheckDataEngineImageCanBeUpgradeWithContext(ctx context.Context
     return
 }
 
+func NewCheckJobSpecNameRequest() (request *CheckJobSpecNameRequest) {
+    request = &CheckJobSpecNameRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CheckJobSpecName")
+    
+    
+    return
+}
+
+func NewCheckJobSpecNameResponse() (response *CheckJobSpecNameResponse) {
+    response = &CheckJobSpecNameResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CheckJobSpecName
+// 训练作业配置与普通 RayJob 配置共用 job_spec 表及 (appId, name) 唯一命名空间，重名检查统一挂在本接口，供两类前端表单复用
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_IMAGEENGINETYPENOTMATCH = "InvalidParameter.ImageEngineTypeNotMatch"
+//  INVALIDPARAMETER_IMAGEISPUBLICNOTMATCH = "InvalidParameter.ImageIsPublicNotMatch"
+//  INVALIDPARAMETER_IMAGESTATENOTMATCH = "InvalidParameter.ImageStateNotMatch"
+//  INVALIDPARAMETER_IMAGEUSERRECORDSTYPENOTMATCH = "InvalidParameter.ImageUserRecordsTypeNotMatch"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_IMAGEVERSIONNOTFOUND = "ResourceNotFound.ImageVersionNotFound"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) CheckJobSpecName(request *CheckJobSpecNameRequest) (response *CheckJobSpecNameResponse, err error) {
+    return c.CheckJobSpecNameWithContext(context.Background(), request)
+}
+
+// CheckJobSpecName
+// 训练作业配置与普通 RayJob 配置共用 job_spec 表及 (appId, name) 唯一命名空间，重名检查统一挂在本接口，供两类前端表单复用
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_IMAGEENGINETYPENOTMATCH = "InvalidParameter.ImageEngineTypeNotMatch"
+//  INVALIDPARAMETER_IMAGEISPUBLICNOTMATCH = "InvalidParameter.ImageIsPublicNotMatch"
+//  INVALIDPARAMETER_IMAGESTATENOTMATCH = "InvalidParameter.ImageStateNotMatch"
+//  INVALIDPARAMETER_IMAGEUSERRECORDSTYPENOTMATCH = "InvalidParameter.ImageUserRecordsTypeNotMatch"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_IMAGEVERSIONNOTFOUND = "ResourceNotFound.ImageVersionNotFound"
+//  UNAUTHORIZEDOPERATION_UNAUTHORIZEDOPERATIONCODE_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.UnauthorizedOperationCode_NoEngineCamPermissions"
+func (c *Client) CheckJobSpecNameWithContext(ctx context.Context, request *CheckJobSpecNameRequest) (response *CheckJobSpecNameResponse, err error) {
+    if request == nil {
+        request = NewCheckJobSpecNameRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CheckJobSpecName")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CheckJobSpecName require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCheckJobSpecNameResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCheckLockMetaDataRequest() (request *CheckLockMetaDataRequest) {
     request = &CheckLockMetaDataRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1513,6 +1795,56 @@ func (c *Client) CheckLockMetaDataWithContext(ctx context.Context, request *Chec
     return
 }
 
+func NewCheckModelIdentifierRequest() (request *CheckModelIdentifierRequest) {
+    request = &CheckModelIdentifierRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CheckModelIdentifier")
+    
+    
+    return
+}
+
+func NewCheckModelIdentifierResponse() (response *CheckModelIdentifierResponse) {
+    response = &CheckModelIdentifierResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CheckModelIdentifier
+// 检查模型标识符是否重复
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) CheckModelIdentifier(request *CheckModelIdentifierRequest) (response *CheckModelIdentifierResponse, err error) {
+    return c.CheckModelIdentifierWithContext(context.Background(), request)
+}
+
+// CheckModelIdentifier
+// 检查模型标识符是否重复
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) CheckModelIdentifierWithContext(ctx context.Context, request *CheckModelIdentifierRequest) (response *CheckModelIdentifierResponse, err error) {
+    if request == nil {
+        request = NewCheckModelIdentifierRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CheckModelIdentifier")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CheckModelIdentifier require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCheckModelIdentifierResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCheckModifyPartitionRequest() (request *CheckModifyPartitionRequest) {
     request = &CheckModifyPartitionRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1536,7 +1868,7 @@ func NewCheckModifyPartitionResponse() (response *CheckModifyPartitionResponse) 
 // 变配校验：判断用户的目标配置是否可以执行变配。校验逻辑：对于缩容场景（目标值 < 当前值），检查 default 队列的 min 值是否足够承受缩容差值。
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
 func (c *Client) CheckModifyPartition(request *CheckModifyPartitionRequest) (response *CheckModifyPartitionResponse, err error) {
     return c.CheckModifyPartitionWithContext(context.Background(), request)
 }
@@ -1545,7 +1877,7 @@ func (c *Client) CheckModifyPartition(request *CheckModifyPartitionRequest) (res
 // 变配校验：判断用户的目标配置是否可以执行变配。校验逻辑：对于缩容场景（目标值 < 当前值），检查 default 队列的 min 值是否足够承受缩容差值。
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
 func (c *Client) CheckModifyPartitionWithContext(ctx context.Context, request *CheckModifyPartitionRequest) (response *CheckModifyPartitionResponse, err error) {
     if request == nil {
         request = NewCheckModifyPartitionRequest()
@@ -1586,7 +1918,7 @@ func NewCheckQueueNameResponse() (response *CheckQueueNameResponse) {
 // 资源队列名称合法性检测：校验队列名称是否合法，包括非空校验、格式校验（以小写字母开头，只允许小写字母、数字和连字符，长度1~11）和同分区下重名校验。
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
 func (c *Client) CheckQueueName(request *CheckQueueNameRequest) (response *CheckQueueNameResponse, err error) {
     return c.CheckQueueNameWithContext(context.Background(), request)
 }
@@ -1595,7 +1927,7 @@ func (c *Client) CheckQueueName(request *CheckQueueNameRequest) (response *Check
 // 资源队列名称合法性检测：校验队列名称是否合法，包括非空校验、格式校验（以小写字母开头，只允许小写字母、数字和连字符，长度1~11）和同分区下重名校验。
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
 func (c *Client) CheckQueueNameWithContext(ctx context.Context, request *CheckQueueNameRequest) (response *CheckQueueNameResponse, err error) {
     if request == nil {
         request = NewCheckQueueNameRequest()
@@ -1636,7 +1968,7 @@ func NewCheckResourceNameResponse() (response *CheckResourceNameResponse) {
 // 校验资源名称合法性
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
 func (c *Client) CheckResourceName(request *CheckResourceNameRequest) (response *CheckResourceNameResponse, err error) {
     return c.CheckResourceNameWithContext(context.Background(), request)
 }
@@ -1645,7 +1977,7 @@ func (c *Client) CheckResourceName(request *CheckResourceNameRequest) (response 
 // 校验资源名称合法性
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
 func (c *Client) CheckResourceNameWithContext(ctx context.Context, request *CheckResourceNameRequest) (response *CheckResourceNameResponse, err error) {
     if request == nil {
         request = NewCheckResourceNameRequest()
@@ -1659,6 +1991,56 @@ func (c *Client) CheckResourceNameWithContext(ctx context.Context, request *Chec
     request.SetContext(ctx)
     
     response = NewCheckResourceNameResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCheckServiceNameRequest() (request *CheckServiceNameRequest) {
+    request = &CheckServiceNameRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CheckServiceName")
+    
+    
+    return
+}
+
+func NewCheckServiceNameResponse() (response *CheckServiceNameResponse) {
+    response = &CheckServiceNameResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CheckServiceName
+// 检查推理服务名称是否重复
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) CheckServiceName(request *CheckServiceNameRequest) (response *CheckServiceNameResponse, err error) {
+    return c.CheckServiceNameWithContext(context.Background(), request)
+}
+
+// CheckServiceName
+// 检查推理服务名称是否重复
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) CheckServiceNameWithContext(ctx context.Context, request *CheckServiceNameRequest) (response *CheckServiceNameResponse, err error) {
+    if request == nil {
+        request = NewCheckServiceNameRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CheckServiceName")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CheckServiceName require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCheckServiceNameResponse()
     err = c.Send(request, response)
     return
 }
@@ -1709,6 +2091,106 @@ func (c *Client) CopyJobSpecWithContext(ctx context.Context, request *CopyJobSpe
     request.SetContext(ctx)
     
     response = NewCopyJobSpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateApiKeyRequest() (request *CreateApiKeyRequest) {
+    request = &CreateApiKeyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateApiKey")
+    
+    
+    return
+}
+
+func NewCreateApiKeyResponse() (response *CreateApiKeyResponse) {
+    response = &CreateApiKeyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateApiKey
+// 创建 API Key
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateApiKey(request *CreateApiKeyRequest) (response *CreateApiKeyResponse, err error) {
+    return c.CreateApiKeyWithContext(context.Background(), request)
+}
+
+// CreateApiKey
+// 创建 API Key
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateApiKeyWithContext(ctx context.Context, request *CreateApiKeyRequest) (response *CreateApiKeyResponse, err error) {
+    if request == nil {
+        request = NewCreateApiKeyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateApiKey")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateApiKey require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateApiKeyResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewCreateBenchmarkTaskRequest() (request *CreateBenchmarkTaskRequest) {
+    request = &CreateBenchmarkTaskRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateBenchmarkTask")
+    
+    
+    return
+}
+
+func NewCreateBenchmarkTaskResponse() (response *CreateBenchmarkTaskResponse) {
+    response = &CreateBenchmarkTaskResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateBenchmarkTask
+// 创建性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateBenchmarkTask(request *CreateBenchmarkTaskRequest) (response *CreateBenchmarkTaskResponse, err error) {
+    return c.CreateBenchmarkTaskWithContext(context.Background(), request)
+}
+
+// CreateBenchmarkTask
+// 创建性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) CreateBenchmarkTaskWithContext(ctx context.Context, request *CreateBenchmarkTaskRequest) (response *CreateBenchmarkTaskResponse, err error) {
+    if request == nil {
+        request = NewCreateBenchmarkTaskRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateBenchmarkTask")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateBenchmarkTask require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateBenchmarkTaskResponse()
     err = c.Send(request, response)
     return
 }
@@ -2216,6 +2698,7 @@ func NewCreateDatasourceConnectionResponse() (response *CreateDatasourceConnecti
 //  INVALIDPARAMETER_DUPLICATEDATASOURCENAME = "InvalidParameter.DuplicateDatasourceName"
 //  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
 //  INVALIDPARAMETER_INVALIDDATASOURCECONNECTIONCONFIG = "InvalidParameter.InvalidDatasourceConnectionConfig"
+//  INVALIDPARAMETER_INVALIDDATASOURCENAME = "InvalidParameter.InvalidDatasourceName"
 //  INVALIDPARAMETER_INVALIDHIVEVERSION = "InvalidParameter.InvalidHiveVersion"
 //  INVALIDPARAMETER_URLFORMATERROR = "InvalidParameter.UrlFormatError"
 //  INVALIDPARAMETER_VPCCIDRFORMATERROR = "InvalidParameter.VpcCidrFormatError"
@@ -2238,6 +2721,7 @@ func (c *Client) CreateDatasourceConnection(request *CreateDatasourceConnectionR
 //  INVALIDPARAMETER_DUPLICATEDATASOURCENAME = "InvalidParameter.DuplicateDatasourceName"
 //  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
 //  INVALIDPARAMETER_INVALIDDATASOURCECONNECTIONCONFIG = "InvalidParameter.InvalidDatasourceConnectionConfig"
+//  INVALIDPARAMETER_INVALIDDATASOURCENAME = "InvalidParameter.InvalidDatasourceName"
 //  INVALIDPARAMETER_INVALIDHIVEVERSION = "InvalidParameter.InvalidHiveVersion"
 //  INVALIDPARAMETER_URLFORMATERROR = "InvalidParameter.UrlFormatError"
 //  INVALIDPARAMETER_VPCCIDRFORMATERROR = "InvalidParameter.VpcCidrFormatError"
@@ -2723,6 +3207,92 @@ func (c *Client) CreateMetaDatabaseWithContext(ctx context.Context, request *Cre
     return
 }
 
+func NewCreateMlflowServerRequest() (request *CreateMlflowServerRequest) {
+    request = &CreateMlflowServerRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateMlflowServer")
+    
+    
+    return
+}
+
+func NewCreateMlflowServerResponse() (response *CreateMlflowServerResponse) {
+    response = &CreateMlflowServerResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateMlflowServer
+// 创建 MlFlow Server
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_GOVERNERROR = "FailedOperation.GovernError"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCENOTFOUND_SYSTEMCONFIGNOTFOUND = "ResourceNotFound.SystemConfigNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) CreateMlflowServer(request *CreateMlflowServerRequest) (response *CreateMlflowServerResponse, err error) {
+    return c.CreateMlflowServerWithContext(context.Background(), request)
+}
+
+// CreateMlflowServer
+// 创建 MlFlow Server
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  FAILEDOPERATION_GOVERNERROR = "FailedOperation.GovernError"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCENOTFOUND_SYSTEMCONFIGNOTFOUND = "ResourceNotFound.SystemConfigNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) CreateMlflowServerWithContext(ctx context.Context, request *CreateMlflowServerRequest) (response *CreateMlflowServerResponse, err error) {
+    if request == nil {
+        request = NewCreateMlflowServerRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateMlflowServer")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateMlflowServer require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateMlflowServerResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateModelVersionRequest() (request *CreateModelVersionRequest) {
     request = &CreateModelVersionRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -3058,17 +3628,11 @@ func NewCreatePartitionResponse() (response *CreatePartitionResponse) {
 // 新增资源包
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
-//  INVALIDPARAMETER_INVALIDSTATEMENTKINDTYPE = "InvalidParameter.InvalidStatementKindType"
-//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
-//  RESOURCENOTFOUND = "ResourceNotFound"
-//  RESOURCENOTFOUND_RESULTSAVEPATHNOTFOUND = "ResourceNotFound.ResultSavePathNotFound"
-//  RESOURCENOTFOUND_SESSIONNOTFOUND = "ResourceNotFound.SessionNotFound"
-//  RESOURCENOTFOUND_SESSIONSTATEDEAD = "ResourceNotFound.SessionStateDead"
+//  FAILEDOPERATION_APICALLFAILED = "FailedOperation.ApiCallFailed"
+//  INVALIDPARAMETERVALUE_BILLINGITEMSTEP = "InvalidParameterValue.BillingItemStep"
+//  INVALIDPARAMETERVALUE_POSTPAYPARTITIONNAME = "InvalidParameterValue.PostpayPartitionName"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  RESOURCEINSUFFICIENT = "ResourceInsufficient"
 func (c *Client) CreatePartition(request *CreatePartitionRequest) (response *CreatePartitionResponse, err error) {
     return c.CreatePartitionWithContext(context.Background(), request)
 }
@@ -3077,17 +3641,11 @@ func (c *Client) CreatePartition(request *CreatePartitionRequest) (response *Cre
 // 新增资源包
 //
 // 可能返回的错误码:
-//  FAILEDOPERATION = "FailedOperation"
-//  INTERNALERROR = "InternalError"
-//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
-//  INVALIDPARAMETER = "InvalidParameter"
-//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
-//  INVALIDPARAMETER_INVALIDSTATEMENTKINDTYPE = "InvalidParameter.InvalidStatementKindType"
-//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
-//  RESOURCENOTFOUND = "ResourceNotFound"
-//  RESOURCENOTFOUND_RESULTSAVEPATHNOTFOUND = "ResourceNotFound.ResultSavePathNotFound"
-//  RESOURCENOTFOUND_SESSIONNOTFOUND = "ResourceNotFound.SessionNotFound"
-//  RESOURCENOTFOUND_SESSIONSTATEDEAD = "ResourceNotFound.SessionStateDead"
+//  FAILEDOPERATION_APICALLFAILED = "FailedOperation.ApiCallFailed"
+//  INVALIDPARAMETERVALUE_BILLINGITEMSTEP = "InvalidParameterValue.BillingItemStep"
+//  INVALIDPARAMETERVALUE_POSTPAYPARTITIONNAME = "InvalidParameterValue.PostpayPartitionName"
+//  LIMITEXCEEDED = "LimitExceeded"
+//  RESOURCEINSUFFICIENT = "ResourceInsufficient"
 func (c *Client) CreatePartitionWithContext(ctx context.Context, request *CreatePartitionRequest) (response *CreatePartitionResponse, err error) {
     if request == nil {
         request = NewCreatePartitionRequest()
@@ -4461,6 +5019,78 @@ func (c *Client) CreateTcIcebergTableWithContext(ctx context.Context, request *C
     return
 }
 
+func NewCreateTrainingJobInstanceRequest() (request *CreateTrainingJobInstanceRequest) {
+    request = &CreateTrainingJobInstanceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "CreateTrainingJobInstance")
+    
+    
+    return
+}
+
+func NewCreateTrainingJobInstanceResponse() (response *CreateTrainingJobInstanceResponse) {
+    response = &CreateTrainingJobInstanceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateTrainingJobInstance
+// 基于配置创建实例并提交 RayJob
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDCOLUMNNAMELENGTH = "InvalidParameter.InvalidColumnNameLength"
+//  INVALIDPARAMETER_INVALIDCOLUMNNUMBER = "InvalidParameter.InvalidColumnNumber"
+//  INVALIDPARAMETER_INVALIDDECIMALTYPE = "InvalidParameter.InvalidDecimalType"
+//  INVALIDPARAMETER_INVALIDTABLENAMELENGTH = "InvalidParameter.InvalidTableNameLength"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) CreateTrainingJobInstance(request *CreateTrainingJobInstanceRequest) (response *CreateTrainingJobInstanceResponse, err error) {
+    return c.CreateTrainingJobInstanceWithContext(context.Background(), request)
+}
+
+// CreateTrainingJobInstance
+// 基于配置创建实例并提交 RayJob
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDCOLUMNNAMELENGTH = "InvalidParameter.InvalidColumnNameLength"
+//  INVALIDPARAMETER_INVALIDCOLUMNNUMBER = "InvalidParameter.InvalidColumnNumber"
+//  INVALIDPARAMETER_INVALIDDECIMALTYPE = "InvalidParameter.InvalidDecimalType"
+//  INVALIDPARAMETER_INVALIDTABLENAMELENGTH = "InvalidParameter.InvalidTableNameLength"
+//  INVALIDPARAMETER_PARAMETERNOTFOUNDORBENONE = "InvalidParameter.ParameterNotFoundOrBeNone"
+//  RESOURCEUNAVAILABLE = "ResourceUnavailable"
+//  UNAUTHORIZEDOPERATION = "UnauthorizedOperation"
+//  UNSUPPORTEDOPERATION = "UnsupportedOperation"
+func (c *Client) CreateTrainingJobInstanceWithContext(ctx context.Context, request *CreateTrainingJobInstanceRequest) (response *CreateTrainingJobInstanceResponse, err error) {
+    if request == nil {
+        request = NewCreateTrainingJobInstanceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "CreateTrainingJobInstance")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateTrainingJobInstance require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateTrainingJobInstanceResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateUserRequest() (request *CreateUserRequest) {
     request = &CreateUserRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -4727,6 +5357,106 @@ func (c *Client) CreateWorkGroupWithContext(ctx context.Context, request *Create
     return
 }
 
+func NewDeleteApiKeyRequest() (request *DeleteApiKeyRequest) {
+    request = &DeleteApiKeyRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteApiKey")
+    
+    
+    return
+}
+
+func NewDeleteApiKeyResponse() (response *DeleteApiKeyResponse) {
+    response = &DeleteApiKeyResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteApiKey
+// 删除 API Key
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteApiKey(request *DeleteApiKeyRequest) (response *DeleteApiKeyResponse, err error) {
+    return c.DeleteApiKeyWithContext(context.Background(), request)
+}
+
+// DeleteApiKey
+// 删除 API Key
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteApiKeyWithContext(ctx context.Context, request *DeleteApiKeyRequest) (response *DeleteApiKeyResponse, err error) {
+    if request == nil {
+        request = NewDeleteApiKeyRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteApiKey")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteApiKey require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteApiKeyResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteBenchmarkTaskRequest() (request *DeleteBenchmarkTaskRequest) {
+    request = &DeleteBenchmarkTaskRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteBenchmarkTask")
+    
+    
+    return
+}
+
+func NewDeleteBenchmarkTaskResponse() (response *DeleteBenchmarkTaskResponse) {
+    response = &DeleteBenchmarkTaskResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteBenchmarkTask
+// 删除性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteBenchmarkTask(request *DeleteBenchmarkTaskRequest) (response *DeleteBenchmarkTaskResponse, err error) {
+    return c.DeleteBenchmarkTaskWithContext(context.Background(), request)
+}
+
+// DeleteBenchmarkTask
+// 删除性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteBenchmarkTaskWithContext(ctx context.Context, request *DeleteBenchmarkTaskRequest) (response *DeleteBenchmarkTaskResponse, err error) {
+    if request == nil {
+        request = NewDeleteBenchmarkTaskRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteBenchmarkTask")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteBenchmarkTask require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteBenchmarkTaskResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteCHDFSBindingProductRequest() (request *DeleteCHDFSBindingProductRequest) {
     request = &DeleteCHDFSBindingProductRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -4979,6 +5709,106 @@ func (c *Client) DeleteDataMaskStrategyWithContext(ctx context.Context, request 
     return
 }
 
+func NewDeleteDeploymentRequest() (request *DeleteDeploymentRequest) {
+    request = &DeleteDeploymentRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteDeployment")
+    
+    
+    return
+}
+
+func NewDeleteDeploymentResponse() (response *DeleteDeploymentResponse) {
+    response = &DeleteDeploymentResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteDeployment
+// 删除指定部署
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteDeployment(request *DeleteDeploymentRequest) (response *DeleteDeploymentResponse, err error) {
+    return c.DeleteDeploymentWithContext(context.Background(), request)
+}
+
+// DeleteDeployment
+// 删除指定部署
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteDeploymentWithContext(ctx context.Context, request *DeleteDeploymentRequest) (response *DeleteDeploymentResponse, err error) {
+    if request == nil {
+        request = NewDeleteDeploymentRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteDeployment")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteDeployment require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteDeploymentResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteInferenceServiceRequest() (request *DeleteInferenceServiceRequest) {
+    request = &DeleteInferenceServiceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteInferenceService")
+    
+    
+    return
+}
+
+func NewDeleteInferenceServiceResponse() (response *DeleteInferenceServiceResponse) {
+    response = &DeleteInferenceServiceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteInferenceService
+// 删除推理服务（含所有部署）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteInferenceService(request *DeleteInferenceServiceRequest) (response *DeleteInferenceServiceResponse, err error) {
+    return c.DeleteInferenceServiceWithContext(context.Background(), request)
+}
+
+// DeleteInferenceService
+// 删除推理服务（含所有部署）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteInferenceServiceWithContext(ctx context.Context, request *DeleteInferenceServiceRequest) (response *DeleteInferenceServiceResponse, err error) {
+    if request == nil {
+        request = NewDeleteInferenceServiceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteInferenceService")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteInferenceService require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteInferenceServiceResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteJobSpecRequest() (request *DeleteJobSpecRequest) {
     request = &DeleteJobSpecRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -5165,6 +5995,220 @@ func (c *Client) DeleteMetaDatabaseWithContext(ctx context.Context, request *Del
     return
 }
 
+func NewDeleteMlflowServerRequest() (request *DeleteMlflowServerRequest) {
+    request = &DeleteMlflowServerRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteMlflowServer")
+    
+    
+    return
+}
+
+func NewDeleteMlflowServerResponse() (response *DeleteMlflowServerResponse) {
+    response = &DeleteMlflowServerResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteMlflowServer
+// 删除 MlFlow Server 请求
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) DeleteMlflowServer(request *DeleteMlflowServerRequest) (response *DeleteMlflowServerResponse, err error) {
+    return c.DeleteMlflowServerWithContext(context.Background(), request)
+}
+
+// DeleteMlflowServer
+// 删除 MlFlow Server 请求
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) DeleteMlflowServerWithContext(ctx context.Context, request *DeleteMlflowServerRequest) (response *DeleteMlflowServerResponse, err error) {
+    if request == nil {
+        request = NewDeleteMlflowServerRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteMlflowServer")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteMlflowServer require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteMlflowServerResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteModelRequest() (request *DeleteModelRequest) {
+    request = &DeleteModelRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteModel")
+    
+    
+    return
+}
+
+func NewDeleteModelResponse() (response *DeleteModelResponse) {
+    response = &DeleteModelResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteModel
+// 删除模型及其所有版本（平台托管模型同时删除 COS 文件，用户自带桶仅删除元数据）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) DeleteModel(request *DeleteModelRequest) (response *DeleteModelResponse, err error) {
+    return c.DeleteModelWithContext(context.Background(), request)
+}
+
+// DeleteModel
+// 删除模型及其所有版本（平台托管模型同时删除 COS 文件，用户自带桶仅删除元数据）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDFAILURETOLERANCE = "InvalidParameter.InvalidFailureTolerance"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_INVALIDSQLNUM = "InvalidParameter.InvalidSQLNum"
+//  INVALIDPARAMETER_INVALIDSTORELOCATION = "InvalidParameter.InvalidStoreLocation"
+//  INVALIDPARAMETER_INVALIDTASKTYPE = "InvalidParameter.InvalidTaskType"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SQLPARAMETERPREPROCESSINGFAILED = "InvalidParameter.SQLParameterPreprocessingFailed"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+//  RESOURCENOTFOUND_DATAENGINENOTRUNNING = "ResourceNotFound.DataEngineNotRunning"
+//  RESOURCENOTFOUND_DATAENGINENOTUNIQUE = "ResourceNotFound.DataEngineNotUnique"
+//  RESOURCENOTFOUND_DEFAULTDATAENGINENOTFOUND = "ResourceNotFound.DefaultDataEngineNotFound"
+//  RESOURCEUNAVAILABLE_BALANCEINSUFFICIENT = "ResourceUnavailable.BalanceInsufficient"
+func (c *Client) DeleteModelWithContext(ctx context.Context, request *DeleteModelRequest) (response *DeleteModelResponse, err error) {
+    if request == nil {
+        request = NewDeleteModelRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteModel")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteModel require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteModelResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteModelVersionRequest() (request *DeleteModelVersionRequest) {
+    request = &DeleteModelVersionRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteModelVersion")
+    
+    
+    return
+}
+
+func NewDeleteModelVersionResponse() (response *DeleteModelVersionResponse) {
+    response = &DeleteModelVersionResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteModelVersion
+// 删除模型版本（平台托管模型同时删除 COS 文件，用户自带桶仅删除元数据）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteModelVersion(request *DeleteModelVersionRequest) (response *DeleteModelVersionResponse, err error) {
+    return c.DeleteModelVersionWithContext(context.Background(), request)
+}
+
+// DeleteModelVersion
+// 删除模型版本（平台托管模型同时删除 COS 文件，用户自带桶仅删除元数据）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DeleteModelVersionWithContext(ctx context.Context, request *DeleteModelVersionRequest) (response *DeleteModelVersionResponse, err error) {
+    if request == nil {
+        request = NewDeleteModelVersionRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteModelVersion")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteModelVersion require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteModelVersionResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteNativeSparkSessionRequest() (request *DeleteNativeSparkSessionRequest) {
     request = &DeleteNativeSparkSessionRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -5191,6 +6235,7 @@ func NewDeleteNativeSparkSessionResponse() (response *DeleteNativeSparkSessionRe
 //  FAILEDOPERATION = "FailedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
+//  UNAUTHORIZEDOPERATION_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.NoEngineCamPermissions"
 //  UNAUTHORIZEDOPERATION_OPERATECOMPUTINGENGINE = "UnauthorizedOperation.OperateComputingEngine"
 func (c *Client) DeleteNativeSparkSession(request *DeleteNativeSparkSessionRequest) (response *DeleteNativeSparkSessionResponse, err error) {
     return c.DeleteNativeSparkSessionWithContext(context.Background(), request)
@@ -5203,6 +6248,7 @@ func (c *Client) DeleteNativeSparkSession(request *DeleteNativeSparkSessionReque
 //  FAILEDOPERATION = "FailedOperation"
 //  INTERNALERROR = "InternalError"
 //  INVALIDPARAMETER = "InvalidParameter"
+//  UNAUTHORIZEDOPERATION_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.NoEngineCamPermissions"
 //  UNAUTHORIZEDOPERATION_OPERATECOMPUTINGENGINE = "UnauthorizedOperation.OperateComputingEngine"
 func (c *Client) DeleteNativeSparkSessionWithContext(ctx context.Context, request *DeleteNativeSparkSessionRequest) (response *DeleteNativeSparkSessionResponse, err error) {
     if request == nil {
@@ -5779,6 +6825,114 @@ func (c *Client) DeleteThirdPartyAccessUserWithContext(ctx context.Context, requ
     return
 }
 
+func NewDeleteTrainingJobInstanceRequest() (request *DeleteTrainingJobInstanceRequest) {
+    request = &DeleteTrainingJobInstanceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteTrainingJobInstance")
+    
+    
+    return
+}
+
+func NewDeleteTrainingJobInstanceResponse() (response *DeleteTrainingJobInstanceResponse) {
+    response = &DeleteTrainingJobInstanceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteTrainingJobInstance
+// 删除训练作业实例（软删除本地元数据，仅终态实例可删除）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) DeleteTrainingJobInstance(request *DeleteTrainingJobInstanceRequest) (response *DeleteTrainingJobInstanceResponse, err error) {
+    return c.DeleteTrainingJobInstanceWithContext(context.Background(), request)
+}
+
+// DeleteTrainingJobInstance
+// 删除训练作业实例（软删除本地元数据，仅终态实例可删除）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) DeleteTrainingJobInstanceWithContext(ctx context.Context, request *DeleteTrainingJobInstanceRequest) (response *DeleteTrainingJobInstanceResponse, err error) {
+    if request == nil {
+        request = NewDeleteTrainingJobInstanceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteTrainingJobInstance")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteTrainingJobInstance require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteTrainingJobInstanceResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteTrainingJobSpecRequest() (request *DeleteTrainingJobSpecRequest) {
+    request = &DeleteTrainingJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DeleteTrainingJobSpec")
+    
+    
+    return
+}
+
+func NewDeleteTrainingJobSpecResponse() (response *DeleteTrainingJobSpecResponse) {
+    response = &DeleteTrainingJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteTrainingJobSpec
+// 删除训练作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) DeleteTrainingJobSpec(request *DeleteTrainingJobSpecRequest) (response *DeleteTrainingJobSpecResponse, err error) {
+    return c.DeleteTrainingJobSpecWithContext(context.Background(), request)
+}
+
+// DeleteTrainingJobSpec
+// 删除训练作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) DeleteTrainingJobSpecWithContext(ctx context.Context, request *DeleteTrainingJobSpecRequest) (response *DeleteTrainingJobSpecResponse, err error) {
+    if request == nil {
+        request = NewDeleteTrainingJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DeleteTrainingJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteTrainingJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteTrainingJobSpecResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDeleteUserRequest() (request *DeleteUserRequest) {
     request = &DeleteUserRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -6083,6 +7237,156 @@ func (c *Client) DescribeAdvancedStoreLocationWithContext(ctx context.Context, r
     request.SetContext(ctx)
     
     response = NewDescribeAdvancedStoreLocationResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeBindablePrometheusRequest() (request *DescribeBindablePrometheusRequest) {
+    request = &DescribeBindablePrometheusRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeBindablePrometheus")
+    
+    
+    return
+}
+
+func NewDescribeBindablePrometheusResponse() (response *DescribeBindablePrometheusResponse) {
+    response = &DescribeBindablePrometheusResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeBindablePrometheus
+// 查询 TKE 集群可绑定的托管 Prometheus 实例列表。若 TKE 已绑定，返回 Bound=true 与 BoundInstance；若未绑定，返回 Bound=false 与候选列表 Instances（同 VPC 实例前置）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeBindablePrometheus(request *DescribeBindablePrometheusRequest) (response *DescribeBindablePrometheusResponse, err error) {
+    return c.DescribeBindablePrometheusWithContext(context.Background(), request)
+}
+
+// DescribeBindablePrometheus
+// 查询 TKE 集群可绑定的托管 Prometheus 实例列表。若 TKE 已绑定，返回 Bound=true 与 BoundInstance；若未绑定，返回 Bound=false 与候选列表 Instances（同 VPC 实例前置）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeBindablePrometheusWithContext(ctx context.Context, request *DescribeBindablePrometheusRequest) (response *DescribeBindablePrometheusResponse, err error) {
+    if request == nil {
+        request = NewDescribeBindablePrometheusRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeBindablePrometheus")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeBindablePrometheus require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeBindablePrometheusResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeClsTopicsRequest() (request *DescribeClsTopicsRequest) {
+    request = &DescribeClsTopicsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeClsTopics")
+    
+    
+    return
+}
+
+func NewDescribeClsTopicsResponse() (response *DescribeClsTopicsResponse) {
+    response = &DescribeClsTopicsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeClsTopics
+// 查询 CLS 日志主题列表：TopicName 走模糊匹配，TopicId 走精确匹配，两者均可为空；分页返回。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeClsTopics(request *DescribeClsTopicsRequest) (response *DescribeClsTopicsResponse, err error) {
+    return c.DescribeClsTopicsWithContext(context.Background(), request)
+}
+
+// DescribeClsTopics
+// 查询 CLS 日志主题列表：TopicName 走模糊匹配，TopicId 走精确匹配，两者均可为空；分页返回。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeClsTopicsWithContext(ctx context.Context, request *DescribeClsTopicsRequest) (response *DescribeClsTopicsResponse, err error) {
+    if request == nil {
+        request = NewDescribeClsTopicsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeClsTopics")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClsTopics require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeClsTopicsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeClusterEventLogSwitchRequest() (request *DescribeClusterEventLogSwitchRequest) {
+    request = &DescribeClusterEventLogSwitchRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeClusterEventLogSwitch")
+    
+    
+    return
+}
+
+func NewDescribeClusterEventLogSwitchResponse() (response *DescribeClusterEventLogSwitchResponse) {
+    response = &DescribeClusterEventLogSwitchResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeClusterEventLogSwitch
+// 查询指定 TKE 集群是否开启了事件日志。已开启时同时返回关联的 CLS 日志集 ID、日志主题 ID 与主题所在地域。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeClusterEventLogSwitch(request *DescribeClusterEventLogSwitchRequest) (response *DescribeClusterEventLogSwitchResponse, err error) {
+    return c.DescribeClusterEventLogSwitchWithContext(context.Background(), request)
+}
+
+// DescribeClusterEventLogSwitch
+// 查询指定 TKE 集群是否开启了事件日志。已开启时同时返回关联的 CLS 日志集 ID、日志主题 ID 与主题所在地域。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeClusterEventLogSwitchWithContext(ctx context.Context, request *DescribeClusterEventLogSwitchRequest) (response *DescribeClusterEventLogSwitchResponse, err error) {
+    if request == nil {
+        request = NewDescribeClusterEventLogSwitchRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeClusterEventLogSwitch")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeClusterEventLogSwitch require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeClusterEventLogSwitchResponse()
     err = c.Send(request, response)
     return
 }
@@ -7247,6 +8551,56 @@ func (c *Client) DescribeDatasourceConnectionWithContext(ctx context.Context, re
     return
 }
 
+func NewDescribeEmrClusterInfoRequest() (request *DescribeEmrClusterInfoRequest) {
+    request = &DescribeEmrClusterInfoRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeEmrClusterInfo")
+    
+    
+    return
+}
+
+func NewDescribeEmrClusterInfoResponse() (response *DescribeEmrClusterInfoResponse) {
+    response = &DescribeEmrClusterInfoResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeEmrClusterInfo
+// 按 EMR 集群 ID 精确查询单个 EMR 集群的详细信息，包含 VPC、COS Bucket、关联 TKE 集群 ID、资源用量等。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeEmrClusterInfo(request *DescribeEmrClusterInfoRequest) (response *DescribeEmrClusterInfoResponse, err error) {
+    return c.DescribeEmrClusterInfoWithContext(context.Background(), request)
+}
+
+// DescribeEmrClusterInfo
+// 按 EMR 集群 ID 精确查询单个 EMR 集群的详细信息，包含 VPC、COS Bucket、关联 TKE 集群 ID、资源用量等。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeEmrClusterInfoWithContext(ctx context.Context, request *DescribeEmrClusterInfoRequest) (response *DescribeEmrClusterInfoResponse, err error) {
+    if request == nil {
+        request = NewDescribeEmrClusterInfoRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeEmrClusterInfo")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeEmrClusterInfo require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeEmrClusterInfoResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeEngineNetworksRequest() (request *DescribeEngineNetworksRequest) {
     request = &DescribeEngineNetworksRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -7953,6 +9307,354 @@ func (c *Client) DescribeMCPTaskResultWithContext(ctx context.Context, request *
     request.SetContext(ctx)
     
     response = NewDescribeMCPTaskResultResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeMlFlowConfigRequest() (request *DescribeMlFlowConfigRequest) {
+    request = &DescribeMlFlowConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeMlFlowConfig")
+    
+    
+    return
+}
+
+func NewDescribeMlFlowConfigResponse() (response *DescribeMlFlowConfigResponse) {
+    response = &DescribeMlFlowConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeMlFlowConfig
+// 查询训练实例的 MLflow 接入配置。 
+//
+// MlFlowMode 表示接入的 mlflow 模式，支持 local=Sidecar / remote=已有 Server / none=不启用。云上默认为 remote。
+//
+// MlFlowUrl 表示访问的 MLflow URL。
+//
+// RunID, ExperimentID 对应MLflow 实验追踪用的参数 RunID, ExperimentID
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMlFlowConfig(request *DescribeMlFlowConfigRequest) (response *DescribeMlFlowConfigResponse, err error) {
+    return c.DescribeMlFlowConfigWithContext(context.Background(), request)
+}
+
+// DescribeMlFlowConfig
+// 查询训练实例的 MLflow 接入配置。 
+//
+// MlFlowMode 表示接入的 mlflow 模式，支持 local=Sidecar / remote=已有 Server / none=不启用。云上默认为 remote。
+//
+// MlFlowUrl 表示访问的 MLflow URL。
+//
+// RunID, ExperimentID 对应MLflow 实验追踪用的参数 RunID, ExperimentID
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMlFlowConfigWithContext(ctx context.Context, request *DescribeMlFlowConfigRequest) (response *DescribeMlFlowConfigResponse, err error) {
+    if request == nil {
+        request = NewDescribeMlFlowConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeMlFlowConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeMlFlowConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeMlFlowConfigResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeMlflowServerRequest() (request *DescribeMlflowServerRequest) {
+    request = &DescribeMlflowServerRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeMlflowServer")
+    
+    
+    return
+}
+
+func NewDescribeMlflowServerResponse() (response *DescribeMlflowServerResponse) {
+    response = &DescribeMlflowServerResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeMlflowServer
+// 查询 MlFlow Server 状态
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMlflowServer(request *DescribeMlflowServerRequest) (response *DescribeMlflowServerResponse, err error) {
+    return c.DescribeMlflowServerWithContext(context.Background(), request)
+}
+
+// DescribeMlflowServer
+// 查询 MlFlow Server 状态
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMlflowServerWithContext(ctx context.Context, request *DescribeMlflowServerRequest) (response *DescribeMlflowServerResponse, err error) {
+    if request == nil {
+        request = NewDescribeMlflowServerRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeMlflowServer")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeMlflowServer require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeMlflowServerResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeMlflowServerEventsRequest() (request *DescribeMlflowServerEventsRequest) {
+    request = &DescribeMlflowServerEventsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeMlflowServerEvents")
+    
+    
+    return
+}
+
+func NewDescribeMlflowServerEventsResponse() (response *DescribeMlflowServerEventsResponse) {
+    response = &DescribeMlflowServerEventsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeMlflowServerEvents
+// 查询 MlFlow Server K8s 事件
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMlflowServerEvents(request *DescribeMlflowServerEventsRequest) (response *DescribeMlflowServerEventsResponse, err error) {
+    return c.DescribeMlflowServerEventsWithContext(context.Background(), request)
+}
+
+// DescribeMlflowServerEvents
+// 查询 MlFlow Server K8s 事件
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMlflowServerEventsWithContext(ctx context.Context, request *DescribeMlflowServerEventsRequest) (response *DescribeMlflowServerEventsResponse, err error) {
+    if request == nil {
+        request = NewDescribeMlflowServerEventsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeMlflowServerEvents")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeMlflowServerEvents require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeMlflowServerEventsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeMlflowServerPodsRequest() (request *DescribeMlflowServerPodsRequest) {
+    request = &DescribeMlflowServerPodsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeMlflowServerPods")
+    
+    
+    return
+}
+
+func NewDescribeMlflowServerPodsResponse() (response *DescribeMlflowServerPodsResponse) {
+    response = &DescribeMlflowServerPodsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeMlflowServerPods
+// MlFlow Server Pod 列表响应
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMlflowServerPods(request *DescribeMlflowServerPodsRequest) (response *DescribeMlflowServerPodsResponse, err error) {
+    return c.DescribeMlflowServerPodsWithContext(context.Background(), request)
+}
+
+// DescribeMlflowServerPods
+// MlFlow Server Pod 列表响应
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeMlflowServerPodsWithContext(ctx context.Context, request *DescribeMlflowServerPodsRequest) (response *DescribeMlflowServerPodsResponse, err error) {
+    if request == nil {
+        request = NewDescribeMlflowServerPodsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeMlflowServerPods")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeMlflowServerPods require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeMlflowServerPodsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeModelEnginesRequest() (request *DescribeModelEnginesRequest) {
+    request = &DescribeModelEnginesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeModelEngines")
+    
+    
+    return
+}
+
+func NewDescribeModelEnginesResponse() (response *DescribeModelEnginesResponse) {
+    response = &DescribeModelEnginesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeModelEngines
+// 根据模型 UID 查询该模型可选的推理引擎列表。后端自动根据模型的 SupportedEngines 声明或 ModelType 进行引擎过滤
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeModelEngines(request *DescribeModelEnginesRequest) (response *DescribeModelEnginesResponse, err error) {
+    return c.DescribeModelEnginesWithContext(context.Background(), request)
+}
+
+// DescribeModelEngines
+// 根据模型 UID 查询该模型可选的推理引擎列表。后端自动根据模型的 SupportedEngines 声明或 ModelType 进行引擎过滤
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeModelEnginesWithContext(ctx context.Context, request *DescribeModelEnginesRequest) (response *DescribeModelEnginesResponse, err error) {
+    if request == nil {
+        request = NewDescribeModelEnginesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeModelEngines")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeModelEngines require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeModelEnginesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeModelTaskOptionsRequest() (request *DescribeModelTaskOptionsRequest) {
+    request = &DescribeModelTaskOptionsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeModelTaskOptions")
+    
+    
+    return
+}
+
+func NewDescribeModelTaskOptionsResponse() (response *DescribeModelTaskOptionsResponse) {
+    response = &DescribeModelTaskOptionsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeModelTaskOptions
+// 查询指定模型类型下可选的任务类型列表。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeModelTaskOptions(request *DescribeModelTaskOptionsRequest) (response *DescribeModelTaskOptionsResponse, err error) {
+    return c.DescribeModelTaskOptionsWithContext(context.Background(), request)
+}
+
+// DescribeModelTaskOptions
+// 查询指定模型类型下可选的任务类型列表。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_HTTPCLIENTDOREQUESTFAILED = "FailedOperation.HttpClientDoRequestFailed"
+//  FAILEDOPERATION_SQLTASKRESULTOVERSIZE = "FailedOperation.SQLTaskResultOversize"
+//  FAILEDOPERATION_TASKOVERTIMEFETCHRESULT = "FailedOperation.TaskOvertimeFetchResult"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+func (c *Client) DescribeModelTaskOptionsWithContext(ctx context.Context, request *DescribeModelTaskOptionsRequest) (response *DescribeModelTaskOptionsResponse, err error) {
+    if request == nil {
+        request = NewDescribeModelTaskOptionsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeModelTaskOptions")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeModelTaskOptions require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeModelTaskOptionsResponse()
     err = c.Send(request, response)
     return
 }
@@ -8669,6 +10371,108 @@ func (c *Client) DescribePartitionsWithContext(ctx context.Context, request *Des
     return
 }
 
+func NewDescribePostTrainingPresetRequest() (request *DescribePostTrainingPresetRequest) {
+    request = &DescribePostTrainingPresetRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribePostTrainingPreset")
+    
+    
+    return
+}
+
+func NewDescribePostTrainingPresetResponse() (response *DescribePostTrainingPresetResponse) {
+    response = &DescribePostTrainingPresetResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribePostTrainingPreset
+// 获取零代码后训练的推荐参数和资源规格配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribePostTrainingPreset(request *DescribePostTrainingPresetRequest) (response *DescribePostTrainingPresetResponse, err error) {
+    return c.DescribePostTrainingPresetWithContext(context.Background(), request)
+}
+
+// DescribePostTrainingPreset
+// 获取零代码后训练的推荐参数和资源规格配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+func (c *Client) DescribePostTrainingPresetWithContext(ctx context.Context, request *DescribePostTrainingPresetRequest) (response *DescribePostTrainingPresetResponse, err error) {
+    if request == nil {
+        request = NewDescribePostTrainingPresetRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribePostTrainingPreset")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribePostTrainingPreset require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribePostTrainingPresetResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeRecommendedParamsRequest() (request *DescribeRecommendedParamsRequest) {
+    request = &DescribeRecommendedParamsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeRecommendedParams")
+    
+    
+    return
+}
+
+func NewDescribeRecommendedParamsResponse() (response *DescribeRecommendedParamsResponse) {
+    response = &DescribeRecommendedParamsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeRecommendedParams
+// 获取推荐的高级参数
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeRecommendedParams(request *DescribeRecommendedParamsRequest) (response *DescribeRecommendedParamsResponse, err error) {
+    return c.DescribeRecommendedParamsWithContext(context.Background(), request)
+}
+
+// DescribeRecommendedParams
+// 获取推荐的高级参数
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) DescribeRecommendedParamsWithContext(ctx context.Context, request *DescribeRecommendedParamsRequest) (response *DescribeRecommendedParamsResponse, err error) {
+    if request == nil {
+        request = NewDescribeRecommendedParamsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeRecommendedParams")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeRecommendedParams require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeRecommendedParamsResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewDescribeResourceGroupUsageInfoRequest() (request *DescribeResourceGroupUsageInfoRequest) {
     request = &DescribeResourceGroupUsageInfoRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -8845,7 +10649,7 @@ func NewDescribeSaleResourceInfoResponse() (response *DescribeSaleResourceInfoRe
 }
 
 // DescribeSaleResourceInfo
-// 查询当前地域可售卖的资源规格和最大配额
+// 查询当前地域可售卖的资源规格、最大配额，以及库存情况。StatusCategory 与 DescribePartitionAvailableQuota 数据同源，将实时可新增数量映射为库存分级；当请求 Region 与资源池实际部署地域不一致，或服务 cold-start 快照尚未就绪时，StatusCategory 为 null。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -8854,7 +10658,7 @@ func (c *Client) DescribeSaleResourceInfo(request *DescribeSaleResourceInfoReque
 }
 
 // DescribeSaleResourceInfo
-// 查询当前地域可售卖的资源规格和最大配额
+// 查询当前地域可售卖的资源规格、最大配额，以及库存情况。StatusCategory 与 DescribePartitionAvailableQuota 数据同源，将实时可新增数量映射为库存分级；当请求 Region 与资源池实际部署地域不一致，或服务 cold-start 快照尚未就绪时，StatusCategory 为 null。
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION = "FailedOperation"
@@ -10699,6 +12503,222 @@ func (c *Client) DescribeThirdPartyAccessUserWithContext(ctx context.Context, re
     request.SetContext(ctx)
     
     response = NewDescribeThirdPartyAccessUserResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeTkeClusterImportInfoRequest() (request *DescribeTkeClusterImportInfoRequest) {
+    request = &DescribeTkeClusterImportInfoRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeTkeClusterImportInfo")
+    
+    
+    return
+}
+
+func NewDescribeTkeClusterImportInfoResponse() (response *DescribeTkeClusterImportInfoResponse) {
+    response = &DescribeTkeClusterImportInfoResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTkeClusterImportInfo
+// 按 EMR 集群 ID 查询已导入的 TKE 集群详情，返回 tke_cluster 表中该条导入记录的核心字段，并对 LoadBalancerId / PrometheusInstanceId / ContainerLogTopicId 三个 ID 分别回查腾讯云 API 获取对应名称一并返回。名称查询失败或查不到时对应字段返回空字符串，不影响主接口返回。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTkeClusterImportInfo(request *DescribeTkeClusterImportInfoRequest) (response *DescribeTkeClusterImportInfoResponse, err error) {
+    return c.DescribeTkeClusterImportInfoWithContext(context.Background(), request)
+}
+
+// DescribeTkeClusterImportInfo
+// 按 EMR 集群 ID 查询已导入的 TKE 集群详情，返回 tke_cluster 表中该条导入记录的核心字段，并对 LoadBalancerId / PrometheusInstanceId / ContainerLogTopicId 三个 ID 分别回查腾讯云 API 获取对应名称一并返回。名称查询失败或查不到时对应字段返回空字符串，不影响主接口返回。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTkeClusterImportInfoWithContext(ctx context.Context, request *DescribeTkeClusterImportInfoRequest) (response *DescribeTkeClusterImportInfoResponse, err error) {
+    if request == nil {
+        request = NewDescribeTkeClusterImportInfoRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeTkeClusterImportInfo")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTkeClusterImportInfo require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTkeClusterImportInfoResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeTrainingCheckpointsRequest() (request *DescribeTrainingCheckpointsRequest) {
+    request = &DescribeTrainingCheckpointsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeTrainingCheckpoints")
+    
+    
+    return
+}
+
+func NewDescribeTrainingCheckpointsResponse() (response *DescribeTrainingCheckpointsResponse) {
+    response = &DescribeTrainingCheckpointsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTrainingCheckpoints
+// 列出训练实例 Checkpoint 文件列表的响应
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTrainingCheckpoints(request *DescribeTrainingCheckpointsRequest) (response *DescribeTrainingCheckpointsResponse, err error) {
+    return c.DescribeTrainingCheckpointsWithContext(context.Background(), request)
+}
+
+// DescribeTrainingCheckpoints
+// 列出训练实例 Checkpoint 文件列表的响应
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTrainingCheckpointsWithContext(ctx context.Context, request *DescribeTrainingCheckpointsRequest) (response *DescribeTrainingCheckpointsResponse, err error) {
+    if request == nil {
+        request = NewDescribeTrainingCheckpointsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeTrainingCheckpoints")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTrainingCheckpoints require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTrainingCheckpointsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeTrainingJobInstanceRequest() (request *DescribeTrainingJobInstanceRequest) {
+    request = &DescribeTrainingJobInstanceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeTrainingJobInstance")
+    
+    
+    return
+}
+
+func NewDescribeTrainingJobInstanceResponse() (response *DescribeTrainingJobInstanceResponse) {
+    response = &DescribeTrainingJobInstanceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTrainingJobInstance
+// 查询训练实例详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTrainingJobInstance(request *DescribeTrainingJobInstanceRequest) (response *DescribeTrainingJobInstanceResponse, err error) {
+    return c.DescribeTrainingJobInstanceWithContext(context.Background(), request)
+}
+
+// DescribeTrainingJobInstance
+// 查询训练实例详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTrainingJobInstanceWithContext(ctx context.Context, request *DescribeTrainingJobInstanceRequest) (response *DescribeTrainingJobInstanceResponse, err error) {
+    if request == nil {
+        request = NewDescribeTrainingJobInstanceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeTrainingJobInstance")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTrainingJobInstance require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTrainingJobInstanceResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeTrainingJobSpecRequest() (request *DescribeTrainingJobSpecRequest) {
+    request = &DescribeTrainingJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "DescribeTrainingJobSpec")
+    
+    
+    return
+}
+
+func NewDescribeTrainingJobSpecResponse() (response *DescribeTrainingJobSpecResponse) {
+    response = &DescribeTrainingJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeTrainingJobSpec
+// 获取训练作业配置详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTrainingJobSpec(request *DescribeTrainingJobSpecRequest) (response *DescribeTrainingJobSpecResponse, err error) {
+    return c.DescribeTrainingJobSpecWithContext(context.Background(), request)
+}
+
+// DescribeTrainingJobSpec
+// 获取训练作业配置详情
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  RESOURCENOTFOUND = "ResourceNotFound"
+func (c *Client) DescribeTrainingJobSpecWithContext(ctx context.Context, request *DescribeTrainingJobSpecRequest) (response *DescribeTrainingJobSpecResponse, err error) {
+    if request == nil {
+        request = NewDescribeTrainingJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "DescribeTrainingJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeTrainingJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeTrainingJobSpecResponse()
     err = c.Send(request, response)
     return
 }
@@ -13385,6 +15405,110 @@ func (c *Client) GrantDLCCatalogAccessWithContext(ctx context.Context, request *
     return
 }
 
+func NewImportExternalClusterRequest() (request *ImportExternalClusterRequest) {
+    request = &ImportExternalClusterRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ImportExternalCluster")
+    
+    
+    return
+}
+
+func NewImportExternalClusterResponse() (response *ImportExternalClusterResponse) {
+    response = &ImportExternalClusterResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ImportExternalCluster
+// 通过 ClusterType 区分两种导入模式：TKE（直接导入裸 TKE 集群，ClusterId 为 TKE 集群 ID）或 EMR（通过 EMR 集群导入，ClusterId 为 EMR 集群 ID，底层会关联查询对应的 TKE 集群 ID 一并落库）。两种模式均将 TKE 集群 ID 存入 tke_cluster 表。接口是异步的，返回的 WorkflowId 可用于轮询注册进度；ResourcePoolId / ResourcePoolCode 为资源池的唯一标识。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) ImportExternalCluster(request *ImportExternalClusterRequest) (response *ImportExternalClusterResponse, err error) {
+    return c.ImportExternalClusterWithContext(context.Background(), request)
+}
+
+// ImportExternalCluster
+// 通过 ClusterType 区分两种导入模式：TKE（直接导入裸 TKE 集群，ClusterId 为 TKE 集群 ID）或 EMR（通过 EMR 集群导入，ClusterId 为 EMR 集群 ID，底层会关联查询对应的 TKE 集群 ID 一并落库）。两种模式均将 TKE 集群 ID 存入 tke_cluster 表。接口是异步的，返回的 WorkflowId 可用于轮询注册进度；ResourcePoolId / ResourcePoolCode 为资源池的唯一标识。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) ImportExternalClusterWithContext(ctx context.Context, request *ImportExternalClusterRequest) (response *ImportExternalClusterResponse, err error) {
+    if request == nil {
+        request = NewImportExternalClusterRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ImportExternalCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ImportExternalCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewImportExternalClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewImportTkeClusterRequest() (request *ImportTkeClusterRequest) {
+    request = &ImportTkeClusterRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ImportTkeCluster")
+    
+    
+    return
+}
+
+func NewImportTkeClusterResponse() (response *ImportTkeClusterResponse) {
+    response = &ImportTkeClusterResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ImportTkeCluster
+// 将用户在控制台选择的 EMR-TKE 集群及配套的 COS Bucket、Prometheus 实例、负载均衡、容器日志主题等资源，注册为 DLC 的外部资源池（EXTERNAL_TKE）。接口是异步的，返回的 WorkflowId 可用于轮询注册进度；ResourcePoolId / ResourcePoolCode 为资源池的唯一标识。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) ImportTkeCluster(request *ImportTkeClusterRequest) (response *ImportTkeClusterResponse, err error) {
+    return c.ImportTkeClusterWithContext(context.Background(), request)
+}
+
+// ImportTkeCluster
+// 将用户在控制台选择的 EMR-TKE 集群及配套的 COS Bucket、Prometheus 实例、负载均衡、容器日志主题等资源，注册为 DLC 的外部资源池（EXTERNAL_TKE）。接口是异步的，返回的 WorkflowId 可用于轮询注册进度；ResourcePoolId / ResourcePoolCode 为资源池的唯一标识。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
+func (c *Client) ImportTkeClusterWithContext(ctx context.Context, request *ImportTkeClusterRequest) (response *ImportTkeClusterResponse, err error) {
+    if request == nil {
+        request = NewImportTkeClusterRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ImportTkeCluster")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ImportTkeCluster require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewImportTkeClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewInitializeTCLakeRequest() (request *InitializeTCLakeRequest) {
     request = &InitializeTCLakeRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -13409,6 +15533,7 @@ func NewInitializeTCLakeResponse() (response *InitializeTCLakeResponse) {
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
 func (c *Client) InitializeTCLake(request *InitializeTCLakeRequest) (response *InitializeTCLakeResponse, err error) {
     return c.InitializeTCLakeWithContext(context.Background(), request)
 }
@@ -13418,6 +15543,7 @@ func (c *Client) InitializeTCLake(request *InitializeTCLakeRequest) (response *I
 //
 // 可能返回的错误码:
 //  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  INVALIDPARAMETER = "InvalidParameter"
 func (c *Client) InitializeTCLakeWithContext(ctx context.Context, request *InitializeTCLakeRequest) (response *InitializeTCLakeResponse, err error) {
     if request == nil {
         request = NewInitializeTCLakeRequest()
@@ -13497,6 +15623,206 @@ func (c *Client) LaunchStandardEngineResourceGroupsWithContext(ctx context.Conte
     return
 }
 
+func NewListApiKeysRequest() (request *ListApiKeysRequest) {
+    request = &ListApiKeysRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListApiKeys")
+    
+    
+    return
+}
+
+func NewListApiKeysResponse() (response *ListApiKeysResponse) {
+    response = &ListApiKeysResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListApiKeys
+// 列出 API Key
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListApiKeys(request *ListApiKeysRequest) (response *ListApiKeysResponse, err error) {
+    return c.ListApiKeysWithContext(context.Background(), request)
+}
+
+// ListApiKeys
+// 列出 API Key
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListApiKeysWithContext(ctx context.Context, request *ListApiKeysRequest) (response *ListApiKeysResponse, err error) {
+    if request == nil {
+        request = NewListApiKeysRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListApiKeys")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListApiKeys require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListApiKeysResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListAvailableApiKeysRequest() (request *ListAvailableApiKeysRequest) {
+    request = &ListAvailableApiKeysRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListAvailableApiKeys")
+    
+    
+    return
+}
+
+func NewListAvailableApiKeysResponse() (response *ListAvailableApiKeysResponse) {
+    response = &ListAvailableApiKeysResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListAvailableApiKeys
+// 列出空闲 API Key（未绑定服务）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListAvailableApiKeys(request *ListAvailableApiKeysRequest) (response *ListAvailableApiKeysResponse, err error) {
+    return c.ListAvailableApiKeysWithContext(context.Background(), request)
+}
+
+// ListAvailableApiKeys
+// 列出空闲 API Key（未绑定服务）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListAvailableApiKeysWithContext(ctx context.Context, request *ListAvailableApiKeysRequest) (response *ListAvailableApiKeysResponse, err error) {
+    if request == nil {
+        request = NewListAvailableApiKeysRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListAvailableApiKeys")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListAvailableApiKeys require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListAvailableApiKeysResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListBenchmarkSummaryRequest() (request *ListBenchmarkSummaryRequest) {
+    request = &ListBenchmarkSummaryRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListBenchmarkSummary")
+    
+    
+    return
+}
+
+func NewListBenchmarkSummaryResponse() (response *ListBenchmarkSummaryResponse) {
+    response = &ListBenchmarkSummaryResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListBenchmarkSummary
+// 查询评测排行榜（所有模型的评测汇总数据）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListBenchmarkSummary(request *ListBenchmarkSummaryRequest) (response *ListBenchmarkSummaryResponse, err error) {
+    return c.ListBenchmarkSummaryWithContext(context.Background(), request)
+}
+
+// ListBenchmarkSummary
+// 查询评测排行榜（所有模型的评测汇总数据）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListBenchmarkSummaryWithContext(ctx context.Context, request *ListBenchmarkSummaryRequest) (response *ListBenchmarkSummaryResponse, err error) {
+    if request == nil {
+        request = NewListBenchmarkSummaryRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListBenchmarkSummary")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListBenchmarkSummary require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListBenchmarkSummaryResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListBenchmarkTasksRequest() (request *ListBenchmarkTasksRequest) {
+    request = &ListBenchmarkTasksRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListBenchmarkTasks")
+    
+    
+    return
+}
+
+func NewListBenchmarkTasksResponse() (response *ListBenchmarkTasksResponse) {
+    response = &ListBenchmarkTasksResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListBenchmarkTasks
+// 列出性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListBenchmarkTasks(request *ListBenchmarkTasksRequest) (response *ListBenchmarkTasksResponse, err error) {
+    return c.ListBenchmarkTasksWithContext(context.Background(), request)
+}
+
+// ListBenchmarkTasks
+// 列出性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListBenchmarkTasksWithContext(ctx context.Context, request *ListBenchmarkTasksRequest) (response *ListBenchmarkTasksResponse, err error) {
+    if request == nil {
+        request = NewListBenchmarkTasksRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListBenchmarkTasks")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListBenchmarkTasks require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListBenchmarkTasksResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewListClusterGroupsRequest() (request *ListClusterGroupsRequest) {
     request = &ListClusterGroupsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -13543,6 +15869,106 @@ func (c *Client) ListClusterGroupsWithContext(ctx context.Context, request *List
     request.SetContext(ctx)
     
     response = NewListClusterGroupsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListDeploymentReplicasRequest() (request *ListDeploymentReplicasRequest) {
+    request = &ListDeploymentReplicasRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListDeploymentReplicas")
+    
+    
+    return
+}
+
+func NewListDeploymentReplicasResponse() (response *ListDeploymentReplicasResponse) {
+    response = &ListDeploymentReplicasResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListDeploymentReplicas
+// 列出部署的副本列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListDeploymentReplicas(request *ListDeploymentReplicasRequest) (response *ListDeploymentReplicasResponse, err error) {
+    return c.ListDeploymentReplicasWithContext(context.Background(), request)
+}
+
+// ListDeploymentReplicas
+// 列出部署的副本列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListDeploymentReplicasWithContext(ctx context.Context, request *ListDeploymentReplicasRequest) (response *ListDeploymentReplicasResponse, err error) {
+    if request == nil {
+        request = NewListDeploymentReplicasRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListDeploymentReplicas")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListDeploymentReplicas require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListDeploymentReplicasResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListDeploymentsRequest() (request *ListDeploymentsRequest) {
+    request = &ListDeploymentsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListDeployments")
+    
+    
+    return
+}
+
+func NewListDeploymentsResponse() (response *ListDeploymentsResponse) {
+    response = &ListDeploymentsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListDeployments
+// 列出推理服务的部署列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListDeployments(request *ListDeploymentsRequest) (response *ListDeploymentsResponse, err error) {
+    return c.ListDeploymentsWithContext(context.Background(), request)
+}
+
+// ListDeployments
+// 列出推理服务的部署列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListDeploymentsWithContext(ctx context.Context, request *ListDeploymentsRequest) (response *ListDeploymentsResponse, err error) {
+    if request == nil {
+        request = NewListDeploymentsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListDeployments")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListDeployments require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListDeploymentsResponse()
     err = c.Send(request, response)
     return
 }
@@ -13743,6 +16169,56 @@ func (c *Client) ListExamplesWithContext(ctx context.Context, request *ListExamp
     request.SetContext(ctx)
     
     response = NewListExamplesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListImagesRequest() (request *ListImagesRequest) {
+    request = &ListImagesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListImages")
+    
+    
+    return
+}
+
+func NewListImagesResponse() (response *ListImagesResponse) {
+    response = &ListImagesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListImages
+// 列出所有镜像
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListImages(request *ListImagesRequest) (response *ListImagesResponse, err error) {
+    return c.ListImagesWithContext(context.Background(), request)
+}
+
+// ListImages
+// 列出所有镜像
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListImagesWithContext(ctx context.Context, request *ListImagesRequest) (response *ListImagesResponse, err error) {
+    if request == nil {
+        request = NewListImagesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListImages")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListImages require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListImagesResponse()
     err = c.Send(request, response)
     return
 }
@@ -14047,6 +16523,106 @@ func (c *Client) ListLabsWithContext(ctx context.Context, request *ListLabsReque
     return
 }
 
+func NewListMlflowServerTrainingInstancesRequest() (request *ListMlflowServerTrainingInstancesRequest) {
+    request = &ListMlflowServerTrainingInstancesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListMlflowServerTrainingInstances")
+    
+    
+    return
+}
+
+func NewListMlflowServerTrainingInstancesResponse() (response *ListMlflowServerTrainingInstancesResponse) {
+    response = &ListMlflowServerTrainingInstancesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListMlflowServerTrainingInstances
+// 查询 MlFlow Server 关联的训练实例列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListMlflowServerTrainingInstances(request *ListMlflowServerTrainingInstancesRequest) (response *ListMlflowServerTrainingInstancesResponse, err error) {
+    return c.ListMlflowServerTrainingInstancesWithContext(context.Background(), request)
+}
+
+// ListMlflowServerTrainingInstances
+// 查询 MlFlow Server 关联的训练实例列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListMlflowServerTrainingInstancesWithContext(ctx context.Context, request *ListMlflowServerTrainingInstancesRequest) (response *ListMlflowServerTrainingInstancesResponse, err error) {
+    if request == nil {
+        request = NewListMlflowServerTrainingInstancesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListMlflowServerTrainingInstances")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListMlflowServerTrainingInstances require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListMlflowServerTrainingInstancesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListMlflowServersRequest() (request *ListMlflowServersRequest) {
+    request = &ListMlflowServersRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListMlflowServers")
+    
+    
+    return
+}
+
+func NewListMlflowServersResponse() (response *ListMlflowServersResponse) {
+    response = &ListMlflowServersResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListMlflowServers
+// 列出 MlFlow Server
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListMlflowServers(request *ListMlflowServersRequest) (response *ListMlflowServersResponse, err error) {
+    return c.ListMlflowServersWithContext(context.Background(), request)
+}
+
+// ListMlflowServers
+// 列出 MlFlow Server
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListMlflowServersWithContext(ctx context.Context, request *ListMlflowServersRequest) (response *ListMlflowServersResponse, err error) {
+    if request == nil {
+        request = NewListMlflowServersRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListMlflowServers")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListMlflowServers require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListMlflowServersResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewListModelVersionsRequest() (request *ListModelVersionsRequest) {
     request = &ListModelVersionsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -14247,6 +16823,56 @@ func (c *Client) ListRayJobsWithContext(ctx context.Context, request *ListRayJob
     return
 }
 
+func NewListRegionLbsRequest() (request *ListRegionLbsRequest) {
+    request = &ListRegionLbsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListRegionLbs")
+    
+    
+    return
+}
+
+func NewListRegionLbsResponse() (response *ListRegionLbsResponse) {
+    response = &ListRegionLbsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListRegionLbs
+// 列出用户在指定地域下的 CLB 负载均衡实例，返回实例 ID、名称与网络类型（OPEN/INTERNAL）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListRegionLbs(request *ListRegionLbsRequest) (response *ListRegionLbsResponse, err error) {
+    return c.ListRegionLbsWithContext(context.Background(), request)
+}
+
+// ListRegionLbs
+// 列出用户在指定地域下的 CLB 负载均衡实例，返回实例 ID、名称与网络类型（OPEN/INTERNAL）。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListRegionLbsWithContext(ctx context.Context, request *ListRegionLbsRequest) (response *ListRegionLbsResponse, err error) {
+    if request == nil {
+        request = NewListRegionLbsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListRegionLbs")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListRegionLbs require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListRegionLbsResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewListResourceConfigsRequest() (request *ListResourceConfigsRequest) {
     request = &ListResourceConfigsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -14293,6 +16919,56 @@ func (c *Client) ListResourceConfigsWithContext(ctx context.Context, request *Li
     request.SetContext(ctx)
     
     response = NewListResourceConfigsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListServiceApiKeysRequest() (request *ListServiceApiKeysRequest) {
+    request = &ListServiceApiKeysRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListServiceApiKeys")
+    
+    
+    return
+}
+
+func NewListServiceApiKeysResponse() (response *ListServiceApiKeysResponse) {
+    response = &ListServiceApiKeysResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListServiceApiKeys
+// 列出指定推理服务绑定的 API Key
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListServiceApiKeys(request *ListServiceApiKeysRequest) (response *ListServiceApiKeysResponse, err error) {
+    return c.ListServiceApiKeysWithContext(context.Background(), request)
+}
+
+// ListServiceApiKeys
+// 列出指定推理服务绑定的 API Key
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListServiceApiKeysWithContext(ctx context.Context, request *ListServiceApiKeysRequest) (response *ListServiceApiKeysResponse, err error) {
+    if request == nil {
+        request = NewListServiceApiKeysRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListServiceApiKeys")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListServiceApiKeys require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListServiceApiKeysResponse()
     err = c.Send(request, response)
     return
 }
@@ -14433,6 +17109,168 @@ func (c *Client) ListTaskJobLogNameWithContext(ctx context.Context, request *Lis
     request.SetContext(ctx)
     
     response = NewListTaskJobLogNameResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListTkeCosBucketsRequest() (request *ListTkeCosBucketsRequest) {
+    request = &ListTkeCosBucketsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListTkeCosBuckets")
+    
+    
+    return
+}
+
+func NewListTkeCosBucketsResponse() (response *ListTkeCosBucketsResponse) {
+    response = &ListTkeCosBucketsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListTkeCosBuckets
+// 获取tke纳管cos列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  RESOURCENOTFOUND_BATCHSQLTASKNOTFOUND = "ResourceNotFound.BatchSQLTaskNotFound"
+func (c *Client) ListTkeCosBuckets(request *ListTkeCosBucketsRequest) (response *ListTkeCosBucketsResponse, err error) {
+    return c.ListTkeCosBucketsWithContext(context.Background(), request)
+}
+
+// ListTkeCosBuckets
+// 获取tke纳管cos列表
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR = "InternalError"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER = "InvalidParameter"
+//  INVALIDPARAMETER_INVALIDSQL = "InvalidParameter.InvalidSQL"
+//  INVALIDPARAMETER_SQLTASKNOTFOUND = "InvalidParameter.SQLTaskNotFound"
+//  RESOURCENOTFOUND_BATCHSQLTASKNOTFOUND = "ResourceNotFound.BatchSQLTaskNotFound"
+func (c *Client) ListTkeCosBucketsWithContext(ctx context.Context, request *ListTkeCosBucketsRequest) (response *ListTkeCosBucketsResponse, err error) {
+    if request == nil {
+        request = NewListTkeCosBucketsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListTkeCosBuckets")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListTkeCosBuckets require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListTkeCosBucketsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListTrainingJobInstanceRequest() (request *ListTrainingJobInstanceRequest) {
+    request = &ListTrainingJobInstanceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListTrainingJobInstance")
+    
+    
+    return
+}
+
+func NewListTrainingJobInstanceResponse() (response *ListTrainingJobInstanceResponse) {
+    response = &ListTrainingJobInstanceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListTrainingJobInstance
+// 列出训练作业实例
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListTrainingJobInstance(request *ListTrainingJobInstanceRequest) (response *ListTrainingJobInstanceResponse, err error) {
+    return c.ListTrainingJobInstanceWithContext(context.Background(), request)
+}
+
+// ListTrainingJobInstance
+// 列出训练作业实例
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListTrainingJobInstanceWithContext(ctx context.Context, request *ListTrainingJobInstanceRequest) (response *ListTrainingJobInstanceResponse, err error) {
+    if request == nil {
+        request = NewListTrainingJobInstanceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListTrainingJobInstance")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListTrainingJobInstance require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListTrainingJobInstanceResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewListTrainingJobSpecRequest() (request *ListTrainingJobSpecRequest) {
+    request = &ListTrainingJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ListTrainingJobSpec")
+    
+    
+    return
+}
+
+func NewListTrainingJobSpecResponse() (response *ListTrainingJobSpecResponse) {
+    response = &ListTrainingJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ListTrainingJobSpec
+// 获取训练作业配置的列表。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListTrainingJobSpec(request *ListTrainingJobSpecRequest) (response *ListTrainingJobSpecResponse, err error) {
+    return c.ListTrainingJobSpecWithContext(context.Background(), request)
+}
+
+// ListTrainingJobSpec
+// 获取训练作业配置的列表。
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ListTrainingJobSpecWithContext(ctx context.Context, request *ListTrainingJobSpecRequest) (response *ListTrainingJobSpecResponse, err error) {
+    if request == nil {
+        request = NewListTrainingJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ListTrainingJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ListTrainingJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewListTrainingJobSpecResponse()
     err = c.Send(request, response)
     return
 }
@@ -15091,6 +17929,80 @@ func (c *Client) ModifySparkAppForTDLCWithContext(ctx context.Context, request *
     request.SetContext(ctx)
     
     response = NewModifySparkAppForTDLCResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyTrainingJobSpecRequest() (request *ModifyTrainingJobSpecRequest) {
+    request = &ModifyTrainingJobSpecRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ModifyTrainingJobSpec")
+    
+    
+    return
+}
+
+func NewModifyTrainingJobSpecResponse() (response *ModifyTrainingJobSpecResponse) {
+    response = &ModifyTrainingJobSpecResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyTrainingJobSpec
+// 就地更新训练作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_INVALIDAPPFILEFORMAT = "InvalidParameter.InvalidAppFileFormat"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDDRIVERSIZE = "InvalidParameter.InvalidDriverSize"
+//  INVALIDPARAMETER_INVALIDEXECUTORSIZE = "InvalidParameter.InvalidExecutorSize"
+//  INVALIDPARAMETER_INVALIDFILECOMPRESSIONFORMAT = "InvalidParameter.InvalidFileCompressionFormat"
+//  INVALIDPARAMETER_INVALIDFILEPATHFORMAT = "InvalidParameter.InvalidFilePathFormat"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_SPARKJOBONLYSUPPORTSPARKBATCHENGINE = "InvalidParameter.SparkJobOnlySupportSparkBatchEngine"
+//  RESOURCEINSUFFICIENT_SPARKJOBINSUFFICIENTRESOURCES = "ResourceInsufficient.SparkJobInsufficientResources"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+func (c *Client) ModifyTrainingJobSpec(request *ModifyTrainingJobSpecRequest) (response *ModifyTrainingJobSpecResponse, err error) {
+    return c.ModifyTrainingJobSpecWithContext(context.Background(), request)
+}
+
+// ModifyTrainingJobSpec
+// 就地更新训练作业配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION = "FailedOperation"
+//  INTERNALERROR_INTERNALSYSTEMEXCEPTION = "InternalError.InternalSystemException"
+//  INVALIDPARAMETER_INVALIDAPPFILEFORMAT = "InvalidParameter.InvalidAppFileFormat"
+//  INVALIDPARAMETER_INVALIDDATAENGINENAME = "InvalidParameter.InvalidDataEngineName"
+//  INVALIDPARAMETER_INVALIDDRIVERSIZE = "InvalidParameter.InvalidDriverSize"
+//  INVALIDPARAMETER_INVALIDEXECUTORSIZE = "InvalidParameter.InvalidExecutorSize"
+//  INVALIDPARAMETER_INVALIDFILECOMPRESSIONFORMAT = "InvalidParameter.InvalidFileCompressionFormat"
+//  INVALIDPARAMETER_INVALIDFILEPATHFORMAT = "InvalidParameter.InvalidFilePathFormat"
+//  INVALIDPARAMETER_SQLBASE64DECODEFAIL = "InvalidParameter.SQLBase64DecodeFail"
+//  INVALIDPARAMETER_SPARKJOBNOTFOUND = "InvalidParameter.SparkJobNotFound"
+//  INVALIDPARAMETER_SPARKJOBONLYSUPPORTSPARKBATCHENGINE = "InvalidParameter.SparkJobOnlySupportSparkBatchEngine"
+//  RESOURCEINSUFFICIENT_SPARKJOBINSUFFICIENTRESOURCES = "ResourceInsufficient.SparkJobInsufficientResources"
+//  RESOURCENOTFOUND_DATAENGINENOTFOUND = "ResourceNotFound.DataEngineNotFound"
+func (c *Client) ModifyTrainingJobSpecWithContext(ctx context.Context, request *ModifyTrainingJobSpecRequest) (response *ModifyTrainingJobSpecResponse, err error) {
+    if request == nil {
+        request = NewModifyTrainingJobSpecRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ModifyTrainingJobSpec")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyTrainingJobSpec require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyTrainingJobSpecResponse()
     err = c.Send(request, response)
     return
 }
@@ -15873,6 +18785,56 @@ func (c *Client) ReportHeartbeatMetaDataWithContext(ctx context.Context, request
     return
 }
 
+func NewRerunBenchmarkTaskRequest() (request *RerunBenchmarkTaskRequest) {
+    request = &RerunBenchmarkTaskRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "RerunBenchmarkTask")
+    
+    
+    return
+}
+
+func NewRerunBenchmarkTaskResponse() (response *RerunBenchmarkTaskResponse) {
+    response = &RerunBenchmarkTaskResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// RerunBenchmarkTask
+// 重新运行性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) RerunBenchmarkTask(request *RerunBenchmarkTaskRequest) (response *RerunBenchmarkTaskResponse, err error) {
+    return c.RerunBenchmarkTaskWithContext(context.Background(), request)
+}
+
+// RerunBenchmarkTask
+// 重新运行性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) RerunBenchmarkTaskWithContext(ctx context.Context, request *RerunBenchmarkTaskRequest) (response *RerunBenchmarkTaskResponse, err error) {
+    if request == nil {
+        request = NewRerunBenchmarkTaskRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "RerunBenchmarkTask")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("RerunBenchmarkTask require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewRerunBenchmarkTaskResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewRestartDataEngineRequest() (request *RestartDataEngineRequest) {
     request = &RestartDataEngineRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -15937,6 +18899,56 @@ func (c *Client) RestartDataEngineWithContext(ctx context.Context, request *Rest
     return
 }
 
+func NewRestartDeploymentRequest() (request *RestartDeploymentRequest) {
+    request = &RestartDeploymentRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "RestartDeployment")
+    
+    
+    return
+}
+
+func NewRestartDeploymentResponse() (response *RestartDeploymentResponse) {
+    response = &RestartDeploymentResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// RestartDeployment
+// 再次运行部署（以当前配置重新部署）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) RestartDeployment(request *RestartDeploymentRequest) (response *RestartDeploymentResponse, err error) {
+    return c.RestartDeploymentWithContext(context.Background(), request)
+}
+
+// RestartDeployment
+// 再次运行部署（以当前配置重新部署）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) RestartDeploymentWithContext(ctx context.Context, request *RestartDeploymentRequest) (response *RestartDeploymentResponse, err error) {
+    if request == nil {
+        request = NewRestartDeploymentRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "RestartDeployment")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("RestartDeployment require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewRestartDeploymentResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewRestartInferenceServiceRequest() (request *RestartInferenceServiceRequest) {
     request = &RestartInferenceServiceRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -15983,6 +18995,56 @@ func (c *Client) RestartInferenceServiceWithContext(ctx context.Context, request
     request.SetContext(ctx)
     
     response = NewRestartInferenceServiceResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewResumeTrainingJobInstanceRequest() (request *ResumeTrainingJobInstanceRequest) {
+    request = &ResumeTrainingJobInstanceRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "ResumeTrainingJobInstance")
+    
+    
+    return
+}
+
+func NewResumeTrainingJobInstanceResponse() (response *ResumeTrainingJobInstanceResponse) {
+    response = &ResumeTrainingJobInstanceResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ResumeTrainingJobInstance
+// 断点续训（克隆实例）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ResumeTrainingJobInstance(request *ResumeTrainingJobInstanceRequest) (response *ResumeTrainingJobInstanceResponse, err error) {
+    return c.ResumeTrainingJobInstanceWithContext(context.Background(), request)
+}
+
+// ResumeTrainingJobInstance
+// 断点续训（克隆实例）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) ResumeTrainingJobInstanceWithContext(ctx context.Context, request *ResumeTrainingJobInstanceRequest) (response *ResumeTrainingJobInstanceResponse, err error) {
+    if request == nil {
+        request = NewResumeTrainingJobInstanceRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "ResumeTrainingJobInstance")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ResumeTrainingJobInstance require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewResumeTrainingJobInstanceResponse()
     err = c.Send(request, response)
     return
 }
@@ -16291,6 +19353,58 @@ func (c *Client) StartLabWithContext(ctx context.Context, request *StartLabReque
     return
 }
 
+func NewStartMlflowServerRequest() (request *StartMlflowServerRequest) {
+    request = &StartMlflowServerRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StartMlflowServer")
+    
+    
+    return
+}
+
+func NewStartMlflowServerResponse() (response *StartMlflowServerResponse) {
+    response = &StartMlflowServerResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StartMlflowServer
+// 启动 MlFlow Server（apply K8s 资源，幂等可重试）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) StartMlflowServer(request *StartMlflowServerRequest) (response *StartMlflowServerResponse, err error) {
+    return c.StartMlflowServerWithContext(context.Background(), request)
+}
+
+// StartMlflowServer
+// 启动 MlFlow Server（apply K8s 资源，幂等可重试）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) StartMlflowServerWithContext(ctx context.Context, request *StartMlflowServerRequest) (response *StartMlflowServerResponse, err error) {
+    if request == nil {
+        request = NewStartMlflowServerRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StartMlflowServer")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StartMlflowServer require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStartMlflowServerResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewStartRayClusterRequest() (request *StartRayClusterRequest) {
     request = &StartRayClusterRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -16337,6 +19451,106 @@ func (c *Client) StartRayClusterWithContext(ctx context.Context, request *StartR
     request.SetContext(ctx)
     
     response = NewStartRayClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewStopBenchmarkTaskRequest() (request *StopBenchmarkTaskRequest) {
+    request = &StopBenchmarkTaskRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StopBenchmarkTask")
+    
+    
+    return
+}
+
+func NewStopBenchmarkTaskResponse() (response *StopBenchmarkTaskResponse) {
+    response = &StopBenchmarkTaskResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StopBenchmarkTask
+// 停止性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) StopBenchmarkTask(request *StopBenchmarkTaskRequest) (response *StopBenchmarkTaskResponse, err error) {
+    return c.StopBenchmarkTaskWithContext(context.Background(), request)
+}
+
+// StopBenchmarkTask
+// 停止性能评测任务
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) StopBenchmarkTaskWithContext(ctx context.Context, request *StopBenchmarkTaskRequest) (response *StopBenchmarkTaskResponse, err error) {
+    if request == nil {
+        request = NewStopBenchmarkTaskRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StopBenchmarkTask")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StopBenchmarkTask require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStopBenchmarkTaskResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewStopDeploymentRequest() (request *StopDeploymentRequest) {
+    request = &StopDeploymentRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StopDeployment")
+    
+    
+    return
+}
+
+func NewStopDeploymentResponse() (response *StopDeploymentResponse) {
+    response = &StopDeploymentResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StopDeployment
+// 停止部署
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) StopDeployment(request *StopDeploymentRequest) (response *StopDeploymentResponse, err error) {
+    return c.StopDeploymentWithContext(context.Background(), request)
+}
+
+// StopDeployment
+// 停止部署
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) StopDeploymentWithContext(ctx context.Context, request *StopDeploymentRequest) (response *StopDeploymentResponse, err error) {
+    if request == nil {
+        request = NewStopDeploymentRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StopDeployment")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StopDeployment require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStopDeploymentResponse()
     err = c.Send(request, response)
     return
 }
@@ -16443,6 +19657,58 @@ func (c *Client) StopLabWithContext(ctx context.Context, request *StopLabRequest
     return
 }
 
+func NewStopMlflowServerRequest() (request *StopMlflowServerRequest) {
+    request = &StopMlflowServerRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "StopMlflowServer")
+    
+    
+    return
+}
+
+func NewStopMlflowServerResponse() (response *StopMlflowServerResponse) {
+    response = &StopMlflowServerResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// StopMlflowServer
+// 停止 MlFlow Server
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) StopMlflowServer(request *StopMlflowServerRequest) (response *StopMlflowServerResponse, err error) {
+    return c.StopMlflowServerWithContext(context.Background(), request)
+}
+
+// StopMlflowServer
+// 停止 MlFlow Server
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+//  FAILEDOPERATION_LABNOTFOUND = "FailedOperation.LabNotFound"
+func (c *Client) StopMlflowServerWithContext(ctx context.Context, request *StopMlflowServerRequest) (response *StopMlflowServerResponse, err error) {
+    if request == nil {
+        request = NewStopMlflowServerRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "StopMlflowServer")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("StopMlflowServer require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewStopMlflowServerResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewStopRayClusterRequest() (request *StopRayClusterRequest) {
     request = &StopRayClusterRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -16489,6 +19755,56 @@ func (c *Client) StopRayClusterWithContext(ctx context.Context, request *StopRay
     request.SetContext(ctx)
     
     response = NewStopRayClusterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewSubmitTrainingJobRequest() (request *SubmitTrainingJobRequest) {
+    request = &SubmitTrainingJobRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "SubmitTrainingJob")
+    
+    
+    return
+}
+
+func NewSubmitTrainingJobResponse() (response *SubmitTrainingJobResponse) {
+    response = &SubmitTrainingJobResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// SubmitTrainingJob
+// 断点续训（克隆实例）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) SubmitTrainingJob(request *SubmitTrainingJobRequest) (response *SubmitTrainingJobResponse, err error) {
+    return c.SubmitTrainingJobWithContext(context.Background(), request)
+}
+
+// SubmitTrainingJob
+// 断点续训（克隆实例）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_OTHEREXCEPTION = "FailedOperation.OtherException"
+func (c *Client) SubmitTrainingJobWithContext(ctx context.Context, request *SubmitTrainingJobRequest) (response *SubmitTrainingJobResponse, err error) {
+    if request == nil {
+        request = NewSubmitTrainingJobRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "SubmitTrainingJob")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("SubmitTrainingJob require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewSubmitTrainingJobResponse()
     err = c.Send(request, response)
     return
 }
@@ -16865,6 +20181,56 @@ func (c *Client) UnlockMetaDataWithContext(ctx context.Context, request *UnlockM
     return
 }
 
+func NewUpdateApiKeyStatusRequest() (request *UpdateApiKeyStatusRequest) {
+    request = &UpdateApiKeyStatusRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateApiKeyStatus")
+    
+    
+    return
+}
+
+func NewUpdateApiKeyStatusResponse() (response *UpdateApiKeyStatusResponse) {
+    response = &UpdateApiKeyStatusResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateApiKeyStatus
+// 更新 API Key 状态
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateApiKeyStatus(request *UpdateApiKeyStatusRequest) (response *UpdateApiKeyStatusResponse, err error) {
+    return c.UpdateApiKeyStatusWithContext(context.Background(), request)
+}
+
+// UpdateApiKeyStatus
+// 更新 API Key 状态
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateApiKeyStatusWithContext(ctx context.Context, request *UpdateApiKeyStatusRequest) (response *UpdateApiKeyStatusResponse, err error) {
+    if request == nil {
+        request = NewUpdateApiKeyStatusRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateApiKeyStatus")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateApiKeyStatus require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateApiKeyStatusResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewUpdateClusterGroupRequest() (request *UpdateClusterGroupRequest) {
     request = &UpdateClusterGroupRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -17143,6 +20509,56 @@ func (c *Client) UpdateDataMaskStrategyWithContext(ctx context.Context, request 
     request.SetContext(ctx)
     
     response = NewUpdateDataMaskStrategyResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateDeploymentRequest() (request *UpdateDeploymentRequest) {
+    request = &UpdateDeploymentRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateDeployment")
+    
+    
+    return
+}
+
+func NewUpdateDeploymentResponse() (response *UpdateDeploymentResponse) {
+    response = &UpdateDeploymentResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateDeployment
+// 更新部署配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateDeployment(request *UpdateDeploymentRequest) (response *UpdateDeploymentResponse, err error) {
+    return c.UpdateDeploymentWithContext(context.Background(), request)
+}
+
+// UpdateDeployment
+// 更新部署配置
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateDeploymentWithContext(ctx context.Context, request *UpdateDeploymentRequest) (response *UpdateDeploymentResponse, err error) {
+    if request == nil {
+        request = NewUpdateDeploymentRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateDeployment")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateDeployment require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateDeploymentResponse()
     err = c.Send(request, response)
     return
 }
@@ -17665,6 +21081,56 @@ func (c *Client) UpdateRowFilterWithContext(ctx context.Context, request *Update
     request.SetContext(ctx)
     
     response = NewUpdateRowFilterResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewUpdateServiceAuthConfigRequest() (request *UpdateServiceAuthConfigRequest) {
+    request = &UpdateServiceAuthConfigRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dlc", APIVersion, "UpdateServiceAuthConfig")
+    
+    
+    return
+}
+
+func NewUpdateServiceAuthConfigResponse() (response *UpdateServiceAuthConfigResponse) {
+    response = &UpdateServiceAuthConfigResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// UpdateServiceAuthConfig
+// 更新推理服务的 API-Key 鉴权配置（启用/停用）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateServiceAuthConfig(request *UpdateServiceAuthConfigRequest) (response *UpdateServiceAuthConfigResponse, err error) {
+    return c.UpdateServiceAuthConfigWithContext(context.Background(), request)
+}
+
+// UpdateServiceAuthConfig
+// 更新推理服务的 API-Key 鉴权配置（启用/停用）
+//
+// 可能返回的错误码:
+//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
+func (c *Client) UpdateServiceAuthConfigWithContext(ctx context.Context, request *UpdateServiceAuthConfigRequest) (response *UpdateServiceAuthConfigResponse, err error) {
+    if request == nil {
+        request = NewUpdateServiceAuthConfigRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "UpdateServiceAuthConfig")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("UpdateServiceAuthConfig require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewUpdateServiceAuthConfigResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/errors.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/errors.go
@@ -35,6 +35,9 @@ const (
 	// 另一个请求正在处理中，请稍后再试。
 	FAILEDOPERATION_ANOTHERREQUESTPROCESSING = "FailedOperation.AnotherRequestProcessing"
 
+	// 调用下游计费接口失败，资源销毁通知未送达
+	FAILEDOPERATION_APICALLFAILED = "FailedOperation.ApiCallFailed"
+
 	// 账户余额不足。
 	FAILEDOPERATION_BALANCENOTENOUGH = "FailedOperation.BalanceNotEnough"
 
@@ -356,6 +359,9 @@ const (
 	// 数据源连接配置异常，请重试，或者提交工单联系我们
 	INVALIDPARAMETER_INVALIDDATASOURCECONNECTIONCONFIG = "InvalidParameter.InvalidDatasourceConnectionConfig"
 
+	// 数据源连接名称不合法
+	INVALIDPARAMETER_INVALIDDATASOURCENAME = "InvalidParameter.InvalidDatasourceName"
+
 	// DecimalType设置非法，Precision必须大于等于Scale，且Precision必须小于38
 	INVALIDPARAMETER_INVALIDDECIMALTYPE = "InvalidParameter.InvalidDecimalType"
 
@@ -608,6 +614,12 @@ const (
 	// 参数取值错误。
 	INVALIDPARAMETERVALUE = "InvalidParameterValue"
 
+	// 机型步长不规范，cpu需要为32倍数
+	INVALIDPARAMETERVALUE_BILLINGITEMSTEP = "InvalidParameterValue.BillingItemStep"
+
+	// 按量计费资源包名称不规范
+	INVALIDPARAMETERVALUE_POSTPAYPARTITIONNAME = "InvalidParameterValue.PostpayPartitionName"
+
 	// 队列 Id 与 PartitionCode/QueueName 不一致
 	INVALIDPARAMETERVALUE_QUEUEIDMISMATCH = "InvalidParameterValue.QueueIdMismatch"
 
@@ -643,6 +655,9 @@ const (
 
 	// 有SQL任务尚未执行完成。
 	RESOURCEINUSE_UNFINISHEDSQLS = "ResourceInUse.UnfinishedSQLs"
+
+	// 资源不足。
+	RESOURCEINSUFFICIENT = "ResourceInsufficient"
 
 	// 指定的spark作业资源不足，请调整driver/executor规格
 	RESOURCEINSUFFICIENT_SPARKJOBINSUFFICIENTRESOURCES = "ResourceInsufficient.SparkJobInsufficientResources"
@@ -844,6 +859,9 @@ const (
 
 	// 子用户无权查看引擎监控。
 	UNAUTHORIZEDOPERATION_MONITORCOMPUTINGENGINE = "UnauthorizedOperation.MonitorComputingEngine"
+
+	// 无引擎cam权限
+	UNAUTHORIZEDOPERATION_NOENGINECAMPERMISSIONS = "UnauthorizedOperation.NoEngineCamPermissions"
 
 	// 没有支付权限。
 	UNAUTHORIZEDOPERATION_NOPAYMENTAUTHORITY = "UnauthorizedOperation.NoPaymentAuthority"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/models.go
@@ -91,6 +91,228 @@ func (r *AddDMSPartitionsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type AddDeploymentRequestParams struct {
+	// <p>ServiceId</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>部署名称</p>
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>推理引擎（vllm / xgboost）</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>副本数</p>
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>资源分区 ID（目标 K8s 集群分区）</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>模型版本（如 v1, v2），未提供时使用最新版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>是否开启 ray head 高可用</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>高级参数（JSON 字符串，可选）</p>
+	AdvancedParams *string `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// <p>队列名（K8s namespace）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>是否启用弹性伸缩</p>
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>镜像名称</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>高级参数</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+}
+
+type AddDeploymentRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>ServiceId</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>部署名称</p>
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>推理引擎（vllm / xgboost）</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>副本数</p>
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>资源分区 ID（目标 K8s 集群分区）</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>模型版本（如 v1, v2），未提供时使用最新版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>是否开启 ray head 高可用</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>高级参数（JSON 字符串，可选）</p>
+	AdvancedParams *string `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// <p>队列名（K8s namespace）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>是否启用弹性伸缩</p>
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>镜像名称</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>高级参数</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+}
+
+func (r *AddDeploymentRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *AddDeploymentRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	delete(f, "DeploymentName")
+	delete(f, "Engine")
+	delete(f, "Replicas")
+	delete(f, "ResourcePartitionId")
+	delete(f, "ModelVersion")
+	delete(f, "HeadHighAvailabilityEnabled")
+	delete(f, "AdvancedParams")
+	delete(f, "Queue")
+	delete(f, "AutoscalingEnabled")
+	delete(f, "Image")
+	delete(f, "AdvancedOptions")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "AddDeploymentRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type AddDeploymentResponseParams struct {
+	// <p>DeploymentId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>部署名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>部署使用的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>部署状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>推理引擎（vLLM/SGLang 等）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>期望副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>可用副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AvailableReplicas *int64 `json:"AvailableReplicas,omitnil,omitempty" name:"AvailableReplicas"`
+
+	// <p>资源配置（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>是否开启 ray head 高可用</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>高级参数（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AdvancedParams *string `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// <p>是否开启自动伸缩</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>模型存储配置（Catalog JSON，记录模型 COS 挂载信息）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelStorageConfig *string `json:"ModelStorageConfig,omitnil,omitempty" name:"ModelStorageConfig"`
+
+	// <p>AppId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>Uin</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>Neutrino Serve ID (RayService CR name)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NeutrinoServeId *string `json:"NeutrinoServeId,omitnil,omitempty" name:"NeutrinoServeId"`
+
+	// <p>资源分区 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源队列名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>SubAccountUin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>镜像名称</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>高级参数</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type AddDeploymentResponse struct {
+	*tchttp.BaseResponse
+	Response *AddDeploymentResponseParams `json:"Response"`
+}
+
+func (r *AddDeploymentResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *AddDeploymentResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type AddOptimizerEnginesRequestParams struct {
 	// 数据目录名称
 	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
@@ -673,6 +895,76 @@ type AnalysisTaskResults struct {
 	ShuffleWriteBytesSum *int64 `json:"ShuffleWriteBytesSum,omitnil,omitempty" name:"ShuffleWriteBytesSum"`
 }
 
+type ApiKeyInfo struct {
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>apiKey名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>apiKey</p>
+	ApiKey *string `json:"ApiKey,omitnil,omitempty" name:"ApiKey"`
+
+	// <p>推理服务Id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>推理服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>状态</p><p>枚举值：</p><ul><li>Active： 正常</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>appid</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号uin</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>子账号uin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+}
+
+type ApiKeyResponseInfo struct {
+	// <p>apiKey的id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>apikey名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>apikey内容</p>
+	ApiKey *string `json:"ApiKey,omitnil,omitempty" name:"ApiKey"`
+
+	// <p>推理服务id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>推理服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>apikey状态</p><p>枚举值：</p><ul><li>Active： 正常</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>appid</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号uin</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子账号uin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>创建时间</p>
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+}
+
 type Asset struct {
 	// 主键
 	// 注意：此字段可能返回 null，表示取不到有效值。
@@ -1113,6 +1405,319 @@ type BatchSqlTask struct {
 
 	// 任务信息，成功则返回：Task Success!，失败则返回异常信息
 	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+}
+
+type BenchmarkResourceInfo struct {
+	// <p>评测容器所在资源包 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>评测容器所在资源组</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>评测容器计费项（规格）</p>
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
+
+	// <p>规格数量</p>
+	Spec *int64 `json:"Spec,omitnil,omitempty" name:"Spec"`
+}
+
+type BenchmarkSummaryInfo struct {
+	// <p>模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>模型提供方</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Provider *string `json:"Provider,omitnil,omitempty" name:"Provider"`
+
+	// <p>模型类型</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>参数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ParameterSize *string `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+
+	// <p>评测所用的服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>评测任务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
+
+	// <p>该模型的评测任务总数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	BenchmarkCount *uint64 `json:"BenchmarkCount,omitnil,omitempty" name:"BenchmarkCount"`
+
+	// <p>输入 Token 数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InputTokens *uint64 `json:"InputTokens,omitnil,omitempty" name:"InputTokens"`
+
+	// <p>输出 Token 数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	OutputTokens *uint64 `json:"OutputTokens,omitnil,omitempty" name:"OutputTokens"`
+
+	// <p>每秒请求数 (QPS)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
+
+	// <p>最大并发数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MaxConcurrency *uint64 `json:"MaxConcurrency,omitnil,omitempty" name:"MaxConcurrency"`
+
+	// <p>TTFT 平均值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimeToFirstTokenAvg *float64 `json:"TimeToFirstTokenAvg,omitnil,omitempty" name:"TimeToFirstTokenAvg"`
+
+	// <p>TTFT 中间值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimeToFirstTokenMedian *float64 `json:"TimeToFirstTokenMedian,omitnil,omitempty" name:"TimeToFirstTokenMedian"`
+
+	// <p>TTFT P99 值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimeToFirstTokenP99 *float64 `json:"TimeToFirstTokenP99,omitnil,omitempty" name:"TimeToFirstTokenP99"`
+
+	// <p>TPOT 平均值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimePerOutputTokenAvg *float64 `json:"TimePerOutputTokenAvg,omitnil,omitempty" name:"TimePerOutputTokenAvg"`
+
+	// <p>TPOT 中间值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimePerOutputTokenMedian *float64 `json:"TimePerOutputTokenMedian,omitnil,omitempty" name:"TimePerOutputTokenMedian"`
+
+	// <p>TPOT P99 值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimePerOutputTokenP99 *float64 `json:"TimePerOutputTokenP99,omitnil,omitempty" name:"TimePerOutputTokenP99"`
+
+	// <p>ITL 平均值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InterTokenLatencyAvg *float64 `json:"InterTokenLatencyAvg,omitnil,omitempty" name:"InterTokenLatencyAvg"`
+
+	// <p>ITL 中间值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InterTokenLatencyMedian *float64 `json:"InterTokenLatencyMedian,omitnil,omitempty" name:"InterTokenLatencyMedian"`
+
+	// <p>ITL P99 值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InterTokenLatencyP99 *float64 `json:"InterTokenLatencyP99,omitnil,omitempty" name:"InterTokenLatencyP99"`
+
+	// <p>E2E 平均值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndToEndAvg *float64 `json:"EndToEndAvg,omitnil,omitempty" name:"EndToEndAvg"`
+
+	// <p>E2E 中间值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndToEndMedian *float64 `json:"EndToEndMedian,omitnil,omitempty" name:"EndToEndMedian"`
+
+	// <p>E2E P99 值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndToEndP99 *float64 `json:"EndToEndP99,omitnil,omitempty" name:"EndToEndP99"`
+
+	// <p>评测完成时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+}
+
+type BenchmarkTaskInfo struct {
+	// <p>benchmark任务id</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>任务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
+
+	// <p>关联的推理服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>关联的推理服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>任务状态（Running/Completed/Failed/Pending/Stopped）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>输入 Token 数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InputTokens *uint64 `json:"InputTokens,omitnil,omitempty" name:"InputTokens"`
+
+	// <p>输出 Token 数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	OutputTokens *uint64 `json:"OutputTokens,omitnil,omitempty" name:"OutputTokens"`
+
+	// <p>每秒请求数 (QPS)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
+
+	// <p>最大并发数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MaxConcurrency *uint64 `json:"MaxConcurrency,omitnil,omitempty" name:"MaxConcurrency"`
+
+	// <p>Prompts 总数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TotalPrompts *uint64 `json:"TotalPrompts,omitnil,omitempty" name:"TotalPrompts"`
+
+	// <p>是否经 Ingress 网关（true=网关, false=集群内直连 SVC）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UseGateway *bool `json:"UseGateway,omitnil,omitempty" name:"UseGateway"`
+
+	// <p>直连模式下使用的部署名称（仅 UseGateway=false 时有值）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>API Key ID（走网关时使用的 API Key 标识）</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>API Key 名称</p>
+	ApiKeyName *string `json:"ApiKeyName,omitnil,omitempty" name:"ApiKeyName"`
+
+	// <p>TTFT 平均值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimeToFirstTokenAvg *float64 `json:"TimeToFirstTokenAvg,omitnil,omitempty" name:"TimeToFirstTokenAvg"`
+
+	// <p>TTFT 中间值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimeToFirstTokenMedian *float64 `json:"TimeToFirstTokenMedian,omitnil,omitempty" name:"TimeToFirstTokenMedian"`
+
+	// <p>TTFT P99 值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimeToFirstTokenP99 *float64 `json:"TimeToFirstTokenP99,omitnil,omitempty" name:"TimeToFirstTokenP99"`
+
+	// <p>TPOT 平均值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimePerOutputTokenAvg *float64 `json:"TimePerOutputTokenAvg,omitnil,omitempty" name:"TimePerOutputTokenAvg"`
+
+	// <p>TPOT 中间值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimePerOutputTokenMedian *float64 `json:"TimePerOutputTokenMedian,omitnil,omitempty" name:"TimePerOutputTokenMedian"`
+
+	// <p>TPOT P99 值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TimePerOutputTokenP99 *float64 `json:"TimePerOutputTokenP99,omitnil,omitempty" name:"TimePerOutputTokenP99"`
+
+	// <p>ITL 平均值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InterTokenLatencyAvg *float64 `json:"InterTokenLatencyAvg,omitnil,omitempty" name:"InterTokenLatencyAvg"`
+
+	// <p>ITL 中间值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InterTokenLatencyMedian *float64 `json:"InterTokenLatencyMedian,omitnil,omitempty" name:"InterTokenLatencyMedian"`
+
+	// <p>ITL P99 值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InterTokenLatencyP99 *float64 `json:"InterTokenLatencyP99,omitnil,omitempty" name:"InterTokenLatencyP99"`
+
+	// <p>E2E 平均值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndToEndAvg *float64 `json:"EndToEndAvg,omitnil,omitempty" name:"EndToEndAvg"`
+
+	// <p>E2E 中间值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndToEndMedian *float64 `json:"EndToEndMedian,omitnil,omitempty" name:"EndToEndMedian"`
+
+	// <p>E2E P99 值(ms)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndToEndP99 *float64 `json:"EndToEndP99,omitnil,omitempty" name:"EndToEndP99"`
+
+	// <p>Token 吞吐量 (output tokens/s)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TokenThroughput *float64 `json:"TokenThroughput,omitnil,omitempty" name:"TokenThroughput"`
+
+	// <p>请求吞吐量 (requests/s)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RequestThroughput *float64 `json:"RequestThroughput,omitnil,omitempty" name:"RequestThroughput"`
+
+	// <p>错误信息（失败时）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ErrorMessage *string `json:"ErrorMessage,omitnil,omitempty" name:"ErrorMessage"`
+
+	// <p>appid</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>主账号uin</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>子账号uin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+}
+
+// Predefined struct for user
+type BindApiKeyRequestParams struct {
+	// <p>apiKey的Id</p>
+	ApiKeyIds []*string `json:"ApiKeyIds,omitnil,omitempty" name:"ApiKeyIds"`
+
+	// <p>服务Id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+type BindApiKeyRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>apiKey的Id</p>
+	ApiKeyIds []*string `json:"ApiKeyIds,omitnil,omitempty" name:"ApiKeyIds"`
+
+	// <p>服务Id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+func (r *BindApiKeyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *BindApiKeyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ApiKeyIds")
+	delete(f, "ServiceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "BindApiKeyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type BindApiKeyResponseParams struct {
+	// <p>ApiKey成功返回</p>
+	SuccessList []*ApiKeyResponseInfo `json:"SuccessList,omitnil,omitempty" name:"SuccessList"`
+
+	// <p>失败列表</p>
+	FailedList []*FailedItem `json:"FailedList,omitnil,omitempty" name:"FailedList"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type BindApiKeyResponse struct {
+	*tchttp.BaseResponse
+	Response *BindApiKeyResponseParams `json:"Response"`
+}
+
+func (r *BindApiKeyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *BindApiKeyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
@@ -1564,6 +2169,120 @@ func (r *CancelTasksResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type CancelTrainingJobInstanceRequestParams struct {
+	// <p>实例 ID（即 RayJob UUID，与 JobId 同值，保留兼容）</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type CancelTrainingJobInstanceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>实例 ID（即 RayJob UUID，与 JobId 同值，保留兼容）</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *CancelTrainingJobInstanceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CancelTrainingJobInstanceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CancelTrainingJobInstanceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CancelTrainingJobInstanceResponseParams struct {
+	// <p>训练实例详情</p>
+	Instance *TrainingJobInstance `json:"Instance,omitnil,omitempty" name:"Instance"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CancelTrainingJobInstanceResponse struct {
+	*tchttp.BaseResponse
+	Response *CancelTrainingJobInstanceResponseParams `json:"Response"`
+}
+
+func (r *CancelTrainingJobInstanceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CancelTrainingJobInstanceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckApiKeyNameRequestParams struct {
+	// <p>apiKey名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+}
+
+type CheckApiKeyNameRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>apiKey名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+}
+
+func (r *CheckApiKeyNameRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckApiKeyNameRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CheckApiKeyNameRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckApiKeyNameResponseParams struct {
+	// <p>apiKey是否存在</p>
+	Exists *bool `json:"Exists,omitnil,omitempty" name:"Exists"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CheckApiKeyNameResponse struct {
+	*tchttp.BaseResponse
+	Response *CheckApiKeyNameResponseParams `json:"Response"`
+}
+
+func (r *CheckApiKeyNameResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckApiKeyNameResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CheckDataEngineConfigPairsValidityRequestParams struct {
 	// 引擎小版本ID
 	ChildImageVersionId *string `json:"ChildImageVersionId,omitnil,omitempty" name:"ChildImageVersionId"`
@@ -1761,6 +2480,73 @@ func (r *CheckDataEngineImageCanBeUpgradeResponse) FromJsonString(s string) erro
 }
 
 // Predefined struct for user
+type CheckJobSpecNameRequestParams struct {
+	// <p>训练作业配置名</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>排除的配置 ID（编辑场景排除自己；创建场景不传）</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+type CheckJobSpecNameRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练作业配置名</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>排除的配置 ID（编辑场景排除自己；创建场景不传）</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+func (r *CheckJobSpecNameRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckJobSpecNameRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecName")
+	delete(f, "SpecId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CheckJobSpecNameRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckJobSpecNameResponseParams struct {
+	// <p>名称是否可用（未重名且不含保留字）</p>
+	Available *bool `json:"Available,omitnil,omitempty" name:"Available"`
+
+	// <p>不可用时的原因；可用时为 null</p>
+	Reason *string `json:"Reason,omitnil,omitempty" name:"Reason"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CheckJobSpecNameResponse struct {
+	*tchttp.BaseResponse
+	Response *CheckJobSpecNameResponseParams `json:"Response"`
+}
+
+func (r *CheckJobSpecNameResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckJobSpecNameResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CheckLockMetaDataRequestParams struct {
 	// 锁ID
 	LockId *int64 `json:"LockId,omitnil,omitempty" name:"LockId"`
@@ -1838,6 +2624,63 @@ func (r *CheckLockMetaDataResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CheckLockMetaDataResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckModelIdentifierRequestParams struct {
+	// <p>模型标识符</p>
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+}
+
+type CheckModelIdentifierRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型标识符</p>
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+}
+
+func (r *CheckModelIdentifierRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckModelIdentifierRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelIdentifier")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CheckModelIdentifierRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckModelIdentifierResponseParams struct {
+	// <p>模型标识符是否已存在</p>
+	Exists *bool `json:"Exists,omitnil,omitempty" name:"Exists"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CheckModelIdentifierResponse struct {
+	*tchttp.BaseResponse
+	Response *CheckModelIdentifierResponseParams `json:"Response"`
+}
+
+func (r *CheckModelIdentifierResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckModelIdentifierResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2032,6 +2875,131 @@ func (r *CheckResourceNameResponse) ToJsonString() string {
 // because it has no param check, nor strict type check
 func (r *CheckResourceNameResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckServiceNameRequestParams struct {
+	// <p>服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+}
+
+type CheckServiceNameRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+}
+
+func (r *CheckServiceNameRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckServiceNameRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CheckServiceNameRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CheckServiceNameResponseParams struct {
+	// <p>名称是否已存在</p>
+	Exists *bool `json:"Exists,omitnil,omitempty" name:"Exists"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CheckServiceNameResponse struct {
+	*tchttp.BaseResponse
+	Response *CheckServiceNameResponseParams `json:"Response"`
+}
+
+func (r *CheckServiceNameResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CheckServiceNameResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+type CheckpointConfig struct {
+	// <p>Checkpoint 产出存储的 Catalog 配置 JSON（结构同顶层 Catalog）</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>保存策略：steps / epoch / none，默认 steps；GRPO 仅支持 steps / none</p>
+	SaveStrategy *string `json:"SaveStrategy,omitnil,omitempty" name:"SaveStrategy"`
+
+	// <p>保存频率（每 N 步或每 N epoch），默认 500</p>
+	SaveFreq *int64 `json:"SaveFreq,omitnil,omitempty" name:"SaveFreq"`
+
+	// <p>最大保留数量，0 表示不限制，默认 3</p>
+	MaxKeep *int64 `json:"MaxKeep,omitnil,omitempty" name:"MaxKeep"`
+
+	// <p>容器内输出目录回退值（可选；正常场景由 Checkpoint 挂载路径决定，仅在挂载路径为空时生效，默认 /workspace/output/{mode}）</p>
+	OutputDir *string `json:"OutputDir,omitnil,omitempty" name:"OutputDir"`
+}
+
+type CheckpointMetrics struct {
+	// <p>当前 checkpoint 对应的 epoch</p>
+	Epoch *float64 `json:"Epoch,omitnil,omitempty" name:"Epoch"`
+
+	// <p>全局训练步数</p>
+	Step *int64 `json:"Step,omitnil,omitempty" name:"Step"`
+
+	// <p>训练 loss（归一化后）</p>
+	Loss *float64 `json:"Loss,omitnil,omitempty" name:"Loss"`
+
+	// <p>评估 loss（归一化后）</p>
+	EvalLoss *float64 `json:"EvalLoss,omitnil,omitempty" name:"EvalLoss"`
+
+	// <p>学习率</p>
+	LearningRate *float64 `json:"LearningRate,omitnil,omitempty" name:"LearningRate"`
+
+	// <p>snapshot 中的原始 metrics 键值对列表（前端可展开查看）</p>
+	RawMetrics []*MetricItem `json:"RawMetrics,omitnil,omitempty" name:"RawMetrics"`
+}
+
+type CheckpointMountInfo struct {
+	// <p>存储类型：COS / CFS / CFS_TURBO / GOOSEFS</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
+
+	// <p>容器内挂载路径</p>
+	MountPath *string `json:"MountPath,omitnil,omitempty" name:"MountPath"`
+
+	// <p>COS key 前缀 或 CFS/GooseFS 子路径</p>
+	VolumeSubPath *string `json:"VolumeSubPath,omitnil,omitempty" name:"VolumeSubPath"`
+
+	// <p>实际访问的 COS bucket</p>
+	Bucket *string `json:"Bucket,omitnil,omitempty" name:"Bucket"`
+
+	// <p>COS region</p>
+	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
+
+	// <p>是否平台托管桶（影响凭证选择）</p>
+	PlatformManaged *bool `json:"PlatformManaged,omitnil,omitempty" name:"PlatformManaged"`
+
+	// <p>快照在平台 COS 桶中的 key（仅 CFS/GooseFS 有值）</p>
+	SnapshotKey *string `json:"SnapshotKey,omitnil,omitempty" name:"SnapshotKey"`
+}
+
+type ClsTopicItem struct {
+	// <p>日志主题 ID</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+
+	// <p>日志主题名称</p>
+	TopicName *string `json:"TopicName,omitnil,omitempty" name:"TopicName"`
 }
 
 type ClusterGroup struct {
@@ -2406,6 +3374,308 @@ type CpuSummaryItem struct {
 
 	// <p>运行中的副本总数</p>
 	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+}
+
+// Predefined struct for user
+type CreateApiKeyRequestParams struct {
+	// <p>API Key 名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>绑定的推理服务ID（可选，为空表示创建后不绑定任何服务）</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+type CreateApiKeyRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>API Key 名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>绑定的推理服务ID（可选，为空表示创建后不绑定任何服务）</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+}
+
+func (r *CreateApiKeyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateApiKeyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "ServiceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateApiKeyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateApiKeyResponseParams struct {
+	// <p>API Key ID（唯一标识）</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>API Key 名称（用户创建时指定的可读名称）</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>API Key 值（完整密钥字符串，用于鉴权时携带在请求头中）</p>
+	ApiKey *string `json:"ApiKey,omitnil,omitempty" name:"ApiKey"`
+
+	// <p>关联的推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>关联的推理服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>API Key 状态，可选值：Active（活跃可用）/ Revoked（已停用）。空闲 Key 通常为 Active 状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateApiKeyResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateApiKeyResponseParams `json:"Response"`
+}
+
+func (r *CreateApiKeyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateApiKeyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateBenchmarkTaskRequestParams struct {
+	// <p>推理服务Id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>任务名称（可选，不填则自动生成）</p>
+	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
+
+	// <p>每个 Prompt 的平均输入 Token 数</p>
+	InputTokens *uint64 `json:"InputTokens,omitnil,omitempty" name:"InputTokens"`
+
+	// <p>模型输出的最大 Token 数</p>
+	OutputTokens *uint64 `json:"OutputTokens,omitnil,omitempty" name:"OutputTokens"`
+
+	// <p>每秒发送的请求数 (QPS)</p>
+	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
+
+	// <p>最大同时并发请求数</p>
+	MaxConcurrency *uint64 `json:"MaxConcurrency,omitnil,omitempty" name:"MaxConcurrency"`
+
+	// <p>评测使用的 Prompt 总数</p>
+	TotalPrompts *uint64 `json:"TotalPrompts,omitnil,omitempty" name:"TotalPrompts"`
+
+	// <p>是否经 Ingress 网关访问推理服务（默认 true；false 则集群内直连 SVC）</p>
+	UseGateway *bool `json:"UseGateway,omitnil,omitempty" name:"UseGateway"`
+
+	// <p>ray部署集群Id</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>评测容器所在资源包 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>评测容器所在资源包下的资源组名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>评测容器计费项（规格）。仅允许 CPU 计费项。</p>
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
+
+	// <p>评测容器计费项规格倍数</p>
+	Spec *int64 `json:"Spec,omitnil,omitempty" name:"Spec"`
+}
+
+type CreateBenchmarkTaskRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理服务Id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>任务名称（可选，不填则自动生成）</p>
+	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
+
+	// <p>每个 Prompt 的平均输入 Token 数</p>
+	InputTokens *uint64 `json:"InputTokens,omitnil,omitempty" name:"InputTokens"`
+
+	// <p>模型输出的最大 Token 数</p>
+	OutputTokens *uint64 `json:"OutputTokens,omitnil,omitempty" name:"OutputTokens"`
+
+	// <p>每秒发送的请求数 (QPS)</p>
+	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
+
+	// <p>最大同时并发请求数</p>
+	MaxConcurrency *uint64 `json:"MaxConcurrency,omitnil,omitempty" name:"MaxConcurrency"`
+
+	// <p>评测使用的 Prompt 总数</p>
+	TotalPrompts *uint64 `json:"TotalPrompts,omitnil,omitempty" name:"TotalPrompts"`
+
+	// <p>是否经 Ingress 网关访问推理服务（默认 true；false 则集群内直连 SVC）</p>
+	UseGateway *bool `json:"UseGateway,omitnil,omitempty" name:"UseGateway"`
+
+	// <p>ray部署集群Id</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>评测容器所在资源包 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>评测容器所在资源包下的资源组名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>评测容器计费项（规格）。仅允许 CPU 计费项。</p>
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
+
+	// <p>评测容器计费项规格倍数</p>
+	Spec *int64 `json:"Spec,omitnil,omitempty" name:"Spec"`
+}
+
+func (r *CreateBenchmarkTaskRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateBenchmarkTaskRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	delete(f, "TaskName")
+	delete(f, "InputTokens")
+	delete(f, "OutputTokens")
+	delete(f, "RequestsPerSecond")
+	delete(f, "MaxConcurrency")
+	delete(f, "TotalPrompts")
+	delete(f, "UseGateway")
+	delete(f, "DeploymentId")
+	delete(f, "ApiKeyId")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Queue")
+	delete(f, "BillingItem")
+	delete(f, "Spec")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateBenchmarkTaskRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateBenchmarkTaskResponseParams struct {
+	// <p>benchmark任务id</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>benchmark任务名称</p>
+	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
+
+	// <p>推理服务id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>推理服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>任务状态</p><p>枚举值：</p><ul><li>Completed： 完成</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>输入token量</p>
+	InputTokens *uint64 `json:"InputTokens,omitnil,omitempty" name:"InputTokens"`
+
+	// <p>输出token量</p>
+	OutputTokens *uint64 `json:"OutputTokens,omitnil,omitempty" name:"OutputTokens"`
+
+	// <p>每秒请求量</p>
+	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
+
+	// <p>最大并发量</p>
+	MaxConcurrency *uint64 `json:"MaxConcurrency,omitnil,omitempty" name:"MaxConcurrency"`
+
+	// <p>prompts总量</p>
+	TotalPrompts *uint64 `json:"TotalPrompts,omitnil,omitempty" name:"TotalPrompts"`
+
+	// <p>是否使用Gateway</p>
+	UseGateway *bool `json:"UseGateway,omitnil,omitempty" name:"UseGateway"`
+
+	// <p>部署集群名称</p>
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>apikey的id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>apikey名称</p>
+	ApiKeyName *string `json:"ApiKeyName,omitnil,omitempty" name:"ApiKeyName"`
+
+	// <p>主账号uin</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>appid</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>子账号uin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>与本次评测关联的部署及其资源规格。</p>
+	DeploymentResources []*DeploymentResourceInfo `json:"DeploymentResources,omitnil,omitempty" name:"DeploymentResources"`
+
+	// <p>评测容器自身使用的资源规格</p>
+	Resources *BenchmarkResourceInfo `json:"Resources,omitnil,omitempty" name:"Resources"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateBenchmarkTaskResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateBenchmarkTaskResponseParams `json:"Response"`
+}
+
+func (r *CreateBenchmarkTaskResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateBenchmarkTaskResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
@@ -3559,6 +4829,15 @@ type CreateInferenceModelRequestParams struct {
 
 	// <p>模型 UID（可选，前端预先生成的 UID，不传则后端自动生成）</p>
 	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
+	// <p>模型文件来源于goosefs</p>
+	GooseFSConfig *GooseFSConfig `json:"GooseFSConfig,omitnil,omitempty" name:"GooseFSConfig"`
+
+	// <p>模型上传来源类型</p><p>枚举值：</p><ul><li>Local： 本地上传</li><li>COS： COS上传</li><li>CFS： CFS上传</li><li>CFSTurbo： CFSTurbo上传</li><li>GooseFS： GooseFS上传</li></ul>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
 }
 
 type CreateInferenceModelRequest struct {
@@ -3596,6 +4875,15 @@ type CreateInferenceModelRequest struct {
 
 	// <p>模型 UID（可选，前端预先生成的 UID，不传则后端自动生成）</p>
 	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
+	// <p>模型文件来源于goosefs</p>
+	GooseFSConfig *GooseFSConfig `json:"GooseFSConfig,omitnil,omitempty" name:"GooseFSConfig"`
+
+	// <p>模型上传来源类型</p><p>枚举值：</p><ul><li>Local： 本地上传</li><li>COS： COS上传</li><li>CFS： CFS上传</li><li>CFSTurbo： CFSTurbo上传</li><li>GooseFS： GooseFS上传</li></ul>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
 }
 
 func (r *CreateInferenceModelRequest) ToJsonString() string {
@@ -3621,6 +4909,9 @@ func (r *CreateInferenceModelRequest) FromJsonString(s string) error {
 	delete(f, "UseCustomStorage")
 	delete(f, "Tasks")
 	delete(f, "ModelUid")
+	delete(f, "ResourceTags")
+	delete(f, "GooseFSConfig")
+	delete(f, "StorageType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateInferenceModelRequest has unknown keys!", "")
 	}
@@ -3689,6 +4980,9 @@ type CreateInferenceModelResponseParams struct {
 
 	// <p>Sub UIN</p>
 	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -3765,6 +5059,18 @@ type CreateInferenceServiceRequestParams struct {
 
 	// <p>ApiKeyIds</p>
 	ApiKeyIds []*string `json:"ApiKeyIds,omitnil,omitempty" name:"ApiKeyIds"`
+
+	// <p>AdvancedOptions 高级参数 JSON 字符串（可选），扁平 KV 结构，作用于 K8s RayService CR YAML 字段级</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
+	// <p>自定义RayServe提交</p>
+	IsCustom *bool `json:"IsCustom,omitnil,omitempty" name:"IsCustom"`
+
+	// <p>python runtime env</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
 }
 
 type CreateInferenceServiceRequest struct {
@@ -3823,6 +5129,18 @@ type CreateInferenceServiceRequest struct {
 
 	// <p>ApiKeyIds</p>
 	ApiKeyIds []*string `json:"ApiKeyIds,omitnil,omitempty" name:"ApiKeyIds"`
+
+	// <p>AdvancedOptions 高级参数 JSON 字符串（可选），扁平 KV 结构，作用于 K8s RayService CR YAML 字段级</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
+	// <p>自定义RayServe提交</p>
+	IsCustom *bool `json:"IsCustom,omitnil,omitempty" name:"IsCustom"`
+
+	// <p>python runtime env</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
 }
 
 func (r *CreateInferenceServiceRequest) ToJsonString() string {
@@ -3855,6 +5173,10 @@ func (r *CreateInferenceServiceRequest) FromJsonString(s string) error {
 	delete(f, "MaxReplicas")
 	delete(f, "AutoscalerOptions")
 	delete(f, "ApiKeyIds")
+	delete(f, "AdvancedOptions")
+	delete(f, "ResourceTags")
+	delete(f, "IsCustom")
+	delete(f, "RuntimeEnv")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateInferenceServiceRequest has unknown keys!", "")
 	}
@@ -3961,6 +5283,18 @@ type CreateInferenceServiceResponseParams struct {
 
 	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
 	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>AdvancedOptions 高级参数 JSON 字符串（扁平 KV 结构，取自第一个部署）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
+	// <p>部署模式</p>
+	DeploymentMode *string `json:"DeploymentMode,omitnil,omitempty" name:"DeploymentMode"`
+
+	// <p>是否是自定义 RayServe 创建</p>
+	IsCustom *bool `json:"IsCustom,omitnil,omitempty" name:"IsCustom"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -4377,20 +5711,20 @@ type CreateLabRequestParams struct {
 	// <p>数据实验室名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
-	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
-
 	// <p>资源分区ID</p>
 	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
 
 	// <p>队列名称</p>
 	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
 
-	// <p>数据实验室描述</p>
-	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
-
 	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
 	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>数据实验室描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
 	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
 	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
@@ -4447,20 +5781,20 @@ type CreateLabRequest struct {
 	// <p>数据实验室名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
-	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
-
 	// <p>资源分区ID</p>
 	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
 
 	// <p>队列名称</p>
 	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
 
-	// <p>数据实验室描述</p>
-	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
-
 	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
 	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
+	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
+
+	// <p>数据实验室描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
 	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
 	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
@@ -4524,11 +5858,11 @@ func (r *CreateLabRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "Name")
-	delete(f, "LabImage")
 	delete(f, "ResourcePartitionId")
 	delete(f, "Queue")
-	delete(f, "Description")
 	delete(f, "Image")
+	delete(f, "LabImage")
+	delete(f, "Description")
 	delete(f, "ImagePullPolicy")
 	delete(f, "ResourceConfig")
 	delete(f, "ResourceConfigId")
@@ -4742,6 +6076,112 @@ func (r *CreateMetaDatabaseResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type CreateMlflowServerRequestParams struct {
+	// <p>MlFlow Server 名称</p>
+	ServerName *string `json:"ServerName,omitnil,omitempty" name:"ServerName"`
+
+	// <p>资源分区 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源组（逻辑队列名，可选）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>MlFlow 镜像</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储配置 JSON，按 StorageMode 解释：cos={bucket,region,path}，cfs={fileSystemId,path}（cos/cfs 必填，local 为空）</p>
+	StorageConfig *string `json:"StorageConfig,omitnil,omitempty" name:"StorageConfig"`
+
+	// <p>存储模式: cos / cfs / local</p>
+	StorageMode *string `json:"StorageMode,omitnil,omitempty" name:"StorageMode"`
+
+	// <p>MlFlow的资源配置</p>
+	ResourceConfig *MlFlowResourceConfig `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>标签列表（TagKey-TagValue），用于将 MLflow Server 与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+type CreateMlflowServerRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>MlFlow Server 名称</p>
+	ServerName *string `json:"ServerName,omitnil,omitempty" name:"ServerName"`
+
+	// <p>资源分区 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源组（逻辑队列名，可选）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>MlFlow 镜像</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储配置 JSON，按 StorageMode 解释：cos={bucket,region,path}，cfs={fileSystemId,path}（cos/cfs 必填，local 为空）</p>
+	StorageConfig *string `json:"StorageConfig,omitnil,omitempty" name:"StorageConfig"`
+
+	// <p>存储模式: cos / cfs / local</p>
+	StorageMode *string `json:"StorageMode,omitnil,omitempty" name:"StorageMode"`
+
+	// <p>MlFlow的资源配置</p>
+	ResourceConfig *MlFlowResourceConfig `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>标签列表（TagKey-TagValue），用于将 MLflow Server 与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+}
+
+func (r *CreateMlflowServerRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateMlflowServerRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServerName")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Queue")
+	delete(f, "Image")
+	delete(f, "StorageConfig")
+	delete(f, "StorageMode")
+	delete(f, "ResourceConfig")
+	delete(f, "Tags")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateMlflowServerRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateMlflowServerResponseParams struct {
+	// <p>MlFlow Server 业务信息</p>
+	MlFlowServer *MlFlowServerInfo `json:"MlFlowServer,omitnil,omitempty" name:"MlFlowServer"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateMlflowServerResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateMlflowServerResponseParams `json:"Response"`
+}
+
+func (r *CreateMlflowServerResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateMlflowServerResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CreateModelVersionRequestParams struct {
 	// <p>模型UID</p>
 	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
@@ -4757,6 +6197,12 @@ type CreateModelVersionRequestParams struct {
 
 	// <p>是否使用用户自带存储桶（默认 false 表示平台托管）</p>
 	UseCustomStorage *bool `json:"UseCustomStorage,omitnil,omitempty" name:"UseCustomStorage"`
+
+	// <p>创建模型时，模型从goosfe里面选取，则需要传递该参数</p>
+	GooseFSConfig *GooseFSConfig `json:"GooseFSConfig,omitnil,omitempty" name:"GooseFSConfig"`
+
+	// <p>模型上传路径类型</p><p>枚举值：</p><ul><li>LOCAL： 本地上传</li><li>CFS： CFS上传</li><li>COS： COS上传</li><li>CFSTurbo： CFSTurbo上传</li><li>GooseFS： GooseFS上传</li></ul><p>选择cos、cfs、cfstrubo则必须要传storageuri，选择local时不能传递goosefsconfig</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
 }
 
 type CreateModelVersionRequest struct {
@@ -4776,6 +6222,12 @@ type CreateModelVersionRequest struct {
 
 	// <p>是否使用用户自带存储桶（默认 false 表示平台托管）</p>
 	UseCustomStorage *bool `json:"UseCustomStorage,omitnil,omitempty" name:"UseCustomStorage"`
+
+	// <p>创建模型时，模型从goosfe里面选取，则需要传递该参数</p>
+	GooseFSConfig *GooseFSConfig `json:"GooseFSConfig,omitnil,omitempty" name:"GooseFSConfig"`
+
+	// <p>模型上传路径类型</p><p>枚举值：</p><ul><li>LOCAL： 本地上传</li><li>CFS： CFS上传</li><li>COS： COS上传</li><li>CFSTurbo： CFSTurbo上传</li><li>GooseFS： GooseFS上传</li></ul><p>选择cos、cfs、cfstrubo则必须要传storageuri，选择local时不能传递goosefsconfig</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
 }
 
 func (r *CreateModelVersionRequest) ToJsonString() string {
@@ -4795,6 +6247,8 @@ func (r *CreateModelVersionRequest) FromJsonString(s string) error {
 	delete(f, "Description")
 	delete(f, "StorageUri")
 	delete(f, "UseCustomStorage")
+	delete(f, "GooseFSConfig")
+	delete(f, "StorageType")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateModelVersionRequest has unknown keys!", "")
 	}
@@ -5267,19 +6721,19 @@ func (r *CreatePartitionQueueResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreatePartitionRequestParams struct {
-	// <p>交易类型：purchase-新购，renew-续费，modify-变配</p>
+	// <p>交易类型：purchase-新购</p>
 	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
 
-	// <p>付费模式：0-后付费，1-预付费</p>
+	// <p>付费模式：1-预付费</p>
 	PayMode *uint64 `json:"PayMode,omitnil,omitempty" name:"PayMode"`
 
 	// <p>资源配额列表（计费项+数量）</p>
 	ResourceQuotaList []*ResourceQuota `json:"ResourceQuotaList,omitnil,omitempty" name:"ResourceQuotaList"`
 
-	// <p>时间大小，预付费时为购买月数，后付费时为3600</p>
+	// <p>时间大小，预付费时为购买月数</p>
 	TimeSpan *int64 `json:"TimeSpan,omitnil,omitempty" name:"TimeSpan"`
 
-	// <p>时间单位，预付费为m（月），后付费为s（秒）</p>
+	// <p>时间单位，预付费为m（月）</p>
 	TimeUnit *string `json:"TimeUnit,omitnil,omitempty" name:"TimeUnit"`
 
 	// <p>自动续费标志：0-默认，1-自动续费，2-不自动续费（仅预付费有效）</p>
@@ -5288,26 +6742,26 @@ type CreatePartitionRequestParams struct {
 	// <p>弹性资源池名称，用于订单页展示</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// <p>队列描述</p>
+	// <p>资源包描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 }
 
 type CreatePartitionRequest struct {
 	*tchttp.BaseRequest
 	
-	// <p>交易类型：purchase-新购，renew-续费，modify-变配</p>
+	// <p>交易类型：purchase-新购</p>
 	ActionType *string `json:"ActionType,omitnil,omitempty" name:"ActionType"`
 
-	// <p>付费模式：0-后付费，1-预付费</p>
+	// <p>付费模式：1-预付费</p>
 	PayMode *uint64 `json:"PayMode,omitnil,omitempty" name:"PayMode"`
 
 	// <p>资源配额列表（计费项+数量）</p>
 	ResourceQuotaList []*ResourceQuota `json:"ResourceQuotaList,omitnil,omitempty" name:"ResourceQuotaList"`
 
-	// <p>时间大小，预付费时为购买月数，后付费时为3600</p>
+	// <p>时间大小，预付费时为购买月数</p>
 	TimeSpan *int64 `json:"TimeSpan,omitnil,omitempty" name:"TimeSpan"`
 
-	// <p>时间单位，预付费为m（月），后付费为s（秒）</p>
+	// <p>时间单位，预付费为m（月）</p>
 	TimeUnit *string `json:"TimeUnit,omitnil,omitempty" name:"TimeUnit"`
 
 	// <p>自动续费标志：0-默认，1-自动续费，2-不自动续费（仅预付费有效）</p>
@@ -5316,7 +6770,7 @@ type CreatePartitionRequest struct {
 	// <p>弹性资源池名称，用于订单页展示</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// <p>队列描述</p>
+	// <p>资源包描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 }
 
@@ -7482,6 +8936,63 @@ func (r *CreateTcIcebergTableResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type CreateTrainingJobInstanceRequestParams struct {
+	// <p>训练作业配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+type CreateTrainingJobInstanceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练作业配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+func (r *CreateTrainingJobInstanceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateTrainingJobInstanceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateTrainingJobInstanceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateTrainingJobInstanceResponseParams struct {
+	// <p>训练实例详情配置</p>
+	Instance *TrainingJobInstance `json:"Instance,omitnil,omitempty" name:"Instance"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateTrainingJobInstanceResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateTrainingJobInstanceResponseParams `json:"Response"`
+}
+
+func (r *CreateTrainingJobInstanceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateTrainingJobInstanceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type CreateUserRequestParams struct {
 	// 需要授权的子用户uin，可以通过腾讯云控制台右上角 → “账号信息” → “账号ID进行查看”。
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
@@ -8697,52 +10208,72 @@ type DatabaseResponseInfo struct {
 	IsInformationSchema *bool `json:"IsInformationSchema,omitnil,omitempty" name:"IsInformationSchema"`
 }
 
+type DatasetMount struct {
+	// <p>数据集ID</p>
+	DatasetId *string `json:"DatasetId,omitnil,omitempty" name:"DatasetId"`
+
+	// <p>数据集名称</p>
+	DatasetName *string `json:"DatasetName,omitnil,omitempty" name:"DatasetName"`
+
+	// <p>挂载信息</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>验证集信息</p>
+	Eval *EvalDatasetConfig `json:"Eval,omitnil,omitempty" name:"Eval"`
+
+	// <p>数据集为单个文件时，若需挂载单个文件，需提供文件名</p>
+	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
+}
+
 type DatasourceConnectionConfig struct {
-	// Mysql数据源连接的属性
+	// <p>Mysql数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Mysql *MysqlInfo `json:"Mysql,omitnil,omitempty" name:"Mysql"`
 
-	// Hive数据源连接的属性
+	// <p>Hive数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Hive *HiveInfo `json:"Hive,omitnil,omitempty" name:"Hive"`
 
-	// Kafka数据源连接的属性
+	// <p>Kafka数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Kafka *KafkaInfo `json:"Kafka,omitnil,omitempty" name:"Kafka"`
 
-	// 其他数据源连接的属性
+	// <p>其他数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	OtherDatasourceConnection *OtherDatasourceConnection `json:"OtherDatasourceConnection,omitnil,omitempty" name:"OtherDatasourceConnection"`
 
-	// PostgreSQL数据源连接的属性
+	// <p>PostgreSQL数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	PostgreSql *DataSourceInfo `json:"PostgreSql,omitnil,omitempty" name:"PostgreSql"`
 
-	// SQLServer数据源连接的属性
+	// <p>SQLServer数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	SqlServer *DataSourceInfo `json:"SqlServer,omitnil,omitempty" name:"SqlServer"`
 
-	// ClickHouse数据源连接的属性
+	// <p>ClickHouse数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ClickHouse *DataSourceInfo `json:"ClickHouse,omitnil,omitempty" name:"ClickHouse"`
 
-	// Elasticsearch数据源连接的属性
+	// <p>Elasticsearch数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Elasticsearch *ElasticsearchInfo `json:"Elasticsearch,omitnil,omitempty" name:"Elasticsearch"`
 
-	// TDSQL-PostgreSQL数据源连接的属性
+	// <p>TDSQL-PostgreSQL数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	TDSQLPostgreSql *DataSourceInfo `json:"TDSQLPostgreSql,omitnil,omitempty" name:"TDSQLPostgreSql"`
 
-	// Doris数据源连接的属性
+	// <p>Doris数据源连接的属性</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	TCHouseD *TCHouseD `json:"TCHouseD,omitnil,omitempty" name:"TCHouseD"`
 
-	// TccHive数据目录连接信息
+	// <p>TccHive数据目录连接信息</p>
 	TccHive *TccHive `json:"TccHive,omitnil,omitempty" name:"TccHive"`
 
-	// MongoDB 数据源
+	// <p>MongoDB 数据源</p>
 	MongoDB *DataSourceInfo `json:"MongoDB,omitnil,omitempty" name:"MongoDB"`
+
+	// <p>TCHouseP数据源</p>
+	TCHouseP *TCHousePInfo `json:"TCHouseP,omitnil,omitempty" name:"TCHouseP"`
 }
 
 type DatasourceConnectionInfo struct {
@@ -8819,6 +10350,114 @@ type DatasourceConnectionLocation struct {
 
 	// Subnet的IPv4 CIDR
 	SubnetCidrBlock *string `json:"SubnetCidrBlock,omitnil,omitempty" name:"SubnetCidrBlock"`
+}
+
+// Predefined struct for user
+type DeleteApiKeyRequestParams struct {
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+}
+
+type DeleteApiKeyRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+}
+
+func (r *DeleteApiKeyRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteApiKeyRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ApiKeyId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteApiKeyRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteApiKeyResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteApiKeyResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteApiKeyResponseParams `json:"Response"`
+}
+
+func (r *DeleteApiKeyResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteApiKeyResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteBenchmarkTaskRequestParams struct {
+	// <p>评测任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+type DeleteBenchmarkTaskRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>评测任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+func (r *DeleteBenchmarkTaskRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteBenchmarkTaskRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TaskId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteBenchmarkTaskRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteBenchmarkTaskResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteBenchmarkTaskResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteBenchmarkTaskResponseParams `json:"Response"`
+}
+
+func (r *DeleteBenchmarkTaskResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteBenchmarkTaskResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
@@ -9109,6 +10748,121 @@ func (r *DeleteDataMaskStrategyResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DeleteDeploymentRequestParams struct {
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+}
+
+type DeleteDeploymentRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+}
+
+func (r *DeleteDeploymentRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDeploymentRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DeploymentId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteDeploymentRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteDeploymentResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteDeploymentResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteDeploymentResponseParams `json:"Response"`
+}
+
+func (r *DeleteDeploymentResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDeploymentResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteInferenceServiceRequestParams struct {
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>删除关联的 APIKeys</p>
+	DeleteBoundApiKeys *bool `json:"DeleteBoundApiKeys,omitnil,omitempty" name:"DeleteBoundApiKeys"`
+}
+
+type DeleteInferenceServiceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>删除关联的 APIKeys</p>
+	DeleteBoundApiKeys *bool `json:"DeleteBoundApiKeys,omitnil,omitempty" name:"DeleteBoundApiKeys"`
+}
+
+func (r *DeleteInferenceServiceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteInferenceServiceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	delete(f, "DeleteBoundApiKeys")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteInferenceServiceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteInferenceServiceResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteInferenceServiceResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteInferenceServiceResponseParams `json:"Response"`
+}
+
+func (r *DeleteInferenceServiceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteInferenceServiceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DeleteJobSpecRequestParams struct {
 	// 配置ID
 	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
@@ -9280,6 +11034,182 @@ func (r *DeleteMetaDatabaseResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DeleteMetaDatabaseResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteMlflowServerRequestParams struct {
+	// <p>MlFlow Server的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+type DeleteMlflowServerRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>MlFlow Server的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+func (r *DeleteMlflowServerRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteMlflowServerRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServerId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteMlflowServerRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteMlflowServerResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteMlflowServerResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteMlflowServerResponseParams `json:"Response"`
+}
+
+func (r *DeleteMlflowServerResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteMlflowServerResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteModelRequestParams struct {
+	// <p>模型 UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+}
+
+type DeleteModelRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型 UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+}
+
+func (r *DeleteModelRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteModelRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteModelRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteModelResponseParams struct {
+	// <p>删除的模型版本数量</p>
+	DeletedVersionCount *int64 `json:"DeletedVersionCount,omitnil,omitempty" name:"DeletedVersionCount"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteModelResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteModelResponseParams `json:"Response"`
+}
+
+func (r *DeleteModelResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteModelResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteModelVersionRequestParams struct {
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>要删除的版本号（如 v1, v2）</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+}
+
+type DeleteModelVersionRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型UID</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>要删除的版本号（如 v1, v2）</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+}
+
+func (r *DeleteModelVersionRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteModelVersionRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	delete(f, "ModelVersion")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteModelVersionRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteModelVersionResponseParams struct {
+	// <p>是否整个模型已被删除（最后一个版本被删除时为 true）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelDeleted *bool `json:"ModelDeleted,omitnil,omitempty" name:"ModelDeleted"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteModelVersionResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteModelVersionResponseParams `json:"Response"`
+}
+
+func (r *DeleteModelVersionResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteModelVersionResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -9906,6 +11836,114 @@ func (r *DeleteThirdPartyAccessUserResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DeleteTrainingJobInstanceRequestParams struct {
+	// <p>训练实例 ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type DeleteTrainingJobInstanceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练实例 ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *DeleteTrainingJobInstanceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteTrainingJobInstanceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteTrainingJobInstanceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteTrainingJobInstanceResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteTrainingJobInstanceResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteTrainingJobInstanceResponseParams `json:"Response"`
+}
+
+func (r *DeleteTrainingJobInstanceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteTrainingJobInstanceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteTrainingJobSpecRequestParams struct {
+	// <p>训练作业配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+type DeleteTrainingJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练作业配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+func (r *DeleteTrainingJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteTrainingJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteTrainingJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteTrainingJobSpecResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteTrainingJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteTrainingJobSpecResponseParams `json:"Response"`
+}
+
+func (r *DeleteTrainingJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteTrainingJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DeleteUserRequestParams struct {
 	// 需要删除的用户的Id
 	UserIds []*string `json:"UserIds,omitnil,omitempty" name:"UserIds"`
@@ -10169,6 +12207,209 @@ type DependencyPackage struct {
 	PackagePath *string `json:"PackagePath,omitnil,omitempty" name:"PackagePath"`
 }
 
+type DeploymentInfo struct {
+	// <p>部署 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>部署名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>部署使用的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>部署状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>推理引擎（vLLM/SGLang 等）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>期望副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>可用副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AvailableReplicas *int64 `json:"AvailableReplicas,omitnil,omitempty" name:"AvailableReplicas"`
+
+	// <p>资源配置（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>ray head 是否开启高可用</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>高级参数（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AdvancedParams *string `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// <p>是否开启自动伸缩</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>模型存储配置（Catalog JSON，记录模型 COS 挂载信息）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelStorageConfig *string `json:"ModelStorageConfig,omitnil,omitempty" name:"ModelStorageConfig"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>Neutrino Serve ID (RayService CR name)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NeutrinoServeId *string `json:"NeutrinoServeId,omitnil,omitempty" name:"NeutrinoServeId"`
+
+	// <p>Ray Dashboard 访问地址（通过 Ingress 代理，仅 Running 状态的部署有值）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RayDashboardUrl *string `json:"RayDashboardUrl,omitnil,omitempty" name:"RayDashboardUrl"`
+
+	// <p>资源分区 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源队列名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>App id</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>Uin</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>SubAccountUin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>AdvancedOptions 高级参数（JSON 字符串，扁平 KV 结构，key 形如 spec.rayClusterConfig.headGroupSpec.serviceType）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>自定义镜像地址（为空则使用引擎默认镜像）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>资源分区名称（后端按 ResourcePartitionId 反查 ResourceService 填充；分区不存在或 ResourceManager 未启用时可能为 null）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+}
+
+type DeploymentReplicaInfo struct {
+	// <p>关联的部署ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentId *uint64 `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>副本名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>副本状态（Running/Pending/Failed/Terminated）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>重启次数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RestartCount *int64 `json:"RestartCount,omitnil,omitempty" name:"RestartCount"`
+
+	// <p>节点类型（head/worker）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NodeType *string `json:"NodeType,omitnil,omitempty" name:"NodeType"`
+
+	// <p>启动时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>Pod IP</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PodIp *string `json:"PodIp,omitnil,omitempty" name:"PodIp"`
+
+	// <p>节点名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NodeName *string `json:"NodeName,omitnil,omitempty" name:"NodeName"`
+
+	// <p>节点 IP</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NodeIp *string `json:"NodeIp,omitnil,omitempty" name:"NodeIp"`
+
+	// <p>命名空间</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// <p>CPU 请求</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CpuRequest *string `json:"CpuRequest,omitnil,omitempty" name:"CpuRequest"`
+
+	// <p>CPU 限制</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CpuLimit *string `json:"CpuLimit,omitnil,omitempty" name:"CpuLimit"`
+
+	// <p>内存请求</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MemoryRequest *string `json:"MemoryRequest,omitnil,omitempty" name:"MemoryRequest"`
+
+	// <p>内存限制</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MemoryLimit *string `json:"MemoryLimit,omitnil,omitempty" name:"MemoryLimit"`
+
+	// <p>GPU 数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GpuCount *int64 `json:"GpuCount,omitnil,omitempty" name:"GpuCount"`
+
+	// <p>容器镜像</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+}
+
+type DeploymentResourceInfo struct {
+	// <p>部署业务唯一标识（deploymentUid）</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>部署名称</p>
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>部署状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>Worker 节点 BillingItem</p>
+	WorkerBillingItem *string `json:"WorkerBillingItem,omitnil,omitempty" name:"WorkerBillingItem"`
+
+	// <p>Worker 节点规格倍数</p>
+	WorkerSpec *int64 `json:"WorkerSpec,omitnil,omitempty" name:"WorkerSpec"`
+
+	// <p>Worker 节点资源类型，枚举： • GU — GPU 计费单位 • CU — CPU 计费单位</p>
+	WorkerResourceType *string `json:"WorkerResourceType,omitnil,omitempty" name:"WorkerResourceType"`
+
+	// <p>Head 节点 BillingItem</p>
+	HeadBillingItem *string `json:"HeadBillingItem,omitnil,omitempty" name:"HeadBillingItem"`
+
+	// <p>Head 节点规格倍数</p>
+	HeadSpec *int64 `json:"HeadSpec,omitnil,omitempty" name:"HeadSpec"`
+
+	// <p>Head 节点资源类型。当前实现恒为 CU</p>
+	HeadResourceType *string `json:"HeadResourceType,omitnil,omitempty" name:"HeadResourceType"`
+
+	// <p>GPU 型号。CPU 部署或型号未知时为空串 &quot;&quot;</p>
+	GpuType *string `json:"GpuType,omitnil,omitempty" name:"GpuType"`
+
+	// <p>期望副本数</p>
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+}
+
 // Predefined struct for user
 type DescribeAdvancedStoreLocationRequestParams struct {
 
@@ -10232,6 +12473,242 @@ func (r *DescribeAdvancedStoreLocationResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeAdvancedStoreLocationResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeBindablePrometheusRequestParams struct {
+	// <p>TKE 集群 ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>Prometheus 实例 ID（用于列表精确搜索）</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>分页大小，默认 20，最大 100</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// <p>分页偏移，默认 0</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+}
+
+type DescribeBindablePrometheusRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>TKE 集群 ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>Prometheus 实例 ID（用于列表精确搜索）</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>分页大小，默认 20，最大 100</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// <p>分页偏移，默认 0</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+}
+
+func (r *DescribeBindablePrometheusRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeBindablePrometheusRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "InstanceId")
+	delete(f, "Limit")
+	delete(f, "Offset")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeBindablePrometheusRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeBindablePrometheusResponseParams struct {
+	// <p>TKE 集群是否已绑定 Prometheus 实例</p>
+	Bound *bool `json:"Bound,omitnil,omitempty" name:"Bound"`
+
+	// <p>Prometheus 实例总数（未分页前）；Bound=false 时有意义</p>
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// <p>Prometheus 实例列表；Bound=false 时返回；已按同 VPC 优先稳定排序</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Instances []*PrometheusInstanceItem `json:"Instances,omitnil,omitempty" name:"Instances"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeBindablePrometheusResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeBindablePrometheusResponseParams `json:"Response"`
+}
+
+func (r *DescribeBindablePrometheusResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeBindablePrometheusResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClsTopicsRequestParams struct {
+	// <p>日志主题名称（模糊匹配），可为空</p>
+	TopicName *string `json:"TopicName,omitnil,omitempty" name:"TopicName"`
+
+	// <p>日志主题 ID（精确匹配），可为空</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+
+	// <p>分页偏移量，从 0 开始，默认 0</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>分页每页条数，默认 20，最大 100</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeClsTopicsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>日志主题名称（模糊匹配），可为空</p>
+	TopicName *string `json:"TopicName,omitnil,omitempty" name:"TopicName"`
+
+	// <p>日志主题 ID（精确匹配），可为空</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+
+	// <p>分页偏移量，从 0 开始，默认 0</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>分页每页条数，默认 20，最大 100</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *DescribeClsTopicsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClsTopicsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TopicName")
+	delete(f, "TopicId")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeClsTopicsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClsTopicsResponseParams struct {
+	// <p>满足条件的日志主题总数（与入参 Limit 无关）</p>
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// <p>日志主题列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Topics []*ClsTopicItem `json:"Topics,omitnil,omitempty" name:"Topics"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeClsTopicsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeClsTopicsResponseParams `json:"Response"`
+}
+
+func (r *DescribeClsTopicsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClsTopicsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterEventLogSwitchRequestParams struct {
+	// <p>TKE 集群 ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+type DescribeClusterEventLogSwitchRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>TKE 集群 ID</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+}
+
+func (r *DescribeClusterEventLogSwitchRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterEventLogSwitchRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeClusterEventLogSwitchRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeClusterEventLogSwitchResponseParams struct {
+	// <p>TKE 集群 ID（回显）</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>事件日志是否已开启</p>
+	Enable *bool `json:"Enable,omitnil,omitempty" name:"Enable"`
+
+	// <p>关联的 CLS 日志集 ID（Enable=true 时返回）</p>
+	LogsetId *string `json:"LogsetId,omitnil,omitempty" name:"LogsetId"`
+
+	// <p>关联的 CLS 日志主题 ID（Enable=true 时返回）</p>
+	TopicId *string `json:"TopicId,omitnil,omitempty" name:"TopicId"`
+
+	// <p>关联的 CLS 日志主题所在地域（Enable=true 时返回）</p>
+	TopicRegion *string `json:"TopicRegion,omitnil,omitempty" name:"TopicRegion"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeClusterEventLogSwitchResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeClusterEventLogSwitchResponseParams `json:"Response"`
+}
+
+func (r *DescribeClusterEventLogSwitchResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeClusterEventLogSwitchResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -12054,6 +14531,76 @@ func (r *DescribeDatasourceConnectionResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeEmrClusterInfoRequestParams struct {
+	// <p>EMR 集群 ID，例如 emr-40ybwbbn</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type DescribeEmrClusterInfoRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>EMR 集群 ID，例如 emr-40ybwbbn</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *DescribeEmrClusterInfoRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeEmrClusterInfoRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeEmrClusterInfoRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeEmrClusterInfoResponseParams struct {
+	// <p>EMR 集群 ID，例如 emr-40ybwbbn</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>EMR 集群名称</p>
+	ClusterName *string `json:"ClusterName,omitnil,omitempty" name:"ClusterName"`
+
+	// <p>集群绑定的 COS Bucket 名称</p>
+	CosBucket *string `json:"CosBucket,omitnil,omitempty" name:"CosBucket"`
+
+	// <p>关联的 TKE 集群 ID，例如 cls-xxxxxxxx</p>
+	TkeClusterId *string `json:"TkeClusterId,omitnil,omitempty" name:"TkeClusterId"`
+
+	// <p>集群资源用量（Cpu / Mem）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceUsage *EmrResourceUsage `json:"ResourceUsage,omitnil,omitempty" name:"ResourceUsage"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeEmrClusterInfoResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeEmrClusterInfoResponseParams `json:"Response"`
+}
+
+func (r *DescribeEmrClusterInfoResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeEmrClusterInfoResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeEngineNetworksRequestParams struct {
 	// 排序字段
 	SortBy *string `json:"SortBy,omitnil,omitempty" name:"SortBy"`
@@ -12746,6 +15293,9 @@ func (r *DescribeMCPTaskResponse) FromJsonString(s string) error {
 type DescribeMCPTaskResultRequestParams struct {
 	// <p>任务ID</p>
 	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>下一次请求数据</p>
+	NextToken *string `json:"NextToken,omitnil,omitempty" name:"NextToken"`
 }
 
 type DescribeMCPTaskResultRequest struct {
@@ -12753,6 +15303,9 @@ type DescribeMCPTaskResultRequest struct {
 	
 	// <p>任务ID</p>
 	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>下一次请求数据</p>
+	NextToken *string `json:"NextToken,omitnil,omitempty" name:"NextToken"`
 }
 
 func (r *DescribeMCPTaskResultRequest) ToJsonString() string {
@@ -12768,6 +15321,7 @@ func (r *DescribeMCPTaskResultRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "TaskId")
+	delete(f, "NextToken")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMCPTaskResultRequest has unknown keys!", "")
 	}
@@ -12796,6 +15350,411 @@ func (r *DescribeMCPTaskResultResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeMCPTaskResultResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMlFlowConfigRequestParams struct {
+	// <p>训练实例 ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type DescribeMlFlowConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练实例 ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *DescribeMlFlowConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMlFlowConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMlFlowConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMlFlowConfigResponseParams struct {
+	// <p>MLflow 的实验 ID，对应训练作业配置</p>
+	ExperimentID *string `json:"ExperimentID,omitnil,omitempty" name:"ExperimentID"`
+
+	// <p>MLflow 的 RunID，对应训练作业实例 ID</p>
+	RunID *string `json:"RunID,omitnil,omitempty" name:"RunID"`
+
+	// <p>实例级 MLflow 模式：local / remote / none。云上一般为 Remote</p><p>枚举值：</p><ul><li>remote： 使用远程 MLflow </li><li>local： 使用本地启动的 MLflow</li><li>none： 不启用 MLflow</li></ul>
+	MlFlowMode *string `json:"MlFlowMode,omitnil,omitempty" name:"MlFlowMode"`
+
+	// <p>实例级 MLflow 访问 URL</p>
+	MlFlowUrl *string `json:"MlFlowUrl,omitnil,omitempty" name:"MlFlowUrl"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeMlFlowConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeMlFlowConfigResponseParams `json:"Response"`
+}
+
+func (r *DescribeMlFlowConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMlFlowConfigResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMlflowServerEventsRequestParams struct {
+	// <p>MlFlowServer的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+
+	// <p>查询起始时间，单位ms</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>查询结束时间，单位ms</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>翻页上下文，首次查询不传，后续翻页传入上一次返回的 Context 值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+
+	// <p>事件类型过滤，仅允许 ASCII 字母（如 Normal、Warning）</p>
+	EventType *string `json:"EventType,omitnil,omitempty" name:"EventType"`
+
+	// <p>每次查询数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>排序字段，目前只支持EventTime</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type DescribeMlflowServerEventsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>MlFlowServer的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+
+	// <p>查询起始时间，单位ms</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>查询结束时间，单位ms</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>翻页上下文，首次查询不传，后续翻页传入上一次返回的 Context 值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+
+	// <p>事件类型过滤，仅允许 ASCII 字母（如 Normal、Warning）</p>
+	EventType *string `json:"EventType,omitnil,omitempty" name:"EventType"`
+
+	// <p>每次查询数量</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>排序字段，目前只支持EventTime</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *DescribeMlflowServerEventsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMlflowServerEventsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServerId")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Context")
+	delete(f, "EventType")
+	delete(f, "PageSize")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMlflowServerEventsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMlflowServerEventsResponseParams struct {
+	// <p>翻页上下文，下一次分页请求时传入此值</p>
+	Context *string `json:"Context,omitnil,omitempty" name:"Context"`
+
+	// <p>是否已经返回所有符合条件的日志，true 表示已全部返回</p>
+	ListOver *bool `json:"ListOver,omitnil,omitempty" name:"ListOver"`
+
+	// <p>本次检索实际使用的起始时间（Unix 时间戳，毫秒）</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>本次检索实际使用的结束时间（Unix 时间戳，毫秒）</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>事件列表</p>
+	Events []*EventItem `json:"Events,omitnil,omitempty" name:"Events"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeMlflowServerEventsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeMlflowServerEventsResponseParams `json:"Response"`
+}
+
+func (r *DescribeMlflowServerEventsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMlflowServerEventsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMlflowServerPodsRequestParams struct {
+	// <p>MlFlowServer所使用的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+type DescribeMlflowServerPodsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>MlFlowServer所使用的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+func (r *DescribeMlflowServerPodsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMlflowServerPodsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServerId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMlflowServerPodsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMlflowServerPodsResponseParams struct {
+	// <p>MlFlowServer的Pod列表，实际上只有1个POD</p>
+	Items []*PodItem `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeMlflowServerPodsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeMlflowServerPodsResponseParams `json:"Response"`
+}
+
+func (r *DescribeMlflowServerPodsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMlflowServerPodsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMlflowServerRequestParams struct {
+	// <p>MlFlowServer的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+type DescribeMlflowServerRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>MlFlowServer的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+func (r *DescribeMlflowServerRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMlflowServerRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServerId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeMlflowServerRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeMlflowServerResponseParams struct {
+	// <p>MlFlowServer的详情</p>
+	MlFlowServer *MlFlowServerInfo `json:"MlFlowServer,omitnil,omitempty" name:"MlFlowServer"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeMlflowServerResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeMlflowServerResponseParams `json:"Response"`
+}
+
+func (r *DescribeMlflowServerResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeMlflowServerResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeModelEnginesRequestParams struct {
+	// <p>模型业务唯一标识</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+}
+
+type DescribeModelEnginesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型业务唯一标识</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+}
+
+func (r *DescribeModelEnginesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeModelEnginesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeModelEnginesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeModelEnginesResponseParams struct {
+	// <p>可用的推理引擎列表</p>
+	Engines []*InferenceEngineInfo `json:"Engines,omitnil,omitempty" name:"Engines"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeModelEnginesResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeModelEnginesResponseParams `json:"Response"`
+}
+
+func (r *DescribeModelEnginesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeModelEnginesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeModelTaskOptionsRequestParams struct {
+	// <p>模型类型（如 LLM、Embedding、ML），不传返回全部类型的 Tasks</p>
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+}
+
+type DescribeModelTaskOptionsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型类型（如 LLM、Embedding、ML），不传返回全部类型的 Tasks</p>
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+}
+
+func (r *DescribeModelTaskOptionsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeModelTaskOptionsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelType")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeModelTaskOptionsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeModelTaskOptionsResponseParams struct {
+	// <p>各模型类型对应的可选任务列表</p>
+	TaskOptions []*TaskOptions `json:"TaskOptions,omitnil,omitempty" name:"TaskOptions"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeModelTaskOptionsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeModelTaskOptionsResponseParams `json:"Response"`
+}
+
+func (r *DescribeModelTaskOptionsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeModelTaskOptionsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -13757,6 +16716,156 @@ func (r *DescribePartitionsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribePostTrainingPresetRequestParams struct {
+	// <p>使用的大模型微调算法</p><p>枚举值：</p><ul><li>sft： Supervised Fine-Tuning，监督微调</li><li>dpo： Direct Preference Optimization，模型偏好训练微调</li><li>grpo： Group Relative Policy Optimization，组相对策略优化</li></ul>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// <p>训练模式，会根据不同训练模式推荐不同的训练参数</p><p>枚举值：</p><ul><li>balanced： 均衡模式，标准配置，兼顾训练速度和模型效果</li><li>quality： 质量优先，更低学习率 / 更多轮次 / 更大 LoRA rank，追求最佳效果</li><li>speed： 速度优先，大 batch / 关闭 grad_ckpt / 短序列，最快迭代验证</li><li>custom： 自定义模式，手动调整各项参数</li></ul><p>默认值：balanced</p>
+	TrainingMode *string `json:"TrainingMode,omitnil,omitempty" name:"TrainingMode"`
+
+	// <p>参数微调方式</p><p>枚举值：</p><ul><li>lora： 轻量级微调大模型的方法</li><li>full： 全参数大模型微调</li></ul>
+	FineTuneType *string `json:"FineTuneType,omitnil,omitempty" name:"FineTuneType"`
+
+	// <p>模型参数大小，如 0.8B，就是 0.8的参数量。370B 模型，就是 370</p>
+	ParameterSize *float64 `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+}
+
+type DescribePostTrainingPresetRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>使用的大模型微调算法</p><p>枚举值：</p><ul><li>sft： Supervised Fine-Tuning，监督微调</li><li>dpo： Direct Preference Optimization，模型偏好训练微调</li><li>grpo： Group Relative Policy Optimization，组相对策略优化</li></ul>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// <p>训练模式，会根据不同训练模式推荐不同的训练参数</p><p>枚举值：</p><ul><li>balanced： 均衡模式，标准配置，兼顾训练速度和模型效果</li><li>quality： 质量优先，更低学习率 / 更多轮次 / 更大 LoRA rank，追求最佳效果</li><li>speed： 速度优先，大 batch / 关闭 grad_ckpt / 短序列，最快迭代验证</li><li>custom： 自定义模式，手动调整各项参数</li></ul><p>默认值：balanced</p>
+	TrainingMode *string `json:"TrainingMode,omitnil,omitempty" name:"TrainingMode"`
+
+	// <p>参数微调方式</p><p>枚举值：</p><ul><li>lora： 轻量级微调大模型的方法</li><li>full： 全参数大模型微调</li></ul>
+	FineTuneType *string `json:"FineTuneType,omitnil,omitempty" name:"FineTuneType"`
+
+	// <p>模型参数大小，如 0.8B，就是 0.8的参数量。370B 模型，就是 370</p>
+	ParameterSize *float64 `json:"ParameterSize,omitnil,omitempty" name:"ParameterSize"`
+}
+
+func (r *DescribePostTrainingPresetRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribePostTrainingPresetRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Mode")
+	delete(f, "TrainingMode")
+	delete(f, "FineTuneType")
+	delete(f, "ParameterSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribePostTrainingPresetRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribePostTrainingPresetResponseParams struct {
+	// <p>推荐的训练资源</p>
+	Resource *PostTrainingResources `json:"Resource,omitnil,omitempty" name:"Resource"`
+
+	// <p>推荐的训练参数</p>
+	TrainingParams *TrainingParams `json:"TrainingParams,omitnil,omitempty" name:"TrainingParams"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribePostTrainingPresetResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribePostTrainingPresetResponseParams `json:"Response"`
+}
+
+func (r *DescribePostTrainingPresetResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribePostTrainingPresetResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeRecommendedParamsRequestParams struct {
+	// <p>模型业务唯一标识</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>推理引擎 ID，如 vllm、xgboost（必填）</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+}
+
+type DescribeRecommendedParamsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>模型业务唯一标识</p>
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>推理引擎 ID，如 vllm、xgboost（必填）</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+}
+
+func (r *DescribeRecommendedParamsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeRecommendedParamsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ModelUid")
+	delete(f, "Engine")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeRecommendedParamsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeRecommendedParamsResponseParams struct {
+	// <p>推荐来源: builtin | matched | default</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Source *string `json:"Source,omitnil,omitempty" name:"Source"`
+
+	// <p>推荐的高级参数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AdvancedParams *RecommendedAdvancedParams `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeRecommendedParamsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeRecommendedParamsResponseParams `json:"Response"`
+}
+
+func (r *DescribeRecommendedParamsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeRecommendedParamsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeResourceGroupUsageInfoRequestParams struct {
 	// 资源组ID
 	SessionId *string `json:"SessionId,omitnil,omitempty" name:"SessionId"`
@@ -13976,7 +17085,7 @@ func (r *DescribeSaleResourceInfoRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type DescribeSaleResourceInfoResponseParams struct {
-	// 可售卖资源规格列表
+	// 可售卖资源规格列表，包含规格、步长、单账户上限、以及库存情况
 	SaleResourceInfoList []*ResourceSaleInfo `json:"SaleResourceInfoList,omitnil,omitempty" name:"SaleResourceInfoList"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
@@ -16428,6 +19537,283 @@ func (r *DescribeThirdPartyAccessUserResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type DescribeTkeClusterImportInfoRequestParams struct {
+	// <p>EMR 集群 ID（注意：不是 TKE 集群 ID）。</p>
+	EmrClusterId *string `json:"EmrClusterId,omitnil,omitempty" name:"EmrClusterId"`
+}
+
+type DescribeTkeClusterImportInfoRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>EMR 集群 ID（注意：不是 TKE 集群 ID）。</p>
+	EmrClusterId *string `json:"EmrClusterId,omitnil,omitempty" name:"EmrClusterId"`
+}
+
+func (r *DescribeTkeClusterImportInfoRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTkeClusterImportInfoRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "EmrClusterId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTkeClusterImportInfoRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTkeClusterImportInfoResponseParams struct {
+	// <p>分区名称。</p>
+	PartitionName *string `json:"PartitionName,omitnil,omitempty" name:"PartitionName"`
+
+	// <p>EMR 集群 ID。</p>
+	EmrClusterId *string `json:"EmrClusterId,omitnil,omitempty" name:"EmrClusterId"`
+
+	// <p>COS Bucket 名称。</p>
+	CosBucketId *string `json:"CosBucketId,omitnil,omitempty" name:"CosBucketId"`
+
+	// <p>Prometheus 托管实例 ID。</p>
+	PrometheusInstanceId *string `json:"PrometheusInstanceId,omitnil,omitempty" name:"PrometheusInstanceId"`
+
+	// <p>Prometheus 托管实例名称；查询失败或未命中返回空字符串。</p>
+	PrometheusInstanceName *string `json:"PrometheusInstanceName,omitnil,omitempty" name:"PrometheusInstanceName"`
+
+	// <p>负载均衡实例 ID。</p>
+	LoadBalancerId *string `json:"LoadBalancerId,omitnil,omitempty" name:"LoadBalancerId"`
+
+	// <p>负载均衡实例名称；查询失败或未命中返回空字符串。</p>
+	LoadBalancerName *string `json:"LoadBalancerName,omitnil,omitempty" name:"LoadBalancerName"`
+
+	// <p>容器日志 CLS 日志主题 ID。</p>
+	ContainerLogTopicId *string `json:"ContainerLogTopicId,omitnil,omitempty" name:"ContainerLogTopicId"`
+
+	// <p>容器日志 CLS 日志主题名称；查询失败或未命中返回空字符串。</p>
+	ContainerLogTopicName *string `json:"ContainerLogTopicName,omitnil,omitempty" name:"ContainerLogTopicName"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTkeClusterImportInfoResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTkeClusterImportInfoResponseParams `json:"Response"`
+}
+
+func (r *DescribeTkeClusterImportInfoResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTkeClusterImportInfoResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTrainingCheckpointsRequestParams struct {
+	// <p>训练作业实例ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>当前浏览的子路径</p>
+	SubPath *string `json:"SubPath,omitnil,omitempty" name:"SubPath"`
+}
+
+type DescribeTrainingCheckpointsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练作业实例ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>当前浏览的子路径</p>
+	SubPath *string `json:"SubPath,omitnil,omitempty" name:"SubPath"`
+}
+
+func (r *DescribeTrainingCheckpointsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTrainingCheckpointsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	delete(f, "SubPath")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTrainingCheckpointsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTrainingCheckpointsResponseParams struct {
+	// <p>当前层级文件/目录列表</p>
+	Items []*SharedMountFileItem `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>当前挂载路径</p>
+	MountPath *string `json:"MountPath,omitnil,omitempty" name:"MountPath"`
+
+	// <p>当前浏览的子路径</p>
+	SubPath *string `json:"SubPath,omitnil,omitempty" name:"SubPath"`
+
+	// <p>存储类型：COS / CFS / CFS_TURBO / GOOSEFS</p>
+	StorageType *string `json:"StorageType,omitnil,omitempty" name:"StorageType"`
+
+	// <p>存储路径（COS 桶路径或 CFS/GooseFSx 挂载路径）</p>
+	StoragePath *string `json:"StoragePath,omitnil,omitempty" name:"StoragePath"`
+
+	// <p>错误或提示信息（仅在请求异常时有值）</p>
+	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
+
+	// <p>快照时间戳（仅 CFS/GooseFSx 存储时有值）</p>
+	SnapshotTimestamp *int64 `json:"SnapshotTimestamp,omitnil,omitempty" name:"SnapshotTimestamp"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTrainingCheckpointsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTrainingCheckpointsResponseParams `json:"Response"`
+}
+
+func (r *DescribeTrainingCheckpointsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTrainingCheckpointsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTrainingJobInstanceRequestParams struct {
+	// <p>训练实例ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type DescribeTrainingJobInstanceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练实例ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *DescribeTrainingJobInstanceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTrainingJobInstanceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTrainingJobInstanceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTrainingJobInstanceResponseParams struct {
+	// <p>训练实例详情</p>
+	Instance *TrainingJobInstance `json:"Instance,omitnil,omitempty" name:"Instance"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTrainingJobInstanceResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTrainingJobInstanceResponseParams `json:"Response"`
+}
+
+func (r *DescribeTrainingJobInstanceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTrainingJobInstanceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTrainingJobSpecRequestParams struct {
+	// <p>配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+type DescribeTrainingJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+}
+
+func (r *DescribeTrainingJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTrainingJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeTrainingJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeTrainingJobSpecResponseParams struct {
+	// <p>训练作业配置详情</p>
+	Spec *TrainingJobSpec `json:"Spec,omitnil,omitempty" name:"Spec"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeTrainingJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeTrainingJobSpecResponseParams `json:"Response"`
+}
+
+func (r *DescribeTrainingJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeTrainingJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeUDFPolicyRequestParams struct {
 	// udf名称
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
@@ -17948,6 +21334,14 @@ type ElasticsearchInfo struct {
 	ServiceInfo []*IpPortPair `json:"ServiceInfo,omitnil,omitempty" name:"ServiceInfo"`
 }
 
+type EmrResourceUsage struct {
+	// <p>CPU 用量，例如 2core</p>
+	Cpu *string `json:"Cpu,omitnil,omitempty" name:"Cpu"`
+
+	// <p>内存用量，例如 4GB</p>
+	Mem *string `json:"Mem,omitnil,omitempty" name:"Mem"`
+}
+
 type EngineCapabilities struct {
 	// <p>GPU 是否可选</p>
 	GpuOptional *bool `json:"GpuOptional,omitnil,omitempty" name:"GpuOptional"`
@@ -18038,6 +21432,26 @@ type Env struct {
 
 	// <p>值</p>
 	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
+type EvalDatasetConfig struct {
+	// <p>验证集模式：none / split / separate</p>
+	EvalMode *string `json:"EvalMode,omitnil,omitempty" name:"EvalMode"`
+
+	// <p>自动拆分比例（1-20，即 1%-20%），仅 split 生效</p>
+	EvalSplitRatio *float64 `json:"EvalSplitRatio,omitnil,omitempty" name:"EvalSplitRatio"`
+
+	// <p>独立验证数据集 ID（dataset 表），仅 separate 生效；与 Catalog 二选一</p>
+	EvalDatasetId *string `json:"EvalDatasetId,omitnil,omitempty" name:"EvalDatasetId"`
+
+	// <p>验证数据集名称（dataset 表 name 字段，与 EvalDatasetId 配对）</p>
+	EvalDatasetName *string `json:"EvalDatasetName,omitnil,omitempty" name:"EvalDatasetName"`
+
+	// <p>原始 Catalog 卷定义 JSON（仅 separate 生效，无数据集 ID 时使用，直接并入顶层 Catalog；与 EvalDatasetId 二选一）</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>验证用单文件名（可选，JSONL/parquet 文件名，位于挂载目录下；仅基于单个文件验证时指定）</p>
+	FileName *string `json:"FileName,omitnil,omitempty" name:"FileName"`
 }
 
 type EventItem struct {
@@ -18157,6 +21571,14 @@ type ExampleTag struct {
 type Execution struct {
 	// 自动生成SQL语句。
 	SQL *string `json:"SQL,omitnil,omitempty" name:"SQL"`
+}
+
+type FailedItem struct {
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>失败原因</p>
+	Reason *string `json:"Reason,omitnil,omitempty" name:"Reason"`
 }
 
 type FavorInfo struct {
@@ -18697,6 +22119,10 @@ type GetInferenceModelResponseParams struct {
 	// <p>Sub UIN</p>
 	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
 
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
@@ -18847,6 +22273,15 @@ type GetInferenceServiceResponseParams struct {
 
 	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
 	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>部署模式</p>
+	DeploymentMode *string `json:"DeploymentMode,omitnil,omitempty" name:"DeploymentMode"`
+
+	// <p>是否为自定义代码部署</p>
+	IsCustom *bool `json:"IsCustom,omitnil,omitempty" name:"IsCustom"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -21254,8 +24689,29 @@ func (r *GetResourceConfigResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
-type GpuSummaryItem struct {
+type GooseFSConfig struct {
+	// <p>goosefs集群id</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
+	// <p>goosefs命名空间名称</p>
+	GooseFSPath *string `json:"GooseFSPath,omitnil,omitempty" name:"GooseFSPath"`
+
+	// <p>主从节点信息</p>
+	MasterAddresses []*string `json:"MasterAddresses,omitnil,omitempty" name:"MasterAddresses"`
+}
+
+type GpuSummaryItem struct {
+	// <p>GPU 型号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GpuType *string `json:"GpuType,omitnil,omitempty" name:"GpuType"`
+
+	// <p>GPU 总数（gpuNum × replicas）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GpuCount *int64 `json:"GpuCount,omitnil,omitempty" name:"GpuCount"`
+
+	// <p>运行中的副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
 }
 
 // Predefined struct for user
@@ -21498,6 +24954,270 @@ type IcebergTablePartition struct {
 	Location *LocationInfo `json:"Location,omitnil,omitempty" name:"Location"`
 }
 
+type ImageDto struct {
+	// <p>镜像ID</p>
+	Id *int64 `json:"Id,omitnil,omitempty" name:"Id"`
+
+	// <p>镜像名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>镜像地址</p>
+	Url *string `json:"Url,omitnil,omitempty" name:"Url"`
+
+	// <p>镜像描述</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>镜像类型（Ray/Workspace）</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>镜像内置的 Ray 版本号</p>
+	RayVersion *string `json:"RayVersion,omitnil,omitempty" name:"RayVersion"`
+
+	// <p>创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+}
+
+// Predefined struct for user
+type ImportExternalClusterRequestParams struct {
+	// <p>资源池对应的分区名称。</p>
+	PartitionName *string `json:"PartitionName,omitnil,omitempty" name:"PartitionName"`
+
+	// <p>集群类型。TKE：直接导入裸 TKE 集群，ClusterId 填 TKE 集群 ID（如 cls-xxxxxxxx）；EMR：通过 EMR 集群导入，ClusterId 填 EMR 集群 ID（如 emr-xxxxxxxx）。</p>
+	ClusterType *string `json:"ClusterType,omitnil,omitempty" name:"ClusterType"`
+
+	// <p>集群 ID。ClusterType=TKE 时填 TKE 集群 ID（如 cls-xxxxxxxx）；ClusterType=EMR 时填 EMR 集群 ID（如 emr-xxxxxxxx）。</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>COS Bucket 名称（含 AppId 后缀），例如 my-bucket-1250000000。</p>
+	CosBucketId *string `json:"CosBucketId,omitnil,omitempty" name:"CosBucketId"`
+
+	// <p>Prometheus 托管实例 ID，例如 prom-xxxxxxxx。</p>
+	PrometheusInstanceId *string `json:"PrometheusInstanceId,omitnil,omitempty" name:"PrometheusInstanceId"`
+
+	// <p>负载均衡实例 ID，例如 lb-xxxxxxxx。</p>
+	LoadBalancerId *string `json:"LoadBalancerId,omitnil,omitempty" name:"LoadBalancerId"`
+
+	// <p>节点标签键值对（Key-Value 列表），用于将资源池调度限定到具备对应标签的节点。</p>
+	NodeLabels []*KVPair `json:"NodeLabels,omitnil,omitempty" name:"NodeLabels"`
+
+	// <p>资源池对应的默认分区描述，透传给下游 ResourceManager 用于分区创建。</p>
+	PartitionDescription *string `json:"PartitionDescription,omitnil,omitempty" name:"PartitionDescription"`
+
+	// <p>目标账号 AppId（跨账号导入时填写，不填则使用当前账号）。TargetAppId 和 TargetUin 必须同时填写或同时不填。</p>
+	TargetAppId *int64 `json:"TargetAppId,omitnil,omitempty" name:"TargetAppId"`
+
+	// <p>目标账号 UIN（跨账号导入时填写，不填则使用当前账号）。TargetAppId 和 TargetUin 必须同时填写或同时不填。</p>
+	TargetUin *string `json:"TargetUin,omitnil,omitempty" name:"TargetUin"`
+}
+
+type ImportExternalClusterRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>资源池对应的分区名称。</p>
+	PartitionName *string `json:"PartitionName,omitnil,omitempty" name:"PartitionName"`
+
+	// <p>集群类型。TKE：直接导入裸 TKE 集群，ClusterId 填 TKE 集群 ID（如 cls-xxxxxxxx）；EMR：通过 EMR 集群导入，ClusterId 填 EMR 集群 ID（如 emr-xxxxxxxx）。</p>
+	ClusterType *string `json:"ClusterType,omitnil,omitempty" name:"ClusterType"`
+
+	// <p>集群 ID。ClusterType=TKE 时填 TKE 集群 ID（如 cls-xxxxxxxx）；ClusterType=EMR 时填 EMR 集群 ID（如 emr-xxxxxxxx）。</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>COS Bucket 名称（含 AppId 后缀），例如 my-bucket-1250000000。</p>
+	CosBucketId *string `json:"CosBucketId,omitnil,omitempty" name:"CosBucketId"`
+
+	// <p>Prometheus 托管实例 ID，例如 prom-xxxxxxxx。</p>
+	PrometheusInstanceId *string `json:"PrometheusInstanceId,omitnil,omitempty" name:"PrometheusInstanceId"`
+
+	// <p>负载均衡实例 ID，例如 lb-xxxxxxxx。</p>
+	LoadBalancerId *string `json:"LoadBalancerId,omitnil,omitempty" name:"LoadBalancerId"`
+
+	// <p>节点标签键值对（Key-Value 列表），用于将资源池调度限定到具备对应标签的节点。</p>
+	NodeLabels []*KVPair `json:"NodeLabels,omitnil,omitempty" name:"NodeLabels"`
+
+	// <p>资源池对应的默认分区描述，透传给下游 ResourceManager 用于分区创建。</p>
+	PartitionDescription *string `json:"PartitionDescription,omitnil,omitempty" name:"PartitionDescription"`
+
+	// <p>目标账号 AppId（跨账号导入时填写，不填则使用当前账号）。TargetAppId 和 TargetUin 必须同时填写或同时不填。</p>
+	TargetAppId *int64 `json:"TargetAppId,omitnil,omitempty" name:"TargetAppId"`
+
+	// <p>目标账号 UIN（跨账号导入时填写，不填则使用当前账号）。TargetAppId 和 TargetUin 必须同时填写或同时不填。</p>
+	TargetUin *string `json:"TargetUin,omitnil,omitempty" name:"TargetUin"`
+}
+
+func (r *ImportExternalClusterRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ImportExternalClusterRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionName")
+	delete(f, "ClusterType")
+	delete(f, "ClusterId")
+	delete(f, "CosBucketId")
+	delete(f, "PrometheusInstanceId")
+	delete(f, "LoadBalancerId")
+	delete(f, "NodeLabels")
+	delete(f, "PartitionDescription")
+	delete(f, "TargetAppId")
+	delete(f, "TargetUin")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ImportExternalClusterRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ImportExternalClusterResponseParams struct {
+	// <p>已落库的 resource_pool 主行 ID。</p>
+	ResourcePoolId *int64 `json:"ResourcePoolId,omitnil,omitempty" name:"ResourcePoolId"`
+
+	// <p>资源池唯一编码。</p>
+	ResourcePoolCode *string `json:"ResourcePoolCode,omitnil,omitempty" name:"ResourcePoolCode"`
+
+	// <p>注册工作流 ID，可用于查询进度。</p>
+	WorkflowId *int64 `json:"WorkflowId,omitnil,omitempty" name:"WorkflowId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ImportExternalClusterResponse struct {
+	*tchttp.BaseResponse
+	Response *ImportExternalClusterResponseParams `json:"Response"`
+}
+
+func (r *ImportExternalClusterResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ImportExternalClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ImportTkeClusterRequestParams struct {
+	// <p>资源池对应的分区名称。</p>
+	PartitionName *string `json:"PartitionName,omitnil,omitempty" name:"PartitionName"`
+
+	// <p>EMR 集群 ID（注意：不是 TKE 集群 ID）。</p>
+	EmrClusterId *string `json:"EmrClusterId,omitnil,omitempty" name:"EmrClusterId"`
+
+	// <p>COS Bucket 名称（含 AppId 后缀），例如 my-bucket-1250000000。</p>
+	CosBucketId *string `json:"CosBucketId,omitnil,omitempty" name:"CosBucketId"`
+
+	// <p>Prometheus 托管实例 ID，例如 prom-xxxxxxxx。</p>
+	PrometheusInstanceId *string `json:"PrometheusInstanceId,omitnil,omitempty" name:"PrometheusInstanceId"`
+
+	// <p>负载均衡实例 ID，例如 lb-xxxxxxxx。</p>
+	LoadBalancerId *string `json:"LoadBalancerId,omitnil,omitempty" name:"LoadBalancerId"`
+
+	// <p>容器日志 CLS 日志主题 ID。</p>
+	ContainerLogTopicId *string `json:"ContainerLogTopicId,omitnil,omitempty" name:"ContainerLogTopicId"`
+
+	// <p>节点标签键值对（Key-Value 列表），用于将资源池调度限定到具备对应标签的 EMR-TKE 节点。</p>
+	NodeLabels []*KVPair `json:"NodeLabels,omitnil,omitempty" name:"NodeLabels"`
+
+	// <p>资源池对应的默认分区描述，透传给下游 ResourceManager 用于分区创建。</p>
+	PartitionDescription *string `json:"PartitionDescription,omitnil,omitempty" name:"PartitionDescription"`
+}
+
+type ImportTkeClusterRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>资源池对应的分区名称。</p>
+	PartitionName *string `json:"PartitionName,omitnil,omitempty" name:"PartitionName"`
+
+	// <p>EMR 集群 ID（注意：不是 TKE 集群 ID）。</p>
+	EmrClusterId *string `json:"EmrClusterId,omitnil,omitempty" name:"EmrClusterId"`
+
+	// <p>COS Bucket 名称（含 AppId 后缀），例如 my-bucket-1250000000。</p>
+	CosBucketId *string `json:"CosBucketId,omitnil,omitempty" name:"CosBucketId"`
+
+	// <p>Prometheus 托管实例 ID，例如 prom-xxxxxxxx。</p>
+	PrometheusInstanceId *string `json:"PrometheusInstanceId,omitnil,omitempty" name:"PrometheusInstanceId"`
+
+	// <p>负载均衡实例 ID，例如 lb-xxxxxxxx。</p>
+	LoadBalancerId *string `json:"LoadBalancerId,omitnil,omitempty" name:"LoadBalancerId"`
+
+	// <p>容器日志 CLS 日志主题 ID。</p>
+	ContainerLogTopicId *string `json:"ContainerLogTopicId,omitnil,omitempty" name:"ContainerLogTopicId"`
+
+	// <p>节点标签键值对（Key-Value 列表），用于将资源池调度限定到具备对应标签的 EMR-TKE 节点。</p>
+	NodeLabels []*KVPair `json:"NodeLabels,omitnil,omitempty" name:"NodeLabels"`
+
+	// <p>资源池对应的默认分区描述，透传给下游 ResourceManager 用于分区创建。</p>
+	PartitionDescription *string `json:"PartitionDescription,omitnil,omitempty" name:"PartitionDescription"`
+}
+
+func (r *ImportTkeClusterRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ImportTkeClusterRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "PartitionName")
+	delete(f, "EmrClusterId")
+	delete(f, "CosBucketId")
+	delete(f, "PrometheusInstanceId")
+	delete(f, "LoadBalancerId")
+	delete(f, "ContainerLogTopicId")
+	delete(f, "NodeLabels")
+	delete(f, "PartitionDescription")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ImportTkeClusterRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ImportTkeClusterResponseParams struct {
+	// <p>已落库的 resource_pool 主行 ID。</p>
+	ResourcePoolId *int64 `json:"ResourcePoolId,omitnil,omitempty" name:"ResourcePoolId"`
+
+	// <p>资源池唯一编码。</p>
+	ResourcePoolCode *string `json:"ResourcePoolCode,omitnil,omitempty" name:"ResourcePoolCode"`
+
+	// <p>注册工作流 ID，可用于查询进度。</p>
+	WorkflowId *int64 `json:"WorkflowId,omitnil,omitempty" name:"WorkflowId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ImportTkeClusterResponse struct {
+	*tchttp.BaseResponse
+	Response *ImportTkeClusterResponseParams `json:"Response"`
+}
+
+func (r *ImportTkeClusterResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ImportTkeClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type InferenceEngineInfo struct {
 	// <p>引擎标识符</p>
 	EngineId *string `json:"EngineId,omitnil,omitempty" name:"EngineId"`
@@ -21617,6 +25337,10 @@ type InferenceModelInfo struct {
 
 	// <p>云账户的 Sub UIN</p>
 	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 }
 
 type InferenceServiceInfo struct {
@@ -22167,32 +25891,38 @@ type LakeFileSystemToken struct {
 }
 
 type LakeFsInfo struct {
-	// 托管存储名称
+	// <p>托管存储名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 托管存储类型
+	// <p>托管存储类型</p>
 	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
 
-	// 存储用量
+	// <p>存储用量</p>
 	SpaceUsedSize *float64 `json:"SpaceUsedSize,omitnil,omitempty" name:"SpaceUsedSize"`
 
-	// 创建时候的时间戳
+	// <p>创建时候的时间戳</p>
 	CreateTimeStamp *int64 `json:"CreateTimeStamp,omitnil,omitempty" name:"CreateTimeStamp"`
 
-	// 是否是用户默认桶，0：默认桶，1：非默认桶
+	// <p>是否是用户默认桶，0：默认桶，1：非默认桶</p>
 	DefaultBucket *int64 `json:"DefaultBucket,omitnil,omitempty" name:"DefaultBucket"`
 
-	// 托管存储short name
+	// <p>托管存储short name</p>
 	ShortName *string `json:"ShortName,omitnil,omitempty" name:"ShortName"`
 
-	// 桶描述信息
+	// <p>桶描述信息</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
 
-	// 托管桶状态，当前取值为：creating、bind、readOnly、isolate
+	// <p>托管桶状态，当前取值为：creating、bind、readOnly、isolate</p>
 	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
 
-	// 托管存储桶标签列表
+	// <p>托管存储桶标签列表</p>
 	TagList []*TagInfo `json:"TagList,omitnil,omitempty" name:"TagList"`
+
+	// <p>是否是多AZ存储桶</p>
+	MultiAZ *bool `json:"MultiAZ,omitnil,omitempty" name:"MultiAZ"`
+
+	// <p>存储桶配置信息</p>
+	Configuration []*KVPair `json:"Configuration,omitnil,omitempty" name:"Configuration"`
 }
 
 // Predefined struct for user
@@ -22253,6 +25983,17 @@ func (r *LaunchStandardEngineResourceGroupsResponse) FromJsonString(s string) er
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type LbItem struct {
+	// <p>负载均衡实例 ID，例如 lb-xxxxxxxx</p>
+	LoadBalancerId *string `json:"LoadBalancerId,omitnil,omitempty" name:"LoadBalancerId"`
+
+	// <p>负载均衡实例名称</p>
+	LoadBalancerName *string `json:"LoadBalancerName,omitnil,omitempty" name:"LoadBalancerName"`
+
+	// <p>网络类型：OPEN=公网属性；INTERNAL=内网属性</p>
+	LoadBalancerType *string `json:"LoadBalancerType,omitnil,omitempty" name:"LoadBalancerType"`
+}
+
 type LinkedServiceInfo struct {
 	// <p>服务 UID</p>
 	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
@@ -22260,6 +26001,406 @@ type LinkedServiceInfo struct {
 	// <p>服务名称</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+}
+
+// Predefined struct for user
+type ListApiKeysRequestParams struct {
+	// <p>页码（默认1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤-毫秒时间戳</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-毫秒时间戳</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件。支持的过滤字段：Keyword（Key 名称模糊搜索，取第一个 Value）、Status（状态精确匹配，取第一个 Value，如 Active、Revoked）</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListApiKeysRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>页码（默认1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤-毫秒时间戳</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-毫秒时间戳</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件。支持的过滤字段：Keyword（Key 名称模糊搜索，取第一个 Value）、Status（状态精确匹配，取第一个 Value，如 Active、Revoked）</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListApiKeysRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListApiKeysRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListApiKeysRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListApiKeysResponseParams struct {
+	// <p>ApiKey列表</p>
+	Items []*ApiKeyInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>ApiKey总记录数</p>
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>ApiKey总页数</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>单页最大记录数</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>记录总页数</p>
+	TotalPages *uint64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListApiKeysResponse struct {
+	*tchttp.BaseResponse
+	Response *ListApiKeysResponseParams `json:"Response"`
+}
+
+func (r *ListApiKeysResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListApiKeysResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListAvailableApiKeysRequestParams struct {
+	// <p>页数</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>单页大小</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type ListAvailableApiKeysRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>页数</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>单页大小</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *ListAvailableApiKeysRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListAvailableApiKeysRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListAvailableApiKeysRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListAvailableApiKeysResponseParams struct {
+	// <p>总共apikey数量</p>
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>页数</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>单页大小</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *uint64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// <p>具体apikey 列表</p>
+	Items []*ApiKeyInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListAvailableApiKeysResponse struct {
+	*tchttp.BaseResponse
+	Response *ListAvailableApiKeysResponseParams `json:"Response"`
+}
+
+func (r *ListAvailableApiKeysResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListAvailableApiKeysResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListBenchmarkSummaryRequestParams struct {
+	// <p>页码（从1开始）</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListBenchmarkSummaryRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>页码（从1开始）</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListBenchmarkSummaryRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListBenchmarkSummaryRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListBenchmarkSummaryRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListBenchmarkSummaryResponseParams struct {
+	// <p>模型评测汇总列表（排行榜数据）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Items []*BenchmarkSummaryInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>总记录数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TotalPages *uint64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListBenchmarkSummaryResponse struct {
+	*tchttp.BaseResponse
+	Response *ListBenchmarkSummaryResponseParams `json:"Response"`
+}
+
+func (r *ListBenchmarkSummaryResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListBenchmarkSummaryResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListBenchmarkTasksRequestParams struct {
+	// <p>推理服务Id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>页数</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页大小</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListBenchmarkTasksRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理服务Id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>页数</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页大小</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>开始时间</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListBenchmarkTasksRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListBenchmarkTasksRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListBenchmarkTasksRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListBenchmarkTasksResponseParams struct {
+	// <p>benchmark列表</p>
+	Items []*BenchmarkTaskInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>总量</p>
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>页数</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>页大小</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>页总量</p>
+	TotalPages *uint64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListBenchmarkTasksResponse struct {
+	*tchttp.BaseResponse
+	Response *ListBenchmarkTasksResponseParams `json:"Response"`
+}
+
+func (r *ListBenchmarkTasksResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListBenchmarkTasksResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
@@ -22363,6 +26504,238 @@ func (r *ListClusterGroupsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ListClusterGroupsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListDeploymentReplicasRequestParams struct {
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>起始时间</p><p>单位： ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p><p>单位： ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListDeploymentReplicasRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>起始时间</p><p>单位： ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>结束时间</p><p>单位： ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListDeploymentReplicasRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListDeploymentReplicasRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DeploymentId")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListDeploymentReplicasRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListDeploymentReplicasResponseParams struct {
+	// <p>副本列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Items []*DeploymentReplicaInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>总记录数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListDeploymentReplicasResponse struct {
+	*tchttp.BaseResponse
+	Response *ListDeploymentReplicasResponseParams `json:"Response"`
+}
+
+func (r *ListDeploymentReplicasResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListDeploymentReplicasResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListDeploymentsRequestParams struct {
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>额外过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListDeploymentsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>页码（从1开始）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始</p><p>单位：ms</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止</p><p>单位：ms</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>额外过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListDeploymentsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListDeploymentsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListDeploymentsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListDeploymentsResponseParams struct {
+	// <p>部署列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Items []*DeploymentInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>总记录数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TotalPages *uint64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListDeploymentsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListDeploymentsResponseParams `json:"Response"`
+}
+
+func (r *ListDeploymentsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListDeploymentsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -22688,6 +27061,96 @@ func (r *ListExamplesResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ListExamplesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListImagesRequestParams struct {
+	// 关键词搜索（模糊匹配名称或描述）
+	Keyword *string `json:"Keyword,omitnil,omitempty" name:"Keyword"`
+
+	// 镜像类型过滤（Ray/Workspace）
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// 页数
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 数量
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type ListImagesRequest struct {
+	*tchttp.BaseRequest
+	
+	// 关键词搜索（模糊匹配名称或描述）
+	Keyword *string `json:"Keyword,omitnil,omitempty" name:"Keyword"`
+
+	// 镜像类型过滤（Ray/Workspace）
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// 页数
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 数量
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *ListImagesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListImagesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Keyword")
+	delete(f, "Type")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListImagesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListImagesResponseParams struct {
+	// 总记录数
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// 当前页码（从1开始）
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// 页数
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// 总页数
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 镜像列表
+	Items []*ImageDto `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListImagesResponse struct {
+	*tchttp.BaseResponse
+	Response *ListImagesResponseParams `json:"Response"`
+}
+
+func (r *ListImagesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListImagesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -23347,6 +27810,221 @@ func (r *ListLabsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ListMlflowServerTrainingInstancesRequestParams struct {
+	// <p>MlFlowServer的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+
+	// <p>分页过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>分页筛选条件</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>分页开始时间范围</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>分页结束时间范围</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>分页当前页号</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>分页每页大小</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type ListMlflowServerTrainingInstancesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>MlFlowServer的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+
+	// <p>分页过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>分页筛选条件</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>分页开始时间范围</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>分页结束时间范围</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>分页当前页号</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>分页每页大小</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *ListMlflowServerTrainingInstancesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListMlflowServerTrainingInstancesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServerId")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListMlflowServerTrainingInstancesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListMlflowServerTrainingInstancesResponseParams struct {
+	// <p>返回训练实例列表</p>
+	Items []*TrainingJobInstance `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>总数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页大小</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListMlflowServerTrainingInstancesResponse struct {
+	*tchttp.BaseResponse
+	Response *ListMlflowServerTrainingInstancesResponseParams `json:"Response"`
+}
+
+func (r *ListMlflowServerTrainingInstancesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListMlflowServerTrainingInstancesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListMlflowServersRequestParams struct {
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 200，最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤（毫秒时间戳）</p><p>单位：ms</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤（毫秒时间戳）</p><p>单位：ms</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListMlflowServersRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 200，最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤（毫秒时间戳）</p><p>单位：ms</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤（毫秒时间戳）</p><p>单位：ms</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListMlflowServersRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListMlflowServersRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListMlflowServersRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListMlflowServersResponseParams struct {
+	// <p>MlFlow列表</p>
+	Items []*MlFlowServerInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>MlFlow总数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 200，最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListMlflowServersResponse struct {
+	*tchttp.BaseResponse
+	Response *ListMlflowServersResponseParams `json:"Response"`
+}
+
+func (r *ListMlflowServersResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListMlflowServersResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ListModelVersionsRequestParams struct {
 	// <p>模型UID</p>
 	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
@@ -23772,6 +28450,88 @@ func (r *ListRayJobsResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ListRegionLbsRequestParams struct {
+	// <p>TKE 集群 ID，用于查询集群所属 VPC，进而过滤同 VPC 下的独占型 CLB，例如 cls-xxxxxxxx</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>负载均衡实例 ID 列表，最多 20 个；不传则查询同地域全部实例</p>
+	LoadBalancerIds []*string `json:"LoadBalancerIds,omitnil,omitempty" name:"LoadBalancerIds"`
+
+	// <p>分页偏移量，从 0 开始，默认 0</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>分页每页条数，默认 20，最大 100</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type ListRegionLbsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>TKE 集群 ID，用于查询集群所属 VPC，进而过滤同 VPC 下的独占型 CLB，例如 cls-xxxxxxxx</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>负载均衡实例 ID 列表，最多 20 个；不传则查询同地域全部实例</p>
+	LoadBalancerIds []*string `json:"LoadBalancerIds,omitnil,omitempty" name:"LoadBalancerIds"`
+
+	// <p>分页偏移量，从 0 开始，默认 0</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>分页每页条数，默认 20，最大 100</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *ListRegionLbsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListRegionLbsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "LoadBalancerIds")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListRegionLbsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListRegionLbsResponseParams struct {
+	// <p>满足条件的负载均衡实例总数（与入参 Limit 无关）</p>
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// <p>负载均衡信息列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Lbs []*LbItem `json:"Lbs,omitnil,omitempty" name:"Lbs"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListRegionLbsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListRegionLbsResponseParams `json:"Response"`
+}
+
+func (r *ListRegionLbsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListRegionLbsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ListResourceConfigsRequestParams struct {
 	// 当前页码（从1开始）
 	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
@@ -23872,6 +28632,117 @@ func (r *ListResourceConfigsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ListResourceConfigsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListServiceApiKeysRequestParams struct {
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>创建时间起始过滤-毫秒时间戳</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-毫秒时间戳</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>额外过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>页码（默认1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+type ListServiceApiKeysRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>创建时间起始过滤-毫秒时间戳</p>
+	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤-毫秒时间戳</p>
+	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>额外过滤条件</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>页码（默认1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+}
+
+func (r *ListServiceApiKeysRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListServiceApiKeysRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	delete(f, "Page")
+	delete(f, "PageSize")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListServiceApiKeysRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListServiceApiKeysResponseParams struct {
+	// <p>API Key记录</p>
+	Items []*ApiKeyInfo `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>API Key记录总数</p>
+	Total *uint64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码</p>
+	Page *uint64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页记录数量</p>
+	PageSize *uint64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *uint64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListServiceApiKeysResponse struct {
+	*tchttp.BaseResponse
+	Response *ListServiceApiKeysResponseParams `json:"Response"`
+}
+
+func (r *ListServiceApiKeysResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListServiceApiKeysResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -24065,6 +28936,285 @@ func (r *ListTaskJobLogNameResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ListTaskJobLogNameResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListTkeCosBucketsRequestParams struct {
+	// <p>cos 桶名字</p>
+	BucketName *string `json:"BucketName,omitnil,omitempty" name:"BucketName"`
+
+	// <p>分页 Limit</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// <p>分页 Offset</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+}
+
+type ListTkeCosBucketsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>cos 桶名字</p>
+	BucketName *string `json:"BucketName,omitnil,omitempty" name:"BucketName"`
+
+	// <p>分页 Limit</p>
+	Limit *uint64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+
+	// <p>分页 Offset</p>
+	Offset *uint64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+}
+
+func (r *ListTkeCosBucketsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListTkeCosBucketsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "BucketName")
+	delete(f, "Limit")
+	delete(f, "Offset")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListTkeCosBucketsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListTkeCosBucketsResponseParams struct {
+	// <p>cos 桶列表</p>
+	Buckets []*string `json:"Buckets,omitnil,omitempty" name:"Buckets"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListTkeCosBucketsResponse struct {
+	*tchttp.BaseResponse
+	Response *ListTkeCosBucketsResponseParams `json:"Response"`
+}
+
+func (r *ListTkeCosBucketsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListTkeCosBucketsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListTrainingJobInstanceRequestParams struct {
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 10）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件列表，每项含 Name、Operator、Values</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表，每项含 Field、Order（ASC/DESC）</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>创建时间起始过滤（毫秒时间戳）</p><p>单位：ms</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤（毫秒时间戳）</p><p>单位：ms</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+}
+
+type ListTrainingJobInstanceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 10）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>过滤条件列表，每项含 Name、Operator、Values</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表，每项含 Field、Order（ASC/DESC）</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+
+	// <p>创建时间起始过滤（毫秒时间戳）</p><p>单位：ms</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤（毫秒时间戳）</p><p>单位：ms</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+}
+
+func (r *ListTrainingJobInstanceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListTrainingJobInstanceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListTrainingJobInstanceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListTrainingJobInstanceResponseParams struct {
+	// <p>训练作业实例列表</p>
+	Items []*TrainingJobInstance `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>列表元素个数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 200，最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListTrainingJobInstanceResponse struct {
+	*tchttp.BaseResponse
+	Response *ListTrainingJobInstanceResponseParams `json:"Response"`
+}
+
+func (r *ListTrainingJobInstanceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListTrainingJobInstanceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListTrainingJobSpecRequestParams struct {
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 200，最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤（毫秒时间戳）</p><p>单位：ms</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤（毫秒时间戳）</p><p>单位：ms</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件列表，每项含 Name、Operator、Values。</p><p>提交模式过滤：LAB / CUSTOM_CODE / POST_TRAINING。示例：{&quot;Name&quot;:&quot;kind&quot;,&quot;Operator&quot;:&quot;EQ&quot;,&quot;Values&quot;:[&quot;LAB&quot;]}</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表，每项含 Field、Order（ASC/DESC）。默认按 updateTime DESC</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+type ListTrainingJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 200，最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>创建时间起始过滤（毫秒时间戳）</p><p>单位：ms</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+
+	// <p>创建时间截止过滤（毫秒时间戳）</p><p>单位：ms</p>
+	EndTime *int64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
+
+	// <p>过滤条件列表，每项含 Name、Operator、Values。</p><p>提交模式过滤：LAB / CUSTOM_CODE / POST_TRAINING。示例：{&quot;Name&quot;:&quot;kind&quot;,&quot;Operator&quot;:&quot;EQ&quot;,&quot;Values&quot;:[&quot;LAB&quot;]}</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>排序字段列表，每项含 Field、Order（ASC/DESC）。默认按 updateTime DESC</p>
+	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
+}
+
+func (r *ListTrainingJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListTrainingJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Page")
+	delete(f, "PageSize")
+	delete(f, "StartTime")
+	delete(f, "EndTime")
+	delete(f, "Filters")
+	delete(f, "SortFields")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ListTrainingJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ListTrainingJobSpecResponseParams struct {
+	// <p>训练配置列表信息</p>
+	Items []*TrainingJobSpec `json:"Items,omitnil,omitempty" name:"Items"`
+
+	// <p>训练配置总数</p>
+	Total *int64 `json:"Total,omitnil,omitempty" name:"Total"`
+
+	// <p>当前页码，从 1 开始（默认 1）</p>
+	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
+
+	// <p>每页数量（默认 200，最大 200）</p>
+	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
+
+	// <p>总页数</p>
+	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ListTrainingJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *ListTrainingJobSpecResponseParams `json:"Response"`
+}
+
+func (r *ListTrainingJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ListTrainingJobSpecResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -24316,6 +29466,14 @@ type MetaDatabaseInfo struct {
 	Comment *string `json:"Comment,omitnil,omitempty" name:"Comment"`
 }
 
+type MetricItem struct {
+	// <p>指标名</p>
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// <p>指标值（字符串形式）</p>
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
 type MetricsData struct {
 	// <p>每秒请求数（QPS）</p>
 	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
@@ -24381,6 +29539,88 @@ type MixedTablePartitions struct {
 
 	// hive表分区信息
 	HivePartitions []*HiveTablePartition `json:"HivePartitions,omitnil,omitempty" name:"HivePartitions"`
+}
+
+type MlFlowConfig struct {
+	// <p>MlFlow 追踪模式：local=MlFlow Sidecar / remote=已有 MlFlow Server / none=不启用</p>
+	MlFlowMode *string `json:"MlFlowMode,omitnil,omitempty" name:"MlFlowMode"`
+
+	// <p>已有MlFlow Server 的 ID（仅 mlFlowMode=remote 时填写，前端下拉选择后传入）</p>
+	MlFlowServerId *string `json:"MlFlowServerId,omitnil,omitempty" name:"MlFlowServerId"`
+
+	// <p>MlFlow Sidecar 持久化存储的 COS 路径（仅 mlFlowMode=local 时填写）</p>
+	MlFlowCosPath *string `json:"MlFlowCosPath,omitnil,omitempty" name:"MlFlowCosPath"`
+}
+
+type MlFlowResourceConfig struct {
+	// <p>资源 ID（规格模式必填）</p>
+	BillingItem *string `json:"BillingItem,omitnil,omitempty" name:"BillingItem"`
+
+	// <p>购买份数（规格模式必填，每 Pod 的规格倍数）</p>
+	Spec *int64 `json:"Spec,omitnil,omitempty" name:"Spec"`
+
+	// <p>pod CPU 核数（手动模式必填，单 Pod 粒度）</p>
+	PodCpu *int64 `json:"PodCpu,omitnil,omitempty" name:"PodCpu"`
+
+	// <p>pod 内存大小 GB（手动模式必填，单 Pod 粒度）</p>
+	PodMem *int64 `json:"PodMem,omitnil,omitempty" name:"PodMem"`
+}
+
+type MlFlowServerInfo struct {
+	// <p>MLflow 实例的 ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+
+	// <p>实例名称</p>
+	ServerName *string `json:"ServerName,omitnil,omitempty" name:"ServerName"`
+
+	// <p>资源分区 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源包名</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>资源组（逻辑队列名，可选）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>集群内MLflow访问地址。用于训练作业上报 metrics</p>
+	TrackingUri *string `json:"TrackingUri,omitnil,omitempty" name:"TrackingUri"`
+
+	// <p>集群外访问地址（Ingress URL）</p>
+	UiUrl *string `json:"UiUrl,omitnil,omitempty" name:"UiUrl"`
+
+	// <p>状态：CREATED / CREATING / RUNNING / FAILED / STOPPED</p><p>枚举值：</p><ul><li>CREATED： 已创建</li><li>CREATING： 创建中</li><li>RUNNING： 运行中</li><li>FAILED： 失败</li><li>STOPPED： 已停止</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>仅失败时展示错误信息</p>
+	ErrorMessage *string `json:"ErrorMessage,omitnil,omitempty" name:"ErrorMessage"`
+
+	// <p>MLflow 镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>存储配置 JSON，具体结构按 storageMode 解释（cos / cfs / local）</p>
+	StorageConfig *string `json:"StorageConfig,omitnil,omitempty" name:"StorageConfig"`
+
+	// <p>存储模式</p><p>枚举值：</p><ul><li>cos： cos 对象存储</li><li>cfs： cfs 文件系统存储</li></ul>
+	StorageMode *string `json:"StorageMode,omitnil,omitempty" name:"StorageMode"`
+
+	// <p>应用 ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>创建者 UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（epoch 毫秒）</p><p>单位：毫秒</p>
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（epoch 毫秒）</p><p>单位：毫秒</p>
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>资源配置 JSON</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 }
 
 type ModelVersionInfo struct {
@@ -25664,6 +30904,231 @@ func (r *ModifySparkAppResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type ModifyTrainingJobSpecRequestParams struct {
+	// <p>配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>配置名称（不传则不更新）</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>配置描述（不传则不更新）</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>启动命令（不传则不更新）</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址（不传则不更新）</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（BuiltIn / Custom / CustomCcr，不传则不更新）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always / IfNotPresent / Never，不传则不更新）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>代码包 COS URL（不传则不更新）</p>
+	CodePackageUrl *string `json:"CodePackageUrl,omitnil,omitempty" name:"CodePackageUrl"`
+
+	// <p>运行时环境配置 JSON（不传则不更新）</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>资源配置模板 ID（可选）</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置 JSON（不传则不更新）</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源分区 ID（不传则不更新）</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>队列名称（不传则不更新）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>存储卷挂载配置 JSON（不传则不更新）</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>作业优先级 1-9（不传则不更新）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>高级参数 JSON（不传则不更新）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>MlFlow 实验追踪配置（不传则不更新）</p>
+	MlFlowConfig *MlFlowConfig `json:"MlFlowConfig,omitnil,omitempty" name:"MlFlowConfig"`
+
+	// <p>标签列表（TagKey-TagValue），null 不修改，空数组清空，非空全量替换</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>基础模型ID（用于模型挂载）</p>
+	BaseModelUid *string `json:"BaseModelUid,omitnil,omitempty" name:"BaseModelUid"`
+
+	// <p>输出模型名（用于产出模型自动注册）</p>
+	OutputModelName *string `json:"OutputModelName,omitnil,omitempty" name:"OutputModelName"`
+
+	// <p>训练模式：sft / dpo / cpt / grpo（仅 POST_TRAINING 有值）</p>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// <p>数据集挂载列表（整体替换，不传则不更新）</p>
+	Datasets []*DatasetMount `json:"Datasets,omitnil,omitempty" name:"Datasets"`
+
+	// <p>Checkpoint 产出配置（整体替换，不传则不更新）</p>
+	Checkpoint *CheckpointConfig `json:"Checkpoint,omitnil,omitempty" name:"Checkpoint"`
+
+	// <p>是否启用断点续训（创建时的意图声明；实际续训由实例级「断点续训」按钮触发，不传则不更新）</p>
+	ResumeTraining *bool `json:"ResumeTraining,omitnil,omitempty" name:"ResumeTraining"`
+
+	// <p>调优参数（整体替换，未填字段回模板默认值；不传则不更新；仅 POST_TRAINING）</p>
+	TuningParams *TrainingTuningParams `json:"TuningParams,omitnil,omitempty" name:"TuningParams"`
+}
+
+type ModifyTrainingJobSpecRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>配置名称（不传则不更新）</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>配置描述（不传则不更新）</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>启动命令（不传则不更新）</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址（不传则不更新）</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（BuiltIn / Custom / CustomCcr，不传则不更新）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always / IfNotPresent / Never，不传则不更新）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>代码包 COS URL（不传则不更新）</p>
+	CodePackageUrl *string `json:"CodePackageUrl,omitnil,omitempty" name:"CodePackageUrl"`
+
+	// <p>运行时环境配置 JSON（不传则不更新）</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>资源配置模板 ID（可选）</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置 JSON（不传则不更新）</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源分区 ID（不传则不更新）</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>队列名称（不传则不更新）</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>存储卷挂载配置 JSON（不传则不更新）</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>作业优先级 1-9（不传则不更新）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>高级参数 JSON（不传则不更新）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>MlFlow 实验追踪配置（不传则不更新）</p>
+	MlFlowConfig *MlFlowConfig `json:"MlFlowConfig,omitnil,omitempty" name:"MlFlowConfig"`
+
+	// <p>标签列表（TagKey-TagValue），null 不修改，空数组清空，非空全量替换</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>基础模型ID（用于模型挂载）</p>
+	BaseModelUid *string `json:"BaseModelUid,omitnil,omitempty" name:"BaseModelUid"`
+
+	// <p>输出模型名（用于产出模型自动注册）</p>
+	OutputModelName *string `json:"OutputModelName,omitnil,omitempty" name:"OutputModelName"`
+
+	// <p>训练模式：sft / dpo / cpt / grpo（仅 POST_TRAINING 有值）</p>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// <p>数据集挂载列表（整体替换，不传则不更新）</p>
+	Datasets []*DatasetMount `json:"Datasets,omitnil,omitempty" name:"Datasets"`
+
+	// <p>Checkpoint 产出配置（整体替换，不传则不更新）</p>
+	Checkpoint *CheckpointConfig `json:"Checkpoint,omitnil,omitempty" name:"Checkpoint"`
+
+	// <p>是否启用断点续训（创建时的意图声明；实际续训由实例级「断点续训」按钮触发，不传则不更新）</p>
+	ResumeTraining *bool `json:"ResumeTraining,omitnil,omitempty" name:"ResumeTraining"`
+
+	// <p>调优参数（整体替换，未填字段回模板默认值；不传则不更新；仅 POST_TRAINING）</p>
+	TuningParams *TrainingTuningParams `json:"TuningParams,omitnil,omitempty" name:"TuningParams"`
+}
+
+func (r *ModifyTrainingJobSpecRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyTrainingJobSpecRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecId")
+	delete(f, "SpecName")
+	delete(f, "Description")
+	delete(f, "Entrypoint")
+	delete(f, "Image")
+	delete(f, "ImagePullType")
+	delete(f, "ImagePullPolicy")
+	delete(f, "CodePackageUrl")
+	delete(f, "RuntimeEnv")
+	delete(f, "ResourceConfigId")
+	delete(f, "ResourceConfig")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Queue")
+	delete(f, "Catalog")
+	delete(f, "Priority")
+	delete(f, "AdvancedOptions")
+	delete(f, "MlFlowConfig")
+	delete(f, "Tags")
+	delete(f, "BaseModelUid")
+	delete(f, "OutputModelName")
+	delete(f, "Mode")
+	delete(f, "Datasets")
+	delete(f, "Checkpoint")
+	delete(f, "ResumeTraining")
+	delete(f, "TuningParams")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyTrainingJobSpecRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyTrainingJobSpecResponseParams struct {
+	// <p>训练作业配置详情</p>
+	Spec *TrainingJobSpec `json:"Spec,omitnil,omitempty" name:"Spec"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyTrainingJobSpecResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyTrainingJobSpecResponseParams `json:"Response"`
+}
+
+func (r *ModifyTrainingJobSpecResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyTrainingJobSpecResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyUserRequestParams struct {
 	// 用户Id，和CAM侧Uin匹配
 	UserId *string `json:"UserId,omitnil,omitempty" name:"UserId"`
@@ -26438,6 +31903,47 @@ type PersistentWorkDir struct {
 	VolumeSubPath *string `json:"VolumeSubPath,omitnil,omitempty" name:"VolumeSubPath"`
 }
 
+type PodItem struct {
+	// <p>Pod 名称</p>
+	PodName *string `json:"PodName,omitnil,omitempty" name:"PodName"`
+
+	// <p>命名空间</p>
+	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
+
+	// <p>K8s Pod Phase</p>
+	Phase *string `json:"Phase,omitnil,omitempty" name:"Phase"`
+
+	// <p>计算后的状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>Pod IP</p>
+	PodIp *string `json:"PodIp,omitnil,omitempty" name:"PodIp"`
+
+	// <p>调度节点名</p>
+	NodeName *string `json:"NodeName,omitnil,omitempty" name:"NodeName"`
+
+	// <p>容器镜像</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>CPU 请求</p>
+	CpuRequest *string `json:"CpuRequest,omitnil,omitempty" name:"CpuRequest"`
+
+	// <p>CPU 限制</p>
+	CpuLimit *string `json:"CpuLimit,omitnil,omitempty" name:"CpuLimit"`
+
+	// <p>内存请求</p>
+	MemoryRequest *string `json:"MemoryRequest,omitnil,omitempty" name:"MemoryRequest"`
+
+	// <p>内存限制</p>
+	MemoryLimit *string `json:"MemoryLimit,omitnil,omitempty" name:"MemoryLimit"`
+
+	// <p>创建时间（epoch millis）</p>
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>启动时间（epoch millis）</p>
+	StartTime *int64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
+}
+
 type Policy struct {
 	// <p>需要授权的数据库名，填 * 代表当前Catalog下所有数据库。当授权类型为管理员级别时，只允许填 “*”，当授权类型为数据连接级别时只允许填空，其他类型下可以任意指定数据库。</p>
 	Database *string `json:"Database,omitnil,omitempty" name:"Database"`
@@ -26524,6 +32030,14 @@ type Policys struct {
 	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
 }
 
+type PostTrainingResources struct {
+	// <p>Head 节点资源规格</p>
+	Head *HeadSpecDTO `json:"Head,omitnil,omitempty" name:"Head"`
+
+	// <p>Worker 节点资源规格</p>
+	Worker []*WorkerSpecDTO `json:"Worker,omitnil,omitempty" name:"Worker"`
+}
+
 type PrestoMonitorMetrics struct {
 	// 	Alluxio本地缓存命中率
 	// 注意：此字段可能返回 null，表示取不到有效值。
@@ -26532,6 +32046,26 @@ type PrestoMonitorMetrics struct {
 	// Fragment缓存命中率
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	FragmentCacheHitRate *float64 `json:"FragmentCacheHitRate,omitnil,omitempty" name:"FragmentCacheHitRate"`
+}
+
+type PrometheusInstanceItem struct {
+	// <p>Prometheus 实例 ID，例如 prom-xxxxxxxx</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>实例名称</p>
+	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
+
+	// <p>所属 VPC ID</p>
+	VpcId *string `json:"VpcId,omitnil,omitempty" name:"VpcId"`
+
+	// <p>所属子网 ID</p>
+	SubnetId *string `json:"SubnetId,omitnil,omitempty" name:"SubnetId"`
+
+	// <p>实例状态：1=创建中, 2=运行中, 3=异常, 4=重启中, 5=销毁中, 6=已停机, 7=已删除, 8=欠费停服中, 9=欠费已停服</p>
+	InstanceStatus *int64 `json:"InstanceStatus,omitnil,omitempty" name:"InstanceStatus"`
+
+	// <p>是否与 TKE 集群同 VPC；true 会被前置排序</p>
+	SameVpcWithTke *bool `json:"SameVpcWithTke,omitnil,omitempty" name:"SameVpcWithTke"`
 }
 
 type Property struct {
@@ -27273,6 +32807,50 @@ type RayJobSubmitEntity struct {
 	JobSource *string `json:"JobSource,omitnil,omitempty" name:"JobSource"`
 }
 
+type RecommendedAdvancedParams struct {
+	// <p>是否启用 trust_remote_code</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EnableRemoteCode *bool `json:"EnableRemoteCode,omitnil,omitempty" name:"EnableRemoteCode"`
+
+	// <p>GPU 显存利用率（百分比，例如 90 表示 90%）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	GpuMemoryUtilization *int64 `json:"GpuMemoryUtilization,omitnil,omitempty" name:"GpuMemoryUtilization"`
+
+	// <p>Tensor 并行度</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TensorParallelSize *int64 `json:"TensorParallelSize,omitnil,omitempty" name:"TensorParallelSize"`
+
+	// <p>Pipeline 并行度</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	PipelineParallelSize *int64 `json:"PipelineParallelSize,omitnil,omitempty" name:"PipelineParallelSize"`
+
+	// <p>Data 并行度</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DataParallelSize *int64 `json:"DataParallelSize,omitnil,omitempty" name:"DataParallelSize"`
+
+	// <p>推理引擎参数列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EngineArgs []*RecommendedKeyValue `json:"EngineArgs,omitnil,omitempty" name:"EngineArgs"`
+
+	// <p>环境变量列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EnvVars []*RecommendedKeyValue `json:"EnvVars,omitnil,omitempty" name:"EnvVars"`
+
+	// <p>Ray Actor Options 列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RayOptions []*RecommendedKeyValue `json:"RayOptions,omitnil,omitempty" name:"RayOptions"`
+}
+
+type RecommendedKeyValue struct {
+	// <p>键</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// <p>值</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+}
+
 type RegionInfo struct {
 	// <p>地域编码，如 ap-chongqing</p>
 	RegionCode *string `json:"RegionCode,omitnil,omitempty" name:"RegionCode"`
@@ -27493,6 +33071,123 @@ func (r *ReportHeartbeatMetaDataResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+// Predefined struct for user
+type RerunBenchmarkTaskRequestParams struct {
+	// <p>评测任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+type RerunBenchmarkTaskRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>评测任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+func (r *RerunBenchmarkTaskRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *RerunBenchmarkTaskRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TaskId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RerunBenchmarkTaskRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type RerunBenchmarkTaskResponseParams struct {
+	// <p>任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>任务名称</p>
+	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
+
+	// <p>关联的推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>关联的推理服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>任务状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>输入 Token 数</p>
+	InputTokens *uint64 `json:"InputTokens,omitnil,omitempty" name:"InputTokens"`
+
+	// <p>输出 Token 数</p>
+	OutputTokens *uint64 `json:"OutputTokens,omitnil,omitempty" name:"OutputTokens"`
+
+	// <p>每秒请求数 (QPS)</p>
+	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
+
+	// <p>最大并发数</p>
+	MaxConcurrency *uint64 `json:"MaxConcurrency,omitnil,omitempty" name:"MaxConcurrency"`
+
+	// <p>Prompts 总数</p>
+	TotalPrompts *uint64 `json:"TotalPrompts,omitnil,omitempty" name:"TotalPrompts"`
+
+	// <p>是否经网关。true=通过网关访问；false=集群内直连 SVC</p>
+	UseGateway *bool `json:"UseGateway,omitnil,omitempty" name:"UseGateway"`
+
+	// <p>直连模式下使用的部署名称（仅 UseGateway=false 时有值）</p>
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>API Key ID（走网关时使用的 API Key 标识）</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>API Key 名称</p>
+	ApiKeyName *string `json:"ApiKeyName,omitnil,omitempty" name:"ApiKeyName"`
+
+	// <p>主账号UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>评测容器自身使用的资源规格</p>
+	Resources *BenchmarkResourceInfo `json:"Resources,omitnil,omitempty" name:"Resources"`
+
+	// <p>与本次评测关联的部署及其资源规格</p>
+	DeploymentResources []*DeploymentResourceInfo `json:"DeploymentResources,omitnil,omitempty" name:"DeploymentResources"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type RerunBenchmarkTaskResponse struct {
+	*tchttp.BaseResponse
+	Response *RerunBenchmarkTaskResponseParams `json:"Response"`
+}
+
+func (r *RerunBenchmarkTaskResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *RerunBenchmarkTaskResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
 type ResourceConf struct {
 	// 当为TCLake优化资源时，优化任务的并行度
 	Parallelism *int64 `json:"Parallelism,omitnil,omitempty" name:"Parallelism"`
@@ -27579,6 +33274,10 @@ type ResourceSaleInfo struct {
 	// <p>最大资源数量，仅GU有值</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	MaxSpec *int64 `json:"MaxSpec,omitnil,omitempty" name:"MaxSpec"`
+
+	// <p>库存情况，对当前地域该计费项实时可新增数量的分级预估。取值复用 BcpConstants 库存状态常量：</p><ul><li>EnoughStock：余量充足</li><li>NormalStock：余量正常</li><li>UnderStock：余量紧张</li><li>WithoutStock：无库存</li></ul><p>该值为底层提供的预估值，不代表保证可发货量，仅用于展示库存概况。当请求 Region 与资源池地域不一致、cold-start 缓存未 ready、或该计费项在快照中缺失时返回 null。</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	StatusCategory *string `json:"StatusCategory,omitnil,omitempty" name:"StatusCategory"`
 }
 
 type ResourceSpec struct {
@@ -27675,6 +33374,156 @@ func (r *RestartDataEngineResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *RestartDataEngineResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type RestartDeploymentRequestParams struct {
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+}
+
+type RestartDeploymentRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+}
+
+func (r *RestartDeploymentRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *RestartDeploymentRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DeploymentId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RestartDeploymentRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type RestartDeploymentResponseParams struct {
+	// <p>DeploymentId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>部署名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>部署使用的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>部署状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>推理引擎（vLLM/SGLang 等）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>期望副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>可用副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AvailableReplicas *int64 `json:"AvailableReplicas,omitnil,omitempty" name:"AvailableReplicas"`
+
+	// <p>资源配置（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>高级参数（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AdvancedParams *string `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// <p>是否开启自动伸缩</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>最小副本数（自动伸缩时使用）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MinReplicas *int64 `json:"MinReplicas,omitnil,omitempty" name:"MinReplicas"`
+
+	// <p>最大副本数（自动伸缩时使用）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MaxReplicas *int64 `json:"MaxReplicas,omitnil,omitempty" name:"MaxReplicas"`
+
+	// <p>模型存储配置（Catalog JSON，记录模型 COS 挂载信息）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelStorageConfig *string `json:"ModelStorageConfig,omitnil,omitempty" name:"ModelStorageConfig"`
+
+	// <p>AppId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>Uin</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>Neutrino Serve ID (RayService CR name)</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	NeutrinoServeId *string `json:"NeutrinoServeId,omitnil,omitempty" name:"NeutrinoServeId"`
+
+	// <p>资源分区 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源队列名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>SubAccountUin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>ray head 是否开启高可用</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>镜像名称</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type RestartDeploymentResponse struct {
+	*tchttp.BaseResponse
+	Response *RestartDeploymentResponseParams `json:"Response"`
+}
+
+func (r *RestartDeploymentResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *RestartDeploymentResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -27801,6 +33650,10 @@ type RestartInferenceServiceResponseParams struct {
 	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
 	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
 
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
 }
@@ -27818,6 +33671,63 @@ func (r *RestartInferenceServiceResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *RestartInferenceServiceResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ResumeTrainingJobInstanceRequestParams struct {
+	// <p>训练实例ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+type ResumeTrainingJobInstanceRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练实例ID</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+}
+
+func (r *ResumeTrainingJobInstanceRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ResumeTrainingJobInstanceRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "InstanceId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ResumeTrainingJobInstanceRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ResumeTrainingJobInstanceResponseParams struct {
+	// <p>训练实例详情</p>
+	Instance *TrainingJobInstance `json:"Instance,omitnil,omitempty" name:"Instance"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ResumeTrainingJobInstanceResponse struct {
+	*tchttp.BaseResponse
+	Response *ResumeTrainingJobInstanceResponseParams `json:"Response"`
+}
+
+func (r *ResumeTrainingJobInstanceResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ResumeTrainingJobInstanceResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -28231,6 +34141,26 @@ func (r *SetOptimizerPolicyResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
+type SharedMountFileItem struct {
+	// <p>文件或目录名</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>类型：file / directory</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>文件大小（字节，仅 Type=file 时有值）</p>
+	Size *int64 `json:"Size,omitnil,omitempty" name:"Size"`
+
+	// <p>最后修改时间（毫秒时间戳，仅 Type=file 时有值）</p>
+	LastModified *int64 `json:"LastModified,omitnil,omitempty" name:"LastModified"`
+
+	// <p>相对 MountPath 的完整路径</p>
+	Path *string `json:"Path,omitnil,omitempty" name:"Path"`
+
+	// <p>Checkpoint 训练指标（仅 checkpoint 目录且 snapshot 存在时有值）</p>
+	Metrics *CheckpointMetrics `json:"Metrics,omitnil,omitempty" name:"Metrics"`
+}
+
 type SmartOptimizerChangeTablePolicy struct {
 	// change表的数据保存时间，单位为天
 	DataRetentionTime *int64 `json:"DataRetentionTime,omitnil,omitempty" name:"DataRetentionTime"`
@@ -28538,45 +34468,50 @@ type SparkSessionBatchLogOperate struct {
 }
 
 type SparkSessionInfo struct {
-	// spark session id
+	// <p>spark session id</p>
 	SparkSessionId *string `json:"SparkSessionId,omitnil,omitempty" name:"SparkSessionId"`
 
-	// spark session名称
+	// <p>spark session名称</p>
 	SparkSessionName *string `json:"SparkSessionName,omitnil,omitempty" name:"SparkSessionName"`
 
-	// 资源组id
+	// <p>资源组id</p>
 	ResourceGroupId *string `json:"ResourceGroupId,omitnil,omitempty" name:"ResourceGroupId"`
 
-	// engine session id
+	// <p>engine session id</p>
 	EngineSessionId *string `json:"EngineSessionId,omitnil,omitempty" name:"EngineSessionId"`
 
-	// engine session   
-	// name
+	// <p>engine session<br>name</p>
 	EngineSessionName *string `json:"EngineSessionName,omitnil,omitempty" name:"EngineSessionName"`
 
-	// 自动销毁时间
+	// <p>自动销毁时间</p>
 	IdleTimeoutMin *int64 `json:"IdleTimeoutMin,omitnil,omitempty" name:"IdleTimeoutMin"`
 
-	// driver规格
+	// <p>driver规格</p>
 	DriverSpec *string `json:"DriverSpec,omitnil,omitempty" name:"DriverSpec"`
 
-	// executor规格
+	// <p>executor规格</p>
 	ExecutorSpec *string `json:"ExecutorSpec,omitnil,omitempty" name:"ExecutorSpec"`
 
-	// executor最小数量
+	// <p>executor最小数量</p>
 	ExecutorNumMin *int64 `json:"ExecutorNumMin,omitnil,omitempty" name:"ExecutorNumMin"`
 
-	// executor最大数量
+	// <p>executor最大数量</p>
 	ExecutorNumMax *int64 `json:"ExecutorNumMax,omitnil,omitempty" name:"ExecutorNumMax"`
 
-	// 总规格最小
+	// <p>总规格最小</p>
 	TotalSpecMin *int64 `json:"TotalSpecMin,omitnil,omitempty" name:"TotalSpecMin"`
 
-	// 总规格最大
+	// <p>总规格最大</p>
 	TotalSpecMax *int64 `json:"TotalSpecMax,omitnil,omitempty" name:"TotalSpecMax"`
 
-	// 状态，STARTING、RUNNING、TERMINATED
+	// <p>状态，STARTING、RUNNING、TERMINATED</p>
 	State *string `json:"State,omitnil,omitempty" name:"State"`
+
+	// <p>应用 ID</p>
+	ApplicationId *string `json:"ApplicationId,omitnil,omitempty" name:"ApplicationId"`
+
+	// <p>应用启动时间</p>
+	ApplicationStartTime *int64 `json:"ApplicationStartTime,omitnil,omitempty" name:"ApplicationStartTime"`
 }
 
 type SpecInfo struct {
@@ -28910,6 +34845,63 @@ func (r *StartLabResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type StartMlflowServerRequestParams struct {
+	// <p>MlFlow Server的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+type StartMlflowServerRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>MlFlow Server的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+func (r *StartMlflowServerRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StartMlflowServerRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServerId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StartMlflowServerRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StartMlflowServerResponseParams struct {
+	// <p>MlFlowServer的详情</p>
+	MlFlowServer *MlFlowServerInfo `json:"MlFlowServer,omitnil,omitempty" name:"MlFlowServer"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StartMlflowServerResponse struct {
+	*tchttp.BaseResponse
+	Response *StartMlflowServerResponseParams `json:"Response"`
+}
+
+func (r *StartMlflowServerResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StartMlflowServerResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type StartRayClusterRequestParams struct {
 	// <p>集群ID</p>
 	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
@@ -29076,6 +35068,278 @@ type StatementOutput struct {
 }
 
 // Predefined struct for user
+type StopBenchmarkTaskRequestParams struct {
+	// <p>评测任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+type StopBenchmarkTaskRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>评测任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+}
+
+func (r *StopBenchmarkTaskRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopBenchmarkTaskRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "TaskId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StopBenchmarkTaskRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopBenchmarkTaskResponseParams struct {
+	// <p>任务ID</p>
+	TaskId *string `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// <p>任务名称</p>
+	TaskName *string `json:"TaskName,omitnil,omitempty" name:"TaskName"`
+
+	// <p>关联的推理服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>关联的推理服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>任务状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>输入 Token 数</p>
+	InputTokens *uint64 `json:"InputTokens,omitnil,omitempty" name:"InputTokens"`
+
+	// <p>输出 Token 数</p>
+	OutputTokens *uint64 `json:"OutputTokens,omitnil,omitempty" name:"OutputTokens"`
+
+	// <p>每秒请求数 (QPS)</p>
+	RequestsPerSecond *float64 `json:"RequestsPerSecond,omitnil,omitempty" name:"RequestsPerSecond"`
+
+	// <p>最大并发数</p>
+	MaxConcurrency *uint64 `json:"MaxConcurrency,omitnil,omitempty" name:"MaxConcurrency"`
+
+	// <p>Prompts 总数</p>
+	TotalPrompts *uint64 `json:"TotalPrompts,omitnil,omitempty" name:"TotalPrompts"`
+
+	// <p>是否经网关。true=通过网关访问；false=集群内直连 SVC</p>
+	UseGateway *bool `json:"UseGateway,omitnil,omitempty" name:"UseGateway"`
+
+	// <p>直连模式下使用的部署名称（仅 UseGateway=false 时有值）</p>
+	DeploymentName *string `json:"DeploymentName,omitnil,omitempty" name:"DeploymentName"`
+
+	// <p>API Key ID（走网关时使用的 API Key 标识）</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>API Key 名称</p>
+	ApiKeyName *string `json:"ApiKeyName,omitnil,omitempty" name:"ApiKeyName"`
+
+	// <p>主账号UIN</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>应用ID</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>评测容器自身使用的资源规格</p>
+	Resources *BenchmarkResourceInfo `json:"Resources,omitnil,omitempty" name:"Resources"`
+
+	// <p>与本次评测关联的部署及其资源规格。语义按模式区分： • 网关模式（UseGateway=true）：Service 下所有 Running 部署（长度可能 &gt; 1） • 直连模式（UseGateway=false）：仅绑定的那个部署（长度恒为 1）</p>
+	DeploymentResources []*DeploymentResourceInfo `json:"DeploymentResources,omitnil,omitempty" name:"DeploymentResources"`
+
+	// <p>发生错误时的错误信息</p>
+	ErrorMessage *string `json:"ErrorMessage,omitnil,omitempty" name:"ErrorMessage"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StopBenchmarkTaskResponse struct {
+	*tchttp.BaseResponse
+	Response *StopBenchmarkTaskResponseParams `json:"Response"`
+}
+
+func (r *StopBenchmarkTaskResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopBenchmarkTaskResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopDeploymentRequestParams struct {
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+}
+
+type StopDeploymentRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+}
+
+func (r *StopDeploymentRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopDeploymentRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DeploymentId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StopDeploymentRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopDeploymentResponseParams struct {
+	// <p>DeploymentId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>部署名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>部署使用的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>部署状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>推理引擎（vLLM/SGLang 等）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>期望副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>可用副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AvailableReplicas *int64 `json:"AvailableReplicas,omitnil,omitempty" name:"AvailableReplicas"`
+
+	// <p>资源配置（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>高级参数（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AdvancedParams *string `json:"AdvancedParams,omitnil,omitempty" name:"AdvancedParams"`
+
+	// <p>是否开启自动伸缩</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>最小副本数（自动伸缩时使用）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MinReplicas *int64 `json:"MinReplicas,omitnil,omitempty" name:"MinReplicas"`
+
+	// <p>最大副本数（自动伸缩时使用）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	MaxReplicas *int64 `json:"MaxReplicas,omitnil,omitempty" name:"MaxReplicas"`
+
+	// <p>模型存储配置（Catalog JSON，记录模型 COS 挂载信息）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelStorageConfig *string `json:"ModelStorageConfig,omitnil,omitempty" name:"ModelStorageConfig"`
+
+	// <p>AppId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>Uin</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>资源分区 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源队列名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>SubAccountUin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>ray head 是否开启高可用</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>镜像名称</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取方式</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StopDeploymentResponse struct {
+	*tchttp.BaseResponse
+	Response *StopDeploymentResponseParams `json:"Response"`
+}
+
+func (r *StopDeploymentResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopDeploymentResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type StopInferenceServiceRequestParams struct {
 	// <p>推理服务ID</p>
 	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
@@ -29197,6 +35461,16 @@ type StopInferenceServiceResponseParams struct {
 
 	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
 	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
+
+	// <p>部署模式</p>
+	DeploymentMode *string `json:"DeploymentMode,omitnil,omitempty" name:"DeploymentMode"`
+
+	// <p>是否为自定义代码部署</p>
+	IsCustom *bool `json:"IsCustom,omitnil,omitempty" name:"IsCustom"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -29357,6 +35631,60 @@ func (r *StopLabResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type StopMlflowServerRequestParams struct {
+	// <p>MlFlowServer的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+type StopMlflowServerRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>MlFlowServer的ID</p>
+	ServerId *string `json:"ServerId,omitnil,omitempty" name:"ServerId"`
+}
+
+func (r *StopMlflowServerRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopMlflowServerRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServerId")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "StopMlflowServerRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type StopMlflowServerResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type StopMlflowServerResponse struct {
+	*tchttp.BaseResponse
+	Response *StopMlflowServerResponseParams `json:"Response"`
+}
+
+func (r *StopMlflowServerResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *StopMlflowServerResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type StopRayClusterRequestParams struct {
 	// <p>集群ID</p>
 	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
@@ -29512,6 +35840,231 @@ type StreamingStatistics struct {
 
 	// 平均延时
 	AverageTotalDelay *float64 `json:"AverageTotalDelay,omitnil,omitempty" name:"AverageTotalDelay"`
+}
+
+// Predefined struct for user
+type SubmitTrainingJobRequestParams struct {
+	// <p>训练作业配置名称（≤255 字符）</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>描述（≤1024 字符）</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>启动命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always / IfNotPresent / Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>代码包 COS URL</p>
+	CodePackageUrl *string `json:"CodePackageUrl,omitnil,omitempty" name:"CodePackageUrl"`
+
+	// <p>Ray runtime_env 配置 JSON（含 pip 依赖、env_vars 等，结构参见 2.1）</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>资源配置模板 ID(可选)</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置 JSON</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源分区 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>存储卷挂载配置 JSON（含 Source 字段标记用途）</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>高级参数 JSON（不传则不更新）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>基础模型Uid</p>
+	BaseModelUid *string `json:"BaseModelUid,omitnil,omitempty" name:"BaseModelUid"`
+
+	// <p>算法模式：sft / dpo / cpt / grpo（仅 POST_TRAINING 必填，CUSTOM_CODE / LAB 禁止传入）</p>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// <p>数据集挂载列表（元素含 DatasetId 或 Catalog 二选一 + DatasetName + Eval 属性）</p>
+	Datasets []*DatasetMount `json:"Datasets,omitnil,omitempty" name:"Datasets"`
+
+	// <p>Checkpoint 产出配置（POST_TRAINING 必填；CUSTOM_CODE / LAB 可选）</p>
+	Checkpoint *CheckpointConfig `json:"Checkpoint,omitnil,omitempty" name:"Checkpoint"`
+
+	// <p>是否启用断点续训</p>
+	ResumeTraining *bool `json:"ResumeTraining,omitnil,omitempty" name:"ResumeTraining"`
+
+	// <p>调优参数（高级参数，仅 POST_TRAINING 使用；CUSTOM_CODE / LAB 禁止传入）</p>
+	TuningParams *TrainingTuningParams `json:"TuningParams,omitnil,omitempty" name:"TuningParams"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>提交来源标签：LAB / CUSTOM_CODE（可选，用于溯源，不影响处理逻辑）</p>
+	Kind *string `json:"Kind,omitnil,omitempty" name:"Kind"`
+
+	// <p>MlFlow 实验追踪配置（可选，不传则不启用 MlFlow）</p>
+	MlFlowConfig *MlFlowConfig `json:"MlFlowConfig,omitnil,omitempty" name:"MlFlowConfig"`
+
+	// <p>标签列表（TagKey-TagValue），用于将任务与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>产出模型名称（用于后续模型注册，当前仅保存）</p>
+	OutputModelName *string `json:"OutputModelName,omitnil,omitempty" name:"OutputModelName"`
+}
+
+type SubmitTrainingJobRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>训练作业配置名称（≤255 字符）</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>描述（≤1024 字符）</p>
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>启动命令</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（BuiltIn: 内置, Custom: 自定义-TCR, CustomCcr: 自定义-CCR）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always / IfNotPresent / Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>代码包 COS URL</p>
+	CodePackageUrl *string `json:"CodePackageUrl,omitnil,omitempty" name:"CodePackageUrl"`
+
+	// <p>Ray runtime_env 配置 JSON（含 pip 依赖、env_vars 等，结构参见 2.1）</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>资源配置模板 ID(可选)</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置 JSON</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源分区 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>存储卷挂载配置 JSON（含 Source 字段标记用途）</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>高级参数 JSON（不传则不更新）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>基础模型Uid</p>
+	BaseModelUid *string `json:"BaseModelUid,omitnil,omitempty" name:"BaseModelUid"`
+
+	// <p>算法模式：sft / dpo / cpt / grpo（仅 POST_TRAINING 必填，CUSTOM_CODE / LAB 禁止传入）</p>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// <p>数据集挂载列表（元素含 DatasetId 或 Catalog 二选一 + DatasetName + Eval 属性）</p>
+	Datasets []*DatasetMount `json:"Datasets,omitnil,omitempty" name:"Datasets"`
+
+	// <p>Checkpoint 产出配置（POST_TRAINING 必填；CUSTOM_CODE / LAB 可选）</p>
+	Checkpoint *CheckpointConfig `json:"Checkpoint,omitnil,omitempty" name:"Checkpoint"`
+
+	// <p>是否启用断点续训</p>
+	ResumeTraining *bool `json:"ResumeTraining,omitnil,omitempty" name:"ResumeTraining"`
+
+	// <p>调优参数（高级参数，仅 POST_TRAINING 使用；CUSTOM_CODE / LAB 禁止传入）</p>
+	TuningParams *TrainingTuningParams `json:"TuningParams,omitnil,omitempty" name:"TuningParams"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>提交来源标签：LAB / CUSTOM_CODE（可选，用于溯源，不影响处理逻辑）</p>
+	Kind *string `json:"Kind,omitnil,omitempty" name:"Kind"`
+
+	// <p>MlFlow 实验追踪配置（可选，不传则不启用 MlFlow）</p>
+	MlFlowConfig *MlFlowConfig `json:"MlFlowConfig,omitnil,omitempty" name:"MlFlowConfig"`
+
+	// <p>标签列表（TagKey-TagValue），用于将任务与腾讯云标签系统中的标签绑定</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>产出模型名称（用于后续模型注册，当前仅保存）</p>
+	OutputModelName *string `json:"OutputModelName,omitnil,omitempty" name:"OutputModelName"`
+}
+
+func (r *SubmitTrainingJobRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *SubmitTrainingJobRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "SpecName")
+	delete(f, "Description")
+	delete(f, "Entrypoint")
+	delete(f, "Image")
+	delete(f, "ImagePullType")
+	delete(f, "ImagePullPolicy")
+	delete(f, "CodePackageUrl")
+	delete(f, "RuntimeEnv")
+	delete(f, "ResourceConfigId")
+	delete(f, "ResourceConfig")
+	delete(f, "ResourcePartitionId")
+	delete(f, "Queue")
+	delete(f, "Catalog")
+	delete(f, "AdvancedOptions")
+	delete(f, "BaseModelUid")
+	delete(f, "Mode")
+	delete(f, "Datasets")
+	delete(f, "Checkpoint")
+	delete(f, "ResumeTraining")
+	delete(f, "TuningParams")
+	delete(f, "Priority")
+	delete(f, "Kind")
+	delete(f, "MlFlowConfig")
+	delete(f, "Tags")
+	delete(f, "OutputModelName")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "SubmitTrainingJobRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type SubmitTrainingJobResponseParams struct {
+	// <p>训练作业配置详情</p>
+	Spec *TrainingJobSpec `json:"Spec,omitnil,omitempty" name:"Spec"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type SubmitTrainingJobResponse struct {
+	*tchttp.BaseResponse
+	Response *SubmitTrainingJobResponseParams `json:"Response"`
+}
+
+func (r *SubmitTrainingJobResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *SubmitTrainingJobResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
 }
 
 // Predefined struct for user
@@ -29724,6 +36277,40 @@ type TCHouseD struct {
 	DbName *string `json:"DbName,omitnil,omitempty" name:"DbName"`
 
 	// 访问信息
+	AccessInfo *string `json:"AccessInfo,omitnil,omitempty" name:"AccessInfo"`
+}
+
+type TCHousePInfo struct {
+	// <p>实例id</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>实例名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InstanceName *string `json:"InstanceName,omitnil,omitempty" name:"InstanceName"`
+
+	// <p>JdbcUrl</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	JdbcUrl *string `json:"JdbcUrl,omitnil,omitempty" name:"JdbcUrl"`
+
+	// <p>用户名</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	User *string `json:"User,omitnil,omitempty" name:"User"`
+
+	// <p>密码</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Password *string `json:"Password,omitnil,omitempty" name:"Password"`
+
+	// <p>地址</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Location *DatasourceConnectionLocation `json:"Location,omitnil,omitempty" name:"Location"`
+
+	// <p>数据库名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DbName *string `json:"DbName,omitnil,omitempty" name:"DbName"`
+
+	// <p>地址信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
 	AccessInfo *string `json:"AccessInfo,omitnil,omitempty" name:"AccessInfo"`
 }
 
@@ -30192,6 +36779,14 @@ type TaskMonitorInfo struct {
 	QueryStats *string `json:"QueryStats,omitnil,omitempty" name:"QueryStats"`
 }
 
+type TaskOptions struct {
+	// <p>模型类型</p>
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>任务场景</p>
+	Tasks []*string `json:"Tasks,omitnil,omitempty" name:"Tasks"`
+}
+
 type TaskResponseInfo struct {
 	// 任务所属Database的名称。
 	DatabaseName *string `json:"DatabaseName,omitnil,omitempty" name:"DatabaseName"`
@@ -30457,6 +37052,363 @@ type TextFile struct {
 	Regex *string `json:"Regex,omitnil,omitempty" name:"Regex"`
 }
 
+type TrainingJobInstance struct {
+	// <p>实例 ID（即 RayJob UUID）</p>
+	InstanceId *string `json:"InstanceId,omitnil,omitempty" name:"InstanceId"`
+
+	// <p>关联配置 ID</p>
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>配置名称</p>
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>综合状态</p>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>错误信息</p>
+	ErrorMessage *string `json:"ErrorMessage,omitnil,omitempty" name:"ErrorMessage"`
+
+	// <p>RayJob 实际启动时间（毫秒）</p>
+	JobCreateTime *int64 `json:"JobCreateTime,omitnil,omitempty" name:"JobCreateTime"`
+
+	// <p>RayJob 运行时长（毫秒）</p>
+	JobRunningTime *int64 `json:"JobRunningTime,omitnil,omitempty" name:"JobRunningTime"`
+
+	// <p>Ray Dashboard History 链接</p>
+	HistoryUrl *string `json:"HistoryUrl,omitnil,omitempty" name:"HistoryUrl"`
+
+	// <p>创建人</p>
+	Creator *string `json:"Creator,omitnil,omitempty" name:"Creator"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>资源分区 ID</p>
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>队列名称</p>
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>提交时 runtime_env JSON</p>
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>提交时 entrypoint</p>
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>提交时镜像</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>提交时资源配置 JSON</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>提交时存储卷挂载配置 JSON</p>
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>提交时高级参数 JSON</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// <p>训练子类型快照（LAB / CUSTOM_CODE / POST_TRAINING）</p>
+	Kind *string `json:"Kind,omitnil,omitempty" name:"Kind"`
+
+	// <p>提交时代码包 URL</p>
+	CodePackageUrl *string `json:"CodePackageUrl,omitnil,omitempty" name:"CodePackageUrl"`
+
+	// <p>提交时 MLflow 配置 JSON</p>
+	MlFlowConfig *string `json:"MlFlowConfig,omitnil,omitempty" name:"MlFlowConfig"`
+
+	// <p>Checkpoint 挂载摘要（实例级）</p>
+	CheckpointMountInfo *CheckpointMountInfo `json:"CheckpointMountInfo,omitnil,omitempty" name:"CheckpointMountInfo"`
+
+	// <p>训练方式（sft / dpo / cpt / grpo），仅 POST_TRAINING 有值</p>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// <p>基础模型 modelUid（仅 POST_TRAINING 有值，用于关联推理模型仓库）</p>
+	BaseModelUid *string `json:"BaseModelUid,omitnil,omitempty" name:"BaseModelUid"`
+
+	// <p>基础模型名称（仅 POST_TRAINING 有值）</p>
+	BaseModelName *string `json:"BaseModelName,omitnil,omitempty" name:"BaseModelName"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>创建实例时的数据集挂载列表快照（List&lt;DatasetMount&gt;，仅详情返回）</p>
+	Datasets []*DatasetMount `json:"Datasets,omitnil,omitempty" name:"Datasets"`
+
+	// <p>创建实例时的 Checkpoint 产出配置快照（仅详情返回）</p>
+	Checkpoint *CheckpointConfig `json:"Checkpoint,omitnil,omitempty" name:"Checkpoint"`
+
+	// <p>创建实例时的调优参数快照（仅 POST_TRAINING，仅详情返回）</p>
+	TuningParams *TrainingTuningParams `json:"TuningParams,omitnil,omitempty" name:"TuningParams"`
+
+	// <p>创建实例时的断点续训意图声明快照（仅详情返回）</p>
+	ResumeTraining *bool `json:"ResumeTraining,omitnil,omitempty" name:"ResumeTraining"`
+}
+
+type TrainingJobSpec struct {
+	// <p>训练作业配置 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SpecId *string `json:"SpecId,omitnil,omitempty" name:"SpecId"`
+
+	// <p>训练作业配置名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SpecName *string `json:"SpecName,omitnil,omitempty" name:"SpecName"`
+
+	// <p>配置描述</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
+
+	// <p>提交模式（LAB / CUSTOM_CODE / POST_TRAINING / UNKNOWN）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Kind *string `json:"Kind,omitnil,omitempty" name:"Kind"`
+
+	// <p>启动命令</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Entrypoint *string `json:"Entrypoint,omitnil,omitempty" name:"Entrypoint"`
+
+	// <p>镜像地址</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>镜像拉取类型（BuiltIn / Custom / CustomCcr）</p>
+	ImagePullType *string `json:"ImagePullType,omitnil,omitempty" name:"ImagePullType"`
+
+	// <p>镜像拉取策略（Always / IfNotPresent / Never）</p>
+	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
+
+	// <p>代码包 COS URL</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CodePackageUrl *string `json:"CodePackageUrl,omitnil,omitempty" name:"CodePackageUrl"`
+
+	// <p>Ray runtime_env 配置 JSON</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RuntimeEnv *string `json:"RuntimeEnv,omitnil,omitempty" name:"RuntimeEnv"`
+
+	// <p>资源配置模板 ID</p>
+	ResourceConfigId *string `json:"ResourceConfigId,omitnil,omitempty" name:"ResourceConfigId"`
+
+	// <p>资源配置 JSON</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>资源分区 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>队列名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>Checkpoint 挂载摘要</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CheckpointMountInfo *CheckpointMountInfo `json:"CheckpointMountInfo,omitnil,omitempty" name:"CheckpointMountInfo"`
+
+	// <p>存储卷挂载配置 JSON</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Catalog *string `json:"Catalog,omitnil,omitempty" name:"Catalog"`
+
+	// <p>创建人</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Creator *string `json:"Creator,omitnil,omitempty" name:"Creator"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>关联实例总数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	InstanceCount *int64 `json:"InstanceCount,omitnil,omitempty" name:"InstanceCount"`
+
+	// <p>是否存在运行中实例</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasRunningInstances *bool `json:"HasRunningInstances,omitnil,omitempty" name:"HasRunningInstances"`
+
+	// <p>作业优先级（1-9，数字越大优先级越高）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Priority *int64 `json:"Priority,omitnil,omitempty" name:"Priority"`
+
+	// <p>提交时 MLflow 配置 JSON（含 MlFlowMode / MlFlowTrackingUri 等）</p>
+	MlFlowConfig *string `json:"MlFlowConfig,omitnil,omitempty" name:"MlFlowConfig"`
+
+	// <p>产出模型名称（用于后续模型注册）</p>
+	OutputModelName *string `json:"OutputModelName,omitnil,omitempty" name:"OutputModelName"`
+
+	// <p>训练模式：sft / dpo / cpt / grpo（仅 POST_TRAINING 有值）</p>
+	Mode *string `json:"Mode,omitnil,omitempty" name:"Mode"`
+
+	// <p>基础模型 modelUid（仅 POST_TRAINING 有值）</p>
+	BaseModelUid *string `json:"BaseModelUid,omitnil,omitempty" name:"BaseModelUid"`
+
+	// <p>基础模型名称（仅 POST_TRAINING 有值）</p>
+	BaseModelName *string `json:"BaseModelName,omitnil,omitempty" name:"BaseModelName"`
+
+	// <p>提交时的数据集挂载列表（List&lt;DatasetMount&gt;，仅详情返回）</p>
+	Datasets []*DatasetMount `json:"Datasets,omitnil,omitempty" name:"Datasets"`
+
+	// <p>提交时的 Checkpoint 产出配置（仅详情返回）</p>
+	LastInstanceStatus *string `json:"LastInstanceStatus,omitnil,omitempty" name:"LastInstanceStatus"`
+
+	// <p>标签列表（TagKey-TagValue）</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>提交时的 Checkpoint 产出配置（仅详情返回）</p>
+	Checkpoint *CheckpointConfig `json:"Checkpoint,omitnil,omitempty" name:"Checkpoint"`
+
+	// <p>提交时的调优参数（仅 POST_TRAINING，仅详情返回）</p>
+	TuningParams *TrainingTuningParams `json:"TuningParams,omitnil,omitempty" name:"TuningParams"`
+
+	// <p>提交时的断点续训意图声明（仅详情返回）</p>
+	ResumeTraining *bool `json:"ResumeTraining,omitnil,omitempty" name:"ResumeTraining"`
+
+	// <p>高级参数 JSON（透传给 Neutrino advanced_options）</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+}
+
+type TrainingParams struct {
+	// <p>每卡 batch size，SFT/DPO 用。GRPO 返回 null</p>
+	PerDeviceBatchSize *int64 `json:"PerDeviceBatchSize,omitnil,omitempty" name:"PerDeviceBatchSize"`
+
+	// <p>梯度累积步数，用于放大有效 batch；GRPO 返回 null。</p>
+	GradientAccumulationSteps *int64 `json:"GradientAccumulationSteps,omitnil,omitempty" name:"GradientAccumulationSteps"`
+
+	// <p>是否开启梯度检查点（省显存换计算），GRPO 返回 null。</p>
+	GradientCheckpointing *bool `json:"GradientCheckpointing,omitnil,omitempty" name:"GradientCheckpointing"`
+
+	// <p>最大序列/上下文长度，所有模式都返回。</p>
+	CutoffLen *int64 `json:"CutoffLen,omitnil,omitempty" name:"CutoffLen"`
+
+	// <p>推荐学习率；SFT/DPO 按算法+微调方式给值，GRPO 返回 null（由入口脚本默认值决定）。</p>
+	LearningRate *float64 `json:"LearningRate,omitnil,omitempty" name:"LearningRate"`
+
+	// <p>推荐训练轮次，所有模式都返回。</p>
+	Epochs *int64 `json:"Epochs,omitnil,omitempty" name:"Epochs"`
+
+	// <p>推荐 LoRA rank（仅 finetuneType=lora 有值，全参微调/GRPO 返回 null）。</p>
+	LoraRank *int64 `json:"LoraRank,omitnil,omitempty" name:"LoraRank"`
+
+	// <p>warmup 步数占总步数比例；GRPO 返回 null。</p>
+	WarmupRatio *float64 `json:"WarmupRatio,omitnil,omitempty" name:"WarmupRatio"`
+
+	// <p>GRPO 每步训练的 prompt 总数；SFT/DPO 返回 null。</p>
+	TrainBatchSize *int64 `json:"TrainBatchSize,omitnil,omitempty" name:"TrainBatchSize"`
+
+	// <p>GRPO PPO 阶段 mini-batch 大小；SFT/DPO 返回 null。</p>
+	PPOMiniBatchSize *int64 `json:"PPOMiniBatchSize,omitnil,omitempty" name:"PPOMiniBatchSize"`
+
+	// <p>GRPO rollout（vLLM/sglang）占用 GPU 显存比例（0~1）；SFT/DPO 返回 null。</p>
+	GpuMemoryUtilization *float64 `json:"GpuMemoryUtilization,omitnil,omitempty" name:"GpuMemoryUtilization"`
+
+	// <p>GRPO rollout 单次最大生成长度；SFT/DPO 返回 null。</p>
+	MaxResponseLength *int64 `json:"MaxResponseLength,omitnil,omitempty" name:"MaxResponseLength"`
+
+	// <p>GRPO 每个 prompt 的采样数（group size）；SFT/DPO 返回 null。</p>
+	NumSamplesPerPrompt *int64 `json:"NumSamplesPerPrompt,omitnil,omitempty" name:"NumSamplesPerPrompt"`
+}
+
+type TrainingTuningParams struct {
+	// <p>微调方式：lora / full / freeze；默认由算法决定（SFT/DPO=lora，CPT/GRPO=full）</p>
+	FineTuneType *string `json:"FineTuneType,omitnil,omitempty" name:"FineTuneType"`
+
+	// <p>LoRA rank，仅 finetuneType=lora 时生效</p>
+	LoraRank *int64 `json:"LoraRank,omitnil,omitempty" name:"LoraRank"`
+
+	// <p>LoRA alpha</p>
+	LoraAlpha *int64 `json:"LoraAlpha,omitnil,omitempty" name:"LoraAlpha"`
+
+	// <p>LoRA dropout</p>
+	LoraDropout *float64 `json:"LoraDropout,omitnil,omitempty" name:"LoraDropout"`
+
+	// <p>LoRA 目标层，默认 all</p>
+	LoraTarget *string `json:"LoraTarget,omitnil,omitempty" name:"LoraTarget"`
+
+	// <p>训练模式：balanced / quality / speed / custom</p>
+	TrainingMode *string `json:"TrainingMode,omitnil,omitempty" name:"TrainingMode"`
+
+	// <p>训练轮数</p>
+	Epochs *int64 `json:"Epochs,omitnil,omitempty" name:"Epochs"`
+
+	// <p>学习率</p>
+	LearningRate *float64 `json:"LearningRate,omitnil,omitempty" name:"LearningRate"`
+
+	// <p>每卡 batch size</p>
+	PerDeviceBatchSize *int64 `json:"PerDeviceBatchSize,omitnil,omitempty" name:"PerDeviceBatchSize"`
+
+	// <p>梯度累积步数</p>
+	GradientAccumulationSteps *int64 `json:"GradientAccumulationSteps,omitnil,omitempty" name:"GradientAccumulationSteps"`
+
+	// <p>上下文长度</p>
+	CutoffLen *int64 `json:"CutoffLen,omitnil,omitempty" name:"CutoffLen"`
+
+	// <p>最大样本数</p>
+	MaxSamples *int64 `json:"MaxSamples,omitnil,omitempty" name:"MaxSamples"`
+
+	// <p>是否启用 gradient checkpointing，默认 true</p>
+	GradientCheckPointing *bool `json:"GradientCheckPointing,omitnil,omitempty" name:"GradientCheckPointing"`
+
+	// <p>学习率调度器类型，默认 cosine</p>
+	LrScheduler *string `json:"LrScheduler,omitnil,omitempty" name:"LrScheduler"`
+
+	// <p>warmup 比例，默认 0.03</p>
+	WarmupRatio *float64 `json:"WarmupRatio,omitnil,omitempty" name:"WarmupRatio"`
+
+	// <p>DPO beta，仅 mode=dpo 时生效</p>
+	DPOBeta *float64 `json:"DPOBeta,omitnil,omitempty" name:"DPOBeta"`
+
+	// <p>DPO loss：sigmoid / hinge / ipo / kto_pair</p>
+	DPOLoss *string `json:"DPOLoss,omitnil,omitempty" name:"DPOLoss"`
+
+	// <p>兼容旧请求；当前 GRPO 默认使用 verl 内置 rule reward</p>
+	RewardFunctionCode *string `json:"RewardFunctionCode,omitnil,omitempty" name:"RewardFunctionCode"`
+
+	// <p>兼容旧请求；当前 GRPO 默认使用 verl 内置 rule reward</p>
+	RewardFunctionCosPath *string `json:"RewardFunctionCosPath,omitnil,omitempty" name:"RewardFunctionCosPath"`
+
+	// <p>GRPO KL 系数，默认 0.001</p>
+	KLCoefficient *float64 `json:"KLCoefficient,omitnil,omitempty" name:"KLCoefficient"`
+
+	// <p>每个 prompt 的采样数（group size），默认 8</p>
+	NumSamplesPerPrompt *int64 `json:"NumSamplesPerPrompt,omitnil,omitempty" name:"NumSamplesPerPrompt"`
+
+	// <p>最大响应生成长度，默认 1024</p>
+	MaxResponseLength *int64 `json:"MaxResponseLength,omitnil,omitempty" name:"MaxResponseLength"`
+
+	// <p>rollout 生成温度，默认 1.0</p>
+	RollOutTemperature *float64 `json:"RollOutTemperature,omitnil,omitempty" name:"RollOutTemperature"`
+
+	// <p>rollout backend：vllm / sglang，默认 vllm</p>
+	RollOutBackend *string `json:"RollOutBackend,omitnil,omitempty" name:"RollOutBackend"`
+
+	// <p>PPO clip ratio，默认 0.2</p>
+	ClipRatio *float64 `json:"ClipRatio,omitnil,omitempty" name:"ClipRatio"`
+
+	// <p>PPO mini batch size，默认 128</p>
+	PPOMiniBatchSize *int64 `json:"PPOMiniBatchSize,omitnil,omitempty" name:"PPOMiniBatchSize"`
+
+	// <p>PPO epochs（每批数据的更新轮数），默认 1</p>
+	PPOEpochs *int64 `json:"PPOEpochs,omitnil,omitempty" name:"PPOEpochs"`
+
+	// <p>训练总 batch size（每步 prompt 数量），默认 128</p>
+	TrainBatchSize *int64 `json:"TrainBatchSize,omitnil,omitempty" name:"TrainBatchSize"`
+
+	// <p>rollout tensor model parallel size，默认 1</p>
+	TensorModelParallelSize *int64 `json:"TensorModelParallelSize,omitnil,omitempty" name:"TensorModelParallelSize"`
+
+	// <p>vLLM GPU memory utilization，默认 0.5</p>
+	GpuMemoryUtilization *float64 `json:"GpuMemoryUtilization,omitnil,omitempty" name:"GpuMemoryUtilization"`
+}
+
 type TypeKVPair struct {
 	// <p>key值</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
@@ -30645,6 +37597,100 @@ func (r *UnlockMetaDataResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *UnlockMetaDataResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateApiKeyStatusRequestParams struct {
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>apiKey的状态</p><p>枚举值：</p><ul><li>Revoked： 不可用</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+type UpdateApiKeyStatusRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>apiKey的状态</p><p>枚举值：</p><ul><li>Revoked： 不可用</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+}
+
+func (r *UpdateApiKeyStatusRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateApiKeyStatusRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ApiKeyId")
+	delete(f, "Status")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateApiKeyStatusRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateApiKeyStatusResponseParams struct {
+	// <p>apiKey的Id</p>
+	ApiKeyId *string `json:"ApiKeyId,omitnil,omitempty" name:"ApiKeyId"`
+
+	// <p>apiKey名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>apiKey内容</p>
+	ApiKey *string `json:"ApiKey,omitnil,omitempty" name:"ApiKey"`
+
+	// <p>推理服务id</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>推理服务名称</p>
+	ServiceName *string `json:"ServiceName,omitnil,omitempty" name:"ServiceName"`
+
+	// <p>apiKey状态</p><p>枚举值：</p><ul><li>Revoked： 不可用</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>appid</p>
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>uin</p>
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>apiKey创建时间</p>
+	CreateTime *uint64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>apiKey更新时间</p>
+	UpdateTime *uint64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>子账号uin</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateApiKeyStatusResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateApiKeyStatusResponseParams `json:"Response"`
+}
+
+func (r *UpdateApiKeyStatusResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateApiKeyStatusResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -31055,6 +38101,160 @@ func (r *UpdateDataMaskStrategyResponse) FromJsonString(s string) error {
 }
 
 // Predefined struct for user
+type UpdateDeploymentRequestParams struct {
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>模型版本（如 v1, v2），未提供时保持当前版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>推理引擎（vllm）</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>副本数</p>
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>是否启用弹性伸缩</p>
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+}
+
+type UpdateDeploymentRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>DeploymentId</p>
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>模型版本（如 v1, v2），未提供时保持当前版本</p>
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>推理引擎（vllm）</p>
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>副本数</p>
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>是否启用弹性伸缩</p>
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+}
+
+func (r *UpdateDeploymentRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateDeploymentRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DeploymentId")
+	delete(f, "ModelVersion")
+	delete(f, "Engine")
+	delete(f, "Replicas")
+	delete(f, "AutoscalingEnabled")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateDeploymentRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateDeploymentResponseParams struct {
+	// <p>DeploymentId</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentId *string `json:"DeploymentId,omitnil,omitempty" name:"DeploymentId"`
+
+	// <p>部署名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>部署使用的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>部署状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>推理引擎（vLLM/SGLang 等）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Engine *string `json:"Engine,omitnil,omitempty" name:"Engine"`
+
+	// <p>期望副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Replicas *int64 `json:"Replicas,omitnil,omitempty" name:"Replicas"`
+
+	// <p>可用副本数</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AvailableReplicas *int64 `json:"AvailableReplicas,omitnil,omitempty" name:"AvailableReplicas"`
+
+	// <p>资源配置（JSON 字符串）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// <p>是否开启自动伸缩</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AutoscalingEnabled *bool `json:"AutoscalingEnabled,omitnil,omitempty" name:"AutoscalingEnabled"`
+
+	// <p>模型存储配置（Catalog JSON，记录模型 COS 挂载信息）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelStorageConfig *string `json:"ModelStorageConfig,omitnil,omitempty" name:"ModelStorageConfig"`
+
+	// <p>创建时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（毫秒时间戳）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>资源分区 ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourcePartitionId *string `json:"ResourcePartitionId,omitnil,omitempty" name:"ResourcePartitionId"`
+
+	// <p>资源队列名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Queue *string `json:"Queue,omitnil,omitempty" name:"Queue"`
+
+	// <p>ray head 是否开启高可用</p>
+	HeadHighAvailabilityEnabled *bool `json:"HeadHighAvailabilityEnabled,omitnil,omitempty" name:"HeadHighAvailabilityEnabled"`
+
+	// <p>镜像名称</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
+	// <p>资源分区名称</p>
+	ResourcePartitionName *string `json:"ResourcePartitionName,omitnil,omitempty" name:"ResourcePartitionName"`
+
+	// <p>高级参数</p>
+	AdvancedOptions *string `json:"AdvancedOptions,omitnil,omitempty" name:"AdvancedOptions"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateDeploymentResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateDeploymentResponseParams `json:"Response"`
+}
+
+func (r *UpdateDeploymentResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateDeploymentResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type UpdateEngineResourceGroupNetworkConfigInfoRequestParams struct {
 	// 引擎资源组ID
 	EngineResourceGroupId *string `json:"EngineResourceGroupId,omitnil,omitempty" name:"EngineResourceGroupId"`
@@ -31138,6 +38338,9 @@ type UpdateInferenceModelRequestParams struct {
 
 	// <p>模型标签列表（可选）</p>
 	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 }
 
 type UpdateInferenceModelRequest struct {
@@ -31157,6 +38360,9 @@ type UpdateInferenceModelRequest struct {
 
 	// <p>模型标签列表（可选）</p>
 	Tags []*string `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 }
 
 func (r *UpdateInferenceModelRequest) ToJsonString() string {
@@ -31176,6 +38382,7 @@ func (r *UpdateInferenceModelRequest) FromJsonString(s string) error {
 	delete(f, "Description")
 	delete(f, "ParameterSize")
 	delete(f, "Tags")
+	delete(f, "ResourceTags")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateInferenceModelRequest has unknown keys!", "")
 	}
@@ -31243,6 +38450,10 @@ type UpdateInferenceModelResponseParams struct {
 
 	// <p>SUB UIN</p>
 	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>系统标签列表（TagKey-TagValue）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ResourceTags []*Tag `json:"ResourceTags,omitnil,omitempty" name:"ResourceTags"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -31748,14 +38959,14 @@ type UpdateLabRequestParams struct {
 	// <p>数据实验室名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
 	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
 	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
 
 	// <p>数据实验室描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
-
-	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
-	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
 
 	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
 	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
@@ -31806,14 +39017,14 @@ type UpdateLabRequest struct {
 	// <p>数据实验室名称</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
+	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
+	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
+
 	// <p>Lab 镜像地址（必填，用于开发工具如 Jupyter/VSCode/WebShell）。前端在&quot;内置 / 自定义&quot;两态中选择此值；当 Image 字段未显式传入时，后端会基于该字段按 R1（镜像表命中）/R2（同值 fallback）派生 Ray 集群镜像。</p>
 	LabImage *string `json:"LabImage,omitnil,omitempty" name:"LabImage"`
 
 	// <p>数据实验室描述</p>
 	Description *string `json:"Description,omitnil,omitempty" name:"Description"`
-
-	// <p>Ray 集群镜像地址（可选，OpenAPI/SDK 高级控制入口）。前端不再传递此字段；为空时后端按 R1（镜像表查询命中）→ R2（同值 fallback）顺序自动派生。非空时直接作为 Ray 集群镜像，跳过派生（EXPLICIT），且后端不校验其与 LabImage 的兼容性。</p>
-	Image *string `json:"Image,omitnil,omitempty" name:"Image"`
 
 	// <p>镜像拉取策略（Always, IfNotPresent, Never）</p>
 	ImagePullPolicy *string `json:"ImagePullPolicy,omitnil,omitempty" name:"ImagePullPolicy"`
@@ -31871,9 +39082,9 @@ func (r *UpdateLabRequest) FromJsonString(s string) error {
 		return err
 	}
 	delete(f, "Name")
+	delete(f, "Image")
 	delete(f, "LabImage")
 	delete(f, "Description")
-	delete(f, "Image")
 	delete(f, "ImagePullPolicy")
 	delete(f, "ResourceConfigId")
 	delete(f, "GroupId")
@@ -32583,6 +39794,160 @@ func (r *UpdateRowFilterResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *UpdateRowFilterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateServiceAuthConfigRequestParams struct {
+	// <p>服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>是否启用 API-Key 鉴权</p>
+	ApiKeyAuthEnabled *bool `json:"ApiKeyAuthEnabled,omitnil,omitempty" name:"ApiKeyAuthEnabled"`
+}
+
+type UpdateServiceAuthConfigRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>服务ID</p>
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>是否启用 API-Key 鉴权</p>
+	ApiKeyAuthEnabled *bool `json:"ApiKeyAuthEnabled,omitnil,omitempty" name:"ApiKeyAuthEnabled"`
+}
+
+func (r *UpdateServiceAuthConfigRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateServiceAuthConfigRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ServiceId")
+	delete(f, "ApiKeyAuthEnabled")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "UpdateServiceAuthConfigRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type UpdateServiceAuthConfigResponseParams struct {
+	// <p>服务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ServiceId *string `json:"ServiceId,omitnil,omitempty" name:"ServiceId"`
+
+	// <p>服务名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>关联的模型UID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelUid *string `json:"ModelUid,omitnil,omitempty" name:"ModelUid"`
+
+	// <p>关联的模型名称</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelName *string `json:"ModelName,omitnil,omitempty" name:"ModelName"`
+
+	// <p>关联的模型版本号</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelVersion *string `json:"ModelVersion,omitnil,omitempty" name:"ModelVersion"`
+
+	// <p>模型标识符（OpenAI 兼容 API 中的 model 字段）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelIdentifier *string `json:"ModelIdentifier,omitnil,omitempty" name:"ModelIdentifier"`
+
+	// <p>关联模型的类型（LLM / VLM / Embedding / Reranker / TTS / ASR / CV / NLP / ML）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ModelType *string `json:"ModelType,omitnil,omitempty" name:"ModelType"`
+
+	// <p>服务状态（Running/Stopped/Deploying/Failed）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>服务端点URL</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	EndpointUrl *string `json:"EndpointUrl,omitnil,omitempty" name:"EndpointUrl"`
+
+	// <p>OpenAI 兼容统一入口 URL（通过 API-Key 路由，适用于 LLM/Embedding/Reranker）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedEndpointUrl *string `json:"UnifiedEndpointUrl,omitnil,omitempty" name:"UnifiedEndpointUrl"`
+
+	// <p>KServe V2 协议统一入口 URL（通过 API-Key + model name 路由，适用于 XGBoost 等传统 ML 模型）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UnifiedV2EndpointUrl *string `json:"UnifiedV2EndpointUrl,omitnil,omitempty" name:"UnifiedV2EndpointUrl"`
+
+	// <p>应用ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	AppId *int64 `json:"AppId,omitnil,omitempty" name:"AppId"`
+
+	// <p>主账号UIN</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Uin *string `json:"Uin,omitnil,omitempty" name:"Uin"`
+
+	// <p>创建时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	CreateTime *int64 `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
+
+	// <p>更新时间（Unix 时间戳，毫秒）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	UpdateTime *int64 `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
+
+	// <p>部署数量</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DeploymentCount *int64 `json:"DeploymentCount,omitnil,omitempty" name:"DeploymentCount"`
+
+	// <p>是否存在至少一个运行中的部署</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	HasRunningDeployment *bool `json:"HasRunningDeployment,omitnil,omitempty" name:"HasRunningDeployment"`
+
+	// <p>Ray Dashboard 访问地址（通过 Ingress 代理）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	RayDashboardUrl *string `json:"RayDashboardUrl,omitnil,omitempty" name:"RayDashboardUrl"`
+
+	// <p>是否启用 API-Key 鉴权</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthEnabled *bool `json:"ApiKeyAuthEnabled,omitnil,omitempty" name:"ApiKeyAuthEnabled"`
+
+	// <p>是否强制开启 API-Key 鉴权（生产环境为 true，不允许关闭）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	ApiKeyAuthForceEnabled *bool `json:"ApiKeyAuthForceEnabled,omitnil,omitempty" name:"ApiKeyAuthForceEnabled"`
+
+	// <p>是否跳过 TLS 证书验证（自签证书场景，前端 curl 命令需加 -k 参数）</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SkipTlsVerify *bool `json:"SkipTlsVerify,omitnil,omitempty" name:"SkipTlsVerify"`
+
+	// <p>子账号UIN（实际操作者）</p>
+	SubAccountUin *string `json:"SubAccountUin,omitnil,omitempty" name:"SubAccountUin"`
+
+	// <p>运行中部署的 CPU 资源汇总</p>
+	CpuResourceSummary *CpuSummaryItem `json:"CpuResourceSummary,omitnil,omitempty" name:"CpuResourceSummary"`
+
+	// <p>资源配置（JSON 字符串，取自第一个部署）</p>
+	ResourceConfig *string `json:"ResourceConfig,omitnil,omitempty" name:"ResourceConfig"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type UpdateServiceAuthConfigResponse struct {
+	*tchttp.BaseResponse
+	Response *UpdateServiceAuthConfigResponseParams `json:"Response"`
+}
+
+func (r *UpdateServiceAuthConfigResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *UpdateServiceAuthConfigResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1306,7 +1306,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc/v20180410
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb/v20180411
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.156
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.173
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124

--- a/website/docs/r/dlc_attach_user_policy_attachment.html.markdown
+++ b/website/docs/r/dlc_attach_user_policy_attachment.html.markdown
@@ -26,6 +26,7 @@ resource "tencentcloud_dlc_attach_user_policy_attachment" "example" {
     data_engine = "test_engine"
     operation   = "USE,MONITOR"
     source      = "USER"
+    re_auth     = true
   }
 }
 ```
@@ -85,6 +86,7 @@ The `policy_set` object supports the following:
 * `model` - (Optional, String) The name of the target Model. `*` represents all tables in the current database. To grant admin permissions, it must be `*`; to grant data connection and database permissions, it must be null; to grant other permissions, it can be any table.
 * `operation` - (Optional, String) The target permissions, which vary by permission level. Admin: `ALL` (default); data connection: `CREATE`; database: `ALL`, `CREATE`, `ALTER`, and `DROP`; table: `ALL`, `SELECT`, `INSERT`, `ALTER`, `DELETE`, `DROP`, and `UPDATE`.
 * `policy_type` - (Optional, String) The permission type. Valid values: `ADMIN`, `DATASOURCE`, `DATABASE`, `TABLE`, `VIEW`, `FUNCTION`, `COLUMN`, and `ENGINE`. Note: If it is left empty, `ADMIN` is used.
+* `re_auth` - (Optional, Bool) Whether the grantee is allowed to further grant the permissions. Valid values: `false` (default) and `true` (the grantee can grant permissions gained here to other sub-users).
 * `source` - (Optional, String) The permission source, Valid values: `USER` (from the user) and `WORKGROUP` (from one or more associated work groups).
 * `table` - (Optional, String) The name of the target table. `*` represents all tables in the current database. To grant admin permissions, it must be `*`; to grant data connection and database permissions, it must be null; to grant other permissions, it can be any table.
 * `view` - (Optional, String) The name of the target view. `*` represents all views in the current database. To grant admin permissions, it must be `*`; to grant data connection and database permissions, it must be null; to grant other permissions, it can be any view.
@@ -102,7 +104,6 @@ The `policy_set` object exports the following:
 * `is_admin_policy` - Whether the permission source is admin.
 * `operator` - The operator, which is not required as an input parameter.
 * `policy_id` - The deterministic string PolicyId corresponding to the user and workgroup.
-* `re_auth` - Whether the grantee is allowed to further grant the permissions. Valid values: `false` (default) and `true` (the grantee can grant permissions gained here to other sub-users).
 * `source_id` - The ID of the work group, which applies only when the value of the `Source` field is `WORKGROUP`.
 * `source_name` - The name of the work group, which applies only when the value of the `Source` field is `WORKGROUP`.
 


### PR DESCRIPTION
## Changes

- Modify the `policy_set.re_auth` schema field from `Computed: true` to `Optional: true, Computed: true` so users can set it while it is still populated from the API response on read.
- In the `resourceTencentCloudDlcAttachUserPolicyAttachmentCreate` handler, add mapping of the `re_auth` value from `policy_set` state into the `dlc.Policy.ReAuth` field before calling the `AttachUserPolicy` API.
- Update the resource documentation to reflect that `re_auth` is now an optional input.
- Add unit test coverage for the create path that sets `re_auth`.

## Backward Compatibility

Fully backward compatible. The field becomes optional (not required), so existing configurations without `re_auth` continue to work and the API default (`false`) applies. State continues to be populated from the API response on read.