### PR TITLE
feat(dbdc): [138032516] add disaster_recover_group_ids param to dbdc_db_custom_node resource

### DIFF
--- a/.changelog/4493.txt
+++ b/.changelog/4493.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_dbdc_db_custom_node: support specifying the disaster recover (placement) group via the `disaster_recover_group_ids` parameter and refreshing the bound `disaster_recover_group_id` on Read
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.173
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -123,7 +123,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/csip v1.0.860
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dasb v1.0.970
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.174
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ga2 v1.3.144
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/gwlb v1.0.1127
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/igtm v1.3.29

--- a/go.sum
+++ b/go.sum
@@ -993,7 +993,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.136/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.139/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.141/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.144/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.149/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.153/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.157/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.159/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
@@ -1003,8 +1002,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.168/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.170/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.171/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.172/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173 h1:ROOEWJjiR+R1mHu9kxNNUXTgWXdj2V+1zEREDCGg5hE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174 h1:qOTtWnvYBZidSl1CDQd3nWvnX2OeMNywf5aQ7oY4gGY=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1023,8 +1023,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335 h1:D8qrel
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu v1.0.335/go.mod h1:pz4s3nOhoB9cY0+uWzifuwr7lfh/Gvi1rv0ADxpPzD4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26 h1:UrEmrF2rVN7JxMZqamx0tU/fUx/6Ip++uX09NlNb/KM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26/go.mod h1:1MPBiJ3+3Guw6SDZbZ0smrO6ENIV63qMhJq24nU50gY=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149 h1:VRt5qgAdcyDZKrzNV6Y2TeCTkIOf5iR8MuVyHpREi3g=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149/go.mod h1:qLRT2AtZhjc1VJUivRKud+hSFW4jrBZ58Fj3TfySYog=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.174 h1:kif8iwbLdNZ10maOyJlsYgpPqbOve0DiT8uef6wkGK4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.174/go.mod h1:xqQvJxKZ1gPumG6zc91sxAtZ2O4Sv6bXIIPDitTXg1A=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633 h1:Ul5iNhXoBrrzguMdbFzTDf3lfl15QrKbvOhvVBiqxDI=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633/go.mod h1:tc6Hvf03M1cBtMC1IKSa5mlOn3kpxWOwhWU1fRy+KEE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673 h1:YyjGLjvPDKNlpbGt89WLFif7TjId0fHzcrGOaHSQRNQ=

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/design.md
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The `tencentcloud_dbdc_db_custom_node` resource (RESOURCE_KIND_GENERAL) currently manages the full CRUD lifecycle of a DB Custom node via the `dbdc` v20201029 SDK. It already exposes create-time parameters such as `zone`, `image_id`, `vpc_id`, `subnet_id`, `node_type`, `login_settings`, `security_group_ids`, etc., and computed fields refreshed from `DescribeDBCustomNodes`.
+
+**Current state:**
+- Resource file: `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go`
+- Service layer: `tencentcloud/services/dbdc/service_tencentcloud_dbdc.go` (`DescribeDBCustomNodeById` wraps `DescribeDBCustomNodes`, returns `*dbdcv20201029.DBCustomNode`)
+- SDK: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029` (already vendored, no upgrade needed)
+
+**API behavior analysis (vendored SDK):**
+
+| API | `DisasterRecoverGroupIds` in Request | `DisasterRecoverGroupId` in Response |
+|-----|--------------------------------------|--------------------------------------|
+| `CreateDBCustomNodes` | Yes (`DisasterRecoverGroupIds []*string`, "仅支持指定一个") | No |
+| `DescribeDBCustomNodes` | N/A | Yes (`DBCustomNode.DisasterRecoverGroupId *string`, inside `Response.NodeSet[]`) |
+| `RenewDBCustomNode` / `ModifyDBCustomNodeTags` / `ModifyDBCustomNodeSecurityGroups` | No | N/A |
+| `IsolateDBCustomNode` / `DestroyDBCustomNode` | No | N/A |
+
+**Key constraint:** `DisasterRecoverGroupIds` is only accepted by `CreateDBCustomNodes`. There is no update API that modifies the placement group of an existing node, so the input parameter is `ForceNew`. The `DescribeDBCustomNodes` response includes `DisasterRecoverGroupId`, so it can be refreshed on Read as a computed field.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `disaster_recover_group_ids` (Optional, `ForceNew`, `TypeList` of `TypeString`, `MaxItems: 1`) input parameter to `tencentcloud_dbdc_db_custom_node`, mapped to `request.DisasterRecoverGroupIds` in `CreateDBCustomNodes`. The API documents that only one placement group ID is supported.
+- Add `disaster_recover_group_id` (Computed, `TypeString`) output parameter to `tencentcloud_dbdc_db_custom_node`, mapped to `DBCustomNode.DisasterRecoverGroupId` from the `DescribeDBCustomNodes` response, refreshed during Read.
+- Maintain full backward compatibility — existing configurations continue to work unchanged.
+
+**Non-Goals:**
+- Supporting modification of the placement group after creation (the API has no such update path).
+- Adding placement-group-related parameters to any `dbdc` data source (out of scope).
+
+## Decisions
+
+### Decision 1: `disaster_recover_group_ids` is `ForceNew` (not immutable-args pattern)
+
+**Rationale:** The `CreateDBCustomNodes` API is the only API that accepts `DisasterRecoverGroupIds`; there is no update API that can change a node's placement group. Because changing this value requires recreating the node, `ForceNew: true` is the correct Terraform semantics. Unlike resources that only have CRD-style APIs (where the project convention is to use an `immutableArgs` array), this resource has a real Update flow for other fields (tags, period, security groups), so `ForceNew` on the single immutable input is the idiomatic choice.
+
+### Decision 2: Input is a list (`disaster_recover_group_ids`) with `MaxItems: 1`; output is a single string (`disaster_recover_group_id`)
+
+**Rationale:** The API request field `DisasterRecoverGroupIds` is `[]*string` (an array), so the Terraform input mirrors it as a `TypeList` to preserve the natural mapping and forward compatibility if the API ever relaxes the single-item limit. The API documents "仅支持指定一个", so `MaxItems: 1` is enforced to give users a clear early error. The API response field `DisasterRecoverGroupId` is a single `*string` on the node, so the computed output is a single `TypeString` named `disaster_recover_group_id`. This mirrors the existing pattern in the codebase where list inputs and singular computed outputs coexist.
+
+### Decision 3: Read `disaster_recover_group_id` from the existing `DescribeDBCustomNodeById` result
+
+**Rationale:** The service-layer helper `DescribeDBCustomNodeById` already returns `*dbdcv20201029.DBCustomNode`, whose struct now includes `DisasterRecoverGroupId`. No service-layer change is required — the Read function simply adds a nil-guarded `d.Set("disaster_recover_group_id", respData.DisasterRecoverGroupId)` alongside the existing field reads.
+
+## Risks / Trade-offs
+
+- **[Risk] Changing `disaster_recover_group_ids` destroys and recreates the node**: Using `ForceNew: true` means changing the placement group forces resource replacement.
+  - **Mitigation:** This is the only correct behavior since no update API exists; the recreation is explicit and visible to the user in the plan.
+
+- **[Risk] `disaster_recover_group_id` may be empty for nodes not in a placement group**: The API may return an empty/nil `DisasterRecoverGroupId` for nodes created without a placement group.
+  - **Mitigation:** The Read function nil-checks `respData.DisasterRecoverGroupId` before calling `d.Set`, consistent with the existing Read pattern for all other computed fields.

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/proposal.md
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `dbdc` `CreateDBCustomNodes` API supports specifying a disaster-recover (placement) group via the `DisasterRecoverGroupIds` request parameter, and the `DescribeDBCustomNodes` API returns the bound `DisasterRecoverGroupId` on each node, but the Terraform resource `tencentcloud_dbdc_db_custom_node` does not expose this parameter. Users who want to place a DB Custom node into a placement group at creation time cannot do so through Terraform, forcing them to use the console or API directly.
+
+## What Changes
+
+- Add `disaster_recover_group_ids` (Optional, `ForceNew`, `TypeList` of `TypeString`) parameter to the `tencentcloud_dbdc_db_custom_node` resource. It maps to `request.DisasterRecoverGroupIds` in the `CreateDBCustomNodes` API. The API documents that only one placement group ID is supported ("仅支持指定一个"), so `MaxItems: 1` is enforced.
+- Add `disaster_recover_group_id` (Computed, `TypeString`) parameter to the `tencentcloud_dbdc_db_custom_node` resource. It maps to `response.NodeSet[].DisasterRecoverGroupId` in the `DescribeDBCustomNodes` API and is refreshed during Read.
+
+## Capabilities
+
+### New Capabilities
+- `dbdc-db-custom-node-disaster-recover-group`: Enable the `disaster_recover_group_ids` input parameter and the `disaster_recover_group_id` computed parameter on the `tencentcloud_dbdc_db_custom_node` resource, so a node can be placed into a DB Custom disaster-recover (placement) group at creation time and the bound group can be refreshed on Read.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go` — add `disaster_recover_group_ids` and `disaster_recover_group_id` schema fields, wire `disaster_recover_group_ids` into the Create flow, add Read support for `disaster_recover_group_id`
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node_test.go` — add unit test coverage for the new parameters
+  - `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.md` — update documentation example
+- **SDK dependency:** The vendored `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029` already includes `DisasterRecoverGroupIds` in `CreateDBCustomNodesRequest` and `DisasterRecoverGroupId` in the `DBCustomNode` response struct. No SDK upgrade is required.
+- **Backward compatibility:** fully backward compatible — the new input parameter is Optional and defaults to not being set; the new computed parameter is read-only.
+- **API constraints:** `DisasterRecoverGroupIds` is only accepted by `CreateDBCustomNodes` (not by any update API), so `disaster_recover_group_ids` is `ForceNew`. The `DescribeDBCustomNodes` response includes `DisasterRecoverGroupId`, so Read can refresh `disaster_recover_group_id`.

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/specs/dbdc-db-custom-node-disaster-recover-group/spec.md
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/specs/dbdc-db-custom-node-disaster-recover-group/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Disaster recover group ids on node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `disaster_recover_group_ids` parameter (TypeList of TypeString, MaxItems 1, ForceNew) that is passed to the `CreateDBCustomNodes` API as `request.DisasterRecoverGroupIds`. The API supports specifying only one placement group ID. Changes to `disaster_recover_group_ids` after creation SHALL force replacement of the resource.
+
+#### Scenario: Create node with a disaster recover group
+- **WHEN** a user specifies `disaster_recover_group_ids = ["dbrg-xxxxxxxx"]` in the `tencentcloud_dbdc_db_custom_node` resource configuration
+- **THEN** the provider SHALL pass `DisasterRecoverGroupIds=["dbrg-xxxxxxxx"]` in the `CreateDBCustomNodes` API request
+
+#### Scenario: Create node without a disaster recover group
+- **WHEN** a user does NOT specify `disaster_recover_group_ids` in the `tencentcloud_dbdc_db_custom_node` resource configuration
+- **THEN** the provider SHALL NOT set `DisasterRecoverGroupIds` in the `CreateDBCustomNodes` API request
+
+#### Scenario: More than one disaster recover group id is rejected
+- **WHEN** a user specifies more than one element in `disaster_recover_group_ids`
+- **THEN** the provider SHALL reject the configuration via `MaxItems: 1`
+
+#### Scenario: Changing disaster recover group ids forces replacement
+- **WHEN** a user changes `disaster_recover_group_ids` after creation
+- **THEN** the provider SHALL force replacement (recreate) of the `tencentcloud_dbdc_db_custom_node` resource, because no update API can modify the placement group
+
+### Requirement: Disaster recover group id computed output on Read
+The `tencentcloud_dbdc_db_custom_node` resource SHALL expose a computed `disaster_recover_group_id` parameter (TypeString, Computed) that is refreshed from the `DescribeDBCustomNodes` API response (`response.NodeSet[].DisasterRecoverGroupId`).
+
+#### Scenario: Read node bound to a disaster recover group
+- **WHEN** the provider reads an existing `tencentcloud_dbdc_db_custom_node` whose node is bound to a placement group
+- **THEN** `disaster_recover_group_id` SHALL be refreshed from `DBCustomNode.DisasterRecoverGroupId` returned by `DescribeDBCustomNodes`
+
+#### Scenario: Read node not bound to a disaster recover group
+- **WHEN** the provider reads an existing `tencentcloud_dbdc_db_custom_node` whose node is NOT bound to a placement group
+- **THEN** the provider SHALL skip setting `disaster_recover_group_id` when `DBCustomNode.DisasterRecoverGroupId` is nil, consistent with the nil-guarded Read pattern for other computed fields

--- a/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/tasks.md
+++ b/openspec/changes/archive/2026-09-08-add-dbdc-db-custom-node-disaster-recover-group/tasks.md
@@ -1,0 +1,25 @@
+## 1. Schema Changes
+
+- [x] 1.1 Add `disaster_recover_group_ids` schema field (TypeList of TypeString, Optional, ForceNew, MaxItems 1) to `ResourceTencentCloudDbdcDbCustomNode()` in `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go`, with a description noting it maps to `CreateDBCustomNodes` `DisasterRecoverGroupIds` and that only one ID is supported
+- [x] 1.2 Add `disaster_recover_group_id` schema field (TypeString, Computed) to `ResourceTencentCloudDbdcDbCustomNode()`, with a description noting it is refreshed from `DescribeDBCustomNodes` `DBCustomNode.DisasterRecoverGroupId`
+
+## 2. Create Function Changes
+
+- [x] 2.1 In `resourceTencentCloudDbdcDbCustomNodeCreate`, read `disaster_recover_group_ids` from schema data and populate `request.DisasterRecoverGroupIds` (append each `*string` element), placing the logic alongside the other create-time request fields and before the `resource.Retry` call
+
+## 3. Read Function Changes
+
+- [x] 3.1 In `resourceTencentCloudDbdcDbCustomNodeRead`, add a nil-guarded `d.Set("disaster_recover_group_id", respData.DisasterRecoverGroupId)` block alongside the existing computed field reads (after `respData` is fetched via `DescribeDBCustomNodeById`)
+
+## 4. Tests
+
+- [x] 4.1 Add unit test coverage in `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node_test.go` for the new `disaster_recover_group_ids` input (Create request mapping) and `disaster_recover_group_id` computed output (Read), using gomonkey mocks for the cloud API per the project convention for newly added resources
+
+## 5. Documentation
+
+- [x] 5.1 Update `tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.md` example to include `disaster_recover_group_ids` usage (website docs are generated via `make doc` in the finalize phase; update the source `.md` only)
+
+## 6. Validation
+
+- [x] 6.1 Verify the code compiles successfully
+- [x] 6.2 Verify no lint errors

--- a/openspec/specs/dbdc-db-custom-node-disaster-recover-group/spec.md
+++ b/openspec/specs/dbdc-db-custom-node-disaster-recover-group/spec.md
@@ -1,0 +1,34 @@
+# dbdc-db-custom-node-disaster-recover-group Specification
+
+## Purpose
+TBD - created by syncing change add-dbdc-db-custom-node-disaster-recover-group. Update Purpose after sync.
+## Requirements
+### Requirement: Disaster recover group ids on node creation
+The `tencentcloud_dbdc_db_custom_node` resource SHALL support an optional `disaster_recover_group_ids` parameter (TypeList of TypeString, MaxItems 1, ForceNew) that is passed to the `CreateDBCustomNodes` API as `request.DisasterRecoverGroupIds`. The API supports specifying only one placement group ID. Changes to `disaster_recover_group_ids` after creation SHALL force replacement of the resource.
+
+#### Scenario: Create node with a disaster recover group
+- **WHEN** a user specifies `disaster_recover_group_ids = ["dbrg-xxxxxxxx"]` in the `tencentcloud_dbdc_db_custom_node` resource configuration
+- **THEN** the provider SHALL pass `DisasterRecoverGroupIds=["dbrg-xxxxxxxx"]` in the `CreateDBCustomNodes` API request
+
+#### Scenario: Create node without a disaster recover group
+- **WHEN** a user does NOT specify `disaster_recover_group_ids` in the `tencentcloud_dbdc_db_custom_node` resource configuration
+- **THEN** the provider SHALL NOT set `DisasterRecoverGroupIds` in the `CreateDBCustomNodes` API request
+
+#### Scenario: More than one disaster recover group id is rejected
+- **WHEN** a user specifies more than one element in `disaster_recover_group_ids`
+- **THEN** the provider SHALL reject the configuration via `MaxItems: 1`
+
+#### Scenario: Changing disaster recover group ids forces replacement
+- **WHEN** a user changes `disaster_recover_group_ids` after creation
+- **THEN** the provider SHALL force replacement (recreate) of the `tencentcloud_dbdc_db_custom_node` resource, because no update API can modify the placement group
+
+### Requirement: Disaster recover group id computed output on Read
+The `tencentcloud_dbdc_db_custom_node` resource SHALL expose a computed `disaster_recover_group_id` parameter (TypeString, Computed) that is refreshed from the `DescribeDBCustomNodes` API response (`response.NodeSet[].DisasterRecoverGroupId`).
+
+#### Scenario: Read node bound to a disaster recover group
+- **WHEN** the provider reads an existing `tencentcloud_dbdc_db_custom_node` whose node is bound to a placement group
+- **THEN** `disaster_recover_group_id` SHALL be refreshed from `DBCustomNode.DisasterRecoverGroupId` returned by `DescribeDBCustomNodes`
+
+#### Scenario: Read node not bound to a disaster recover group
+- **WHEN** the provider reads an existing `tencentcloud_dbdc_db_custom_node` whose node is NOT bound to a placement group
+- **THEN** the provider SHALL skip setting `disaster_recover_group_id` when `DBCustomNode.DisasterRecoverGroupId` is nil, consistent with the nil-guarded Read pattern for other computed fields

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go
@@ -234,6 +234,17 @@ func ResourceTencentCloudDbdcDbCustomNode() *schema.Resource {
 				},
 			},
 
+			"disaster_recover_group_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: "Placement (disaster recover) group ID list to bind to the node. Maps to the `DisasterRecoverGroupIds` request field of the `CreateDBCustomNodes` API. The API supports specifying only one placement group ID. Changing this forces replacement of the resource.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			// computed
 			"node_id": {
 				Type:        schema.TypeString,
@@ -305,6 +316,12 @@ func ResourceTencentCloudDbdcDbCustomNode() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Node access IP address when the `NetworkModeCrossTenantENI` network mode is selected. Refreshed from the `DescribeDBCustomNodes` API response.",
+			},
+
+			"disaster_recover_group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Placement (disaster recover) group ID bound to the node. Refreshed from the `DescribeDBCustomNodes` API response (`DBCustomNode.DisasterRecoverGroupId`).",
 			},
 		},
 	}
@@ -445,6 +462,14 @@ func resourceTencentCloudDbdcDbCustomNodeCreate(d *schema.ResourceData, meta int
 		for i := range securityGroupIdsSet {
 			securityGroupId := securityGroupIdsSet[i].(string)
 			request.SecurityGroupIds = append(request.SecurityGroupIds, &securityGroupId)
+		}
+	}
+
+	if v, ok := d.GetOk("disaster_recover_group_ids"); ok {
+		disasterRecoverGroupIdsList := v.([]interface{})
+		for i := range disasterRecoverGroupIdsList {
+			disasterRecoverGroupId := disasterRecoverGroupIdsList[i].(string)
+			request.DisasterRecoverGroupIds = append(request.DisasterRecoverGroupIds, &disasterRecoverGroupId)
 		}
 	}
 
@@ -607,6 +632,10 @@ func resourceTencentCloudDbdcDbCustomNodeRead(d *schema.ResourceData, meta inter
 
 	if respData.EniIP != nil {
 		_ = d.Set("eni_ip", respData.EniIP)
+	}
+
+	if respData.DisasterRecoverGroupId != nil {
+		_ = d.Set("disaster_recover_group_id", respData.DisasterRecoverGroupId)
 	}
 
 	if respData.SystemDisk != nil {

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.go
@@ -237,9 +237,9 @@ func ResourceTencentCloudDbdcDbCustomNode() *schema.Resource {
 			"disaster_recover_group_ids": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				ForceNew:    true,
+				Computed:    true,
 				MaxItems:    1,
-				Description: "Placement (disaster recover) group ID list to bind to the node. Maps to the `DisasterRecoverGroupIds` request field of the `CreateDBCustomNodes` API. The API supports specifying only one placement group ID. Changing this forces replacement of the resource.",
+				Description: "Placement (disaster recover) group ID list to bind to the node. Maps to the `DisasterRecoverGroupIds` request field of the `CreateDBCustomNodes` API. The API supports specifying only one placement group ID.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -317,12 +317,6 @@ func ResourceTencentCloudDbdcDbCustomNode() *schema.Resource {
 				Computed:    true,
 				Description: "Node access IP address when the `NetworkModeCrossTenantENI` network mode is selected. Refreshed from the `DescribeDBCustomNodes` API response.",
 			},
-
-			"disaster_recover_group_id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Placement (disaster recover) group ID bound to the node. Refreshed from the `DescribeDBCustomNodes` API response (`DBCustomNode.DisasterRecoverGroupId`).",
-			},
 		},
 	}
 }
@@ -379,8 +373,9 @@ func resourceTencentCloudDbdcDbCustomNodeCreate(d *schema.ResourceData, meta int
 		if v, ok := dMap["key_ids"]; ok {
 			keyIdsList := v.([]interface{})
 			for i := range keyIdsList {
-				keyId := keyIdsList[i].(string)
-				loginSettings.KeyIds = append(loginSettings.KeyIds, &keyId)
+				if keyId, ok := keyIdsList[i].(string); ok {
+					loginSettings.KeyIds = append(loginSettings.KeyIds, &keyId)
+				}
 			}
 		}
 
@@ -402,8 +397,9 @@ func resourceTencentCloudDbdcDbCustomNodeCreate(d *schema.ResourceData, meta int
 	if v, ok := d.GetOk("voucher_ids"); ok {
 		voucherIdsList := v.([]interface{})
 		for i := range voucherIdsList {
-			voucherId := voucherIdsList[i].(string)
-			request.VoucherIds = append(request.VoucherIds, &voucherId)
+			if voucherId, ok := voucherIdsList[i].(string); ok {
+				request.VoucherIds = append(request.VoucherIds, &voucherId)
+			}
 		}
 	}
 
@@ -460,16 +456,18 @@ func resourceTencentCloudDbdcDbCustomNodeCreate(d *schema.ResourceData, meta int
 	if v, ok := d.GetOk("security_group_ids"); ok {
 		securityGroupIdsSet := v.(*schema.Set).List()
 		for i := range securityGroupIdsSet {
-			securityGroupId := securityGroupIdsSet[i].(string)
-			request.SecurityGroupIds = append(request.SecurityGroupIds, &securityGroupId)
+			if securityGroupId, ok := securityGroupIdsSet[i].(string); ok {
+				request.SecurityGroupIds = append(request.SecurityGroupIds, &securityGroupId)
+			}
 		}
 	}
 
 	if v, ok := d.GetOk("disaster_recover_group_ids"); ok {
 		disasterRecoverGroupIdsList := v.([]interface{})
 		for i := range disasterRecoverGroupIdsList {
-			disasterRecoverGroupId := disasterRecoverGroupIdsList[i].(string)
-			request.DisasterRecoverGroupIds = append(request.DisasterRecoverGroupIds, &disasterRecoverGroupId)
+			if disasterRecoverGroupId, ok := disasterRecoverGroupIdsList[i].(string); ok {
+				request.DisasterRecoverGroupIds = append(request.DisasterRecoverGroupIds, &disasterRecoverGroupId)
+			}
 		}
 	}
 
@@ -635,7 +633,7 @@ func resourceTencentCloudDbdcDbCustomNodeRead(d *schema.ResourceData, meta inter
 	}
 
 	if respData.DisasterRecoverGroupId != nil {
-		_ = d.Set("disaster_recover_group_id", respData.DisasterRecoverGroupId)
+		_ = d.Set("disaster_recover_group_ids", []string{*respData.DisasterRecoverGroupId})
 	}
 
 	if respData.SystemDisk != nil {
@@ -796,8 +794,9 @@ func resourceTencentCloudDbdcDbCustomNodeUpdate(d *schema.ResourceData, meta int
 		if v, ok := d.GetOk("voucher_ids"); ok {
 			voucherIdsList := v.([]interface{})
 			for i := range voucherIdsList {
-				voucherId := voucherIdsList[i].(string)
-				request.VoucherIds = append(request.VoucherIds, &voucherId)
+				if voucherId, ok := voucherIdsList[i].(string); ok {
+					request.VoucherIds = append(request.VoucherIds, &voucherId)
+				}
 			}
 		}
 
@@ -829,8 +828,9 @@ func resourceTencentCloudDbdcDbCustomNodeUpdate(d *schema.ResourceData, meta int
 		request := dbdcv20201029.NewModifyDBCustomNodeSecurityGroupsRequest()
 		request.NodeId = helper.String(nodeId)
 		for i := range newIds {
-			securityGroupId := newIds[i].(string)
-			request.SecurityGroupIds = append(request.SecurityGroupIds, &securityGroupId)
+			if securityGroupId, ok := newIds[i].(string); ok {
+				request.SecurityGroupIds = append(request.SecurityGroupIds, &securityGroupId)
+			}
 		}
 
 		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
@@ -849,6 +849,47 @@ func resourceTencentCloudDbdcDbCustomNodeUpdate(d *schema.ResourceData, meta int
 		if reqErr != nil {
 			log.Printf("[CRITAL]%s modify dbdc db custom node security groups failed, reason:%+v", logId, reqErr)
 			return reqErr
+		}
+	}
+
+	if d.HasChange("disaster_recover_group_ids") {
+		request := dbdcv20201029.NewModifyDBCustomNodesDisasterRecoverGroupRequest()
+		response := dbdcv20201029.NewModifyDBCustomNodesDisasterRecoverGroupResponse()
+		if v, ok := d.GetOk("disaster_recover_group_ids"); ok {
+			disasterRecoverGroupIdsList := v.([]interface{})
+			for i := range disasterRecoverGroupIdsList {
+				if disasterRecoverGroupId, ok := disasterRecoverGroupIdsList[i].(string); ok {
+					request.DisasterRecoverGroupIds = append(request.DisasterRecoverGroupIds, &disasterRecoverGroupId)
+				}
+			}
+		}
+
+		request.NodeIds = helper.Strings([]string{nodeId})
+		reqErr := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDbdcV20201029Client().ModifyDBCustomNodesDisasterRecoverGroupWithContext(ctx, request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			}
+
+			if result == nil || result.Response == nil {
+				return resource.NonRetryableError(fmt.Errorf("Modify dbdc db custom node disaster recover groups failed, Response is nil."))
+			}
+
+			response = result
+			return nil
+		})
+
+		if reqErr != nil {
+			log.Printf("[CRITAL]%s modify dbdc db custom node disaster recover group failed, reason:%+v", logId, reqErr)
+			return reqErr
+		}
+
+		// wait
+		if response.Response.TaskId != nil {
+			service := DbdcService{client: meta.(tccommon.ProviderMeta).GetAPIV3Conn()}
+			if err := waitDBCustomTaskSucceeded(ctx, &service, *response.Response.TaskId, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.md
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node.md
@@ -28,6 +28,34 @@ resource "tencentcloud_dbdc_db_custom_node" "example" {
 }
 ```
 
+Create a PREPAID DBDC db custom node with disaster recover group
+
+```hcl
+resource "tencentcloud_dbdc_db_custom_node" "example" {
+  zone        = "ap-shanghai-5"
+  image_id    = "img-rm13akp3"
+  vpc_id      = "vpc-cseo7req"
+  subnet_id   = "subnet-huka6qhj"
+  node_type   = "DB.AT5.8XLARGE128"
+  period      = 1
+  auto_renew  = 1
+  charge_type = "PREPAID"
+  node_name   = "tf-example"
+
+  login_settings {
+    password = "Password@2026"
+  }
+
+  disaster_recover_group_ids = [
+    "dbrg-xxxxxxxx",
+  ]
+
+  tags = {
+    createBy = "Terraform"
+  }
+}
+```
+
 Create a POSTPAID DBDC db custom node
 
 ```hcl

--- a/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node_test.go
+++ b/tencentcloud/services/dbdc/resource_tc_dbdc_db_custom_node_test.go
@@ -164,6 +164,15 @@ func TestDbdcDbCustomNodeNetworkMode_Read(t *testing.T) {
 		return resp, nil
 	})
 
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodeSecurityGroupsWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodeSecurityGroupsRequest) (*dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodeSecurityGroupsResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponseParams{
+			Groups:    []*dbdcv20201029.SecurityGroup{},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
 	meta := &mockMetaDbdcDbCustomNode{client: mockClient}
 	res := svcdbdc.ResourceTencentCloudDbdcDbCustomNode()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
@@ -206,6 +215,15 @@ func TestDbdcDbCustomNodeNetworkMode_ReadNil(t *testing.T) {
 		return resp, nil
 	})
 
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodeSecurityGroupsWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodeSecurityGroupsRequest) (*dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodeSecurityGroupsResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponseParams{
+			Groups:    []*dbdcv20201029.SecurityGroup{},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
 	meta := &mockMetaDbdcDbCustomNode{client: mockClient}
 	res := svcdbdc.ResourceTencentCloudDbdcDbCustomNode()
 	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
@@ -218,4 +236,254 @@ func TestDbdcDbCustomNodeNetworkMode_ReadNil(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", d.Get("network_mode").(string))
 	assert.Equal(t, "", d.Get("eni_ip").(string))
+}
+
+// TestDbdcDbCustomNodeDisasterRecoverGroup_Schema tests the schema definition of disaster_recover_group_ids and disaster_recover_group_id
+func TestDbdcDbCustomNodeDisasterRecoverGroup_Schema(t *testing.T) {
+	res := svcdbdc.ResourceTencentCloudDbdcDbCustomNode()
+
+	assert.NotNil(t, res)
+
+	disasterRecoverGroupIds, ok := res.Schema["disaster_recover_group_ids"]
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeList, disasterRecoverGroupIds.Type)
+	assert.True(t, disasterRecoverGroupIds.Optional)
+	assert.True(t, disasterRecoverGroupIds.ForceNew)
+	assert.Equal(t, 1, disasterRecoverGroupIds.MaxItems)
+	assert.False(t, disasterRecoverGroupIds.Computed)
+
+	disasterRecoverGroupId, ok := res.Schema["disaster_recover_group_id"]
+	assert.True(t, ok)
+	assert.Equal(t, schema.TypeString, disasterRecoverGroupId.Type)
+	assert.True(t, disasterRecoverGroupId.Computed)
+	assert.False(t, disasterRecoverGroupId.Optional)
+	assert.False(t, disasterRecoverGroupId.ForceNew)
+}
+
+// TestDbdcDbCustomNodeDisasterRecoverGroup_Read tests that disaster_recover_group_id is correctly read from DescribeDBCustomNodes response
+func TestDbdcDbCustomNodeDisasterRecoverGroup_Read(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	mockClient := &connectivity.TencentCloudClient{}
+	patches.ApplyMethodReturn(mockClient, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodesWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrDbdcDbCustomNodeInt64(1),
+			NodeSet: []*dbdcv20201029.DBCustomNode{
+				{
+					NodeId:                 ptrDbdcDbCustomNodeString("dbcn-test-node-id"),
+					NodeName:               ptrDbdcDbCustomNodeString("test-node"),
+					Zone:                   ptrDbdcDbCustomNodeString("ap-shanghai-5"),
+					DisasterRecoverGroupId: ptrDbdcDbCustomNodeString("dbrg-test-group-id"),
+				},
+			},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodeSecurityGroupsWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodeSecurityGroupsRequest) (*dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodeSecurityGroupsResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponseParams{
+			Groups:    []*dbdcv20201029.SecurityGroup{},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := &mockMetaDbdcDbCustomNode{client: mockClient}
+	res := svcdbdc.ResourceTencentCloudDbdcDbCustomNode()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone":                       "ap-shanghai-5",
+		"node_type":                  "DB.AT5.8XLARGE128",
+		"disaster_recover_group_ids": []interface{}{"dbrg-test-group-id"},
+	})
+	d.SetId("dbcn-test-node-id")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "dbrg-test-group-id", d.Get("disaster_recover_group_id").(string))
+}
+
+// TestDbdcDbCustomNodeDisasterRecoverGroup_ReadNil tests that disaster_recover_group_id is not set when the response field is nil
+func TestDbdcDbCustomNodeDisasterRecoverGroup_ReadNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	mockClient := &connectivity.TencentCloudClient{}
+	patches.ApplyMethodReturn(mockClient, "UseDbdcV20201029Client", dbdcClient)
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodesWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrDbdcDbCustomNodeInt64(1),
+			NodeSet: []*dbdcv20201029.DBCustomNode{
+				{
+					NodeId:                 ptrDbdcDbCustomNodeString("dbcn-test-node-id"),
+					NodeName:               ptrDbdcDbCustomNodeString("test-node"),
+					Zone:                   ptrDbdcDbCustomNodeString("ap-shanghai-5"),
+					DisasterRecoverGroupId: nil,
+				},
+			},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodeSecurityGroupsWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodeSecurityGroupsRequest) (*dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodeSecurityGroupsResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponseParams{
+			Groups:    []*dbdcv20201029.SecurityGroup{},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := &mockMetaDbdcDbCustomNode{client: mockClient}
+	res := svcdbdc.ResourceTencentCloudDbdcDbCustomNode()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone":      "ap-shanghai-5",
+		"node_type": "DB.AT5.8XLARGE128",
+	})
+	d.SetId("dbcn-test-node-id")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Get("disaster_recover_group_id").(string))
+}
+
+// TestDbdcDbCustomNodeDisasterRecoverGroup_Create tests that disaster_recover_group_ids is correctly mapped into the CreateDBCustomNodes request
+func TestDbdcDbCustomNodeDisasterRecoverGroup_Create(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	mockClient := &connectivity.TencentCloudClient{}
+	patches.ApplyMethodReturn(mockClient, "UseDbdcV20201029Client", dbdcClient)
+
+	var capturedRequest *dbdcv20201029.CreateDBCustomNodesRequest
+	patches.ApplyMethodFunc(dbdcClient, "CreateDBCustomNodesWithContext", func(_ context.Context, request *dbdcv20201029.CreateDBCustomNodesRequest) (*dbdcv20201029.CreateDBCustomNodesResponse, error) {
+		capturedRequest = request
+		resp := dbdcv20201029.NewCreateDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.CreateDBCustomNodesResponseParams{
+			NodeIds:   []*string{ptrDbdcDbCustomNodeString("dbcn-test-node-id")},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	// Patch the read path invoked at the end of Create.
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodesWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrDbdcDbCustomNodeInt64(1),
+			NodeSet: []*dbdcv20201029.DBCustomNode{
+				{
+					NodeId:                 ptrDbdcDbCustomNodeString("dbcn-test-node-id"),
+					NodeName:               ptrDbdcDbCustomNodeString("test-node"),
+					Zone:                   ptrDbdcDbCustomNodeString("ap-shanghai-5"),
+					DisasterRecoverGroupId: ptrDbdcDbCustomNodeString("dbrg-test-group-id"),
+				},
+			},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodeSecurityGroupsWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodeSecurityGroupsRequest) (*dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodeSecurityGroupsResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponseParams{
+			Groups:    []*dbdcv20201029.SecurityGroup{},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := &mockMetaDbdcDbCustomNode{client: mockClient}
+	res := svcdbdc.ResourceTencentCloudDbdcDbCustomNode()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone":                       "ap-shanghai-5",
+		"image_id":                   "img-xxxxxxxx",
+		"vpc_id":                     "vpc-xxxxxxxx",
+		"subnet_id":                  "subnet-xxxxxxxx",
+		"node_type":                  "DB.AT5.8XLARGE128",
+		"disaster_recover_group_ids": []interface{}{"dbrg-test-group-id"},
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "dbcn-test-node-id", d.Id())
+	// Verify the input parameter was passed through to the API request.
+	assert.NotNil(t, capturedRequest.DisasterRecoverGroupIds)
+	assert.Len(t, capturedRequest.DisasterRecoverGroupIds, 1)
+	assert.Equal(t, "dbrg-test-group-id", *capturedRequest.DisasterRecoverGroupIds[0])
+	// Verify the computed output was refreshed during the Create-time Read.
+	assert.Equal(t, "dbrg-test-group-id", d.Get("disaster_recover_group_id").(string))
+}
+
+// TestDbdcDbCustomNodeDisasterRecoverGroup_CreateWithoutGroup tests that DisasterRecoverGroupIds is not set on the request when the input is absent
+func TestDbdcDbCustomNodeDisasterRecoverGroup_CreateWithoutGroup(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dbdcClient := &dbdcv20201029.Client{}
+	mockClient := &connectivity.TencentCloudClient{}
+	patches.ApplyMethodReturn(mockClient, "UseDbdcV20201029Client", dbdcClient)
+
+	var capturedRequest *dbdcv20201029.CreateDBCustomNodesRequest
+	patches.ApplyMethodFunc(dbdcClient, "CreateDBCustomNodesWithContext", func(_ context.Context, request *dbdcv20201029.CreateDBCustomNodesRequest) (*dbdcv20201029.CreateDBCustomNodesResponse, error) {
+		capturedRequest = request
+		resp := dbdcv20201029.NewCreateDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.CreateDBCustomNodesResponseParams{
+			NodeIds:   []*string{ptrDbdcDbCustomNodeString("dbcn-test-node-id")},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodesWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodesRequest) (*dbdcv20201029.DescribeDBCustomNodesResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodesResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodesResponseParams{
+			TotalCount: ptrDbdcDbCustomNodeInt64(1),
+			NodeSet: []*dbdcv20201029.DBCustomNode{
+				{
+					NodeId:   ptrDbdcDbCustomNodeString("dbcn-test-node-id"),
+					NodeName: ptrDbdcDbCustomNodeString("test-node"),
+					Zone:     ptrDbdcDbCustomNodeString("ap-shanghai-5"),
+				},
+			},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(dbdcClient, "DescribeDBCustomNodeSecurityGroupsWithContext", func(_ context.Context, request *dbdcv20201029.DescribeDBCustomNodeSecurityGroupsRequest) (*dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponse, error) {
+		resp := dbdcv20201029.NewDescribeDBCustomNodeSecurityGroupsResponse()
+		resp.Response = &dbdcv20201029.DescribeDBCustomNodeSecurityGroupsResponseParams{
+			Groups:    []*dbdcv20201029.SecurityGroup{},
+			RequestId: ptrDbdcDbCustomNodeString("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := &mockMetaDbdcDbCustomNode{client: mockClient}
+	res := svcdbdc.ResourceTencentCloudDbdcDbCustomNode()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"zone":      "ap-shanghai-5",
+		"image_id":  "img-xxxxxxxx",
+		"vpc_id":    "vpc-xxxxxxxx",
+		"subnet_id": "subnet-xxxxxxxx",
+		"node_type": "DB.AT5.8XLARGE128",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "dbcn-test-node-id", d.Id())
+	assert.Nil(t, capturedRequest.DisasterRecoverGroupIds)
+	assert.Equal(t, "", d.Get("disaster_recover_group_id").(string))
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.173"
+	params["RequestClient"] = "SDK_GO_1.3.174"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/client.go
@@ -213,6 +213,62 @@ func (c *Client) CreateDBCustomClusterWithContext(ctx context.Context, request *
     return
 }
 
+func NewCreateDBCustomDisasterRecoverGroupRequest() (request *CreateDBCustomDisasterRecoverGroupRequest) {
+    request = &CreateDBCustomDisasterRecoverGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "CreateDBCustomDisasterRecoverGroup")
+    
+    
+    return
+}
+
+func NewCreateDBCustomDisasterRecoverGroupResponse() (response *CreateDBCustomDisasterRecoverGroupResponse) {
+    response = &CreateDBCustomDisasterRecoverGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// CreateDBCustomDisasterRecoverGroup
+// 该接口（CreateDBCustomDisasterRecoverGroup）用于创建 DB Custom 置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) CreateDBCustomDisasterRecoverGroup(request *CreateDBCustomDisasterRecoverGroupRequest) (response *CreateDBCustomDisasterRecoverGroupResponse, err error) {
+    return c.CreateDBCustomDisasterRecoverGroupWithContext(context.Background(), request)
+}
+
+// CreateDBCustomDisasterRecoverGroup
+// 该接口（CreateDBCustomDisasterRecoverGroup）用于创建 DB Custom 置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) CreateDBCustomDisasterRecoverGroupWithContext(ctx context.Context, request *CreateDBCustomDisasterRecoverGroupRequest) (response *CreateDBCustomDisasterRecoverGroupResponse, err error) {
+    if request == nil {
+        request = NewCreateDBCustomDisasterRecoverGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "CreateDBCustomDisasterRecoverGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("CreateDBCustomDisasterRecoverGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewCreateDBCustomDisasterRecoverGroupResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewCreateDBCustomNodesRequest() (request *CreateDBCustomNodesRequest) {
     request = &CreateDBCustomNodesRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -265,6 +321,118 @@ func (c *Client) CreateDBCustomNodesWithContext(ctx context.Context, request *Cr
     request.SetContext(ctx)
     
     response = NewCreateDBCustomNodesResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteDBCustomDisasterRecoverGroupsRequest() (request *DeleteDBCustomDisasterRecoverGroupsRequest) {
+    request = &DeleteDBCustomDisasterRecoverGroupsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DeleteDBCustomDisasterRecoverGroups")
+    
+    
+    return
+}
+
+func NewDeleteDBCustomDisasterRecoverGroupsResponse() (response *DeleteDBCustomDisasterRecoverGroupsResponse) {
+    response = &DeleteDBCustomDisasterRecoverGroupsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteDBCustomDisasterRecoverGroups
+// 该接口（DeleteDBCustomDisasterRecoverGroups）用于删除 DB Custom 置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DeleteDBCustomDisasterRecoverGroups(request *DeleteDBCustomDisasterRecoverGroupsRequest) (response *DeleteDBCustomDisasterRecoverGroupsResponse, err error) {
+    return c.DeleteDBCustomDisasterRecoverGroupsWithContext(context.Background(), request)
+}
+
+// DeleteDBCustomDisasterRecoverGroups
+// 该接口（DeleteDBCustomDisasterRecoverGroups）用于删除 DB Custom 置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DeleteDBCustomDisasterRecoverGroupsWithContext(ctx context.Context, request *DeleteDBCustomDisasterRecoverGroupsRequest) (response *DeleteDBCustomDisasterRecoverGroupsResponse, err error) {
+    if request == nil {
+        request = NewDeleteDBCustomDisasterRecoverGroupsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DeleteDBCustomDisasterRecoverGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteDBCustomDisasterRecoverGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteDBCustomDisasterRecoverGroupsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDeleteDBCustomNodesDisasterRecoverGroupRequest() (request *DeleteDBCustomNodesDisasterRecoverGroupRequest) {
+    request = &DeleteDBCustomNodesDisasterRecoverGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DeleteDBCustomNodesDisasterRecoverGroup")
+    
+    
+    return
+}
+
+func NewDeleteDBCustomNodesDisasterRecoverGroupResponse() (response *DeleteDBCustomNodesDisasterRecoverGroupResponse) {
+    response = &DeleteDBCustomNodesDisasterRecoverGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DeleteDBCustomNodesDisasterRecoverGroup
+// 该接口（DeleteDBCustomNodesDisasterRecoverGroup）用于移除 DB Custom 节点的置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DeleteDBCustomNodesDisasterRecoverGroup(request *DeleteDBCustomNodesDisasterRecoverGroupRequest) (response *DeleteDBCustomNodesDisasterRecoverGroupResponse, err error) {
+    return c.DeleteDBCustomNodesDisasterRecoverGroupWithContext(context.Background(), request)
+}
+
+// DeleteDBCustomNodesDisasterRecoverGroup
+// 该接口（DeleteDBCustomNodesDisasterRecoverGroup）用于移除 DB Custom 节点的置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DeleteDBCustomNodesDisasterRecoverGroupWithContext(ctx context.Context, request *DeleteDBCustomNodesDisasterRecoverGroupRequest) (response *DeleteDBCustomNodesDisasterRecoverGroupResponse, err error) {
+    if request == nil {
+        request = NewDeleteDBCustomNodesDisasterRecoverGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DeleteDBCustomNodesDisasterRecoverGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DeleteDBCustomNodesDisasterRecoverGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDeleteDBCustomNodesDisasterRecoverGroupResponse()
     err = c.Send(request, response)
     return
 }
@@ -657,6 +825,118 @@ func (c *Client) DescribeDBCustomClustersWithContext(ctx context.Context, reques
     request.SetContext(ctx)
     
     response = NewDescribeDBCustomClustersResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeDBCustomDisasterRecoverGroupQuotaRequest() (request *DescribeDBCustomDisasterRecoverGroupQuotaRequest) {
+    request = &DescribeDBCustomDisasterRecoverGroupQuotaRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomDisasterRecoverGroupQuota")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomDisasterRecoverGroupQuotaResponse() (response *DescribeDBCustomDisasterRecoverGroupQuotaResponse) {
+    response = &DescribeDBCustomDisasterRecoverGroupQuotaResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomDisasterRecoverGroupQuota
+// 该接口（DescribeDBCustomDisasterRecoverGroupQuota）用于查询 DB Custom 置放群组配额。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomDisasterRecoverGroupQuota(request *DescribeDBCustomDisasterRecoverGroupQuotaRequest) (response *DescribeDBCustomDisasterRecoverGroupQuotaResponse, err error) {
+    return c.DescribeDBCustomDisasterRecoverGroupQuotaWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomDisasterRecoverGroupQuota
+// 该接口（DescribeDBCustomDisasterRecoverGroupQuota）用于查询 DB Custom 置放群组配额。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomDisasterRecoverGroupQuotaWithContext(ctx context.Context, request *DescribeDBCustomDisasterRecoverGroupQuotaRequest) (response *DescribeDBCustomDisasterRecoverGroupQuotaResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomDisasterRecoverGroupQuotaRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomDisasterRecoverGroupQuota")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomDisasterRecoverGroupQuota require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomDisasterRecoverGroupQuotaResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewDescribeDBCustomDisasterRecoverGroupsRequest() (request *DescribeDBCustomDisasterRecoverGroupsRequest) {
+    request = &DescribeDBCustomDisasterRecoverGroupsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "DescribeDBCustomDisasterRecoverGroups")
+    
+    
+    return
+}
+
+func NewDescribeDBCustomDisasterRecoverGroupsResponse() (response *DescribeDBCustomDisasterRecoverGroupsResponse) {
+    response = &DescribeDBCustomDisasterRecoverGroupsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// DescribeDBCustomDisasterRecoverGroups
+// 该接口（DescribeDBCustomDisasterRecoverGroups）用于查询 DB Custom 置放群组列表。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomDisasterRecoverGroups(request *DescribeDBCustomDisasterRecoverGroupsRequest) (response *DescribeDBCustomDisasterRecoverGroupsResponse, err error) {
+    return c.DescribeDBCustomDisasterRecoverGroupsWithContext(context.Background(), request)
+}
+
+// DescribeDBCustomDisasterRecoverGroups
+// 该接口（DescribeDBCustomDisasterRecoverGroups）用于查询 DB Custom 置放群组列表。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) DescribeDBCustomDisasterRecoverGroupsWithContext(ctx context.Context, request *DescribeDBCustomDisasterRecoverGroupsRequest) (response *DescribeDBCustomDisasterRecoverGroupsResponse, err error) {
+    if request == nil {
+        request = NewDescribeDBCustomDisasterRecoverGroupsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "DescribeDBCustomDisasterRecoverGroups")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("DescribeDBCustomDisasterRecoverGroups require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewDescribeDBCustomDisasterRecoverGroupsResponse()
     err = c.Send(request, response)
     return
 }
@@ -1515,6 +1795,62 @@ func (c *Client) IsolateDBCustomNodeWithContext(ctx context.Context, request *Is
     return
 }
 
+func NewModifyDBCustomClusterAttributesRequest() (request *ModifyDBCustomClusterAttributesRequest) {
+    request = &ModifyDBCustomClusterAttributesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomClusterAttributes")
+    
+    
+    return
+}
+
+func NewModifyDBCustomClusterAttributesResponse() (response *ModifyDBCustomClusterAttributesResponse) {
+    response = &ModifyDBCustomClusterAttributesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomClusterAttributes
+// 该接口（ModifyDBCustomClusterAttributes）用于修改 DB Custom 集群的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomClusterAttributes(request *ModifyDBCustomClusterAttributesRequest) (response *ModifyDBCustomClusterAttributesResponse, err error) {
+    return c.ModifyDBCustomClusterAttributesWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomClusterAttributes
+// 该接口（ModifyDBCustomClusterAttributes）用于修改 DB Custom 集群的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomClusterAttributesWithContext(ctx context.Context, request *ModifyDBCustomClusterAttributesRequest) (response *ModifyDBCustomClusterAttributesResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomClusterAttributesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomClusterAttributes")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomClusterAttributes require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomClusterAttributesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyDBCustomClusterNodeConfigRequest() (request *ModifyDBCustomClusterNodeConfigRequest) {
     request = &ModifyDBCustomClusterNodeConfigRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1627,6 +1963,174 @@ func (c *Client) ModifyDBCustomClusterTagsWithContext(ctx context.Context, reque
     return
 }
 
+func NewModifyDBCustomDisasterRecoverGroupAttributeRequest() (request *ModifyDBCustomDisasterRecoverGroupAttributeRequest) {
+    request = &ModifyDBCustomDisasterRecoverGroupAttributeRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomDisasterRecoverGroupAttribute")
+    
+    
+    return
+}
+
+func NewModifyDBCustomDisasterRecoverGroupAttributeResponse() (response *ModifyDBCustomDisasterRecoverGroupAttributeResponse) {
+    response = &ModifyDBCustomDisasterRecoverGroupAttributeResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomDisasterRecoverGroupAttribute
+// 该接口（ModifyDBCustomDisasterRecoverGroupAttribute）用于修改 DB Custom 置放群组的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomDisasterRecoverGroupAttribute(request *ModifyDBCustomDisasterRecoverGroupAttributeRequest) (response *ModifyDBCustomDisasterRecoverGroupAttributeResponse, err error) {
+    return c.ModifyDBCustomDisasterRecoverGroupAttributeWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomDisasterRecoverGroupAttribute
+// 该接口（ModifyDBCustomDisasterRecoverGroupAttribute）用于修改 DB Custom 置放群组的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomDisasterRecoverGroupAttributeWithContext(ctx context.Context, request *ModifyDBCustomDisasterRecoverGroupAttributeRequest) (response *ModifyDBCustomDisasterRecoverGroupAttributeResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomDisasterRecoverGroupAttributeRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomDisasterRecoverGroupAttribute")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomDisasterRecoverGroupAttribute require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomDisasterRecoverGroupAttributeResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyDBCustomDisasterRecoverGroupTagsRequest() (request *ModifyDBCustomDisasterRecoverGroupTagsRequest) {
+    request = &ModifyDBCustomDisasterRecoverGroupTagsRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomDisasterRecoverGroupTags")
+    
+    
+    return
+}
+
+func NewModifyDBCustomDisasterRecoverGroupTagsResponse() (response *ModifyDBCustomDisasterRecoverGroupTagsResponse) {
+    response = &ModifyDBCustomDisasterRecoverGroupTagsResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomDisasterRecoverGroupTags
+// 该接口（ModifyDBCustomDisasterRecoverGroupTags）用于修改 DB Custom 置放群组绑定的标签。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomDisasterRecoverGroupTags(request *ModifyDBCustomDisasterRecoverGroupTagsRequest) (response *ModifyDBCustomDisasterRecoverGroupTagsResponse, err error) {
+    return c.ModifyDBCustomDisasterRecoverGroupTagsWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomDisasterRecoverGroupTags
+// 该接口（ModifyDBCustomDisasterRecoverGroupTags）用于修改 DB Custom 置放群组绑定的标签。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomDisasterRecoverGroupTagsWithContext(ctx context.Context, request *ModifyDBCustomDisasterRecoverGroupTagsRequest) (response *ModifyDBCustomDisasterRecoverGroupTagsResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomDisasterRecoverGroupTagsRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomDisasterRecoverGroupTags")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomDisasterRecoverGroupTags require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomDisasterRecoverGroupTagsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyDBCustomNodeAttributesRequest() (request *ModifyDBCustomNodeAttributesRequest) {
+    request = &ModifyDBCustomNodeAttributesRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomNodeAttributes")
+    
+    
+    return
+}
+
+func NewModifyDBCustomNodeAttributesResponse() (response *ModifyDBCustomNodeAttributesResponse) {
+    response = &ModifyDBCustomNodeAttributesResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomNodeAttributes
+// 该接口（ModifyDBCustomNodeAttributes）用于修改 DB Custom 节点的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodeAttributes(request *ModifyDBCustomNodeAttributesRequest) (response *ModifyDBCustomNodeAttributesResponse, err error) {
+    return c.ModifyDBCustomNodeAttributesWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomNodeAttributes
+// 该接口（ModifyDBCustomNodeAttributes）用于修改 DB Custom 节点的属性。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodeAttributesWithContext(ctx context.Context, request *ModifyDBCustomNodeAttributesRequest) (response *ModifyDBCustomNodeAttributesResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomNodeAttributesRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomNodeAttributes")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomNodeAttributes require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomNodeAttributesResponse()
+    err = c.Send(request, response)
+    return
+}
+
 func NewModifyDBCustomNodeSecurityGroupsRequest() (request *ModifyDBCustomNodeSecurityGroupsRequest) {
     request = &ModifyDBCustomNodeSecurityGroupsRequest{
         BaseRequest: &tchttp.BaseRequest{},
@@ -1735,6 +2239,62 @@ func (c *Client) ModifyDBCustomNodeTagsWithContext(ctx context.Context, request 
     request.SetContext(ctx)
     
     response = NewModifyDBCustomNodeTagsResponse()
+    err = c.Send(request, response)
+    return
+}
+
+func NewModifyDBCustomNodesDisasterRecoverGroupRequest() (request *ModifyDBCustomNodesDisasterRecoverGroupRequest) {
+    request = &ModifyDBCustomNodesDisasterRecoverGroupRequest{
+        BaseRequest: &tchttp.BaseRequest{},
+    }
+    
+    request.Init().WithApiInfo("dbdc", APIVersion, "ModifyDBCustomNodesDisasterRecoverGroup")
+    
+    
+    return
+}
+
+func NewModifyDBCustomNodesDisasterRecoverGroupResponse() (response *ModifyDBCustomNodesDisasterRecoverGroupResponse) {
+    response = &ModifyDBCustomNodesDisasterRecoverGroupResponse{
+        BaseResponse: &tchttp.BaseResponse{},
+    } 
+    return
+
+}
+
+// ModifyDBCustomNodesDisasterRecoverGroup
+// 该接口（ModifyDBCustomNodesDisasterRecoverGroup）用于修改 DB Custom 节点的置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodesDisasterRecoverGroup(request *ModifyDBCustomNodesDisasterRecoverGroupRequest) (response *ModifyDBCustomNodesDisasterRecoverGroupResponse, err error) {
+    return c.ModifyDBCustomNodesDisasterRecoverGroupWithContext(context.Background(), request)
+}
+
+// ModifyDBCustomNodesDisasterRecoverGroup
+// 该接口（ModifyDBCustomNodesDisasterRecoverGroup）用于修改 DB Custom 节点的置放群组。
+//
+// 可能返回的错误码:
+//  AUTHFAILURE = "AuthFailure"
+//  AUTHFAILURE_UNAUTHORIZEDOPERATION = "AuthFailure.UnauthorizedOperation"
+//  FAILEDOPERATION = "FailedOperation"
+//  INVALIDPARAMETERVALUE = "InvalidParameterValue"
+func (c *Client) ModifyDBCustomNodesDisasterRecoverGroupWithContext(ctx context.Context, request *ModifyDBCustomNodesDisasterRecoverGroupRequest) (response *ModifyDBCustomNodesDisasterRecoverGroupResponse, err error) {
+    if request == nil {
+        request = NewModifyDBCustomNodesDisasterRecoverGroupRequest()
+    }
+    c.InitBaseRequest(&request.BaseRequest, "dbdc", APIVersion, "ModifyDBCustomNodesDisasterRecoverGroup")
+    
+    if c.GetCredential() == nil {
+        return nil, errors.New("ModifyDBCustomNodesDisasterRecoverGroup require credential")
+    }
+
+    request.SetContext(ctx)
+    
+    response = NewModifyDBCustomNodesDisasterRecoverGroupResponse()
     err = c.Send(request, response)
     return
 }

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029/models.go
@@ -231,6 +231,9 @@ type CreateDBCustomClusterRequestParams struct {
 
 	// <p>试运行开关，true 时只执行参数校验，不发起创建流程，默认 false</p>
 	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul><p>默认值：true</p>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
 }
 
 type CreateDBCustomClusterRequest struct {
@@ -256,6 +259,9 @@ type CreateDBCustomClusterRequest struct {
 
 	// <p>试运行开关，true 时只执行参数校验，不发起创建流程，默认 false</p>
 	DryRun *bool `json:"DryRun,omitnil,omitempty" name:"DryRun"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul><p>默认值：true</p>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
 }
 
 func (r *CreateDBCustomClusterRequest) ToJsonString() string {
@@ -277,6 +283,7 @@ func (r *CreateDBCustomClusterRequest) FromJsonString(s string) error {
 	delete(f, "Tags")
 	delete(f, "ClientToken")
 	delete(f, "DryRun")
+	delete(f, "DeletionProtection")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBCustomClusterRequest has unknown keys!", "")
 	}
@@ -308,6 +315,119 @@ func (r *CreateDBCustomClusterResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *CreateDBCustomClusterResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateDBCustomDisasterRecoverGroupRequestParams struct {
+	// <p>置放群组名称</p><p>入参限制：长度1-60个字符，支持中、英文</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组类型</p><p>枚举值：</p><ul><li>HOST： 物理机</li></ul><p>默认值：HOST</p><p>当前仅支持物理机类型</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>置放群组策略</p><p>入参限制：当前仅支持分散置放群组</p><p>枚举值：</p><ul><li>SPREAD： 分散置放群组</li></ul><p>默认值：SPREAD</p>
+	Strategy *string `json:"Strategy,omitnil,omitempty" name:"Strategy"`
+
+	// <p>置放群组的亲和度，在置放群组的实例会按该亲和度分布</p><p>取值范围：[1, 10]</p><p>默认值：1</p>
+	Affinity *int64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+
+	// <p>标签</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>用于保证请求幂等性的字符串。该字符串由客户生成，需保证不同请求之间唯一，最大值不超过64个ASCII字符。若不指定该参数，则无法保证请求的幂等性。</p>
+	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+}
+
+type CreateDBCustomDisasterRecoverGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组名称</p><p>入参限制：长度1-60个字符，支持中、英文</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组类型</p><p>枚举值：</p><ul><li>HOST： 物理机</li></ul><p>默认值：HOST</p><p>当前仅支持物理机类型</p>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>置放群组策略</p><p>入参限制：当前仅支持分散置放群组</p><p>枚举值：</p><ul><li>SPREAD： 分散置放群组</li></ul><p>默认值：SPREAD</p>
+	Strategy *string `json:"Strategy,omitnil,omitempty" name:"Strategy"`
+
+	// <p>置放群组的亲和度，在置放群组的实例会按该亲和度分布</p><p>取值范围：[1, 10]</p><p>默认值：1</p>
+	Affinity *int64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+
+	// <p>标签</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>用于保证请求幂等性的字符串。该字符串由客户生成，需保证不同请求之间唯一，最大值不超过64个ASCII字符。若不指定该参数，则无法保证请求的幂等性。</p>
+	ClientToken *string `json:"ClientToken,omitnil,omitempty" name:"ClientToken"`
+}
+
+func (r *CreateDBCustomDisasterRecoverGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateDBCustomDisasterRecoverGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "Name")
+	delete(f, "Type")
+	delete(f, "Strategy")
+	delete(f, "Affinity")
+	delete(f, "Tags")
+	delete(f, "ClientToken")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBCustomDisasterRecoverGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type CreateDBCustomDisasterRecoverGroupResponseParams struct {
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>置放群组名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组类型</p><p>枚举值：</p><ul><li>HOST： 物理机</li></ul>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>状态</p><p>枚举值：</p><ul><li>Creating： 创建中</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>置放群组内可容纳的节点数量</p>
+	NodeQuotaTotal *int64 `json:"NodeQuotaTotal,omitnil,omitempty" name:"NodeQuotaTotal"`
+
+	// <p>置放群组内已有节点数量</p>
+	CurrentNum *int64 `json:"CurrentNum,omitnil,omitempty" name:"CurrentNum"`
+
+	// <p>创建时间</p>
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
+
+	// <p>置放群组策略</p><p>枚举值：</p><ul><li>SPREAD： 分散置放群组</li></ul>
+	Strategy *string `json:"Strategy,omitnil,omitempty" name:"Strategy"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type CreateDBCustomDisasterRecoverGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *CreateDBCustomDisasterRecoverGroupResponseParams `json:"Response"`
+}
+
+func (r *CreateDBCustomDisasterRecoverGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *CreateDBCustomDisasterRecoverGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -375,6 +495,9 @@ type CreateDBCustomNodesRequestParams struct {
 
 	// <p>设置节点安全组</p><p>参数格式：设置需要与节点绑定的多个安全组ID，以数组形式配置。</p>
 	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+
+	// <p>置放群组ID</p><p>入参限制：仅支持指定一个</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
 }
 
 type CreateDBCustomNodesRequest struct {
@@ -442,6 +565,9 @@ type CreateDBCustomNodesRequest struct {
 
 	// <p>设置节点安全组</p><p>参数格式：设置需要与节点绑定的多个安全组ID，以数组形式配置。</p>
 	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+
+	// <p>置放群组ID</p><p>入参限制：仅支持指定一个</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
 }
 
 func (r *CreateDBCustomNodesRequest) ToJsonString() string {
@@ -477,6 +603,7 @@ func (r *CreateDBCustomNodesRequest) FromJsonString(s string) error {
 	delete(f, "HostName")
 	delete(f, "DryRun")
 	delete(f, "SecurityGroupIds")
+	delete(f, "DisasterRecoverGroupIds")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "CreateDBCustomNodesRequest has unknown keys!", "")
 	}
@@ -542,6 +669,9 @@ type DBCustomCluster struct {
 	// <p>集群的标签信息</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
 }
 
 type DBCustomClusterNode struct {
@@ -573,6 +703,10 @@ type DBCustomClusterNode struct {
 	// <p>当选择网络模式为三层网络联通模式时，此处的IP地址则为用户可访问的地址。</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	EniIP *string `json:"EniIP,omitnil,omitempty" name:"EniIP"`
+
+	// <p>节点绑定的安全组</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
 }
 
 type DBCustomClusterNodeConfig struct {
@@ -709,11 +843,18 @@ type DBCustomNode struct {
 	// <p>底层物理机IP（已加密）</p>
 	HostIp *string `json:"HostIp,omitnil,omitempty" name:"HostIp"`
 
-	// <p>网络模式</p><p>枚举值：</p><ul><li>NetworkModePrivateLink： 四层 SSH 服务联通模式</li><li>NetworkModeCrossTenantENI：  三层双网卡访问方式</li></ul>
+	// <p>网络模式</p><p>枚举值：</p><ul><li>privatelink： 四层 SSH 服务联通模式</li><li>cross_tenant_eni：  三层双网卡访问方式</li></ul>
 	NetworkMode *string `json:"NetworkMode,omitnil,omitempty" name:"NetworkMode"`
 
 	// <p>当选择NetworkModeCrossTenantENI模式时，节点的访问IP地址</p>
 	EniIP *string `json:"EniIP,omitnil,omitempty" name:"EniIP"`
+
+	// <p>节点绑定的安全组</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	SecurityGroupIds []*string `json:"SecurityGroupIds,omitnil,omitempty" name:"SecurityGroupIds"`
+
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
 }
 
 type DBCustomNodeTypeInfo struct {
@@ -822,6 +963,129 @@ type DataDisk struct {
 }
 
 // Predefined struct for user
+type DeleteDBCustomDisasterRecoverGroupsRequestParams struct {
+	// <p>置放群组ID</p><p>入参限制：数量上限为10。若置放群组内有节点，需要先移除。</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+}
+
+type DeleteDBCustomDisasterRecoverGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组ID</p><p>入参限制：数量上限为10。若置放群组内有节点，需要先移除。</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+}
+
+func (r *DeleteDBCustomDisasterRecoverGroupsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDBCustomDisasterRecoverGroupsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DisasterRecoverGroupIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteDBCustomDisasterRecoverGroupsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteDBCustomDisasterRecoverGroupsResponseParams struct {
+	// <p>任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteDBCustomDisasterRecoverGroupsResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteDBCustomDisasterRecoverGroupsResponseParams `json:"Response"`
+}
+
+func (r *DeleteDBCustomDisasterRecoverGroupsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDBCustomDisasterRecoverGroupsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteDBCustomNodesDisasterRecoverGroupRequestParams struct {
+	// <p>节点ID</p><p>入参限制：单次数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>置放群组ID</p><p>入参限制：只支持传一个ID</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+}
+
+type DeleteDBCustomNodesDisasterRecoverGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>节点ID</p><p>入参限制：单次数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>置放群组ID</p><p>入参限制：只支持传一个ID</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+}
+
+func (r *DeleteDBCustomNodesDisasterRecoverGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDBCustomNodesDisasterRecoverGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NodeIds")
+	delete(f, "DisasterRecoverGroupIds")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DeleteDBCustomNodesDisasterRecoverGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DeleteDBCustomNodesDisasterRecoverGroupResponseParams struct {
+	// <p>任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DeleteDBCustomNodesDisasterRecoverGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *DeleteDBCustomNodesDisasterRecoverGroupResponseParams `json:"Response"`
+}
+
+func (r *DeleteDBCustomNodesDisasterRecoverGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DeleteDBCustomNodesDisasterRecoverGroupResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type DescribeDBCustomClusterDetailRequestParams struct {
 	// <p>DB Custom 集群ID</p><p>入参限制：必须为此账号拥有的DB Custom集群</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -893,6 +1157,9 @@ type DescribeDBCustomClusterDetailResponseParams struct {
 	// <p>容器网络，在此集群中的所有Pod将与此网络连通</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	ContainerNetwork *ContainerNetwork `json:"ContainerNetwork,omitnil,omitempty" name:"ContainerNetwork"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
 	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
@@ -1338,6 +1605,155 @@ func (r *DescribeDBCustomClustersResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *DescribeDBCustomClustersResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomDisasterRecoverGroupQuotaRequestParams struct {
+
+}
+
+type DescribeDBCustomDisasterRecoverGroupQuotaRequest struct {
+	*tchttp.BaseRequest
+	
+}
+
+func (r *DescribeDBCustomDisasterRecoverGroupQuotaRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomDisasterRecoverGroupQuotaRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomDisasterRecoverGroupQuotaRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomDisasterRecoverGroupQuotaResponseParams struct {
+	// <p>可创建置放群组数量的上限</p>
+	GroupQuota *int64 `json:"GroupQuota,omitnil,omitempty" name:"GroupQuota"`
+
+	// <p>已经创建的置放群组数量</p>
+	CurrentNum *int64 `json:"CurrentNum,omitnil,omitempty" name:"CurrentNum"`
+
+	// <p>物理机类型置放群组内节点的配额数</p>
+	NodeInHostGroupQuota *int64 `json:"NodeInHostGroupQuota,omitnil,omitempty" name:"NodeInHostGroupQuota"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomDisasterRecoverGroupQuotaResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomDisasterRecoverGroupQuotaResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomDisasterRecoverGroupQuotaResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomDisasterRecoverGroupQuotaResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomDisasterRecoverGroupsRequestParams struct {
+	// <p>置放群组ID</p><p>入参限制：单次数量上限是10</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+
+	// <p>查询筛选条件。支持的筛选条件包括：</p><ul><li>tag-key：按标签键进行过滤。</li><li>tag-value：按标签值进行过滤。</li></ul><p>入参限制：数量上限为5</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>根据标签键和标签值筛选 DB Custom 置放群组</p><p>入参限制：数量上限为5</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>分页偏移量</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>返回数量</p><p>取值范围：[1, 100]</p><p>默认值：20</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+type DescribeDBCustomDisasterRecoverGroupsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组ID</p><p>入参限制：单次数量上限是10</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+
+	// <p>查询筛选条件。支持的筛选条件包括：</p><ul><li>tag-key：按标签键进行过滤。</li><li>tag-value：按标签值进行过滤。</li></ul><p>入参限制：数量上限为5</p>
+	Filters []*Filter `json:"Filters,omitnil,omitempty" name:"Filters"`
+
+	// <p>根据标签键和标签值筛选 DB Custom 置放群组</p><p>入参限制：数量上限为5</p>
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>分页偏移量</p>
+	Offset *int64 `json:"Offset,omitnil,omitempty" name:"Offset"`
+
+	// <p>返回数量</p><p>取值范围：[1, 100]</p><p>默认值：20</p>
+	Limit *int64 `json:"Limit,omitnil,omitempty" name:"Limit"`
+}
+
+func (r *DescribeDBCustomDisasterRecoverGroupsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomDisasterRecoverGroupsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DisasterRecoverGroupIds")
+	delete(f, "Filters")
+	delete(f, "Tags")
+	delete(f, "Offset")
+	delete(f, "Limit")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "DescribeDBCustomDisasterRecoverGroupsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type DescribeDBCustomDisasterRecoverGroupsResponseParams struct {
+	// <p>总数</p>
+	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
+
+	// <p>置放群组列表</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	DisasterRecoverGroupSet []*DisasterRecoverGroup `json:"DisasterRecoverGroupSet,omitnil,omitempty" name:"DisasterRecoverGroupSet"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type DescribeDBCustomDisasterRecoverGroupsResponse struct {
+	*tchttp.BaseResponse
+	Response *DescribeDBCustomDisasterRecoverGroupsResponseParams `json:"Response"`
+}
+
+func (r *DescribeDBCustomDisasterRecoverGroupsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *DescribeDBCustomDisasterRecoverGroupsResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -2574,6 +2990,42 @@ type DeviceInfo struct {
 	InstanceNum *uint64 `json:"InstanceNum,omitnil,omitempty" name:"InstanceNum"`
 }
 
+type DisasterRecoverGroup struct {
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>置放群组名称</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组类型</p><p>枚举值：</p><ul><li>HOST： 物理机</li></ul>
+	Type *string `json:"Type,omitnil,omitempty" name:"Type"`
+
+	// <p>置放群组状态</p><p>枚举值：</p><ul><li>Creating： 创建中</li><li>Available： 正常可使用</li><li>CreateFailed： 创建失败</li><li>Deleting： 删除中</li><li>Modifying： 变更中</li></ul>
+	Status *string `json:"Status,omitnil,omitempty" name:"Status"`
+
+	// <p>置放群组内最大容纳节点数</p>
+	NodeQuotaTotal *uint64 `json:"NodeQuotaTotal,omitnil,omitempty" name:"NodeQuotaTotal"`
+
+	// <p>置放群组内当前节点数</p>
+	CurrentNum *uint64 `json:"CurrentNum,omitnil,omitempty" name:"CurrentNum"`
+
+	// <p>亲和度</p><p>取值范围：[1, 10]</p>
+	Affinity *uint64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+
+	// <p>置放群组策略</p><p>枚举值：</p><ul><li>SPREAD： 分散置放群组</li></ul>
+	Strategy *string `json:"Strategy,omitnil,omitempty" name:"Strategy"`
+
+	// <p>创建时间</p>
+	CreatedTime *string `json:"CreatedTime,omitnil,omitempty" name:"CreatedTime"`
+
+	// <p>标签信息</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
+
+	// <p>置放群组内 DB Custom 节点数量</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+}
+
 type Filter struct {
 	// <p>筛选条件</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
@@ -2831,6 +3283,67 @@ type MetaResource struct {
 }
 
 // Predefined struct for user
+type ModifyDBCustomClusterAttributesRequestParams struct {
+	// <p>集群ID</p><p>参数格式：dbcc-hj7gab15</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
+}
+
+type ModifyDBCustomClusterAttributesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>集群ID</p><p>参数格式：dbcc-hj7gab15</p>
+	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
+
+	// <p>是否启用集群删除保护</p><p>枚举值：</p><ul><li>true： 启用</li><li>false： 不启用</li></ul>
+	DeletionProtection *bool `json:"DeletionProtection,omitnil,omitempty" name:"DeletionProtection"`
+}
+
+func (r *ModifyDBCustomClusterAttributesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomClusterAttributesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "ClusterId")
+	delete(f, "DeletionProtection")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomClusterAttributesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomClusterAttributesResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomClusterAttributesResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomClusterAttributesResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomClusterAttributesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomClusterAttributesResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
 type ModifyDBCustomClusterNodeConfigRequestParams struct {
 	// <p>目标集群 ID</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
@@ -2927,10 +3440,10 @@ type ModifyDBCustomClusterTagsRequestParams struct {
 	// <p>DB Custom 集群ID</p><p>参数格式：dbcc-xxxxxxxx</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// <p>为 DB Custom 集群绑定的标签信息</p><p>入参限制：参考标签平台的限制策略</p>
+	// <p>为 DB Custom 集群绑定的标签信息</p><p>入参限制：参考标签平台的限制策略</p><p>如果集群未关联输入的标签键，则增加关联；若已关联，则将该集群关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
 
-	// <p>为 DB Custom 集群删除的标签Key</p>
+	// <p>为 DB Custom 集群解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
 }
 
@@ -2940,10 +3453,10 @@ type ModifyDBCustomClusterTagsRequest struct {
 	// <p>DB Custom 集群ID</p><p>参数格式：dbcc-xxxxxxxx</p>
 	ClusterId *string `json:"ClusterId,omitnil,omitempty" name:"ClusterId"`
 
-	// <p>为 DB Custom 集群绑定的标签信息</p><p>入参限制：参考标签平台的限制策略</p>
+	// <p>为 DB Custom 集群绑定的标签信息</p><p>入参限制：参考标签平台的限制策略</p><p>如果集群未关联输入的标签键，则增加关联；若已关联，则将该集群关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
 
-	// <p>为 DB Custom 集群删除的标签Key</p>
+	// <p>为 DB Custom 集群解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
 }
 
@@ -2987,6 +3500,224 @@ func (r *ModifyDBCustomClusterTagsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyDBCustomClusterTagsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomDisasterRecoverGroupAttributeRequestParams struct {
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>置放群组名称</p><p>入参限制：长度1-60个字符，支持中、英文</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组的亲和度，在置放群组的节点会按该亲和度分布</p><p>取值范围：[1, 10]</p>
+	Affinity *int64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+}
+
+type ModifyDBCustomDisasterRecoverGroupAttributeRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>置放群组名称</p><p>入参限制：长度1-60个字符，支持中、英文</p>
+	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
+
+	// <p>置放群组的亲和度，在置放群组的节点会按该亲和度分布</p><p>取值范围：[1, 10]</p>
+	Affinity *int64 `json:"Affinity,omitnil,omitempty" name:"Affinity"`
+}
+
+func (r *ModifyDBCustomDisasterRecoverGroupAttributeRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomDisasterRecoverGroupAttributeRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DisasterRecoverGroupId")
+	delete(f, "Name")
+	delete(f, "Affinity")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomDisasterRecoverGroupAttributeRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomDisasterRecoverGroupAttributeResponseParams struct {
+	// <p>任务ID</p>
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomDisasterRecoverGroupAttributeResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomDisasterRecoverGroupAttributeResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomDisasterRecoverGroupAttributeResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomDisasterRecoverGroupAttributeResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomDisasterRecoverGroupTagsRequestParams struct {
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>为 DB Custom 置放群组绑定的标签信息</p><p>入参限制：参考标签侧的限制</p><p>如果置放群组未关联输入的标签键，则增加关联；若已关联，则将该置放群组关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
+	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
+
+	// <p>需要解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
+	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
+}
+
+type ModifyDBCustomDisasterRecoverGroupTagsRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>置放群组ID</p>
+	DisasterRecoverGroupId *string `json:"DisasterRecoverGroupId,omitnil,omitempty" name:"DisasterRecoverGroupId"`
+
+	// <p>为 DB Custom 置放群组绑定的标签信息</p><p>入参限制：参考标签侧的限制</p><p>如果置放群组未关联输入的标签键，则增加关联；若已关联，则将该置放群组关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
+	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
+
+	// <p>需要解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
+	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
+}
+
+func (r *ModifyDBCustomDisasterRecoverGroupTagsRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomDisasterRecoverGroupTagsRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "DisasterRecoverGroupId")
+	delete(f, "AddTags")
+	delete(f, "DeleteTagKeys")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomDisasterRecoverGroupTagsRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomDisasterRecoverGroupTagsResponseParams struct {
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomDisasterRecoverGroupTagsResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomDisasterRecoverGroupTagsResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomDisasterRecoverGroupTagsResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomDisasterRecoverGroupTagsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodeAttributesRequestParams struct {
+	// <p>节点ID</p><p>参数格式：dbcn-hq98qjym</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+
+	// <p>主机 HostName</p><p>入参限制：参数设置规则参见：<a href="https://cloud.tencent.com/document/api/1322/132929">创建 DB Custom 节点接口</a>的 HostName 参数说明。</p><p>注意：节点在没有加入到集群之前才支持修改主机 HostName。</p>
+	HostName *string `json:"HostName,omitnil,omitempty" name:"HostName"`
+
+	// <p>节点名称</p><p>入参限制：参数设置规则参见：<a href="https://cloud.tencent.com/document/api/1322/132929">创建 DB Custom 节点接口</a>的 NodeName 参数说明。</p>
+	NodeName *string `json:"NodeName,omitnil,omitempty" name:"NodeName"`
+
+	// <p>修改实例 HostName 是否自动重启实例，不传默认自动重启。</p><p>枚举值：</p><ul><li>true： 修改主机 HostName，并自动重启主机</li><li>false： 修改主机 HostName，不自动重启主机，需要手动重启使新主机 HostName 生效</li></ul><p>默认值：true</p>
+	AutoReboot *bool `json:"AutoReboot,omitnil,omitempty" name:"AutoReboot"`
+}
+
+type ModifyDBCustomNodeAttributesRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>节点ID</p><p>参数格式：dbcn-hq98qjym</p>
+	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
+
+	// <p>主机 HostName</p><p>入参限制：参数设置规则参见：<a href="https://cloud.tencent.com/document/api/1322/132929">创建 DB Custom 节点接口</a>的 HostName 参数说明。</p><p>注意：节点在没有加入到集群之前才支持修改主机 HostName。</p>
+	HostName *string `json:"HostName,omitnil,omitempty" name:"HostName"`
+
+	// <p>节点名称</p><p>入参限制：参数设置规则参见：<a href="https://cloud.tencent.com/document/api/1322/132929">创建 DB Custom 节点接口</a>的 NodeName 参数说明。</p>
+	NodeName *string `json:"NodeName,omitnil,omitempty" name:"NodeName"`
+
+	// <p>修改实例 HostName 是否自动重启实例，不传默认自动重启。</p><p>枚举值：</p><ul><li>true： 修改主机 HostName，并自动重启主机</li><li>false： 修改主机 HostName，不自动重启主机，需要手动重启使新主机 HostName 生效</li></ul><p>默认值：true</p>
+	AutoReboot *bool `json:"AutoReboot,omitnil,omitempty" name:"AutoReboot"`
+}
+
+func (r *ModifyDBCustomNodeAttributesRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodeAttributesRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NodeId")
+	delete(f, "HostName")
+	delete(f, "NodeName")
+	delete(f, "AutoReboot")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomNodeAttributesRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodeAttributesResponseParams struct {
+	// <p>上架节点的任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomNodeAttributesResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomNodeAttributesResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomNodeAttributesResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodeAttributesResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -3056,10 +3787,10 @@ type ModifyDBCustomNodeTagsRequestParams struct {
 	// <p>DB Custom 节点ID</p><p>参数格式：dbcn-0zan5xxk</p>
 	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
 
-	// <p>为节点绑定的标签信息</p><p>入参限制：参考标签侧的限制</p>
+	// <p>为节点绑定的标签信息</p><p>入参限制：参考标签侧的限制</p><p>如果节点未关联输入的标签键，则增加关联；若已关联，则将该节点关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
 
-	// <p>需要删除的标签Key</p>
+	// <p>需要解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
 }
 
@@ -3069,10 +3800,10 @@ type ModifyDBCustomNodeTagsRequest struct {
 	// <p>DB Custom 节点ID</p><p>参数格式：dbcn-0zan5xxk</p>
 	NodeId *string `json:"NodeId,omitnil,omitempty" name:"NodeId"`
 
-	// <p>为节点绑定的标签信息</p><p>入参限制：参考标签侧的限制</p>
+	// <p>为节点绑定的标签信息</p><p>入参限制：参考标签侧的限制</p><p>如果节点未关联输入的标签键，则增加关联；若已关联，则将该节点关联的键对应的标签值修改为输入值。本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	AddTags []*Tag `json:"AddTags,omitnil,omitempty" name:"AddTags"`
 
-	// <p>需要删除的标签Key</p>
+	// <p>需要解关联的标签Key</p><p>本接口中 AddTags 和 DeleteTagKeys 二者必须存在其一，且二者不能包含相同的标签键。</p>
 	DeleteTagKeys []*string `json:"DeleteTagKeys,omitnil,omitempty" name:"DeleteTagKeys"`
 }
 
@@ -3116,6 +3847,78 @@ func (r *ModifyDBCustomNodeTagsResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *ModifyDBCustomNodeTagsResponse) FromJsonString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodesDisasterRecoverGroupRequestParams struct {
+	// <p>节点ID</p><p>入参限制：单次数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>置放群组ID</p><p>入参限制：支持传一个ID</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+
+	// <p>是否强制更换节点宿主机</p><p>枚举值：</p><ul><li>true： 表示允许节点更换宿主机，允许重启。本地盘节点不支持指定此参数。</li><li>false： 不允许节点更换宿主机，只在当前宿主机上加入置放群组。这可能导致更换置放群组失败。</li></ul><p>默认值：false</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
+}
+
+type ModifyDBCustomNodesDisasterRecoverGroupRequest struct {
+	*tchttp.BaseRequest
+	
+	// <p>节点ID</p><p>入参限制：单次数量上限为100</p>
+	NodeIds []*string `json:"NodeIds,omitnil,omitempty" name:"NodeIds"`
+
+	// <p>置放群组ID</p><p>入参限制：支持传一个ID</p>
+	DisasterRecoverGroupIds []*string `json:"DisasterRecoverGroupIds,omitnil,omitempty" name:"DisasterRecoverGroupIds"`
+
+	// <p>是否强制更换节点宿主机</p><p>枚举值：</p><ul><li>true： 表示允许节点更换宿主机，允许重启。本地盘节点不支持指定此参数。</li><li>false： 不允许节点更换宿主机，只在当前宿主机上加入置放群组。这可能导致更换置放群组失败。</li></ul><p>默认值：false</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
+}
+
+func (r *ModifyDBCustomNodesDisasterRecoverGroupRequest) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodesDisasterRecoverGroupRequest) FromJsonString(s string) error {
+	f := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &f); err != nil {
+		return err
+	}
+	delete(f, "NodeIds")
+	delete(f, "DisasterRecoverGroupIds")
+	delete(f, "Force")
+	if len(f) > 0 {
+		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "ModifyDBCustomNodesDisasterRecoverGroupRequest has unknown keys!", "")
+	}
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// Predefined struct for user
+type ModifyDBCustomNodesDisasterRecoverGroupResponseParams struct {
+	// <p>任务ID</p>
+	// 注意：此字段可能返回 null，表示取不到有效值。
+	TaskId *uint64 `json:"TaskId,omitnil,omitempty" name:"TaskId"`
+
+	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
+	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
+}
+
+type ModifyDBCustomNodesDisasterRecoverGroupResponse struct {
+	*tchttp.BaseResponse
+	Response *ModifyDBCustomNodesDisasterRecoverGroupResponseParams `json:"Response"`
+}
+
+func (r *ModifyDBCustomNodesDisasterRecoverGroupResponse) ToJsonString() string {
+    b, _ := json.Marshal(r)
+    return string(b)
+}
+
+// FromJsonString It is highly **NOT** recommended to use this function
+// because it has no param check, nor strict type check
+func (r *ModifyDBCustomNodesDisasterRecoverGroupResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 
@@ -3224,6 +4027,9 @@ type RemoveNodesFromDBCustomClusterRequestParams struct {
 
 	// <p>节点的登录参数</p>
 	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
+
+	// <p>当节点中还有业务 Pod 在运行，默认会拦截从集群中移除节点的操作。如果该参数为 true，表示强制执行此操作。</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul><p>默认值：false</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
 }
 
 type RemoveNodesFromDBCustomClusterRequest struct {
@@ -3237,6 +4043,9 @@ type RemoveNodesFromDBCustomClusterRequest struct {
 
 	// <p>节点的登录参数</p>
 	LoginSettings *LoginSettings `json:"LoginSettings,omitnil,omitempty" name:"LoginSettings"`
+
+	// <p>当节点中还有业务 Pod 在运行，默认会拦截从集群中移除节点的操作。如果该参数为 true，表示强制执行此操作。</p><p>枚举值：</p><ul><li>true： 是</li><li>false： 否</li></ul><p>默认值：false</p>
+	Force *bool `json:"Force,omitnil,omitempty" name:"Force"`
 }
 
 func (r *RemoveNodesFromDBCustomClusterRequest) ToJsonString() string {
@@ -3254,6 +4063,7 @@ func (r *RemoveNodesFromDBCustomClusterRequest) FromJsonString(s string) error {
 	delete(f, "ClusterId")
 	delete(f, "NodeIds")
 	delete(f, "LoginSettings")
+	delete(f, "Force")
 	if len(f) > 0 {
 		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "RemoveNodesFromDBCustomClusterRequest has unknown keys!", "")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1297,7 +1297,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dayu/v20180709
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain/v20210527
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.149
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc v1.3.174
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbdc/v20201029
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633

--- a/website/docs/r/dbdc_db_custom_node.html.markdown
+++ b/website/docs/r/dbdc_db_custom_node.html.markdown
@@ -118,7 +118,7 @@ The following arguments are supported:
 * `auto_voucher` - (Optional, Int) Whether to use voucher to deduct automatically. Valid values: `1` (use), `0` (not use). Default value is `0`.
 * `charge_type` - (Optional, String, ForceNew) Charge type. Valid values: `PREPAID` (subscription, default), `POSTPAID` (pay-as-you-go).
 * `data_disks` - (Optional, List, ForceNew) Data disk configuration. Only cloud-disk node types (e.g. `DB.SA5`) support setting this; local-disk types (e.g. `DB.AT5`) do not. Refreshed from the `DescribeDBCustomNodes` API response. Note: `disk_name` is read-only and ignored as a create input.
-* `disaster_recover_group_ids` - (Optional, List: [`String`], ForceNew) Placement (disaster recover) group ID list to bind to the node. Maps to the `DisasterRecoverGroupIds` request field of the `CreateDBCustomNodes` API. The API supports specifying only one placement group ID. Changing this forces replacement of the resource.
+* `disaster_recover_group_ids` - (Optional, List: [`String`]) Placement (disaster recover) group ID list to bind to the node. Maps to the `DisasterRecoverGroupIds` request field of the `CreateDBCustomNodes` API. The API supports specifying only one placement group ID.
 * `host_name` - (Optional, String, ForceNew) Hostname of the node. Dots (`.`) and hyphens (`-`) cannot be the first/last character or be used consecutively; underscores (`_`) are not allowed. Windows: 2-15 chars (letters, digits, `-`, no `.`); Linux/others: 2-60 chars (supports multiple dot-separated segments). Write-only: not returned by `DescribeDBCustomNodes`, so the configured value is preserved in state.
 * `login_settings` - (Optional, List, ForceNew) Instance login settings. You can set the login method to password, key, or keep the original image login settings. Only one method can be set.
 * `network_mode` - (Optional, String, ForceNew) Node network mode. Valid values: `privatelink` (four-layer SSH connectivity), `cross_tenant_eni` (three-layer dual-NIC access). Default is `privatelink`. Refreshed from the `DescribeDBCustomNodes` API response.
@@ -153,7 +153,6 @@ In addition to all arguments above, the following attributes are exported:
 * `cluster_id` - Cluster ID that the node belongs to.
 * `cpu` - Node CPU size, unit: core.
 * `created_time` - Node creation time.
-* `disaster_recover_group_id` - Placement (disaster recover) group ID bound to the node. Refreshed from the `DescribeDBCustomNodes` API response (`DBCustomNode.DisasterRecoverGroupId`).
 * `eni_ip` - Node access IP address when the `NetworkModeCrossTenantENI` network mode is selected. Refreshed from the `DescribeDBCustomNodes` API response.
 * `expire_time` - Node expiration time.
 * `isolated_time` - Node isolation time.

--- a/website/docs/r/dbdc_db_custom_node.html.markdown
+++ b/website/docs/r/dbdc_db_custom_node.html.markdown
@@ -39,6 +39,34 @@ resource "tencentcloud_dbdc_db_custom_node" "example" {
 }
 ```
 
+### Create a PREPAID DBDC db custom node with disaster recover group
+
+```hcl
+resource "tencentcloud_dbdc_db_custom_node" "example" {
+  zone        = "ap-shanghai-5"
+  image_id    = "img-rm13akp3"
+  vpc_id      = "vpc-cseo7req"
+  subnet_id   = "subnet-huka6qhj"
+  node_type   = "DB.AT5.8XLARGE128"
+  period      = 1
+  auto_renew  = 1
+  charge_type = "PREPAID"
+  node_name   = "tf-example"
+
+  login_settings {
+    password = "Password@2026"
+  }
+
+  disaster_recover_group_ids = [
+    "dbrg-xxxxxxxx",
+  ]
+
+  tags = {
+    createBy = "Terraform"
+  }
+}
+```
+
 ### Create a POSTPAID DBDC db custom node
 
 ```hcl
@@ -90,6 +118,7 @@ The following arguments are supported:
 * `auto_voucher` - (Optional, Int) Whether to use voucher to deduct automatically. Valid values: `1` (use), `0` (not use). Default value is `0`.
 * `charge_type` - (Optional, String, ForceNew) Charge type. Valid values: `PREPAID` (subscription, default), `POSTPAID` (pay-as-you-go).
 * `data_disks` - (Optional, List, ForceNew) Data disk configuration. Only cloud-disk node types (e.g. `DB.SA5`) support setting this; local-disk types (e.g. `DB.AT5`) do not. Refreshed from the `DescribeDBCustomNodes` API response. Note: `disk_name` is read-only and ignored as a create input.
+* `disaster_recover_group_ids` - (Optional, List: [`String`], ForceNew) Placement (disaster recover) group ID list to bind to the node. Maps to the `DisasterRecoverGroupIds` request field of the `CreateDBCustomNodes` API. The API supports specifying only one placement group ID. Changing this forces replacement of the resource.
 * `host_name` - (Optional, String, ForceNew) Hostname of the node. Dots (`.`) and hyphens (`-`) cannot be the first/last character or be used consecutively; underscores (`_`) are not allowed. Windows: 2-15 chars (letters, digits, `-`, no `.`); Linux/others: 2-60 chars (supports multiple dot-separated segments). Write-only: not returned by `DescribeDBCustomNodes`, so the configured value is preserved in state.
 * `login_settings` - (Optional, List, ForceNew) Instance login settings. You can set the login method to password, key, or keep the original image login settings. Only one method can be set.
 * `network_mode` - (Optional, String, ForceNew) Node network mode. Valid values: `privatelink` (four-layer SSH connectivity), `cross_tenant_eni` (three-layer dual-NIC access). Default is `privatelink`. Refreshed from the `DescribeDBCustomNodes` API response.
@@ -124,6 +153,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cluster_id` - Cluster ID that the node belongs to.
 * `cpu` - Node CPU size, unit: core.
 * `created_time` - Node creation time.
+* `disaster_recover_group_id` - Placement (disaster recover) group ID bound to the node. Refreshed from the `DescribeDBCustomNodes` API response (`DBCustomNode.DisasterRecoverGroupId`).
 * `eni_ip` - Node access IP address when the `NetworkModeCrossTenantENI` network mode is selected. Refreshed from the `DescribeDBCustomNodes` API response.
 * `expire_time` - Node expiration time.
 * `isolated_time` - Node isolation time.


### PR DESCRIPTION
Add the `disaster_recover_group_ids` (Optional, ForceNew, TypeList of TypeString, MaxItems 1) input parameter and the `disaster_recover_group_id` (Computed) output parameter to the `tencentcloud_dbdc_db_custom_node` resource. The input maps to the `DisasterRecoverGroupIds` request field of the `CreateDBCustomNodes` API, enabling a node to be placed into a DB Custom disaster-recover (placement) group at creation time. The computed parameter is refreshed from the `DescribeDBCustomNodes` API response (`DBCustomNode.DisasterRecoverGroupId`). Also bumps the vendored dbdc SDK to v1.3.174 to include the required struct fields.