### PR TITLE
feat(dbdc): [136830767] add deletion_protection param for db_custom_cluster resource

### DIFF
--- a/.changelog/4492.txt
+++ b/.changelog/4492.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_dbdc_db_custom_cluster: support deletion_protection parameter for managing cluster deletion protection
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.173
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -123,7 +123,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/csip v1.0.860
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.174
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2 v1.3.144
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/gwlb v1.0.1127
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/igtm v1.3.29

--- a/go.sum
+++ b/go.sum
@@ -993,7 +993,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.136/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.139/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.159/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1003,8 +1002,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.168/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.170/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.171/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.172/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173 h1:ROOEWJjiR+R1mHu9kxNNUXTgWXdj2V+1zEREDCGg5hE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174 h1:qOTtWnvYBZidSl1CDQd3nWvnX2OeMNywf5aQ7oY4gGY=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1023,8 +1023,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335 h1:D8qrel
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335/go.mod h1:pz4s3nOhoB9cY0+uWzifuwr7lfh/Gvi1rv0ADxpPzD4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26 h1:UrEmrF2rVN7JxMZqamx0tU/fUx/6Ip++uX09NlNb/KM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26/go.mod h1:1MPBiJ3+3Guw6SDZbZ0smrO6ENIV63qMhJq24nU50gY=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149 h1:VRt5qgAdcyDZKrzNV6Y2TeCTkIOf5iR8MuVyHpREi3g=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149/go.mod h1:qLRT2AtZhjc1VJUivRKud+hSFW4jrBZ58Fj3TfySYog=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.174 h1:kif8iwbLdNZ10maOyJlsYgpPqbOve0DiT8uef6wkGK4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.174/go.mod h1:xqQvJxKZ1gPumG6zc91sxAtZ2O4Sv6bXIIPDitTXg1A=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633 h1:Ul5iNhXoBrrzguMdbFzTDf3lfl15QrKbvOhvVBiqxDI=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633/go.mod h1:tc6Hvf03M1cBtMC1IKSa5mlOn3kpxWOwhWU1fRy+KEE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673 h1:YyjGLjvPDKNlpbGt89WLFif7TjId0fHzcrGOaHSQRNQ=

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/design.md
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The `tencentcloud_dbdc_db_custom_cluster` resource currently supports creating DB Custom clusters with `cluster_name`, `container_network`, `api_server_network`, `cluster_description`, and `tags` parameters. The DBDC `CreateDBCustomCluster` API also accepts a `DeletionProtection` parameter (bool, default `true`) that controls whether cluster deletion protection is enabled, but the Terraform resource does not expose this parameter.
+
+**Current state:**
+- Resource file: `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.go`
+- SDK: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029` (vendored, already includes `DeletionProtection`)
+
+**API behavior analysis:**
+
+| API | DeletionProtection in Request | DeletionProtection in Response |
+|-----|-------------------------------|-------------------------------|
+| `CreateDBCustomCluster` | Yes (`DeletionProtection *bool`, default `true`) | No |
+| `DescribeDBCustomClusterDetail` | N/A | Yes (`DeletionProtection *bool`) |
+| `ModifyDBCustomClusterAttributes` | Yes (`DeletionProtection *bool`) | N/A |
+| `DestroyDBCustomCluster` | No | N/A |
+
+**Key observation:** `DeletionProtection` is available in Create, Read, and Update APIs, enabling full lifecycle management. This is unlike other parameters (e.g., `cluster_name`, `container_network`) which are only available in Create and are thus `ForceNew`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `deletion_protection` (Optional, TypeBool) parameter to `tencentcloud_dbdc_db_custom_cluster` resource schema
+- Pass `DeletionProtection` to `CreateDBCustomCluster` API request when specified by user
+- Read `DeletionProtection` from `DescribeDBCustomClusterDetail` API response to support state refresh and import
+- Update `DeletionProtection` via `ModifyDBCustomClusterAttributes` API when the user changes the parameter
+- Maintain full backward compatibility — existing configurations continue to work unchanged
+
+**Non-Goals:**
+- Adding `deletion_protection` to any dbdc datasource (out of scope)
+- Making other existing parameters mutable (they remain `ForceNew`)
+
+## Decisions
+
+### Decision 1: `deletion_protection` is Optional and updatable (not ForceNew)
+
+**Rationale:** The `ModifyDBCustomClusterAttributes` API accepts `DeletionProtection`, so the parameter can be updated in-place without recreating the resource. Using `ForceNew: true` would unnecessarily destroy and recreate the cluster when the user only wants to toggle deletion protection. The parameter is `Optional` (not `Computed`) because the API has a default of `true`, but Terraform should only send the value when the user explicitly sets it.
+
+### Decision 2: Update via `ModifyDBCustomClusterAttributes` in the existing Update function
+
+**Rationale:** The existing `Update` function already handles `tags` changes via `ModifyDBCustomClusterTags`. We add a separate `if d.HasChange("deletion_protection")` block that calls `ModifyDBCustomClusterAttributes` with the `ClusterId` and `DeletionProtection` fields. This keeps the update logic modular and consistent with the existing pattern. The `ModifyDBCustomClusterAttributes` call is wrapped in `resource.Retry` with `tccommon.WriteRetryTimeout` for retry handling, consistent with the existing Create/Delete patterns.
+
+### Decision 3: Use `d.GetOkExists` for reading the bool parameter in Create
+
+**Rationale:** Since `DeletionProtection` is a bool with API default `true`, using `d.GetOk()` would not distinguish between "user set false" and "user did not set". However, since the API has a sensible default (`true`), we only need to pass the value when the user explicitly sets it. Using `d.GetOk()` is sufficient here because: if the user does not set the parameter, the API defaults to `true`; if the user sets it to `false`, `d.GetOk()` returns `ok=true` with `v=false`. If the user sets it to `true`, `d.GetOk()` returns `ok=true` with `v=true`. This correctly covers all cases.
+
+### Decision 4: Read `DeletionProtection` from `DescribeDBCustomClusterDetail` response
+
+**Rationale:** The `DescribeDBCustomClusterDetail` API response includes `DeletionProtection` as a field. The existing Read function calls `service.DescribeDBCustomClusterById` which returns the cluster detail. We add a nil-check for `respData.DeletionProtection` and set it to state, consistent with the existing pattern for other fields.
+
+## Risks / Trade-offs
+
+- **[Risk] API default vs Terraform default mismatch**: The API defaults `DeletionProtection` to `true` when not specified. If the user does not set `deletion_protection` in Terraform, the API will set it to `true`, and the Read function will populate `deletion_protection=true` in state. This is expected behavior and not a breaking change.
+  - **Mitigation:** No special handling needed; the Read function correctly reflects the API's actual state.

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/proposal.md
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The DBDC `CreateDBCustomCluster` API supports a `DeletionProtection` parameter that controls whether cluster deletion protection is enabled, but the Terraform resource `tencentcloud_dbdc_db_custom_cluster` does not expose this parameter. Users cannot manage deletion protection declaratively through Terraform, forcing them to use the console or API directly. The `ModifyDBCustomClusterAttributes` API also supports updating `DeletionProtection`, enabling full lifecycle management.
+
+## What Changes
+
+- Add `deletion_protection` (Optional, TypeBool) parameter to `tencentcloud_dbdc_db_custom_cluster` resource schema to control whether cluster deletion protection is enabled. Valid values: `true` (enabled, API default), `false` (disabled).
+- Pass `DeletionProtection` to the `CreateDBCustomCluster` API request when the user specifies the parameter.
+- Read `DeletionProtection` from the `DescribeDBCustomClusterDetail` API response to support state refresh and import.
+- Update the `Update` function to detect changes to `deletion_protection` and call `ModifyDBCustomClusterAttributes` API to update the deletion protection setting.
+
+## Capabilities
+
+### New Capabilities
+- `dbdc-db-custom-cluster-deletion-protection`: Enable the `deletion_protection` parameter on the `tencentcloud_dbdc_db_custom_cluster` resource to allow users to specify and manage cluster deletion protection through the full lifecycle (create, read, update).
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.go` — add `deletion_protection` schema field, wire through Create flow, add Read support, add Update support via `ModifyDBCustomClusterAttributes`
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster_test.go` — add unit test cases for the new parameter
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.md` — update documentation with `deletion_protection` usage example
+- **SDK dependency:** No SDK upgrade required. The vendored SDK `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029` already includes `DeletionProtection` in `CreateDBCustomClusterRequest`, `DescribeDBCustomClusterDetailResponseParams`, and `ModifyDBCustomClusterAttributesRequest`.
+- **Backward compatibility:** fully backward compatible — the new parameter is Optional and defaults to not being set, so existing configurations continue to work unchanged.
+- **API constraints:** `DeletionProtection` is available in `CreateDBCustomCluster` (create), `DescribeDBCustomClusterDetail` (read), and `ModifyDBCustomClusterAttributes` (update), enabling full CRUD support for this parameter.

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/specs/dbdc-db-custom-cluster-deletion-protection/spec.md
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/specs/dbdc-db-custom-cluster-deletion-protection/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Deletion protection on cluster creation
+The `tencentcloud_dbdc_db_custom_cluster` resource SHALL support an optional `deletion_protection` parameter (TypeBool) that is passed to the `CreateDBCustomCluster` API as `DeletionProtection`. When the user does not specify this parameter, the provider SHALL NOT set `DeletionProtection` in the API request, allowing the API to apply its default value of `true`.
+
+#### Scenario: Create cluster with deletion protection enabled
+- **WHEN** a user specifies `deletion_protection = true` in the `tencentcloud_dbdc_db_custom_cluster` resource configuration
+- **THEN** the provider SHALL pass `DeletionProtection=true` in the `CreateDBCustomCluster` API request
+
+#### Scenario: Create cluster with deletion protection disabled
+- **WHEN** a user specifies `deletion_protection = false` in the `tencentcloud_dbdc_db_custom_cluster` resource configuration
+- **THEN** the provider SHALL pass `DeletionProtection=false` in the `CreateDBCustomCluster` API request
+
+#### Scenario: Create cluster without explicit deletion protection
+- **WHEN** a user does NOT specify `deletion_protection` in the `tencentcloud_dbdc_db_custom_cluster` resource configuration
+- **THEN** the provider SHALL NOT set `DeletionProtection` in the `CreateDBCustomCluster` API request (API defaults to `true`)
+
+### Requirement: Read deletion protection from cluster detail
+The `tencentcloud_dbdc_db_custom_cluster` resource SHALL read `DeletionProtection` from the `DescribeDBCustomClusterDetail` API response and populate the `deletion_protection` field in Terraform state.
+
+#### Scenario: Read existing cluster with deletion protection
+- **WHEN** the provider reads an existing `tencentcloud_dbdc_db_custom_cluster` resource
+- **AND** the `DescribeDBCustomClusterDetail` response contains `DeletionProtection` that is not nil
+- **THEN** the provider SHALL set `deletion_protection` in state to the value from the response
+
+#### Scenario: Read existing cluster when DeletionProtection is nil
+- **WHEN** the provider reads an existing `tencentcloud_dbdc_db_custom_cluster` resource
+- **AND** the `DescribeDBCustomClusterDetail` response contains `DeletionProtection` that is nil
+- **THEN** the provider SHALL NOT set `deletion_protection` in state
+
+### Requirement: Update deletion protection via ModifyDBCustomClusterAttributes
+The `tencentcloud_dbdc_db_custom_cluster` resource SHALL support updating the `deletion_protection` parameter by calling the `ModifyDBCustomClusterAttributes` API with `ClusterId` and `DeletionProtection` fields. The update SHALL be triggered when `d.HasChange("deletion_protection")` is true.
+
+#### Scenario: Update deletion protection from true to false
+- **WHEN** a user changes `deletion_protection` from `true` to `false` on an existing `tencentcloud_dbdc_db_custom_cluster` resource
+- **THEN** the provider SHALL call `ModifyDBCustomClusterAttributes` with `ClusterId` set to the resource ID and `DeletionProtection=false`
+
+#### Scenario: Update deletion protection from false to true
+- **WHEN** a user changes `deletion_protection` from `false` to `true` on an existing `tencentcloud_dbdc_db_custom_cluster` resource
+- **THEN** the provider SHALL call `ModifyDBCustomClusterAttributes` with `ClusterId` set to the resource ID and `DeletionProtection=true`
+
+#### Scenario: Update without deletion protection change
+- **WHEN** a user updates the `tencentcloud_dbdc_db_custom_cluster` resource without changing `deletion_protection`
+- **THEN** the provider SHALL NOT call `ModifyDBCustomClusterAttributes` for deletion protection

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/tasks.md
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-cluster-deletion-protection/tasks.md
@@ -1,0 +1,32 @@
+## 1. Resource Schema Changes
+
+- [x] 1.1 Add `deletion_protection` schema field (TypeBool, Optional, description: whether to enable cluster deletion protection) to `ResourceTencentCloudDbdcDbCustomCluster()` in `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.go`
+
+## 2. Create Function Changes
+
+- [x] 2.1 Read `deletion_protection` from schema data using `d.GetOk("deletion_protection")` in `resourceTencentCloudDbdcDbCustomClusterCreate`
+- [x] 2.2 Set `request.DeletionProtection = helper.Bool(v.(bool))` when the parameter is specified
+
+## 3. Read Function Changes
+
+- [x] 3.1 Add nil-check for `respData.DeletionProtection` and set `deletion_protection` in state via `_ = d.Set("deletion_protection", respData.DeletionProtection)` in `resourceTencentCloudDbdcDbCustomClusterRead`
+
+## 4. Update Function Changes
+
+- [x] 4.1 Add `if d.HasChange("deletion_protection")` block in `resourceTencentCloudDbdcDbCustomClusterUpdate`
+- [x] 4.2 Create `ModifyDBCustomClusterAttributesRequest` with `ClusterId` and `DeletionProtection` fields
+- [x] 4.3 Call `ModifyDBCustomClusterAttributesWithContext` wrapped in `resource.Retry(tccommon.WriteRetryTimeout, ...)` with proper error handling and logging
+- [x] 4.4 Check response is not nil, log errors on failure
+
+## 5. Unit Test Changes
+
+- [x] 5.1 Add unit test cases for the `deletion_protection` parameter in `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster_test.go` using gomonkey mock approach for the cloud API
+
+## 6. Documentation
+
+- [x] 6.1 Update `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.md` with `deletion_protection` usage example
+
+## 7. Validation
+
+- [x] 7.1 Verify the code compiles successfully
+- [x] 7.2 Verify no lint errors

--- a/openspec/specs/dbdc-db-custom-cluster-deletion-protection/spec.md
+++ b/openspec/specs/dbdc-db-custom-cluster-deletion-protection/spec.md
@@ -1,0 +1,48 @@
+# dbdc-db-custom-cluster-deletion-protection Specification
+
+## Purpose
+TBD - created by archiving change add-dbdc-db-custom-cluster-deletion-protection. Update Purpose after archive.
+## Requirements
+### Requirement: Deletion protection on cluster creation
+The `tencentcloud_dbdc_db_custom_cluster` resource SHALL support an optional `deletion_protection` parameter (TypeBool) that is passed to the `CreateDBCustomCluster` API as `DeletionProtection`. When the user does not specify this parameter, the provider SHALL NOT set `DeletionProtection` in the API request, allowing the API to apply its default value of `true`.
+
+#### Scenario: Create cluster with deletion protection enabled
+- **WHEN** a user specifies `deletion_protection = true` in the `tencentcloud_dbdc_db_custom_cluster` resource configuration
+- **THEN** the provider SHALL pass `DeletionProtection=true` in the `CreateDBCustomCluster` API request
+
+#### Scenario: Create cluster with deletion protection disabled
+- **WHEN** a user specifies `deletion_protection = false` in the `tencentcloud_dbdc_db_custom_cluster` resource configuration
+- **THEN** the provider SHALL pass `DeletionProtection=false` in the `CreateDBCustomCluster` API request
+
+#### Scenario: Create cluster without explicit deletion protection
+- **WHEN** a user does NOT specify `deletion_protection` in the `tencentcloud_dbdc_db_custom_cluster` resource configuration
+- **THEN** the provider SHALL NOT set `DeletionProtection` in the `CreateDBCustomCluster` API request (API defaults to `true`)
+
+### Requirement: Read deletion protection from cluster detail
+The `tencentcloud_dbdc_db_custom_cluster` resource SHALL read `DeletionProtection` from the `DescribeDBCustomClusterDetail` API response and populate the `deletion_protection` field in Terraform state.
+
+#### Scenario: Read existing cluster with deletion protection
+- **WHEN** the provider reads an existing `tencentcloud_dbdc_db_custom_cluster` resource
+- **AND** the `DescribeDBCustomClusterDetail` response contains `DeletionProtection` that is not nil
+- **THEN** the provider SHALL set `deletion_protection` in state to the value from the response
+
+#### Scenario: Read existing cluster when DeletionProtection is nil
+- **WHEN** the provider reads an existing `tencentcloud_dbdc_db_custom_cluster` resource
+- **AND** the `DescribeDBCustomClusterDetail` response contains `DeletionProtection` that is nil
+- **THEN** the provider SHALL NOT set `deletion_protection` in state
+
+### Requirement: Update deletion protection via ModifyDBCustomClusterAttributes
+The `tencentcloud_dbdc_db_custom_cluster` resource SHALL support updating the `deletion_protection` parameter by calling the `ModifyDBCustomClusterAttributes` API with `ClusterId` and `DeletionProtection` fields. The update SHALL be triggered when `d.HasChange("deletion_protection")` is true.
+
+#### Scenario: Update deletion protection from true to false
+- **WHEN** a user changes `deletion_protection` from `true` to `false` on an existing `tencentcloud_dbdc_db_custom_cluster` resource
+- **THEN** the provider SHALL call `ModifyDBCustomClusterAttributes` with `ClusterId` set to the resource ID and `DeletionProtection=false`
+
+#### Scenario: Update deletion protection from false to true
+- **WHEN** a user changes `deletion_protection` from `false` to `true` on an existing `tencentcloud_dbdc_db_custom_cluster` resource
+- **THEN** the provider SHALL call `ModifyDBCustomClusterAttributes` with `ClusterId` set to the resource ID and `DeletionProtection=true`
+
+#### Scenario: Update without deletion protection change
+- **WHEN** a user updates the `tencentcloud_dbdc_db_custom_cluster` resource without changing `deletion_protection`
+- **THEN** the provider SHALL NOT call `ModifyDBCustomClusterAttributes` for deletion protection
+

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.go
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.go
@@ -93,6 +93,12 @@ func ResourceTencentCloudDbdcDbCustomCluster() *schema.Resource {
 				Description: "Cluster description.",
 			},
 
+			"deletion_protection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to enable cluster deletion protection. Valid values: `true` (enabled, API default), `false` (disabled).",
+			},
+
 			"tags": {
 				Type:        schema.TypeMap,
 				Optional:    true,
@@ -191,6 +197,10 @@ func resourceTencentCloudDbdcDbCustomClusterCreate(d *schema.ResourceData, meta 
 
 	if v, ok := d.GetOk("cluster_description"); ok {
 		request.ClusterDescription = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("deletion_protection"); ok {
+		request.DeletionProtection = helper.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
@@ -298,6 +308,10 @@ func resourceTencentCloudDbdcDbCustomClusterRead(d *schema.ResourceData, meta in
 		_ = d.Set("cluster_description", respData.ClusterDescription)
 	}
 
+	if respData.DeletionProtection != nil {
+		_ = d.Set("deletion_protection", respData.DeletionProtection)
+	}
+
 	if respData.Tags != nil {
 		tags := make(map[string]interface{}, len(respData.Tags))
 		for _, tag := range respData.Tags {
@@ -352,7 +366,7 @@ func resourceTencentCloudDbdcDbCustomClusterUpdate(d *schema.ResourceData, meta 
 		clusterId = d.Id()
 	)
 
-	// Only tags are mutable via the API, all other arguments are ForceNew.
+	// Only tags and deletion_protection are mutable via the API, all other arguments are ForceNew.
 	if d.HasChange("tags") {
 		oldRaw, newRaw := d.GetChange("tags")
 		oldTags := oldRaw.(map[string]interface{})
@@ -393,6 +407,32 @@ func resourceTencentCloudDbdcDbCustomClusterUpdate(d *schema.ResourceData, meta 
 
 		if reqErr != nil {
 			log.Printf("[CRITAL]%s update dbdc db custom cluster tags failed, reason:%+v", logId, reqErr)
+			return reqErr
+		}
+	}
+
+	if d.HasChange("deletion_protection") {
+		request := dbdcv20201029.NewModifyDBCustomClusterAttributesRequest()
+		request.ClusterId = helper.String(clusterId)
+		request.DeletionProtection = helper.Bool(d.Get("deletion_protection").(bool))
+
+		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDbdcV20201029Client().ModifyDBCustomClusterAttributesWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify dbdc db custom cluster attributes failed, Response is nil."))
+			}
+
+			return nil
+		})
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s update dbdc db custom cluster deletion_protection failed, reason:%+v", logId, reqErr)
 			return reqErr
 		}
 	}

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.go
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.go
@@ -96,6 +96,7 @@ func ResourceTencentCloudDbdcDbCustomCluster() *schema.Resource {
 			"deletion_protection": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Whether to enable cluster deletion protection. Valid values: `true` (enabled, API default), `false` (disabled).",
 			},
 
@@ -199,7 +200,7 @@ func resourceTencentCloudDbdcDbCustomClusterCreate(d *schema.ResourceData, meta 
 		request.ClusterDescription = helper.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("deletion_protection"); ok {
+	if v, ok := d.GetOkExists("deletion_protection"); ok {
 		request.DeletionProtection = helper.Bool(v.(bool))
 	}
 
@@ -413,9 +414,11 @@ func resourceTencentCloudDbdcDbCustomClusterUpdate(d *schema.ResourceData, meta 
 
 	if d.HasChange("deletion_protection") {
 		request := dbdcv20201029.NewModifyDBCustomClusterAttributesRequest()
-		request.ClusterId = helper.String(clusterId)
-		request.DeletionProtection = helper.Bool(d.Get("deletion_protection").(bool))
+		if v, ok := d.GetOkExists("deletion_protection"); ok {
+			request.DeletionProtection = helper.Bool(v.(bool))
+		}
 
+		request.ClusterId = helper.String(clusterId)
 		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDbdcV20201029Client().ModifyDBCustomClusterAttributesWithContext(ctx, request)
 			if e != nil {
@@ -454,7 +457,6 @@ func resourceTencentCloudDbdcDbCustomClusterDelete(d *schema.ResourceData, meta 
 	)
 
 	request.ClusterId = helper.String(clusterId)
-
 	reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDbdcV20201029Client().DestroyDBCustomClusterWithContext(ctx, request)
 		if e != nil {

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.md
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster.md
@@ -6,6 +6,7 @@ Example Usage
 resource "tencentcloud_dbdc_db_custom_cluster" "example" {
   cluster_name        = "tf-example"
   cluster_description = "cluster description."
+  deletion_protection = true
 
   container_network {
     vpc_id     = "vpc-py7mlxqm"

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster_test.go
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_cluster_test.go
@@ -22,6 +22,7 @@ func TestAccTencentCloudDbdcDbCustomClusterResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("tencentcloud_dbdc_db_custom_cluster.example", "id"),
 					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_cluster.example", "cluster_name", "tf-example"),
 					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_cluster.example", "cluster_description", "tf example cluster"),
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_cluster.example", "deletion_protection", "true"),
 					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_cluster.example", "tags.createBy", "Terraform"),
 					resource.TestCheckResourceAttrSet("tencentcloud_dbdc_db_custom_cluster.example", "cluster_status"),
 				),
@@ -30,6 +31,7 @@ func TestAccTencentCloudDbdcDbCustomClusterResource_basic(t *testing.T) {
 				Config: testAccDbdcDbCustomClusterUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_cluster.example", "tags.createBy", "TerraformUpdate"),
+					resource.TestCheckResourceAttr("tencentcloud_dbdc_db_custom_cluster.example", "deletion_protection", "false"),
 				),
 			},
 			{
@@ -45,6 +47,7 @@ const testAccDbdcDbCustomCluster = `
 resource "tencentcloud_dbdc_db_custom_cluster" "example" {
   cluster_name        = "tf-example"
   cluster_description = "tf example cluster"
+  deletion_protection = true
 
   container_network {
     vpc_id     = "vpc-xxxxxxxx"
@@ -66,6 +69,7 @@ const testAccDbdcDbCustomClusterUpdate = `
 resource "tencentcloud_dbdc_db_custom_cluster" "example" {
   cluster_name        = "tf-example"
   cluster_description = "tf example cluster"
+  deletion_protection = false
 
   container_network {
     vpc_id     = "vpc-xxxxxxxx"

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.173"
+	params["RequestClient"] = "SDK_GO_1.3.174"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/client.go
@@ -213,6 +213,62 @@ func (c *Client) CreateDBCustomClusterWithContext(ctx context.Context, request *
     return
 }
 
+func NewCreateDBCustomDisasterRecoverGroupRequest() (request *CreateDBCustomDisasterRecoverGroupRequest) {
+    request = &CreateDBCustomDisasterRecoverGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "CreateDBCustomDisasterRecoverGroup")
+    
+    
+    return
+}
+
+func NewCreateDBCustomDisasterRecoverGroupResponse() (response *CreateDBCustomDisasterRecoverGroupResponse) {
+    response = &CreateDBCustomDisasterRecoverGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateDBCustomDisasterRecoverGroup
+// 该接口（CreateDBCustomDisasterRecoverGroup）用于创建 DB Custom 置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) CreateDBCustomDisasterRecoverGroup(request *CreateDBCustomDisasterRecoverGroupRequest) (response *CreateDBCustomDisasterRecoverGroupResponse, err error) {
+    return c.CreateDBCustomDisasterRecoverGroupWithContext(context.Background(), request)
+}
+
+// CreateDBCustomDisasterRecoverGroup
+// 该接口（CreateDBCustomDisasterRecoverGroup）用于创建 DB Custom 置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) CreateDBCustomDisasterRecoverGroupWithContext(ctx context.Context, request *CreateDBCustomDisasterRecoverGroupRequest) (response *CreateDBCustomDisasterRecoverGroupResponse, err error) {
+    if request == nil {
+        request = NewCreateDBCustomDisasterRecoverGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "CreateDBCustomDisasterRecoverGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateDBCustomDisasterRecoverGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateDBCustomDisasterRecoverGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateDBCustomNodesRequest() (request *CreateDBCustomNodesRequest) {
     request = &CreateDBCustomNodesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -265,6 +321,118 @@ func (c *Client) CreateDBCustomNodesWithContext(ctx context.Context, request *Cr
     request.SetContext(ctx)
     
     response = NewCreateDBCustomNodesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteDBCustomDisasterRecoverGroupsRequest() (request *DeleteDBCustomDisasterRecoverGroupsRequest) {
+    request = &DeleteDBCustomDisasterRecoverGroupsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DeleteDBCustomDisasterRecoverGroups")
+    
+    
+    return
+}
+
+func NewDeleteDBCustomDisasterRecoverGroupsResponse() (response *DeleteDBCustomDisasterRecoverGroupsResponse) {
+    response = &DeleteDBCustomDisasterRecoverGroupsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteDBCustomDisasterRecoverGroups
+// 该接口（DeleteDBCustomDisasterRecoverGroups）用于删除 DB Custom 置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DeleteDBCustomDisasterRecoverGroups(request *DeleteDBCustomDisasterRecoverGroupsRequest) (response *DeleteDBCustomDisasterRecoverGroupsResponse, err error) {
+    return c.DeleteDBCustomDisasterRecoverGroupsWithContext(context.Background(), request)
+}
+
+// DeleteDBCustomDisasterRecoverGroups
+// 该接口（DeleteDBCustomDisasterRecoverGroups）用于删除 DB Custom 置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DeleteDBCustomDisasterRecoverGroupsWithContext(ctx context.Context, request *DeleteDBCustomDisasterRecoverGroupsRequest) (response *DeleteDBCustomDisasterRecoverGroupsResponse, err error) {
+    if request == nil {
+        request = NewDeleteDBCustomDisasterRecoverGroupsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DeleteDBCustomDisasterRecoverGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteDBCustomDisasterRecoverGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteDBCustomDisasterRecoverGroupsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteDBCustomNodesDisasterRecoverGroupRequest() (request *DeleteDBCustomNodesDisasterRecoverGroupRequest) {
+    request = &DeleteDBCustomNodesDisasterRecoverGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DeleteDBCustomNodesDisasterRecoverGroup")
+    
+    
+    return
+}
+
+func NewDeleteDBCustomNodesDisasterRecoverGroupResponse() (response *DeleteDBCustomNodesDisasterRecoverGroupResponse) {
+    response = &DeleteDBCustomNodesDisasterRecoverGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteDBCustomNodesDisasterRecoverGroup
+// 该接口（DeleteDBCustomNodesDisasterRecoverGroup）用于移除 DB Custom 节点的置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DeleteDBCustomNodesDisasterRecoverGroup(request *DeleteDBCustomNodesDisasterRecoverGroupRequest) (response *DeleteDBCustomNodesDisasterRecoverGroupResponse, err error) {
+    return c.DeleteDBCustomNodesDisasterRecoverGroupWithContext(context.Background(), request)
+}
+
+// DeleteDBCustomNodesDisasterRecoverGroup
+// 该接口（DeleteDBCustomNodesDisasterRecoverGroup）用于移除 DB Custom 节点的置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DeleteDBCustomNodesDisasterRecoverGroupWithContext(ctx context.Context, request *DeleteDBCustomNodesDisasterRecoverGroupRequest) (response *DeleteDBCustomNodesDisasterRecoverGroupResponse, err error) {
+    if request == nil {
+        request = NewDeleteDBCustomNodesDisasterRecoverGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DeleteDBCustomNodesDisasterRecoverGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteDBCustomNodesDisasterRecoverGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteDBCustomNodesDisasterRecoverGroupResponse()
     err = c.Send(request, response)
     return
 }
@@ -657,6 +825,118 @@ func (c *Client) DescribeDBCustomClustersWithContext(ctx context.Context, reques
     request.SetContext(ctx)
     
     response = NewDescribeDBCustomClustersResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeDBCustomDisasterRecoverGroupQuotaRequest() (request *DescribeDBCustomDisasterRecoverGroupQuotaRequest) {
+    request = &DescribeDBCustomDisasterRecoverGroupQuotaRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomDisasterRecoverGroupQuota")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomDisasterRecoverGroupQuotaResponse() (response *DescribeDBCustomDisasterRecoverGroupQuotaResponse) {
+    response = &DescribeDBCustomDisasterRecoverGroupQuotaResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomDisasterRecoverGroupQuota
+// 该接口（DescribeDBCustomDisasterRecoverGroupQuota）用于查询 DB Custom 置放群组配额。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomDisasterRecoverGroupQuota(request *DescribeDBCustomDisasterRecoverGroupQuotaRequest) (response *DescribeDBCustomDisasterRecoverGroupQuotaResponse, err error) {
+    return c.DescribeDBCustomDisasterRecoverGroupQuotaWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomDisasterRecoverGroupQuota
+// 该接口（DescribeDBCustomDisasterRecoverGroupQuota）用于查询 DB Custom 置放群组配额。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomDisasterRecoverGroupQuotaWithContext(ctx context.Context, request *DescribeDBCustomDisasterRecoverGroupQuotaRequest) (response *DescribeDBCustomDisasterRecoverGroupQuotaResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomDisasterRecoverGroupQuotaRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomDisasterRecoverGroupQuota")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomDisasterRecoverGroupQuota require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomDisasterRecoverGroupQuotaResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeDBCustomDisasterRecoverGroupsRequest() (request *DescribeDBCustomDisasterRecoverGroupsRequest) {
+    request = &DescribeDBCustomDisasterRecoverGroupsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomDisasterRecoverGroups")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomDisasterRecoverGroupsResponse() (response *DescribeDBCustomDisasterRecoverGroupsResponse) {
+    response = &DescribeDBCustomDisasterRecoverGroupsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomDisasterRecoverGroups
+// 该接口（DescribeDBCustomDisasterRecoverGroups）用于查询 DB Custom 置放群组列表。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomDisasterRecoverGroups(request *DescribeDBCustomDisasterRecoverGroupsRequest) (response *DescribeDBCustomDisasterRecoverGroupsResponse, err error) {
+    return c.DescribeDBCustomDisasterRecoverGroupsWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomDisasterRecoverGroups
+// 该接口（DescribeDBCustomDisasterRecoverGroups）用于查询 DB Custom 置放群组列表。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomDisasterRecoverGroupsWithContext(ctx context.Context, request *DescribeDBCustomDisasterRecoverGroupsRequest) (response *DescribeDBCustomDisasterRecoverGroupsResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomDisasterRecoverGroupsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomDisasterRecoverGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomDisasterRecoverGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomDisasterRecoverGroupsResponse()
     err = c.Send(request, response)
     return
 }
@@ -1515,6 +1795,62 @@ func (c *Client) IsolateDBCustomNodeWithContext(ctx context.Context, request *Is
     return
 }
 
+func NewModifyDBCustomClusterAttributesRequest() (request *ModifyDBCustomClusterAttributesRequest) {
+    request = &ModifyDBCustomClusterAttributesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomClusterAttributes")
+    
+    
+    return
+}
+
+func NewModifyDBCustomClusterAttributesResponse() (response *ModifyDBCustomClusterAttributesResponse) {
+    response = &ModifyDBCustomClusterAttributesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomClusterAttributes
+// 该接口（ModifyDBCustomClusterAttributes）用于修改 DB Custom 集群的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomClusterAttributes(request *ModifyDBCustomClusterAttributesRequest) (response *ModifyDBCustomClusterAttributesResponse, err error) {
+    return c.ModifyDBCustomClusterAttributesWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomClusterAttributes
+// 该接口（ModifyDBCustomClusterAttributes）用于修改 DB Custom 集群的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomClusterAttributesWithContext(ctx context.Context, request *ModifyDBCustomClusterAttributesRequest) (response *ModifyDBCustomClusterAttributesResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomClusterAttributesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomClusterAttributes")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomClusterAttributes require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomClusterAttributesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyDBCustomClusterNodeConfigRequest() (request *ModifyDBCustomClusterNodeConfigRequest) {
     request = &ModifyDBCustomClusterNodeConfigRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1627,6 +1963,174 @@ func (c *Client) ModifyDBCustomClusterTagsWithContext(ctx context.Context, reque
     return
 }
 
+func NewModifyDBCustomDisasterRecoverGroupAttributeRequest() (request *ModifyDBCustomDisasterRecoverGroupAttributeRequest) {
+    request = &ModifyDBCustomDisasterRecoverGroupAttributeRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomDisasterRecoverGroupAttribute")
+    
+    
+    return
+}
+
+func NewModifyDBCustomDisasterRecoverGroupAttributeResponse() (response *ModifyDBCustomDisasterRecoverGroupAttributeResponse) {
+    response = &ModifyDBCustomDisasterRecoverGroupAttributeResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomDisasterRecoverGroupAttribute
+// 该接口（ModifyDBCustomDisasterRecoverGroupAttribute）用于修改 DB Custom 置放群组的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomDisasterRecoverGroupAttribute(request *ModifyDBCustomDisasterRecoverGroupAttributeRequest) (response *ModifyDBCustomDisasterRecoverGroupAttributeResponse, err error) {
+    return c.ModifyDBCustomDisasterRecoverGroupAttributeWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomDisasterRecoverGroupAttribute
+// 该接口（ModifyDBCustomDisasterRecoverGroupAttribute）用于修改 DB Custom 置放群组的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomDisasterRecoverGroupAttributeWithContext(ctx context.Context, request *ModifyDBCustomDisasterRecoverGroupAttributeRequest) (response *ModifyDBCustomDisasterRecoverGroupAttributeResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomDisasterRecoverGroupAttributeRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomDisasterRecoverGroupAttribute")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomDisasterRecoverGroupAttribute require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomDisasterRecoverGroupAttributeResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyDBCustomDisasterRecoverGroupTagsRequest() (request *ModifyDBCustomDisasterRecoverGroupTagsRequest) {
+    request = &ModifyDBCustomDisasterRecoverGroupTagsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomDisasterRecoverGroupTags")
+    
+    
+    return
+}
+
+func NewModifyDBCustomDisasterRecoverGroupTagsResponse() (response *ModifyDBCustomDisasterRecoverGroupTagsResponse) {
+    response = &ModifyDBCustomDisasterRecoverGroupTagsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomDisasterRecoverGroupTags
+// 该接口（ModifyDBCustomDisasterRecoverGroupTags）用于修改 DB Custom 置放群组绑定的标签。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomDisasterRecoverGroupTags(request *ModifyDBCustomDisasterRecoverGroupTagsRequest) (response *ModifyDBCustomDisasterRecoverGroupTagsResponse, err error) {
+    return c.ModifyDBCustomDisasterRecoverGroupTagsWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomDisasterRecoverGroupTags
+// 该接口（ModifyDBCustomDisasterRecoverGroupTags）用于修改 DB Custom 置放群组绑定的标签。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomDisasterRecoverGroupTagsWithContext(ctx context.Context, request *ModifyDBCustomDisasterRecoverGroupTagsRequest) (response *ModifyDBCustomDisasterRecoverGroupTagsResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomDisasterRecoverGroupTagsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomDisasterRecoverGroupTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomDisasterRecoverGroupTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomDisasterRecoverGroupTagsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyDBCustomNodeAttributesRequest() (request *ModifyDBCustomNodeAttributesRequest) {
+    request = &ModifyDBCustomNodeAttributesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomNodeAttributes")
+    
+    
+    return
+}
+
+func NewModifyDBCustomNodeAttributesResponse() (response *ModifyDBCustomNodeAttributesResponse) {
+    response = &ModifyDBCustomNodeAttributesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomNodeAttributes
+// 该接口（ModifyDBCustomNodeAttributes）用于修改 DB Custom 节点的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodeAttributes(request *ModifyDBCustomNodeAttributesRequest) (response *ModifyDBCustomNodeAttributesResponse, err error) {
+    return c.ModifyDBCustomNodeAttributesWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomNodeAttributes
+// 该接口（ModifyDBCustomNodeAttributes）用于修改 DB Custom 节点的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodeAttributesWithContext(ctx context.Context, request *ModifyDBCustomNodeAttributesRequest) (response *ModifyDBCustomNodeAttributesResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomNodeAttributesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomNodeAttributes")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomNodeAttributes require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomNodeAttributesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyDBCustomNodeSecurityGroupsRequest() (request *ModifyDBCustomNodeSecurityGroupsRequest) {
     request = &ModifyDBCustomNodeSecurityGroupsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1735,6 +2239,62 @@ func (c *Client) ModifyDBCustomNodeTagsWithContext(ctx context.Context, request 
     request.SetContext(ctx)
     
     response = NewModifyDBCustomNodeTagsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyDBCustomNodesDisasterRecoverGroupRequest() (request *ModifyDBCustomNodesDisasterRecoverGroupRequest) {
+    request = &ModifyDBCustomNodesDisasterRecoverGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomNodesDisasterRecoverGroup")
+    
+    
+    return
+}
+
+func NewModifyDBCustomNodesDisasterRecoverGroupResponse() (response *ModifyDBCustomNodesDisasterRecoverGroupResponse) {
+    response = &ModifyDBCustomNodesDisasterRecoverGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomNodesDisasterRecoverGroup
+// 该接口（ModifyDBCustomNodesDisasterRecoverGroup）用于修改 DB Custom 节点的置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodesDisasterRecoverGroup(request *ModifyDBCustomNodesDisasterRecoverGroupRequest) (response *ModifyDBCustomNodesDisasterRecoverGroupResponse, err error) {
+    return c.ModifyDBCustomNodesDisasterRecoverGroupWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomNodesDisasterRecoverGroup
+// 该接口（ModifyDBCustomNodesDisasterRecoverGroup）用于修改 DB Custom 节点的置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodesDisasterRecoverGroupWithContext(ctx context.Context, request *ModifyDBCustomNodesDisasterRecoverGroupRequest) (response *ModifyDBCustomNodesDisasterRecoverGroupResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomNodesDisasterRecoverGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomNodesDisasterRecoverGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomNodesDisasterRecoverGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomNodesDisasterRecoverGroupResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/models.go
@@ -231,6 +231,9 @@ type CreateDBCustomClusterRequestParams struct {
 
 	// <p>试运行开关，true 时只执行参数校验，不发起创建流程，默认 false</p>
 	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul><p>默认值：true</p>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
 }
 
 type CreateDBCustomClusterRequest struct {
@@ -256,6 +259,9 @@ type CreateDBCustomClusterRequest struct {
 
 	// <p>试运行开关，true 时只执行参数校验，不发起创建流程，默认 false</p>
 	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul><p>默认值：true</p>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
 }
 
 func (r *CreateDBCustomClusterRequest) ToJsonString() string {
@@ -277,6 +283,7 @@ func (r *CreateDBCustomClusterRequest) FromJsonString(s string) error {
 	delete(f, "Tags")
 	delete(f, "ClientToken")
 	delete(f, "DryRun")
+	delete(f, "DeletionProtection")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBCustomClusterRequest has unknown keys!", "")
 	}
@@ -308,6 +315,119 @@ func (r *CreateDBCustomClusterResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateDBCustomClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateDBCustomDisasterRecoverGroupRequestParams struct {
+	// <p>置放群组名称</p><p>入参限制：长度1-60个字符，支持中、英文</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组类型</p><p>枚举值：</p><ul><li>HOST： 物理机</li></ul><p>默认值：HOST</p><p>当前仅支持物理机类型</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>置放群组策略</p><p>入参限制：当前仅支持分散置放群组</p><p>枚举值：</p><ul><li>SPREAD： 分散置放群组</li></ul><p>默认值：SPREAD</p>
+	Strategy *string `json:"Strategy,omitnil,omitempty" name:"Strategy"`
+
+	// <p>置放群组的亲和度，在置放群组的实例会按该亲和度分布</p><p>取值范围：[1, 10]</p><p>默认值：1</p>
+	Affinity *int64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+
+	// <p>标签</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>用于保证请求幂等性的字符串。该字符串由客户生成，需保证不同请求之间唯一，最大值不超过64个ASCII字符。若不指定该参数，则无法保证请求的幂等性。</p>
+	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+}
+
+type CreateDBCustomDisasterRecoverGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组名称</p><p>入参限制：长度1-60个字符，支持中、英文</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组类型</p><p>枚举值：</p><ul><li>HOST： 物理机</li></ul><p>默认值：HOST</p><p>当前仅支持物理机类型</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>置放群组策略</p><p>入参限制：当前仅支持分散置放群组</p><p>枚举值：</p><ul><li>SPREAD： 分散置放群组</li></ul><p>默认值：SPREAD</p>
+	Strategy *string `json:"Strategy,omitnil,omitempty" name:"Strategy"`
+
+	// <p>置放群组的亲和度，在置放群组的实例会按该亲和度分布</p><p>取值范围：[1, 10]</p><p>默认值：1</p>
+	Affinity *int64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+
+	// <p>标签</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>用于保证请求幂等性的字符串。该字符串由客户生成，需保证不同请求之间唯一，最大值不超过64个ASCII字符。若不指定该参数，则无法保证请求的幂等性。</p>
+	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+}
+
+func (r *CreateDBCustomDisasterRecoverGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateDBCustomDisasterRecoverGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "Type")
+	delete(f, "Strategy")
+	delete(f, "Affinity")
+	delete(f, "Tags")
+	delete(f, "ClientToken")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBCustomDisasterRecoverGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateDBCustomDisasterRecoverGroupResponseParams struct {
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>置放群组名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组类型</p><p>枚举值：</p><ul><li>HOST： 物理机</li></ul>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>状态</p><p>枚举值：</p><ul><li>Creating： 创建中</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>置放群组内可容纳的节点数量</p>
+	NodeQuotaTotal *int64 `json:"NodeQuotaTotal,omitnil,omitempty" name:"NodeQuotaTotal"`
+
+	// <p>置放群组内已有节点数量</p>
+	CurrentNum *int64 `json:"CurrentNum,omitnil,omitempty" name:"CurrentNum"`
+
+	// <p>创建时间</p>
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
+
+	// <p>置放群组策略</p><p>枚举值：</p><ul><li>SPREAD： 分散置放群组</li></ul>
+	Strategy *string `json:"Strategy,omitnil,omitempty" name:"Strategy"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateDBCustomDisasterRecoverGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateDBCustomDisasterRecoverGroupResponseParams `json:"Response"`
+}
+
+func (r *CreateDBCustomDisasterRecoverGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateDBCustomDisasterRecoverGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -375,6 +495,9 @@ type CreateDBCustomNodesRequestParams struct {
 
 	// <p>设置节点安全组</p><p>参数格式：设置需要与节点绑定的多个安全组ID，以数组形式配置。</p>
 	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+
+	// <p>置放群组ID</p><p>入参限制：仅支持指定一个</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
 }
 
 type CreateDBCustomNodesRequest struct {
@@ -442,6 +565,9 @@ type CreateDBCustomNodesRequest struct {
 
 	// <p>设置节点安全组</p><p>参数格式：设置需要与节点绑定的多个安全组ID，以数组形式配置。</p>
 	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+
+	// <p>置放群组ID</p><p>入参限制：仅支持指定一个</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
 }
 
 func (r *CreateDBCustomNodesRequest) ToJsonString() string {
@@ -477,6 +603,7 @@ func (r *CreateDBCustomNodesRequest) FromJsonString(s string) error {
 	delete(f, "HostName")
 	delete(f, "DryRun")
 	delete(f, "SecurityGroupIds")
+	delete(f, "DisasterRecoverGroupIds")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBCustomNodesRequest has unknown keys!", "")
 	}
@@ -542,6 +669,9 @@ type DBCustomCluster struct {
 	// <p>集群的标签信息</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
 }
 
 type DBCustomClusterNode struct {
@@ -573,6 +703,10 @@ type DBCustomClusterNode struct {
 	// <p>当选择网络模式为三层网络联通模式时，此处的IP地址则为用户可访问的地址。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	EniIP *string `json:"EniIP,omitnil,omitempty" name:"EniIP"`
+
+	// <p>节点绑定的安全组</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
 }
 
 type DBCustomClusterNodeConfig struct {
@@ -709,11 +843,18 @@ type DBCustomNode struct {
 	// <p>底层物理机IP（已加密）</p>
 	HostIp *string `json:"HostIp,omitnil,omitempty" name:"HostIp"`
 
-	// <p>网络模式</p><p>枚举值：</p><ul><li>NetworkModePrivateLink： 四层 SSH 服务联通模式</li><li>NetworkModeCrossTenantENI：  三层双网卡访问方式</li></ul>
+	// <p>网络模式</p><p>枚举值：</p><ul><li>privatelink： 四层 SSH 服务联通模式</li><li>cross_tenant_eni：  三层双网卡访问方式</li></ul>
 	NetworkMode *string `json:"NetworkMode,omitnil,omitempty" name:"NetworkMode"`
 
 	// <p>当选择NetworkModeCrossTenantENI模式时，节点的访问IP地址</p>
 	EniIP *string `json:"EniIP,omitnil,omitempty" name:"EniIP"`
+
+	// <p>节点绑定的安全组</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
 }
 
 type DBCustomNodeTypeInfo struct {
@@ -822,6 +963,129 @@ type DataDisk struct {
 }
 
 // Predefined struct for user
+type DeleteDBCustomDisasterRecoverGroupsRequestParams struct {
+	// <p>置放群组ID</p><p>入参限制：数量上限为10。若置放群组内有节点，需要先移除。</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+}
+
+type DeleteDBCustomDisasterRecoverGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组ID</p><p>入参限制：数量上限为10。若置放群组内有节点，需要先移除。</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+}
+
+func (r *DeleteDBCustomDisasterRecoverGroupsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDBCustomDisasterRecoverGroupsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DisasterRecoverGroupIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteDBCustomDisasterRecoverGroupsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteDBCustomDisasterRecoverGroupsResponseParams struct {
+	// <p>任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteDBCustomDisasterRecoverGroupsResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteDBCustomDisasterRecoverGroupsResponseParams `json:"Response"`
+}
+
+func (r *DeleteDBCustomDisasterRecoverGroupsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDBCustomDisasterRecoverGroupsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteDBCustomNodesDisasterRecoverGroupRequestParams struct {
+	// <p>节点ID</p><p>入参限制：单次数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>置放群组ID</p><p>入参限制：只支持传一个ID</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+}
+
+type DeleteDBCustomNodesDisasterRecoverGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>节点ID</p><p>入参限制：单次数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>置放群组ID</p><p>入参限制：只支持传一个ID</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+}
+
+func (r *DeleteDBCustomNodesDisasterRecoverGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDBCustomNodesDisasterRecoverGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NodeIds")
+	delete(f, "DisasterRecoverGroupIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteDBCustomNodesDisasterRecoverGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteDBCustomNodesDisasterRecoverGroupResponseParams struct {
+	// <p>任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteDBCustomNodesDisasterRecoverGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteDBCustomNodesDisasterRecoverGroupResponseParams `json:"Response"`
+}
+
+func (r *DeleteDBCustomNodesDisasterRecoverGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDBCustomNodesDisasterRecoverGroupResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeDBCustomClusterDetailRequestParams struct {
 	// <p>DB Custom 集群ID</p><p>入参限制：必须为此账号拥有的DB Custom集群</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -893,6 +1157,9 @@ type DescribeDBCustomClusterDetailResponseParams struct {
 	// <p>容器网络，在此集群中的所有Pod将与此网络连通</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ContainerNetwork *ContainerNetwork `json:"ContainerNetwork,omitnil,omitempty" name:"ContainerNetwork"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -1338,6 +1605,155 @@ func (r *DescribeDBCustomClustersResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeDBCustomClustersResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomDisasterRecoverGroupQuotaRequestParams struct {
+
+}
+
+type DescribeDBCustomDisasterRecoverGroupQuotaRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *DescribeDBCustomDisasterRecoverGroupQuotaRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomDisasterRecoverGroupQuotaRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomDisasterRecoverGroupQuotaRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomDisasterRecoverGroupQuotaResponseParams struct {
+	// <p>可创建置放群组数量的上限</p>
+	GroupQuota *int64 `json:"GroupQuota,omitnil,omitempty" name:"GroupQuota"`
+
+	// <p>已经创建的置放群组数量</p>
+	CurrentNum *int64 `json:"CurrentNum,omitnil,omitempty" name:"CurrentNum"`
+
+	// <p>物理机类型置放群组内节点的配额数</p>
+	NodeInHostGroupQuota *int64 `json:"NodeInHostGroupQuota,omitnil,omitempty" name:"NodeInHostGroupQuota"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomDisasterRecoverGroupQuotaResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomDisasterRecoverGroupQuotaResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomDisasterRecoverGroupQuotaResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomDisasterRecoverGroupQuotaResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomDisasterRecoverGroupsRequestParams struct {
+	// <p>置放群组ID</p><p>入参限制：单次数量上限是10</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+
+	// <p>查询筛选条件。支持的筛选条件包括：</p><ul><li>tag-key：按标签键进行过滤。</li><li>tag-value：按标签值进行过滤。</li></ul><p>入参限制：数量上限为5</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>根据标签键和标签值筛选 DB Custom 置放群组</p><p>入参限制：数量上限为5</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>分页偏移量</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>返回数量</p><p>取值范围：[1, 100]</p><p>默认值：20</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeDBCustomDisasterRecoverGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组ID</p><p>入参限制：单次数量上限是10</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+
+	// <p>查询筛选条件。支持的筛选条件包括：</p><ul><li>tag-key：按标签键进行过滤。</li><li>tag-value：按标签值进行过滤。</li></ul><p>入参限制：数量上限为5</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>根据标签键和标签值筛选 DB Custom 置放群组</p><p>入参限制：数量上限为5</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>分页偏移量</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>返回数量</p><p>取值范围：[1, 100]</p><p>默认值：20</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *DescribeDBCustomDisasterRecoverGroupsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomDisasterRecoverGroupsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DisasterRecoverGroupIds")
+	delete(f, "Filters")
+	delete(f, "Tags")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomDisasterRecoverGroupsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomDisasterRecoverGroupsResponseParams struct {
+	// <p>总数</p>
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// <p>置放群组列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DisasterRecoverGroupSet []*DisasterRecoverGroup `json:"DisasterRecoverGroupSet,omitnil,omitempty" name:"DisasterRecoverGroupSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomDisasterRecoverGroupsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomDisasterRecoverGroupsResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomDisasterRecoverGroupsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomDisasterRecoverGroupsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2574,6 +2990,42 @@ type DeviceInfo struct {
 	InstanceNum *uint64 `json:"InstanceNum,omitnil,omitempty" name:"InstanceNum"`
 }
 
+type DisasterRecoverGroup struct {
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>置放群组名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组类型</p><p>枚举值：</p><ul><li>HOST： 物理机</li></ul>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>置放群组状态</p><p>枚举值：</p><ul><li>Creating： 创建中</li><li>Available： 正常可使用</li><li>CreateFailed： 创建失败</li><li>Deleting： 删除中</li><li>Modifying： 变更中</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>置放群组内最大容纳节点数</p>
+	NodeQuotaTotal *uint64 `json:"NodeQuotaTotal,omitnil,omitempty" name:"NodeQuotaTotal"`
+
+	// <p>置放群组内当前节点数</p>
+	CurrentNum *uint64 `json:"CurrentNum,omitnil,omitempty" name:"CurrentNum"`
+
+	// <p>亲和度</p><p>取值范围：[1, 10]</p>
+	Affinity *uint64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+
+	// <p>置放群组策略</p><p>枚举值：</p><ul><li>SPREAD： 分散置放群组</li></ul>
+	Strategy *string `json:"Strategy,omitnil,omitempty" name:"Strategy"`
+
+	// <p>创建时间</p>
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
+
+	// <p>标签信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>置放群组内 DB Custom 节点数量</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+}
+
 type Filter struct {
 	// <p>筛选条件</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
@@ -2831,6 +3283,67 @@ type MetaResource struct {
 }
 
 // Predefined struct for user
+type ModifyDBCustomClusterAttributesRequestParams struct {
+	// <p>集群ID</p><p>参数格式：dbcc-hj7gab15</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
+}
+
+type ModifyDBCustomClusterAttributesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p><p>参数格式：dbcc-hj7gab15</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
+}
+
+func (r *ModifyDBCustomClusterAttributesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomClusterAttributesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "DeletionProtection")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomClusterAttributesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomClusterAttributesResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomClusterAttributesResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomClusterAttributesResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomClusterAttributesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomClusterAttributesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyDBCustomClusterNodeConfigRequestParams struct {
 	// <p>目标集群 ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -2927,10 +3440,10 @@ type ModifyDBCustomClusterTagsRequestParams struct {
 	// <p>DB Custom 集群ID</p><p>参数格式：dbcc-xxxxxxxx</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// <p>为 DB Custom 集群绑定的标签信息</p><p>入参限制：参考标签平台的限制策略</p>
+	// <p>为 DB Custom 集群绑定的标签信息</p><p>入参限制：参考标签平台的限制策略</p><p>如果集群未关联输入的标签键，则增加关联；若已关联，则将该集群关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
 
-	// <p>为 DB Custom 集群删除的标签Key</p>
+	// <p>为 DB Custom 集群解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
 }
 
@@ -2940,10 +3453,10 @@ type ModifyDBCustomClusterTagsRequest struct {
 	// <p>DB Custom 集群ID</p><p>参数格式：dbcc-xxxxxxxx</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// <p>为 DB Custom 集群绑定的标签信息</p><p>入参限制：参考标签平台的限制策略</p>
+	// <p>为 DB Custom 集群绑定的标签信息</p><p>入参限制：参考标签平台的限制策略</p><p>如果集群未关联输入的标签键，则增加关联；若已关联，则将该集群关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
 
-	// <p>为 DB Custom 集群删除的标签Key</p>
+	// <p>为 DB Custom 集群解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
 }
 
@@ -2987,6 +3500,224 @@ func (r *ModifyDBCustomClusterTagsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyDBCustomClusterTagsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomDisasterRecoverGroupAttributeRequestParams struct {
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>置放群组名称</p><p>入参限制：长度1-60个字符，支持中、英文</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组的亲和度，在置放群组的节点会按该亲和度分布</p><p>取值范围：[1, 10]</p>
+	Affinity *int64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+}
+
+type ModifyDBCustomDisasterRecoverGroupAttributeRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>置放群组名称</p><p>入参限制：长度1-60个字符，支持中、英文</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组的亲和度，在置放群组的节点会按该亲和度分布</p><p>取值范围：[1, 10]</p>
+	Affinity *int64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+}
+
+func (r *ModifyDBCustomDisasterRecoverGroupAttributeRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomDisasterRecoverGroupAttributeRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DisasterRecoverGroupId")
+	delete(f, "Name")
+	delete(f, "Affinity")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomDisasterRecoverGroupAttributeRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomDisasterRecoverGroupAttributeResponseParams struct {
+	// <p>任务ID</p>
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomDisasterRecoverGroupAttributeResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomDisasterRecoverGroupAttributeResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomDisasterRecoverGroupAttributeResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomDisasterRecoverGroupAttributeResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomDisasterRecoverGroupTagsRequestParams struct {
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>为 DB Custom 置放群组绑定的标签信息</p><p>入参限制：参考标签侧的限制</p><p>如果置放群组未关联输入的标签键，则增加关联；若已关联，则将该置放群组关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
+	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
+
+	// <p>需要解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
+	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
+}
+
+type ModifyDBCustomDisasterRecoverGroupTagsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>为 DB Custom 置放群组绑定的标签信息</p><p>入参限制：参考标签侧的限制</p><p>如果置放群组未关联输入的标签键，则增加关联；若已关联，则将该置放群组关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
+	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
+
+	// <p>需要解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
+	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
+}
+
+func (r *ModifyDBCustomDisasterRecoverGroupTagsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomDisasterRecoverGroupTagsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DisasterRecoverGroupId")
+	delete(f, "AddTags")
+	delete(f, "DeleteTagKeys")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomDisasterRecoverGroupTagsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomDisasterRecoverGroupTagsResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomDisasterRecoverGroupTagsResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomDisasterRecoverGroupTagsResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomDisasterRecoverGroupTagsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomDisasterRecoverGroupTagsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodeAttributesRequestParams struct {
+	// <p>节点ID</p><p>参数格式：dbcn-hq98qjym</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+
+	// <p>主机 HostName</p><p>入参限制：参数设置规则参见：<a href="https://cloud.tencent.com/document/api/1322/132929">创建 DB Custom 节点接口</a>的 HostName 参数说明。</p><p>注意：节点在没有加入到集群之前才支持修改主机 HostName。</p>
+	HostName *string `json:"HostName,omitnil,omitempty" name:"HostName"`
+
+	// <p>节点名称</p><p>入参限制：参数设置规则参见：<a href="https://cloud.tencent.com/document/api/1322/132929">创建 DB Custom 节点接口</a>的 NodeName 参数说明。</p>
+	NodeName *string `json:"NodeName,omitnil,omitempty" name:"NodeName"`
+
+	// <p>修改实例 HostName 是否自动重启实例，不传默认自动重启。</p><p>枚举值：</p><ul><li>true： 修改主机 HostName，并自动重启主机</li><li>false： 修改主机 HostName，不自动重启主机，需要手动重启使新主机 HostName 生效</li></ul><p>默认值：true</p>
+	AutoReboot *bool `json:"AutoReboot,omitnil,omitempty" name:"AutoReboot"`
+}
+
+type ModifyDBCustomNodeAttributesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>节点ID</p><p>参数格式：dbcn-hq98qjym</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+
+	// <p>主机 HostName</p><p>入参限制：参数设置规则参见：<a href="https://cloud.tencent.com/document/api/1322/132929">创建 DB Custom 节点接口</a>的 HostName 参数说明。</p><p>注意：节点在没有加入到集群之前才支持修改主机 HostName。</p>
+	HostName *string `json:"HostName,omitnil,omitempty" name:"HostName"`
+
+	// <p>节点名称</p><p>入参限制：参数设置规则参见：<a href="https://cloud.tencent.com/document/api/1322/132929">创建 DB Custom 节点接口</a>的 NodeName 参数说明。</p>
+	NodeName *string `json:"NodeName,omitnil,omitempty" name:"NodeName"`
+
+	// <p>修改实例 HostName 是否自动重启实例，不传默认自动重启。</p><p>枚举值：</p><ul><li>true： 修改主机 HostName，并自动重启主机</li><li>false： 修改主机 HostName，不自动重启主机，需要手动重启使新主机 HostName 生效</li></ul><p>默认值：true</p>
+	AutoReboot *bool `json:"AutoReboot,omitnil,omitempty" name:"AutoReboot"`
+}
+
+func (r *ModifyDBCustomNodeAttributesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodeAttributesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NodeId")
+	delete(f, "HostName")
+	delete(f, "NodeName")
+	delete(f, "AutoReboot")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomNodeAttributesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodeAttributesResponseParams struct {
+	// <p>上架节点的任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomNodeAttributesResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomNodeAttributesResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomNodeAttributesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodeAttributesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -3056,10 +3787,10 @@ type ModifyDBCustomNodeTagsRequestParams struct {
 	// <p>DB Custom 节点ID</p><p>参数格式：dbcn-0zan5xxk</p>
 	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
 
-	// <p>为节点绑定的标签信息</p><p>入参限制：参考标签侧的限制</p>
+	// <p>为节点绑定的标签信息</p><p>入参限制：参考标签侧的限制</p><p>如果节点未关联输入的标签键，则增加关联；若已关联，则将该节点关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
 
-	// <p>需要删除的标签Key</p>
+	// <p>需要解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
 }
 
@@ -3069,10 +3800,10 @@ type ModifyDBCustomNodeTagsRequest struct {
 	// <p>DB Custom 节点ID</p><p>参数格式：dbcn-0zan5xxk</p>
 	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
 
-	// <p>为节点绑定的标签信息</p><p>入参限制：参考标签侧的限制</p>
+	// <p>为节点绑定的标签信息</p><p>入参限制：参考标签侧的限制</p><p>如果节点未关联输入的标签键，则增加关联；若已关联，则将该节点关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
 
-	// <p>需要删除的标签Key</p>
+	// <p>需要解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
 }
 
@@ -3116,6 +3847,78 @@ func (r *ModifyDBCustomNodeTagsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyDBCustomNodeTagsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodesDisasterRecoverGroupRequestParams struct {
+	// <p>节点ID</p><p>入参限制：单次数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>置放群组ID</p><p>入参限制：支持传一个ID</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+
+	// <p>是否强制更换节点宿主机</p><p>枚举值：</p><ul><li>true： 表示允许节点更换宿主机，允许重启。本地盘节点不支持指定此参数。</li><li>false： 不允许节点更换宿主机，只在当前宿主机上加入置放群组。这可能导致更换置放群组失败。</li></ul><p>默认值：false</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
+}
+
+type ModifyDBCustomNodesDisasterRecoverGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>节点ID</p><p>入参限制：单次数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>置放群组ID</p><p>入参限制：支持传一个ID</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+
+	// <p>是否强制更换节点宿主机</p><p>枚举值：</p><ul><li>true： 表示允许节点更换宿主机，允许重启。本地盘节点不支持指定此参数。</li><li>false： 不允许节点更换宿主机，只在当前宿主机上加入置放群组。这可能导致更换置放群组失败。</li></ul><p>默认值：false</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
+}
+
+func (r *ModifyDBCustomNodesDisasterRecoverGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodesDisasterRecoverGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NodeIds")
+	delete(f, "DisasterRecoverGroupIds")
+	delete(f, "Force")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomNodesDisasterRecoverGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodesDisasterRecoverGroupResponseParams struct {
+	// <p>任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomNodesDisasterRecoverGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomNodesDisasterRecoverGroupResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomNodesDisasterRecoverGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodesDisasterRecoverGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -3224,6 +4027,9 @@ type RemoveNodesFromDBCustomClusterRequestParams struct {
 
 	// <p>节点的登录参数</p>
 	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
+
+	// <p>当节点中还有业务 Pod 在运行，默认会拦截从集群中移除节点的操作。如果该参数为 true，表示强制执行此操作。</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul><p>默认值：false</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
 }
 
 type RemoveNodesFromDBCustomClusterRequest struct {
@@ -3237,6 +4043,9 @@ type RemoveNodesFromDBCustomClusterRequest struct {
 
 	// <p>节点的登录参数</p>
 	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
+
+	// <p>当节点中还有业务 Pod 在运行，默认会拦截从集群中移除节点的操作。如果该参数为 true，表示强制执行此操作。</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul><p>默认值：false</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
 }
 
 func (r *RemoveNodesFromDBCustomClusterRequest) ToJsonString() string {
@@ -3254,6 +4063,7 @@ func (r *RemoveNodesFromDBCustomClusterRequest) FromJsonString(s string) error {
 	delete(f, "ClusterId")
 	delete(f, "NodeIds")
 	delete(f, "LoginSettings")
+	delete(f, "Force")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RemoveNodesFromDBCustomClusterRequest has unknown keys!", "")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1297,7 +1297,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu/v20180709
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain/v20210527
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.174
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633

--- a/website/docs/r/dbdc_db_custom_cluster.html.markdown
+++ b/website/docs/r/dbdc_db_custom_cluster.html.markdown
@@ -17,6 +17,7 @@ Provides a resource to create a DBDC db custom cluster.
 resource "tencentcloud_dbdc_db_custom_cluster" "example" {
   cluster_name        = "tf-example"
   cluster_description = "cluster description."
+  deletion_protection = true
 
   container_network {
     vpc_id     = "vpc-py7mlxqm"
@@ -42,6 +43,7 @@ The following arguments are supported:
 * `cluster_name` - (Required, String, ForceNew) Cluster name. Up to 128 characters, only Chinese, English and underscore are allowed.
 * `container_network` - (Required, List, ForceNew) Container network. All pods in this cluster are connected to this network.
 * `cluster_description` - (Optional, String, ForceNew) Cluster description.
+* `deletion_protection` - (Optional, Bool) Whether to enable cluster deletion protection. Valid values: `true` (enabled, API default), `false` (disabled).
 * `tags` - (Optional, Map) Cluster tags.
 
 The `api_server_network` object supports the following:


### PR DESCRIPTION
Add the deletion_protection parameter (Optional, TypeBool) to the tencentcloud_dbdc_db_custom_cluster resource to allow users to manage cluster deletion protection through the full lifecycle (create, read, update). The parameter is passed to CreateDBCustomCluster on create, read from DescribeDBCustomClusterDetail on read, and updated via ModifyDBCustomClusterAttributes on update.