### PR TITLE
feat(dlc): [138071343] add account_type parameter to tencentcloud_dlc_user resource

### DIFF
--- a/.changelog/4495.txt
+++ b/.changelog/4495.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_dlc_user: support account_type parameter for specifying user account type
+```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.173
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.175
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -55,7 +55,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dbbrain v1.3.26
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.173
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.175
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.0.414
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dts v1.3.153

--- a/go.sum
+++ b/go.sum
@@ -1003,8 +1003,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.170/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.171/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.172/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174 h1:qOTtWnvYBZidSl1CDQd3nWvnX2OeMNywf5aQ7oY4gGY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.175 h1:m714Iqe4LRCRvuoLjwCAJZn9S5WARXbmEExRh/G9W9w=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.175/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1029,8 +1030,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633 h1:Ul5iNhXo
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc v1.0.633/go.mod h1:tc6Hvf03M1cBtMC1IKSa5mlOn3kpxWOwhWU1fRy+KEE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673 h1:YyjGLjvPDKNlpbGt89WLFif7TjId0fHzcrGOaHSQRNQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673/go.mod h1:hXPMop1kJFqAvHj+7TyxxxXS/HGUP4SuKx5gGoAl0Zc=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.173 h1:wDKILuSdQsTkLXcjDkjv07mIKc7eO+iQLzQSKbqumX0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.173/go.mod h1:K/r4Y/iEF7sH77JKw6FILIC/CBpFsaigcGIvzMpjT2w=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.175 h1:N5reVKOi7MA6LuPYVyyCPE1dUa02oYlKJFrCTWSbzpk=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.175/go.mod h1:v+a//8kQvYXNbelhVpxomdBFF6hPi7a5TMMjRyVD8ao=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124 h1:atQm8S0BLrr3E+Yn2383KQUEEXpQ6z31MsprAKzMDDE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124/go.mod h1:zxlW9EAn0Hqx6Eub6MMocnHZz/gHundkyI7CdbIhU3o=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.0.414 h1:egwjvOEUKBaxsoRVn/YSEhp2E8qdh77Ous9A/wftDo0=

--- a/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/design.md
+++ b/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The `tencentcloud_dlc_user` resource manages DLC (Data Lake Compute) users via the TencentCloud DLC API (`dlc/v20210125`). The resource currently supports `user_id`, `user_description`, `user_type`, `user_alias`, and `work_group_ids` parameters.
+
+The DLC cloud API has been updated to support an `AccountType` parameter across all CRUD operations:
+- `CreateUser`: accepts `AccountType` as an optional input (account type: `UserAccount` for user accounts, `RoleAccount` for role accounts; defaults to user account)
+- `DescribeUsers`: returns `AccountType` in the `UserInfo` struct within `UserSet`
+- `ModifyUser`: accepts `AccountType` as an optional input
+- `DeleteUser`: accepts `AccountType` as an optional input
+
+This change adds the `account_type` parameter to the Terraform resource to expose this capability.
+
+### Current State
+- Resource file: `tencentcloud/services/dlc/resource_tc_dlc_user.go`
+- Service layer: `tencentcloud/services/dlc/service_tencentcloud_dlc.go`
+  - `DescribeDlcUserById(ctx, userId)` returns `*dlc.UserInfo`
+  - `DeleteDlcUserById(ctx, userId)` deletes a user
+- The `DescribeDlcUserById` method does not pass `AccountType` in the `DescribeUsers` request
+- The `DeleteDlcUserById` method does not pass `AccountType` in the `DeleteUser` request
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `account_type` as an optional string parameter to the `tencentcloud_dlc_user` resource schema
+- Pass `AccountType` in all four CRUD API calls (`CreateUser`, `DescribeUsers`, `ModifyUser`, `DeleteUser`)
+- Read `AccountType` from the `DescribeUsers` response and set it in Terraform state
+- Support in-place updates of `account_type` via `ModifyUser`
+- Maintain full backward compatibility (parameter is optional)
+
+**Non-Goals:**
+- Do not modify any existing parameters or their behavior
+- Do not change the resource ID format (still uses `user_id` as the sole ID)
+- Do not add `account_type` to the `immutableArgs` list — it supports in-place updates
+- Do not add `ForceNew` to `account_type`
+
+## Decisions
+
+### 1. Parameter Naming
+**Decision**: Use `account_type` (snake_case)
+
+**Rationale**:
+- Follows existing Terraform naming conventions in this resource (`user_id`, `user_type`, etc.)
+- Matches the cloud API field name `AccountType` in snake_case form
+- Consistent with the project's naming pattern
+
+### 2. Parameter Type and Optionality
+**Decision**: `schema.TypeString`, `Optional: true`, no `ForceNew`
+
+**Rationale**:
+- The cloud API field `AccountType` is `*string` in the SDK
+- The API accepts it as optional in `CreateUser`, `ModifyUser`, and `DeleteUser`
+- `ModifyUser` supports updating `AccountType`, so it should not be `ForceNew`
+- Optional ensures backward compatibility (existing configs without `account_type` still work)
+
+### 3. Service Layer Changes
+**Decision**: Update `DescribeDlcUserById` and `DeleteDlcUserById` to accept an `accountType` parameter
+
+**Rationale**:
+- `DescribeDlcUserById`: The `DescribeUsers` request supports `AccountType` as a filter/input. Passing it ensures the correct user is queried (relevant for role vs. user accounts).
+- `DeleteDlcUserById`: The `DeleteUser` request supports `AccountType`. Passing it ensures the correct user type is deleted.
+
+**Implementation**:
+- `DescribeDlcUserById(ctx, userId, accountType string)` — set `request.AccountType` when non-empty
+- `DeleteDlcUserById(ctx, userId, accountType string)` — set `request.AccountType` when non-empty
+- Update all callers in `resource_tc_dlc_user.go` to pass the `account_type` value from the schema
+
+**Alternatives Considered**:
+- Keep service methods unchanged and only pass `AccountType` in resource CRUD: Not feasible because the service layer constructs the API requests, so the parameter must be threaded through.
+
+### 4. Read Operation
+**Decision**: Read `AccountType` from `UserInfo.AccountType` in the `DescribeUsers` response and set it via `d.Set("account_type", ...)` with nil check
+
+**Rationale**:
+- The `UserInfo` struct contains `AccountType *string`
+- Follow the existing pattern in the read function: check nil before calling `d.Set()`
+
+### 5. Update Operation
+**Decision**: Include `account_type` in the `ModifyUser` request when `d.HasChange("account_type")` is true. Do NOT add `account_type` to the `immutableArgs` array.
+
+**Rationale**:
+- The `ModifyUser` API accepts `AccountType`, so in-place updates are supported
+- The existing `immutableArgs` only contains `user_type` and `user_alias`, which cannot be changed via `ModifyUser`
+- Since `account_type` is supported by `ModifyUser`, it should allow updates
+
+### 6. Delete Operation
+**Decision**: Pass `account_type` from the schema to `DeleteDlcUserById`
+
+**Rationale**:
+- The `DeleteUser` API accepts `AccountType`, which may be needed to identify the correct user to delete
+- Thread the value through the service layer
+
+### 7. Test Strategy
+**Decision**: Use Terraform acceptance test suite (since this is a modification to an existing resource, per project conventions)
+
+**Rationale**:
+- Project guidelines specify that modifications to existing resources use the Terraform test suite
+- Add test checks for `account_type` in create, update, and import scenarios
+
+## Risks / Trade-offs
+
+- **[Risk] `DescribeDlcUserById` signature change breaks other callers** → Mitigation: Search the codebase for all callers of `DescribeDlcUserById` and `DeleteDlcUserById` and update them. Based on code review, these methods are only called from `resource_tc_dlc_user.go`, so the blast radius is limited to that file.
+- **[Risk] `AccountType` may be returned as empty string from API** → Mitigation: Use the nil-check pattern (`if user.AccountType != nil`) before `d.Set()`, consistent with existing code.
+- **[Risk] `ModifyUser` may not actually support changing `AccountType` despite the API field existing** → Mitigation: The API SDK includes `AccountType` in `ModifyUserRequest`, indicating the API accepts it. If the backend rejects it, the retry/error handling will surface the error to the user.

--- a/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/proposal.md
+++ b/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The `tencentcloud_dlc_user` resource currently does not expose the `AccountType` parameter, which is supported by the DLC (Data Lake Compute) cloud API in all CRUD operations (`CreateUser`, `DescribeUsers`, `ModifyUser`, `DeleteUser`). This parameter allows users to specify the account type (e.g., `UserAccount` for user accounts, `RoleAccount` for role accounts) when managing DLC users. Without this parameter, Terraform users cannot configure or track the account type, limiting their ability to fully manage DLC user resources.
+
+## What Changes
+
+- Add a new optional `account_type` parameter (string type) to the `tencentcloud_dlc_user` resource schema
+- Include `AccountType` in the `CreateUser` API request during resource creation
+- Read `AccountType` from the `DescribeUsers` API response (`UserInfo.AccountType`) and set it in Terraform state during resource read
+- Include `AccountType` in the `ModifyUser` API request during resource update (support in-place updates)
+- Include `AccountType` in the `DeleteUser` API request during resource deletion (passed through the service layer)
+- Update the service layer methods (`DescribeDlcUserById`, `DeleteDlcUserById`) to accept and pass the `AccountType` parameter
+- Update the resource documentation (`resource_tc_dlc_user.md`) with the new parameter
+- Add unit test coverage for the new parameter
+
+## Capabilities
+
+### New Capabilities
+
+- `dlc-user-account-type`: Adds support for the `account_type` parameter in the `tencentcloud_dlc_user` resource, enabling users to specify and track the DLC user account type across create, read, update, and delete operations.
+
+### Modified Capabilities
+
+None. There are no existing specs for `tencentcloud_dlc_user`, so this is a pure addition.
+
+## Impact
+
+### Affected Code
+- `tencentcloud/services/dlc/resource_tc_dlc_user.go` - Add `account_type` to schema, CRUD operations
+- `tencentcloud/services/dlc/service_tencentcloud_dlc.go` - Update `DescribeDlcUserById` and `DeleteDlcUserById` to support `AccountType`
+- `tencentcloud/services/dlc/resource_tc_dlc_user_test.go` - Add test coverage for the new parameter
+- `tencentcloud/services/dlc/resource_tc_dlc_user.md` - Update documentation
+
+### API References
+- **DLC API** (`dlc/v20210125`):
+  - `CreateUser`: Accepts `AccountType` as an optional input parameter
+  - `DescribeUsers`: Returns `AccountType` in `UserInfo` within `UserSet`
+  - `ModifyUser`: Accepts `AccountType` as an optional input parameter
+  - `DeleteUser`: Accepts `AccountType` as an optional input parameter
+
+### Backward Compatibility
+- **Fully Compatible**: The new `account_type` parameter is optional. Existing configurations without this parameter continue to work unchanged. No state migration is required.

--- a/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/specs/dlc-user-account-type/spec.md
+++ b/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/specs/dlc-user-account-type/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: DLC user resource supports account_type parameter
+
+The `tencentcloud_dlc_user` resource SHALL support an optional `account_type` parameter that specifies the DLC user account type. The parameter SHALL be passed to the `CreateUser`, `DescribeUsers`, `ModifyUser`, and `DeleteUser` cloud API calls. The value SHALL be read back from the `DescribeUsers` API response and stored in Terraform state.
+
+**Rationale**: The DLC cloud API supports the `AccountType` parameter across all user CRUD operations. Exposing it in Terraform allows users to manage user accounts and role accounts distinctly, and ensures Terraform state accurately reflects the cloud resource configuration.
+
+#### Scenario: Create a DLC user with account_type
+
+- **WHEN** a user creates a `tencentcloud_dlc_user` resource with `account_type` set to a valid value (e.g., `UserAccount` or `RoleAccount`)
+- **THEN** the `CreateUser` API SHALL be called with the `AccountType` parameter set to the specified value
+- **AND** the resource SHALL be created successfully
+- **AND** the `account_type` value SHALL be read back from the `DescribeUsers` response and stored in Terraform state
+
+#### Scenario: Create a DLC user without account_type
+
+- **WHEN** a user creates a `tencentcloud_dlc_user` resource without specifying `account_type`
+- **THEN** the `CreateUser` API SHALL be called without the `AccountType` parameter (or with it empty)
+- **AND** the resource SHALL be created successfully using the API default account type
+- **AND** no errors SHALL be raised due to the missing parameter
+
+#### Scenario: Read account_type from DescribeUsers response
+
+- **WHEN** the `DescribeUsers` API returns a `UserInfo` with `AccountType` set to a non-nil value
+- **THEN** the resource read operation SHALL set `account_type` in Terraform state to the returned value
+- **WHEN** the `DescribeUsers` API returns a `UserInfo` with `AccountType` set to nil
+- **THEN** the resource read operation SHALL NOT call `d.Set("account_type", ...)` (skip setting the field)
+
+#### Scenario: Update account_type in-place
+
+- **WHEN** a user updates the `account_type` parameter on an existing `tencentcloud_dlc_user` resource
+- **THEN** the `ModifyUser` API SHALL be called with the `AccountType` parameter set to the new value
+- **AND** the resource SHALL be updated in-place without recreation
+- **AND** the `account_type` parameter SHALL NOT be in the `immutableArgs` list
+
+#### Scenario: Delete a DLC user with account_type
+
+- **WHEN** a user deletes a `tencentcloud_dlc_user` resource that has `account_type` set
+- **THEN** the `DeleteUser` API SHALL be called with the `AccountType` parameter passed from the resource schema
+- **AND** the resource SHALL be deleted successfully
+
+#### Scenario: Delete a DLC user without account_type
+
+- **WHEN** a user deletes a `tencentcloud_dlc_user` resource that does not have `account_type` set
+- **THEN** the `DeleteUser` API SHALL be called without the `AccountType` parameter (or with it empty)
+- **AND** the resource SHALL be deleted successfully
+
+#### Scenario: Import a DLC user with account_type
+
+- **WHEN** a `tencentcloud_dlc_user` resource is imported
+- **THEN** the `account_type` value SHALL be read from the `DescribeUsers` API response and populated in Terraform state
+- **AND** the import SHALL succeed regardless of whether `account_type` was previously configured

--- a/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/tasks.md
+++ b/openspec/changes/archive/2026-09-09-add-dlc-user-account-type/tasks.md
@@ -1,0 +1,37 @@
+## 1. Schema Definition
+
+- [x] 1.1 Add `account_type` field to resource schema in `tencentcloud/services/dlc/resource_tc_dlc_user.go`
+  - Type: `schema.TypeString`
+  - Optional: true
+  - Description: "Account type. Valid values: `UserAccount` (user account), `RoleAccount` (role account). Default is `UserAccount`."
+
+## 2. Service Layer
+
+- [x] 2.1 Update `DescribeDlcUserById` method in `tencentcloud/services/dlc/service_tencentcloud_dlc.go` to accept an `accountType string` parameter and set `request.AccountType` when non-empty
+- [x] 2.2 Update `DeleteDlcUserById` method in `tencentcloud/services/dlc/service_tencentcloud_dlc.go` to accept an `accountType string` parameter and set `request.AccountType` when non-empty
+
+## 3. CRUD Functions
+
+- [x] 3.1 Update `resourceTencentCloudDlcUserCreate` to read `account_type` from schema and set `request.AccountType` in the `CreateUser` API request
+- [x] 3.2 Update `resourceTencentCloudDlcUserRead` to read `AccountType` from the `UserInfo` response (nil-checked) and set `account_type` in Terraform state via `d.Set()`
+- [x] 3.3 Update `resourceTencentCloudDlcUserUpdate` to include `account_type` in the `ModifyUser` API request when `d.HasChange("account_type")` is true; do NOT add `account_type` to the `immutableArgs` array
+- [x] 3.4 Update `resourceTencentCloudDlcUserDelete` to read `account_type` from schema and pass it to the updated `DeleteDlcUserById` service method
+- [x] 3.5 Update `DescribeDlcUserById` callers in read function to pass `account_type` from schema
+
+## 4. Testing
+
+- [x] 4.1 Add test case in `tencentcloud/services/dlc/resource_tc_dlc_user_test.go` for creating a DLC user with `account_type` set
+- [x] 4.2 Add test case for updating `account_type` in-place and verifying the value is correctly updated
+- [x] 4.3 Add test assertion for reading `account_type` from state after create/update
+- [x] 4.4 Add test case for importing a DLC user and verifying `account_type` is populated
+
+## 5. Documentation
+
+- [x] 5.1 Update `tencentcloud/services/dlc/resource_tc_dlc_user.md` to include `account_type` parameter in example usage
+- [ ] 5.2 Run `make doc` (in finalize phase) to generate website documentation
+
+## 6. Code Quality (Finalize Phase)
+
+- [ ] 6.1 Run `gofmt` to format all modified Go files
+- [x] 6.2 Verify all error returns are properly handled (use `_ =` for functions that cannot fail)
+- [ ] 6.3 Create changelog file via `tfpacer-finalize` skill

--- a/openspec/specs/dlc-user-account-type/spec.md
+++ b/openspec/specs/dlc-user-account-type/spec.md
@@ -1,0 +1,56 @@
+# dlc-user-account-type Specification
+
+## Purpose
+TBD - created by archiving change add-dlc-user-account-type. Update Purpose after archive.
+## Requirements
+### Requirement: DLC user resource supports account_type parameter
+
+The `tencentcloud_dlc_user` resource SHALL support an optional `account_type` parameter that specifies the DLC user account type. The parameter SHALL be passed to the `CreateUser`, `DescribeUsers`, `ModifyUser`, and `DeleteUser` cloud API calls. The value SHALL be read back from the `DescribeUsers` API response and stored in Terraform state.
+
+**Rationale**: The DLC cloud API supports the `AccountType` parameter across all user CRUD operations. Exposing it in Terraform allows users to manage user accounts and role accounts distinctly, and ensures Terraform state accurately reflects the cloud resource configuration.
+
+#### Scenario: Create a DLC user with account_type
+
+- **WHEN** a user creates a `tencentcloud_dlc_user` resource with `account_type` set to a valid value (e.g., `UserAccount` or `RoleAccount`)
+- **THEN** the `CreateUser` API SHALL be called with the `AccountType` parameter set to the specified value
+- **AND** the resource SHALL be created successfully
+- **AND** the `account_type` value SHALL be read back from the `DescribeUsers` response and stored in Terraform state
+
+#### Scenario: Create a DLC user without account_type
+
+- **WHEN** a user creates a `tencentcloud_dlc_user` resource without specifying `account_type`
+- **THEN** the `CreateUser` API SHALL be called without the `AccountType` parameter (or with it empty)
+- **AND** the resource SHALL be created successfully using the API default account type
+- **AND** no errors SHALL be raised due to the missing parameter
+
+#### Scenario: Read account_type from DescribeUsers response
+
+- **WHEN** the `DescribeUsers` API returns a `UserInfo` with `AccountType` set to a non-nil value
+- **THEN** the resource read operation SHALL set `account_type` in Terraform state to the returned value
+- **WHEN** the `DescribeUsers` API returns a `UserInfo` with `AccountType` set to nil
+- **THEN** the resource read operation SHALL NOT call `d.Set("account_type", ...)` (skip setting the field)
+
+#### Scenario: Update account_type in-place
+
+- **WHEN** a user updates the `account_type` parameter on an existing `tencentcloud_dlc_user` resource
+- **THEN** the `ModifyUser` API SHALL be called with the `AccountType` parameter set to the new value
+- **AND** the resource SHALL be updated in-place without recreation
+- **AND** the `account_type` parameter SHALL NOT be in the `immutableArgs` list
+
+#### Scenario: Delete a DLC user with account_type
+
+- **WHEN** a user deletes a `tencentcloud_dlc_user` resource that has `account_type` set
+- **THEN** the `DeleteUser` API SHALL be called with the `AccountType` parameter passed from the resource schema
+- **AND** the resource SHALL be deleted successfully
+
+#### Scenario: Delete a DLC user without account_type
+
+- **WHEN** a user deletes a `tencentcloud_dlc_user` resource that does not have `account_type` set
+- **THEN** the `DeleteUser` API SHALL be called without the `AccountType` parameter (or with it empty)
+- **AND** the resource SHALL be deleted successfully
+
+#### Scenario: Import a DLC user with account_type
+
+- **WHEN** a `tencentcloud_dlc_user` resource is imported
+- **THEN** the `account_type` value SHALL be read from the `DescribeUsers` API response and populated in Terraform state
+- **AND** the import SHALL succeed regardless of whether `account_type` was previously configured

--- a/tencentcloud/services/dlc/resource_tc_dlc_user.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_user.go
@@ -51,6 +51,7 @@ func ResourceTencentCloudDlcUser() *schema.Resource {
 
 			"account_type": {
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeString,
 				Description: "Account type. Valid values: `UserAccount` (user account), `RoleAccount` (role account). Default is `UserAccount`.",
 			},
@@ -138,7 +139,7 @@ func resourceTencentCloudDlcUserRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if user == nil {
-		log.Printf("[WARN]%s resource `DlcUser` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
+		log.Printf("[WARN]%s resource `tencentcloud_dlc_user` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -180,9 +181,8 @@ func resourceTencentCloudDlcUserUpdate(d *schema.ResourceData, meta interface{})
 	defer tccommon.InconsistentCheck(d, meta)()
 
 	var (
-		logId   = tccommon.GetLogId(tccommon.ContextNil)
-		request = dlc.NewModifyUserRequest()
-		userId  = d.Id()
+		logId  = tccommon.GetLogId(tccommon.ContextNil)
+		userId = d.Id()
 	)
 
 	immutableArgs := []string{"user_type", "user_alias"}
@@ -192,9 +192,14 @@ func resourceTencentCloudDlcUserUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if d.HasChange("user_description") {
+	if d.HasChange("user_description") || d.HasChange("account_type") {
+		request := dlc.NewModifyUserRequest()
 		if v, ok := d.GetOk("user_description"); ok {
 			request.UserDescription = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("account_type"); ok {
+			request.AccountType = helper.String(v.(string))
 		}
 
 		request.UserId = &userId
@@ -204,30 +209,6 @@ func resourceTencentCloudDlcUserUpdate(d *schema.ResourceData, meta interface{})
 				return tccommon.RetryError(e)
 			} else {
 				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			log.Printf("[CRITAL]%s update dlc user failed, reason:%+v", logId, err)
-			return err
-		}
-	}
-
-	if d.HasChange("account_type") {
-		modifyRequest := dlc.NewModifyUserRequest()
-		modifyRequest.UserId = &userId
-		if v, ok := d.GetOk("account_type"); ok {
-			modifyRequest.AccountType = helper.String(v.(string))
-		}
-
-		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
-			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDlcClient().ModifyUser(modifyRequest)
-			if e != nil {
-				return tccommon.RetryError(e)
-			} else {
-				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, modifyRequest.GetAction(), modifyRequest.ToJsonString(), result.ToJsonString())
 			}
 
 			return nil

--- a/tencentcloud/services/dlc/resource_tc_dlc_user.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_user.go
@@ -39,6 +39,7 @@ func ResourceTencentCloudDlcUser() *schema.Resource {
 
 			"user_type": {
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeString,
 				Description: "Types of users. ADMIN: administrators; COMMON: general users. When the type of user is administrator, the collections of permissions and bound working groups cannot be set. Administrators own all the permissions by default. If the parameter is not filled in, it will be COMMON by default.",
 			},
@@ -192,14 +193,10 @@ func resourceTencentCloudDlcUserUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if d.HasChange("user_description") || d.HasChange("account_type") {
+	if d.HasChange("user_description") {
 		request := dlc.NewModifyUserRequest()
 		if v, ok := d.GetOk("user_description"); ok {
 			request.UserDescription = helper.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("account_type"); ok {
-			request.AccountType = helper.String(v.(string))
 		}
 
 		request.UserId = &userId
@@ -216,6 +213,34 @@ func resourceTencentCloudDlcUserUpdate(d *schema.ResourceData, meta interface{})
 
 		if err != nil {
 			log.Printf("[CRITAL]%s update dlc user failed, reason:%+v", logId, err)
+			return err
+		}
+	}
+
+	if d.HasChange("account_type") {
+		request := dlc.NewModifyUserTypeRequest()
+		if v, ok := d.GetOk("user_type"); ok {
+			request.UserType = helper.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("account_type"); ok {
+			request.AccountType = helper.String(v.(string))
+		}
+
+		request.UserId = &userId
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDlcClient().ModifyUserType(request)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s update dlc user type failed, reason:%+v", logId, err)
 			return err
 		}
 	}

--- a/tencentcloud/services/dlc/resource_tc_dlc_user.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_user.go
@@ -49,6 +49,12 @@ func ResourceTencentCloudDlcUser() *schema.Resource {
 				Description: "User alias, and its characters are less than 50.",
 			},
 
+			"account_type": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "Account type. Valid values: `UserAccount` (user account), `RoleAccount` (role account). Default is `UserAccount`.",
+			},
+
 			"work_group_ids": {
 				Computed:    true,
 				Type:        schema.TypeSet,
@@ -86,6 +92,10 @@ func resourceTencentCloudDlcUserCreate(d *schema.ResourceData, meta interface{})
 		request.UserAlias = helper.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("account_type"); ok {
+		request.AccountType = helper.String(v.(string))
+	}
+
 	err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDlcClient().CreateUser(request)
 		if e != nil {
@@ -121,7 +131,8 @@ func resourceTencentCloudDlcUserRead(d *schema.ResourceData, meta interface{}) e
 		userId  = d.Id()
 	)
 
-	user, err := service.DescribeDlcUserById(ctx, userId)
+	accountType := d.Get("account_type").(string)
+	user, err := service.DescribeDlcUserById(ctx, userId, accountType)
 	if err != nil {
 		return err
 	}
@@ -146,6 +157,10 @@ func resourceTencentCloudDlcUserRead(d *schema.ResourceData, meta interface{}) e
 
 	if user.UserAlias != nil {
 		_ = d.Set("user_alias", user.UserAlias)
+	}
+
+	if user.AccountType != nil {
+		_ = d.Set("account_type", user.AccountType)
 	}
 
 	if user.WorkGroupSet != nil {
@@ -200,6 +215,30 @@ func resourceTencentCloudDlcUserUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
+	if d.HasChange("account_type") {
+		modifyRequest := dlc.NewModifyUserRequest()
+		modifyRequest.UserId = &userId
+		if v, ok := d.GetOk("account_type"); ok {
+			modifyRequest.AccountType = helper.String(v.(string))
+		}
+
+		err := resource.Retry(tccommon.WriteRetryTimeout, func() *resource.RetryError {
+			result, e := meta.(tccommon.ProviderMeta).GetAPIV3Conn().UseDlcClient().ModifyUser(modifyRequest)
+			if e != nil {
+				return tccommon.RetryError(e)
+			} else {
+				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, modifyRequest.GetAction(), modifyRequest.ToJsonString(), result.ToJsonString())
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.Printf("[CRITAL]%s update dlc user failed, reason:%+v", logId, err)
+			return err
+		}
+	}
+
 	return resourceTencentCloudDlcUserRead(d, meta)
 }
 
@@ -214,7 +253,8 @@ func resourceTencentCloudDlcUserDelete(d *schema.ResourceData, meta interface{})
 		userId  = d.Id()
 	)
 
-	if err := service.DeleteDlcUserById(ctx, userId); err != nil {
+	accountType := d.Get("account_type").(string)
+	if err := service.DeleteDlcUserById(ctx, userId, accountType); err != nil {
 		return err
 	}
 

--- a/tencentcloud/services/dlc/resource_tc_dlc_user.md
+++ b/tencentcloud/services/dlc/resource_tc_dlc_user.md
@@ -8,6 +8,7 @@ resource "tencentcloud_dlc_user" "example" {
   user_type        = "COMMON"
   user_alias       = "terraform-test"
   user_description = "for terraform test"
+  account_type     = "UserAccount"
 }
 ```
 

--- a/tencentcloud/services/dlc/resource_tc_dlc_user_test.go
+++ b/tencentcloud/services/dlc/resource_tc_dlc_user_test.go
@@ -39,6 +39,37 @@ func TestAccTencentCloudDlcUserResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccTencentCloudDlcUserResource_accountType(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			tcacctest.AccPreCheck(t)
+		},
+		Providers: tcacctest.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDlcUserAccountType,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tencentcloud_dlc_user.user", "id"),
+					resource.TestCheckResourceAttr("tencentcloud_dlc_user.user", "account_type", "UserAccount"),
+				),
+			},
+			{
+				Config: testAccDlcUserAccountTypeUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tencentcloud_dlc_user.user", "id"),
+					resource.TestCheckResourceAttr("tencentcloud_dlc_user.user", "account_type", "RoleAccount"),
+				),
+			},
+			{
+				ResourceName:      "tencentcloud_dlc_user.user",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 const testAccDlcUser = `
 
 resource "tencentcloud_dlc_user" "user" {
@@ -57,6 +88,30 @@ resource "tencentcloud_dlc_user" "user" {
   user_type        = "COMMON"
   user_alias       = "terraform-test"
   user_description = "for terraform"
+}
+
+`
+
+const testAccDlcUserAccountType = `
+
+resource "tencentcloud_dlc_user" "user" {
+  user_id          = "100027012454"
+  user_type        = "COMMON"
+  user_alias       = "terraform-test-account-type"
+  user_description = "for terraform test account type"
+  account_type     = "UserAccount"
+}
+
+`
+
+const testAccDlcUserAccountTypeUpdate = `
+
+resource "tencentcloud_dlc_user" "user" {
+  user_id          = "100027012454"
+  user_type        = "COMMON"
+  user_alias       = "terraform-test-account-type"
+  user_description = "for terraform test account type"
+  account_type     = "RoleAccount"
 }
 
 `

--- a/tencentcloud/services/dlc/service_tencentcloud_dlc.go
+++ b/tencentcloud/services/dlc/service_tencentcloud_dlc.go
@@ -94,12 +94,15 @@ func (me *DlcService) DeleteDlcWorkGroupById(ctx context.Context, workGroupId st
 	return
 }
 
-func (me *DlcService) DescribeDlcUserById(ctx context.Context, userId string) (user *dlc.UserInfo, errRet error) {
+func (me *DlcService) DescribeDlcUserById(ctx context.Context, userId string, accountType string) (user *dlc.UserInfo, errRet error) {
 	logId := tccommon.GetLogId(ctx)
 
 	request := dlc.NewDescribeUsersRequest()
 	response := dlc.NewDescribeUsersResponse()
 	request.UserId = &userId
+	if accountType != "" {
+		request.AccountType = &accountType
+	}
 
 	defer func() {
 		if errRet != nil {
@@ -134,11 +137,14 @@ func (me *DlcService) DescribeDlcUserById(ctx context.Context, userId string) (u
 	return
 }
 
-func (me *DlcService) DeleteDlcUserById(ctx context.Context, userId string) (errRet error) {
+func (me *DlcService) DeleteDlcUserById(ctx context.Context, userId string, accountType string) (errRet error) {
 	logId := tccommon.GetLogId(ctx)
 
 	request := dlc.NewDeleteUserRequest()
 	request.UserIds = []*string{&userId}
+	if accountType != "" {
+		request.AccountType = &accountType
+	}
 
 	defer func() {
 		if errRet != nil {

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.174"
+	params["RequestClient"] = "SDK_GO_1.3.175"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/client.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/client.go
@@ -15055,56 +15055,6 @@ func (c *Client) GetRayJobEventWithContext(ctx context.Context, request *GetRayJ
     return
 }
 
-func NewGetRayJobEventLogRequest() (request *GetRayJobEventLogRequest) {
-    request = &GetRayJobEventLogRequest{
-        BaseRequest: &tchttp.BaseRequest{},
-    }
-    
-    request.Init().WithApiInfo("dlc", APIVersion, "GetRayJobEventLog")
-    
-    
-    return
-}
-
-func NewGetRayJobEventLogResponse() (response *GetRayJobEventLogResponse) {
-    response = &GetRayJobEventLogResponse{
-        BaseResponse: &tchttp.BaseResponse{},
-    } 
-    return
-
-}
-
-// GetRayJobEventLog
-// 获取作业事件日志
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
-func (c *Client) GetRayJobEventLog(request *GetRayJobEventLogRequest) (response *GetRayJobEventLogResponse, err error) {
-    return c.GetRayJobEventLogWithContext(context.Background(), request)
-}
-
-// GetRayJobEventLog
-// 获取作业事件日志
-//
-// 可能返回的错误码:
-//  FAILEDOPERATION_EXTERNALSERVICE = "FailedOperation.ExternalService"
-func (c *Client) GetRayJobEventLogWithContext(ctx context.Context, request *GetRayJobEventLogRequest) (response *GetRayJobEventLogResponse, err error) {
-    if request == nil {
-        request = NewGetRayJobEventLogRequest()
-    }
-    c.InitBaseRequest(&request.BaseRequest, "dlc", APIVersion, "GetRayJobEventLog")
-    
-    if c.GetCredential() == nil {
-        return nil, errors.New("GetRayJobEventLog require credential")
-    }
-
-    request.SetContext(ctx)
-    
-    response = NewGetRayJobEventLogResponse()
-    err = c.Send(request, response)
-    return
-}
-
 func NewGetRayJobHistoryRequest() (request *GetRayJobHistoryRequest) {
     request = &GetRayJobHistoryRequest{
         BaseRequest: &tchttp.BaseRequest{},

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125/models.go
@@ -21477,20 +21477,6 @@ type EventItem struct {
 	Reason *string `json:"Reason,omitnil,omitempty" name:"Reason"`
 }
 
-type EventLogItem struct {
-	// 事件时间（Unix 时间戳，秒级）
-	EventTime *uint64 `json:"EventTime,omitnil,omitempty" name:"EventTime"`
-
-	// 组件名称
-	Component *string `json:"Component,omitnil,omitempty" name:"Component"`
-
-	// 日志级别（INFO/WARN/ERROR）
-	Level *string `json:"Level,omitnil,omitempty" name:"Level"`
-
-	// 事件内容
-	Message *string `json:"Message,omitnil,omitempty" name:"Message"`
-}
-
 type ExampleCategories struct {
 	// <p>分类名称</p>
 	Categories *string `json:"Categories,omitnil,omitempty" name:"Categories"`
@@ -23931,110 +23917,6 @@ func (r *GetRayClusterYamlResponse) ToJsonString() string {
 // FromJsonString It is highly **NOT** recommended to use this function
 // because it has no param check, nor strict type check
 func (r *GetRayClusterYamlResponse) FromJsonString(s string) error {
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type GetRayJobEventLogRequestParams struct {
-	// ray-jobID
-	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
-
-	// 开始时间
-	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
-
-	// 结束时间
-	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
-
-	// 当前页码（从1开始）
-	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
-
-	// 页数
-	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
-
-	// 排序字段列表（列表字段）
-	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
-}
-
-type GetRayJobEventLogRequest struct {
-	*tchttp.BaseRequest
-	
-	// ray-jobID
-	Id *string `json:"Id,omitnil,omitempty" name:"Id"`
-
-	// 开始时间
-	StartTime *uint64 `json:"StartTime,omitnil,omitempty" name:"StartTime"`
-
-	// 结束时间
-	EndTime *uint64 `json:"EndTime,omitnil,omitempty" name:"EndTime"`
-
-	// 当前页码（从1开始）
-	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
-
-	// 页数
-	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
-
-	// 排序字段列表（列表字段）
-	SortFields []*SortField `json:"SortFields,omitnil,omitempty" name:"SortFields"`
-}
-
-func (r *GetRayJobEventLogRequest) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *GetRayJobEventLogRequest) FromJsonString(s string) error {
-	f := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(s), &f); err != nil {
-		return err
-	}
-	delete(f, "Id")
-	delete(f, "StartTime")
-	delete(f, "EndTime")
-	delete(f, "Page")
-	delete(f, "PageSize")
-	delete(f, "SortFields")
-	if len(f) > 0 {
-		return tcerr.NewTencentCloudSDKError("ClientError.BuildRequestError", "GetRayJobEventLogRequest has unknown keys!", "")
-	}
-	return json.Unmarshal([]byte(s), &r)
-}
-
-// Predefined struct for user
-type GetRayJobEventLogResponseParams struct {
-	// 事件总数
-	TotalCount *int64 `json:"TotalCount,omitnil,omitempty" name:"TotalCount"`
-
-	// 事件列表
-	Events []*EventLogItem `json:"Events,omitnil,omitempty" name:"Events"`
-
-	// 当前页码（从1开始）
-	Page *int64 `json:"Page,omitnil,omitempty" name:"Page"`
-
-	// 页数
-	PageSize *int64 `json:"PageSize,omitnil,omitempty" name:"PageSize"`
-
-	// 总页数
-	TotalPages *int64 `json:"TotalPages,omitnil,omitempty" name:"TotalPages"`
-
-	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。
-	RequestId *string `json:"RequestId,omitnil,omitempty" name:"RequestId"`
-}
-
-type GetRayJobEventLogResponse struct {
-	*tchttp.BaseResponse
-	Response *GetRayJobEventLogResponseParams `json:"Response"`
-}
-
-func (r *GetRayJobEventLogResponse) ToJsonString() string {
-    b, _ := json.Marshal(r)
-    return string(b)
-}
-
-// FromJsonString It is highly **NOT** recommended to use this function
-// because it has no param check, nor strict type check
-func (r *GetRayJobEventLogResponse) FromJsonString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.175
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1306,7 +1306,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dc/v20180410
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb v1.0.673
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dcdb/v20180411
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.173
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc v1.3.175
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dlc/v20210125
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.124

--- a/website/docs/r/dlc_user.html.markdown
+++ b/website/docs/r/dlc_user.html.markdown
@@ -19,6 +19,7 @@ resource "tencentcloud_dlc_user" "example" {
   user_type        = "COMMON"
   user_alias       = "terraform-test"
   user_description = "for terraform test"
+  account_type     = "UserAccount"
 }
 ```
 
@@ -27,6 +28,7 @@ resource "tencentcloud_dlc_user" "example" {
 The following arguments are supported:
 
 * `user_id` - (Required, String, ForceNew) Sub-user UIN that needs to be granted permissions. It can be checked through the upper right corner of Tencent Cloud Console -> Account Information -> Account ID.
+* `account_type` - (Optional, String) Account type. Valid values: `UserAccount` (user account), `RoleAccount` (role account). Default is `UserAccount`.
 * `user_alias` - (Optional, String) User alias, and its characters are less than 50.
 * `user_description` - (Optional, String) User description, which can make it easy to identify different users.
 * `user_type` - (Optional, String) Types of users. ADMIN: administrators; COMMON: general users. When the type of user is administrator, the collections of permissions and bound working groups cannot be set. Administrators own all the permissions by default. If the parameter is not filled in, it will be COMMON by default.


### PR DESCRIPTION
Add the optional `account_type` parameter to the `tencentcloud_dlc_user` resource schema. This parameter supports specifying the DLC user account type (`UserAccount` for user accounts, `RoleAccount` for role accounts) across create, read, update, and delete operations. The DLC SDK has been upgraded to v1.3.175 to support the `AccountType` field in CreateUser, DescribeUsers, ModifyUser, and DeleteUser APIs.