### PR TITLE
feat(monitor): [137885070] add is_bind_all parameter to alarm policy resource

### DIFF
--- a/.changelog/4499.txt
+++ b/.changelog/4499.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/tencentcloud_monitor_alarm_policy: support `is_bind_all` parameter to specify whether the alarm policy binds to all objects
+```

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/live v1.3.95
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.141
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.170
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.171
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mps v1.3.45
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/organization v1.3.110
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/postgres v1.3.172

--- a/go.sum
+++ b/go.sum
@@ -1066,8 +1066,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102 h1:I4Q
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb v1.3.102/go.mod h1:Thfxer0Xf7Oq//ceL5i5nObFEXyQkUxzLHVNFh3p7jw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.141 h1:cvvgcdt3CweSsAIbw3MsrdPEOCdHv1nFYdOs3skBRnk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.141/go.mod h1:BXuG+T2d/4j+1oodFmEHBm6OCd4GR+N1ENNbD4cFUvo=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.170 h1:SInKRvDHuA+o1td/qlYqEB08Ofp95EEhn57HXBi30vU=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.170/go.mod h1:IY7r9JISgJvBtbmmxVLJtWob4Wl2FRVpoURl6DyYiVA=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.171 h1:10nJl24av+kj0HxfrtQtyYna96CZlWpWcJPETk1QAr8=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.171/go.mod h1:a9IF/vffQllM0byPS7kXFACCOeTgVfLiFz1fsi32WOI=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mps v1.3.45 h1:35PD/GXaOl3QhL1fI5a3Q+jcenzR1PqfuGxltOeO48w=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mps v1.3.45/go.mod h1:OrNv7U7R19HZySH5o+/ag3EyAH1tDIwb5z23K5fY5vw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mqtt v1.3.104 h1:+upw3F568kiJctCNy3MiLWl77pPqwtelEqDbFBc6wnI=

--- a/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/design.md
+++ b/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The `tencentcloud_monitor_alarm_policy` resource manages Tencent Cloud Monitor alarm policies. The resource currently supports parameters such as `policy_name`, `monitor_type`, `namespace`, `remark`, `enable`, `conditions`, `event_conditions`, `notice_ids`, `trigger_tasks`, `policy_tag`, `group_by`, `filter`, `hierarchical_notices`, and `notice_content_tmpl_bind_infos`.
+
+**Current state:**
+- Resource file: `tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go`
+- SDK: `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724`
+
+**API behavior analysis:**
+
+| API | IsBindAll in Request | IsBindAll in Response |
+|-----|----------------------|-----------------------|
+| `CreateAlarmPolicy` | Yes (`IsBindAll *int64`, values 0 or 1, default 0) | No |
+| `DescribeAlarmPolicy` | N/A | Yes (`Policy.IsBindAll *int64`) |
+| `ModifyAlarmPolicyInfo` | No | N/A |
+| `ModifyAlarmPolicyStatus` | No | N/A |
+| `ModifyAlarmPolicyCondition` | No | N/A |
+| `ModifyAlarmPolicyTasks` | No | N/A |
+| `ModifyAlarmPolicyNotice` | No | N/A |
+| `DeleteAlarmPolicy` | No | N/A |
+
+**Key constraint:** `IsBindAll` is only available in the Create request for writing. No Modify API supports updating `IsBindAll`. The Describe API's `AlarmPolicy` struct includes the `IsBindAll` field, so it can be refreshed on Read.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `is_bind_all` (Optional, ForceNew, TypeInt) parameter to `tencentcloud_monitor_alarm_policy` with valid values `0` and `1`
+- Pass `IsBindAll` to the `CreateAlarmPolicy` API when specified by the user
+- Read `IsBindAll` from the `DescribeAlarmPolicy` API response (`response.Policy.IsBindAll`) to support state refresh and import
+- Maintain full backward compatibility — existing configurations continue to work unchanged
+
+**Non-Goals:**
+- Making `is_bind_all` updatable (no Modify API supports it; must be immutable via ForceNew)
+- Adding validation that `is_bind_all` conflicts with `filter` (the API handles this server-side; provider-side enforcement is out of scope)
+
+## Decisions
+
+### Decision 1: `is_bind_all` is ForceNew (immutable after creation)
+
+**Rationale:** No Modify API (`ModifyAlarmPolicyInfo`, `ModifyAlarmPolicyStatus`, `ModifyAlarmPolicyCondition`, `ModifyAlarmPolicyTasks`, `ModifyAlarmPolicyNotice`) accepts an `IsBindAll` parameter. Since the value cannot be updated, the parameter is marked with `ForceNew: true`. Changing `is_bind_all` will trigger resource recreation, which is the standard Terraform pattern for immutable parameters. This is simpler and more idiomatic than the `immutableArgs` array pattern, because there is only a single immutable parameter being added and the existing resource does not use the `immutableArgs` pattern.
+
+### Decision 2: Use `TypeInt` with `ValidateAllowedIntValue` for `is_bind_all`
+
+**Rationale:** The cloud API field `IsBindAll` is `*int64` with valid values `0` (no) and `1` (yes). Using `TypeInt` with `tccommon.ValidateAllowedIntValue([]int{0, 1})` is consistent with the existing `enable` field pattern and the cloud API type.
+
+### Decision 3: Read `IsBindAll` from Describe API with nil check
+
+**Rationale:** The `AlarmPolicy` struct's `IsBindAll` field may return null (per SDK documentation). The Read function must check `policy.IsBindAll != nil` before calling `d.Set("is_bind_all", ...)`, consistent with the existing read patterns in the resource and the project's hard constraint of checking nil before setting fields.
+
+### Decision 4: Set `IsBindAll` in Create only when explicitly provided
+
+**Rationale:** The `is_bind_all` parameter is Optional. In the Create function, read the value from schema data and pass it to the request when the user has set it (using `d.GetOk` or by reading the raw value). Since the API default is `0` (not bind all), only setting it when the user explicitly configures it avoids sending unnecessary parameters and maintains backward compatibility.
+
+## Risks / Trade-offs
+
+- **[Risk] Changing `is_bind_all` destroys and recreates the resource**: Using `ForceNew: true` means changing this parameter triggers resource destruction and recreation.
+  - **Mitigation:** This is the expected Terraform behavior for immutable parameters. The resource recreation will delete the old alarm policy and create a new one with the updated `IsBindAll` value. Users are warned via the Terraform plan output that the resource will be replaced.
+
+- **[Risk] `IsBindAll` returns null from Describe API**: The SDK documentation notes `IsBindAll` may return null.
+  - **Mitigation:** The Read function checks `policy.IsBindAll != nil` before setting the field, consistent with the existing read patterns in the resource.

--- a/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/proposal.md
+++ b/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The Tencent Cloud Monitor `CreateAlarmPolicy` API supports an `IsBindAll` parameter that determines whether an alarm policy binds to all objects. When set to `1`, the policy binds to all objects and no `filter` or `BindPolicyObject` call is needed. The Terraform resource `tencentcloud_monitor_alarm_policy` does not currently expose this parameter, so users cannot create "bind all objects" alarm policies through Terraform and are forced to use the console or API directly.
+
+## What Changes
+
+- Add `is_bind_all` (Optional, ForceNew, TypeInt) parameter to the `tencentcloud_monitor_alarm_policy` resource to support specifying whether the alarm policy binds to all objects. Valid values: `0` (no, default) and `1` (yes). This parameter is immutable after creation because no Modify API supports updating `IsBindAll`.
+- Pass `IsBindAll` to the `CreateAlarmPolicy` API request when the parameter is set by the user.
+- Read `IsBindAll` from the `DescribeAlarmPolicy` API response (`response.Policy.IsBindAll`) to support state refresh and import.
+- Maintain full backward compatibility — the new parameter is Optional and defaults to not being set.
+
+## Capabilities
+
+### New Capabilities
+- `monitor-alarm-policy-is-bind-all`: Enable the `is_bind_all` parameter on the `tencentcloud_monitor_alarm_policy` resource to allow users to specify whether an alarm policy binds to all objects at creation time.
+
+### Modified Capabilities
+<!-- No existing specs require modification -->
+
+## Impact
+
+- **Affected files:**
+  - `tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go` — add `is_bind_all` schema field, wire through Create flow, add Read support
+  - `tencentcloud/services/monitor/resource_tc_monitor_alarm_policy_test.go` — add unit test cases for the new `is_bind_all` parameter
+  - `tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.md` — update documentation
+- **SDK dependency:** `github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724` — `CreateAlarmPolicyRequest` already includes the `IsBindAll *int64` field, and `AlarmPolicy` struct (Describe response) already includes `IsBindAll *int64`. No SDK update is needed.
+- **Backward compatibility:** fully backward compatible — the new parameter is Optional and defaults to not being set.
+- **API constraints:** `IsBindAll` is only accepted by `CreateAlarmPolicy` (no Modify API supports it), so this parameter is immutable after creation and marked as `ForceNew`.

--- a/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/specs/monitor-alarm-policy-is-bind-all/spec.md
+++ b/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/specs/monitor-alarm-policy-is-bind-all/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: IsBindAll Parameter for Alarm Policy
+The `tencentcloud_monitor_alarm_policy` resource SHALL support the `is_bind_all` parameter to specify whether the alarm policy binds to all objects. The parameter SHALL be an optional integer with valid values `0` (no, default) and `1` (yes). The parameter SHALL be immutable after creation (ForceNew) because no Modify API supports updating `IsBindAll`.
+
+#### Scenario: Create alarm policy with is_bind_all set to 1
+- **WHEN** user creates a `tencentcloud_monitor_alarm_policy` resource with `is_bind_all` set to `1`
+- **THEN** the provider SHALL pass `IsBindAll` with value `1` to the `CreateAlarmPolicy` API request
+- **AND** the alarm policy SHALL be created as a "bind all objects" policy
+
+#### Scenario: Create alarm policy without is_bind_all
+- **WHEN** user creates a `tencentcloud_monitor_alarm_policy` resource without specifying `is_bind_all`
+- **THEN** the provider SHALL NOT pass `IsBindAll` to the `CreateAlarmPolicy` API request (or pass the default value)
+- **AND** the alarm policy SHALL be created with the API default behavior (not bind all)
+
+#### Scenario: Read alarm policy is_bind_all
+- **WHEN** Terraform performs a read operation on the alarm policy resource
+- **THEN** the provider SHALL read `IsBindAll` from the `DescribeAlarmPolicy` API response (`response.Policy.IsBindAll`)
+- **AND** if `IsBindAll` is nil, the provider SHALL NOT set the `is_bind_all` field
+- **AND** if `IsBindAll` is not nil, the provider SHALL set `is_bind_all` in Terraform state to the returned value
+
+#### Scenario: Update is_bind_all triggers resource recreation
+- **WHEN** user modifies `is_bind_all` in an existing alarm policy resource
+- **THEN** the provider SHALL treat the change as a ForceNew operation
+- **AND** the existing alarm policy SHALL be destroyed and a new one SHALL be created with the updated `is_bind_all` value
+
+#### Scenario: Validate is_bind_all accepts only 0 or 1
+- **WHEN** user sets `is_bind_all` to a value other than `0` or `1`
+- **THEN** the provider SHALL reject the configuration with a validation error
+
+### Requirement: Backward Compatibility for IsBindAll
+The new `is_bind_all` parameter SHALL be fully backward compatible with existing alarm policy configurations.
+
+#### Scenario: Existing configuration without is_bind_all
+- **WHEN** user has an existing alarm policy without `is_bind_all`
+- **THEN** the provider SHALL continue to work without errors
+- **AND** existing Terraform state SHALL remain valid

--- a/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/tasks.md
+++ b/openspec/changes/archive/2026-09-09-add-monitor-alarm-policy-is-bind-all/tasks.md
@@ -1,0 +1,25 @@
+## 1. Resource Schema Changes
+
+- [x] 1.1 Add `is_bind_all` schema field (TypeInt, Optional, ForceNew, ValidateAllowedIntValue [0, 1]) to `ResourceTencentCloudMonitorAlarmPolicy()` in `tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go`
+
+## 2. Create Function Changes
+
+- [x] 2.1 Read `is_bind_all` from schema data in `resourceTencentMonitorAlarmPolicyCreate` and pass `IsBindAll` to the `CreateAlarmPolicy` API request when the user has set it
+
+## 3. Read Function Changes
+
+- [x] 3.1 Read `policy.IsBindAll` from the `DescribeAlarmPolicy` API response in `resourceTencentMonitorAlarmPolicyRead`
+- [x] 3.2 Check `policy.IsBindAll != nil` before calling `d.Set("is_bind_all", ...)` to handle null response fields
+
+## 4. Unit Test Changes
+
+- [x] 4.1 Add unit test cases for the `is_bind_all` parameter in `tencentcloud/services/monitor/resource_tc_monitor_alarm_policy_test.go` using mock (gomonkey) approach for cloud API mocking
+
+## 5. Documentation
+
+- [x] 5.1 Update `tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.md` with `is_bind_all` usage example and description
+
+## 6. Validation
+
+- [x] 6.1 Verify the code compiles successfully
+- [x] 6.2 Verify no lint errors

--- a/openspec/specs/monitor-alarm-policy-is-bind-all/spec.md
+++ b/openspec/specs/monitor-alarm-policy-is-bind-all/spec.md
@@ -1,0 +1,41 @@
+# monitor-alarm-policy-is-bind-all Specification
+
+## Purpose
+TBD - created by archiving change add-monitor-alarm-policy-is-bind-all. Update Purpose after archive.
+## Requirements
+### Requirement: IsBindAll Parameter for Alarm Policy
+The `tencentcloud_monitor_alarm_policy` resource SHALL support the `is_bind_all` parameter to specify whether the alarm policy binds to all objects. The parameter SHALL be an optional integer with valid values `0` (no, default) and `1` (yes). The parameter SHALL be immutable after creation (ForceNew) because no Modify API supports updating `IsBindAll`.
+
+#### Scenario: Create alarm policy with is_bind_all set to 1
+- **WHEN** user creates a `tencentcloud_monitor_alarm_policy` resource with `is_bind_all` set to `1`
+- **THEN** the provider SHALL pass `IsBindAll` with value `1` to the `CreateAlarmPolicy` API request
+- **AND** the alarm policy SHALL be created as a "bind all objects" policy
+
+#### Scenario: Create alarm policy without is_bind_all
+- **WHEN** user creates a `tencentcloud_monitor_alarm_policy` resource without specifying `is_bind_all`
+- **THEN** the provider SHALL NOT pass `IsBindAll` to the `CreateAlarmPolicy` API request (or pass the default value)
+- **AND** the alarm policy SHALL be created with the API default behavior (not bind all)
+
+#### Scenario: Read alarm policy is_bind_all
+- **WHEN** Terraform performs a read operation on the alarm policy resource
+- **THEN** the provider SHALL read `IsBindAll` from the `DescribeAlarmPolicy` API response (`response.Policy.IsBindAll`)
+- **AND** if `IsBindAll` is nil, the provider SHALL NOT set the `is_bind_all` field
+- **AND** if `IsBindAll` is not nil, the provider SHALL set `is_bind_all` in Terraform state to the returned value
+
+#### Scenario: Update is_bind_all triggers resource recreation
+- **WHEN** user modifies `is_bind_all` in an existing alarm policy resource
+- **THEN** the provider SHALL treat the change as a ForceNew operation
+- **AND** the existing alarm policy SHALL be destroyed and a new one SHALL be created with the updated `is_bind_all` value
+
+#### Scenario: Validate is_bind_all accepts only 0 or 1
+- **WHEN** user sets `is_bind_all` to a value other than `0` or `1`
+- **THEN** the provider SHALL reject the configuration with a validation error
+
+### Requirement: Backward Compatibility for IsBindAll
+The new `is_bind_all` parameter SHALL be fully backward compatible with existing alarm policy configurations.
+
+#### Scenario: Existing configuration without is_bind_all
+- **WHEN** user has an existing alarm policy without `is_bind_all`
+- **THEN** the provider SHALL continue to work without errors
+- **AND** existing Terraform state SHALL remain valid
+

--- a/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go
+++ b/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go
@@ -514,7 +514,7 @@ func resourceTencentMonitorAlarmPolicyCreate(d *schema.ResourceData, meta interf
 		}
 	}
 
-	if v, ok := d.GetOk("is_bind_all"); ok {
+	if v, ok := d.GetOkExists("is_bind_all"); ok {
 		request.IsBindAll = helper.IntInt64(v.(int))
 	}
 

--- a/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go
+++ b/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go
@@ -237,6 +237,14 @@ func ResourceTencentCloudMonitorAlarmPolicy() *schema.Resource {
 				},
 			},
 
+			"is_bind_all": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: tccommon.ValidateAllowedIntValue([]int{0, 1}),
+				Description:  "Whether to bind all objects. If yes, no need to pass `filter` or call `BindPolicyObject`. Valid values: `0` (no, default), `1` (yes). Not all policy types support binding all objects. Immutable after creation.",
+			},
+
 			"group_by": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -506,6 +514,10 @@ func resourceTencentMonitorAlarmPolicyCreate(d *schema.ResourceData, meta interf
 		}
 	}
 
+	if v, ok := d.GetOk("is_bind_all"); ok {
+		request.IsBindAll = helper.IntInt64(v.(int))
+	}
+
 	if dMap, ok := helper.InterfacesHeadMap(d, "filter"); ok {
 		alarmPolicyFilter := monitor.AlarmPolicyFilter{}
 		if v, ok := dMap["type"]; ok {
@@ -649,6 +661,10 @@ func resourceTencentMonitorAlarmPolicyRead(d *schema.ResourceData, meta interfac
 		d.Set("enable", policy.Enable),
 		d.Set("project_id", policy.ProjectId),
 	)
+
+	if policy.IsBindAll != nil {
+		errs = append(errs, d.Set("is_bind_all", policy.IsBindAll))
+	}
 
 	if policy.GroupBy != nil {
 		groupBy := []string{}

--- a/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go
+++ b/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.go
@@ -238,11 +238,11 @@ func ResourceTencentCloudMonitorAlarmPolicy() *schema.Resource {
 			},
 
 			"is_bind_all": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: tccommon.ValidateAllowedIntValue([]int{0, 1}),
-				Description:  "Whether to bind all objects. If yes, no need to pass `filter` or call `BindPolicyObject`. Valid values: `0` (no, default), `1` (yes). Not all policy types support binding all objects. Immutable after creation.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Whether to bind all objects. If yes, no need to pass `filter` or call `BindPolicyObject`. Valid values: `0` (no, default), `1` (yes). Not all policy types support binding all objects. Immutable after creation.",
 			},
 
 			"group_by": {
@@ -663,7 +663,7 @@ func resourceTencentMonitorAlarmPolicyRead(d *schema.ResourceData, meta interfac
 	)
 
 	if policy.IsBindAll != nil {
-		errs = append(errs, d.Set("is_bind_all", policy.IsBindAll))
+		_ = d.Set("is_bind_all", policy.IsBindAll)
 	}
 
 	if policy.GroupBy != nil {

--- a/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.md
+++ b/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy.md
@@ -282,6 +282,38 @@ resource "tencentcloud_monitor_alarm_policy" "foo" {
 }
 ```
 
+alarm policy binding all objects
+
+```hcl
+resource "tencentcloud_monitor_alarm_policy" "foo" {
+  policy_name  = "tf-policy-bind-all"
+  monitor_type = "MT_QCE"
+  enable       = 1
+  project_id   = 0
+  namespace    = "cvm_device"
+  is_bind_all  = 1
+
+  conditions {
+    is_union_rule = 1
+    rules {
+      metric_name      = "CpuUsage"
+      period           = 60
+      operator         = "ge"
+      value            = "89.9"
+      continue_period  = 1
+      notice_frequency = 3600
+      is_power_notice  = 0
+    }
+  }
+
+  event_conditions {
+    metric_name = "ping_unreachable"
+  }
+
+  notice_ids = [tencentcloud_monitor_alarm_notice.foo.id]
+}
+```
+
 Import
 
 Alarm policy instance can be imported, e.g.

--- a/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy_test.go
+++ b/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy_test.go
@@ -1,6 +1,7 @@
 package monitor_test
 
 import (
+	"context"
 	"testing"
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
@@ -165,7 +166,7 @@ func TestMonitorAlarmPolicy_Read_IsBindAll(t *testing.T) {
 	monitorClient := &monitor.Client{}
 	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
 
-	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicyWithContext", func(ctx context.Context, request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
 		resp := monitor.NewDescribeAlarmPolicyResponse()
 		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
 			Policy:    buildMockAlarmPolicy(helper.IntInt64(1)),
@@ -196,7 +197,7 @@ func TestMonitorAlarmPolicy_Read_IsBindAllNil(t *testing.T) {
 	monitorClient := &monitor.Client{}
 	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
 
-	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicyWithContext", func(ctx context.Context, request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
 		resp := monitor.NewDescribeAlarmPolicyResponse()
 		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
 			Policy:    buildMockAlarmPolicy(nil),
@@ -228,7 +229,7 @@ func TestMonitorAlarmPolicy_Read_NilPolicy(t *testing.T) {
 	monitorClient := &monitor.Client{}
 	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
 
-	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicyWithContext", func(ctx context.Context, request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
 		resp := monitor.NewDescribeAlarmPolicyResponse()
 		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
 			Policy:    nil,
@@ -260,7 +261,7 @@ func TestMonitorAlarmPolicy_Create_WithIsBindAll(t *testing.T) {
 	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
 
 	var capturedRequest *monitor.CreateAlarmPolicyRequest
-	patches.ApplyMethodFunc(monitorClient, "CreateAlarmPolicy", func(request *monitor.CreateAlarmPolicyRequest) (*monitor.CreateAlarmPolicyResponse, error) {
+	patches.ApplyMethodFunc(monitorClient, "CreateAlarmPolicyWithContext", func(ctx context.Context, request *monitor.CreateAlarmPolicyRequest) (*monitor.CreateAlarmPolicyResponse, error) {
 		capturedRequest = request
 		resp := monitor.NewCreateAlarmPolicyResponse()
 		resp.Response = &monitor.CreateAlarmPolicyResponseParams{
@@ -271,7 +272,7 @@ func TestMonitorAlarmPolicy_Create_WithIsBindAll(t *testing.T) {
 		return resp, nil
 	})
 
-	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicyWithContext", func(ctx context.Context, request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
 		resp := monitor.NewDescribeAlarmPolicyResponse()
 		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
 			Policy:    buildMockAlarmPolicy(helper.IntInt64(1)),
@@ -306,7 +307,7 @@ func TestMonitorAlarmPolicy_Create_WithoutIsBindAll(t *testing.T) {
 	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
 
 	var capturedRequest *monitor.CreateAlarmPolicyRequest
-	patches.ApplyMethodFunc(monitorClient, "CreateAlarmPolicy", func(request *monitor.CreateAlarmPolicyRequest) (*monitor.CreateAlarmPolicyResponse, error) {
+	patches.ApplyMethodFunc(monitorClient, "CreateAlarmPolicyWithContext", func(ctx context.Context, request *monitor.CreateAlarmPolicyRequest) (*monitor.CreateAlarmPolicyResponse, error) {
 		capturedRequest = request
 		resp := monitor.NewCreateAlarmPolicyResponse()
 		resp.Response = &monitor.CreateAlarmPolicyResponseParams{
@@ -317,7 +318,7 @@ func TestMonitorAlarmPolicy_Create_WithoutIsBindAll(t *testing.T) {
 		return resp, nil
 	})
 
-	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicyWithContext", func(ctx context.Context, request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
 		resp := monitor.NewDescribeAlarmPolicyResponse()
 		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
 			Policy:    buildMockAlarmPolicy(nil),
@@ -349,7 +350,7 @@ func TestMonitorAlarmPolicy_Schema_IsBindAll(t *testing.T) {
 	field := res.Schema["is_bind_all"]
 	assert.NotNil(t, field)
 	assert.True(t, field.Optional)
+	assert.True(t, field.Computed)
 	assert.True(t, field.ForceNew)
 	assert.Equal(t, schema.TypeInt, field.Type)
-	assert.NotNil(t, field.ValidateFunc)
 }

--- a/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy_test.go
+++ b/tencentcloud/services/monitor/resource_tc_monitor_alarm_policy_test.go
@@ -4,8 +4,17 @@ import (
 	"testing"
 
 	tcacctest "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/acctest"
+	svcmonitor "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/services/monitor"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	monitor "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724"
+
+	tccommon "github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/common"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/connectivity"
+	"github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 )
 
 func TestAccTencentCloudMonitorAlarmPolicyResource(t *testing.T) {
@@ -104,3 +113,243 @@ resource "tencentcloud_monitor_alarm_policy" "policy" {
   }
 }
 `
+
+// mockMetaForMonitorAlarmPolicy implements tccommon.ProviderMeta
+type mockMetaForMonitorAlarmPolicy struct {
+	client *connectivity.TencentCloudClient
+}
+
+func (m *mockMetaForMonitorAlarmPolicy) GetAPIV3Conn() *connectivity.TencentCloudClient {
+	return m.client
+}
+
+var _ tccommon.ProviderMeta = &mockMetaForMonitorAlarmPolicy{}
+
+func newMockMetaForMonitorAlarmPolicy() *mockMetaForMonitorAlarmPolicy {
+	return &mockMetaForMonitorAlarmPolicy{client: &connectivity.TencentCloudClient{}}
+}
+
+// buildMockAlarmPolicy builds an AlarmPolicy struct with the minimum fields
+// required by resourceTencentMonitorAlarmPolicyRead to avoid nil-pointer panics
+// when iterating Condition.Rules and EventCondition.Rules.
+func buildMockAlarmPolicy(isBindAll *int64) *monitor.AlarmPolicy {
+	return &monitor.AlarmPolicy{
+		PolicyId:    helper.String("policy-fake-id"),
+		PolicyName:  helper.String("terraform"),
+		MonitorType: helper.String("MT_QCE"),
+		Namespace:   helper.String("cvm_device"),
+		Remark:      helper.String(""),
+		Enable:      helper.IntInt64(1),
+		ProjectId:   helper.IntInt64(0),
+		IsBindAll:   isBindAll,
+		Condition: &monitor.AlarmPolicyCondition{
+			IsUnionRule: helper.IntInt64(0),
+			Rules:       []*monitor.AlarmPolicyRule{},
+		},
+		EventCondition: &monitor.AlarmPolicyEventCondition{
+			Rules: []*monitor.AlarmPolicyRule{},
+		},
+		NoticeIds:    []*string{},
+		TriggerTasks: []*monitor.AlarmPolicyTriggerTask{},
+		TagInstances: []*monitor.TagInstance{},
+	}
+}
+
+// go test ./tencentcloud/services/monitor/ -run "TestMonitorAlarmPolicy_Read_IsBindAll" -v -count=1 -gcflags="all=-l"
+
+// TestMonitorAlarmPolicy_Read_IsBindAll tests Read populates is_bind_all from Policy.IsBindAll
+func TestMonitorAlarmPolicy_Read_IsBindAll(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	monitorClient := &monitor.Client{}
+	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
+
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+		resp := monitor.NewDescribeAlarmPolicyResponse()
+		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
+			Policy:    buildMockAlarmPolicy(helper.IntInt64(1)),
+			RequestId: helper.String("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForMonitorAlarmPolicy()
+	res := svcmonitor.ResourceTencentCloudMonitorAlarmPolicy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"policy_name":  "terraform",
+		"monitor_type": "MT_QCE",
+		"namespace":    "cvm_device",
+	})
+	d.SetId("policy-fake-id")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, d.Get("is_bind_all"))
+}
+
+// TestMonitorAlarmPolicy_Read_IsBindAllNil tests Read does not set is_bind_all when IsBindAll is nil
+func TestMonitorAlarmPolicy_Read_IsBindAllNil(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	monitorClient := &monitor.Client{}
+	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
+
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+		resp := monitor.NewDescribeAlarmPolicyResponse()
+		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
+			Policy:    buildMockAlarmPolicy(nil),
+			RequestId: helper.String("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForMonitorAlarmPolicy()
+	res := svcmonitor.ResourceTencentCloudMonitorAlarmPolicy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"policy_name":  "terraform",
+		"monitor_type": "MT_QCE",
+		"namespace":    "cvm_device",
+	})
+	d.SetId("policy-fake-id")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	// is_bind_all should remain zero value because it was not set
+	assert.Equal(t, 0, d.Get("is_bind_all"))
+}
+
+// TestMonitorAlarmPolicy_Read_NilPolicy tests Read handles nil policy
+func TestMonitorAlarmPolicy_Read_NilPolicy(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	monitorClient := &monitor.Client{}
+	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
+
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+		resp := monitor.NewDescribeAlarmPolicyResponse()
+		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
+			Policy:    nil,
+			RequestId: helper.String("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForMonitorAlarmPolicy()
+	res := svcmonitor.ResourceTencentCloudMonitorAlarmPolicy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"policy_name":  "terraform",
+		"monitor_type": "MT_QCE",
+		"namespace":    "cvm_device",
+	})
+	d.SetId("policy-fake-id")
+
+	err := res.Read(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+}
+
+// TestMonitorAlarmPolicy_Create_WithIsBindAll tests Create passes IsBindAll to the CreateAlarmPolicy request
+func TestMonitorAlarmPolicy_Create_WithIsBindAll(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	monitorClient := &monitor.Client{}
+	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
+
+	var capturedRequest *monitor.CreateAlarmPolicyRequest
+	patches.ApplyMethodFunc(monitorClient, "CreateAlarmPolicy", func(request *monitor.CreateAlarmPolicyRequest) (*monitor.CreateAlarmPolicyResponse, error) {
+		capturedRequest = request
+		resp := monitor.NewCreateAlarmPolicyResponse()
+		resp.Response = &monitor.CreateAlarmPolicyResponseParams{
+			PolicyId:  helper.String("policy-fake-id"),
+			OriginId:  helper.String("origin-fake-id"),
+			RequestId: helper.String("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+		resp := monitor.NewDescribeAlarmPolicyResponse()
+		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
+			Policy:    buildMockAlarmPolicy(helper.IntInt64(1)),
+			RequestId: helper.String("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForMonitorAlarmPolicy()
+	res := svcmonitor.ResourceTencentCloudMonitorAlarmPolicy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"policy_name":  "terraform",
+		"monitor_type": "MT_QCE",
+		"namespace":    "cvm_device",
+		"is_bind_all":  1,
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "policy-fake-id", d.Id())
+	// verify IsBindAll was passed to the CreateAlarmPolicy request
+	assert.NotNil(t, capturedRequest.IsBindAll)
+	assert.Equal(t, int64(1), *capturedRequest.IsBindAll)
+}
+
+// TestMonitorAlarmPolicy_Create_WithoutIsBindAll tests Create does not pass IsBindAll when not set
+func TestMonitorAlarmPolicy_Create_WithoutIsBindAll(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	monitorClient := &monitor.Client{}
+	patches.ApplyMethodReturn(newMockMetaForMonitorAlarmPolicy().client, "UseMonitorClient", monitorClient)
+
+	var capturedRequest *monitor.CreateAlarmPolicyRequest
+	patches.ApplyMethodFunc(monitorClient, "CreateAlarmPolicy", func(request *monitor.CreateAlarmPolicyRequest) (*monitor.CreateAlarmPolicyResponse, error) {
+		capturedRequest = request
+		resp := monitor.NewCreateAlarmPolicyResponse()
+		resp.Response = &monitor.CreateAlarmPolicyResponseParams{
+			PolicyId:  helper.String("policy-fake-id"),
+			OriginId:  helper.String("origin-fake-id"),
+			RequestId: helper.String("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	patches.ApplyMethodFunc(monitorClient, "DescribeAlarmPolicy", func(request *monitor.DescribeAlarmPolicyRequest) (*monitor.DescribeAlarmPolicyResponse, error) {
+		resp := monitor.NewDescribeAlarmPolicyResponse()
+		resp.Response = &monitor.DescribeAlarmPolicyResponseParams{
+			Policy:    buildMockAlarmPolicy(nil),
+			RequestId: helper.String("fake-request-id"),
+		}
+		return resp, nil
+	})
+
+	meta := newMockMetaForMonitorAlarmPolicy()
+	res := svcmonitor.ResourceTencentCloudMonitorAlarmPolicy()
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+		"policy_name":  "terraform",
+		"monitor_type": "MT_QCE",
+		"namespace":    "cvm_device",
+	})
+
+	err := res.Create(d, meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "policy-fake-id", d.Id())
+	// verify IsBindAll was NOT passed to the CreateAlarmPolicy request
+	assert.Nil(t, capturedRequest.IsBindAll)
+}
+
+// TestMonitorAlarmPolicy_Schema_IsBindAll tests the is_bind_all schema definition
+func TestMonitorAlarmPolicy_Schema_IsBindAll(t *testing.T) {
+	res := svcmonitor.ResourceTencentCloudMonitorAlarmPolicy()
+
+	assert.Contains(t, res.Schema, "is_bind_all")
+	field := res.Schema["is_bind_all"]
+	assert.NotNil(t, field)
+	assert.True(t, field.Optional)
+	assert.True(t, field.ForceNew)
+	assert.Equal(t, schema.TypeInt, field.Type)
+	assert.NotNil(t, field.ValidateFunc)
+}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724/models.go
@@ -1461,134 +1461,140 @@ func (r *CreateAlarmNoticeResponse) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateAlarmPolicyRequestParams struct {
-	// 固定值，为"monitor"
+	// <p>固定值，为&quot;monitor&quot;</p>
 	Module *string `json:"Module,omitnil,omitempty" name:"Module"`
 
-	// 策略名称，不超过60字符
+	// <p>策略名称，不超过60字符</p>
 	PolicyName *string `json:"PolicyName,omitnil,omitempty" name:"PolicyName"`
 
-	// 监控类型 MT_QCE=云产品监控
+	// <p>监控类型 MT_QCE=云产品监控</p>
 	MonitorType *string `json:"MonitorType,omitnil,omitempty" name:"MonitorType"`
 
-	// 告警策略类型，由 [DescribeAllNamespaces](https://cloud.tencent.com/document/product/248/48683) 获得。对于云产品监控，取接口出参的 QceNamespacesNew.N.Id，例如 cvm_device
+	// <p>告警策略类型，由 <a href="https://cloud.tencent.com/document/product/248/48683">DescribeAllNamespaces</a> 获得。对于云产品监控，取接口出参的 QceNamespacesNew.N.Id，例如 cvm_device</p>
 	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
 
-	// 备注，不超过100字符，仅支持中英文、数字、下划线、-
+	// <p>备注，不超过100字符，仅支持中英文、数字、下划线、-</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 是否启用 0=停用 1=启用，可不传 默认为1
+	// <p>是否启用 0=停用 1=启用，可不传 默认为1</p>
 	Enable *int64 `json:"Enable,omitnil,omitempty" name:"Enable"`
 
-	// 项目 Id，对于区分项目的产品必须传入非 -1 的值。 -1=无项目 0=默认项目，如不传 默认为 -1。支持的项目 Id 可以在控制台 [账号中心-项目管理](https://console.cloud.tencent.com/project) 中查看。
+	// <p>项目 Id，对于区分项目的产品必须传入非 -1 的值。 -1=无项目 0=默认项目，如不传 默认为 -1。支持的项目 Id 可以在控制台 <a href="https://console.cloud.tencent.com/project">账号中心-项目管理</a> 中查看。</p>
 	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
-	// 触发条件模板 Id，该参数与 Condition 参数二选一。如果策略绑定触发条件模板，则传该参数；否则不传该参数，而是传 Condition 参数。触发条件模板 Id 可以从 [DescribeConditionsTemplateList](https://cloud.tencent.com/document/api/248/70250) 接口获取。
+	// <p>触发条件模板 Id，该参数与 Condition 参数二选一。如果策略绑定触发条件模板，则传该参数；否则不传该参数，而是传 Condition 参数。触发条件模板 Id 可以从 <a href="https://cloud.tencent.com/document/api/248/70250">DescribeConditionsTemplateList</a> 接口获取。</p>
 	ConditionTemplateId *int64 `json:"ConditionTemplateId,omitnil,omitempty" name:"ConditionTemplateId"`
 
-	// 指标触发条件，支持的指标可以从 [DescribeAlarmMetrics](https://cloud.tencent.com/document/product/248/51283) 查询。
+	// <p>指标触发条件，支持的指标可以从 <a href="https://cloud.tencent.com/document/product/248/51283">DescribeAlarmMetrics</a> 查询。</p>
 	Condition *AlarmPolicyCondition `json:"Condition,omitnil,omitempty" name:"Condition"`
 
-	// 事件触发条件，支持的事件可以从 [DescribeAlarmEvents](https://cloud.tencent.com/document/product/248/51284) 查询。
+	// <p>事件触发条件，支持的事件可以从 <a href="https://cloud.tencent.com/document/product/248/51284">DescribeAlarmEvents</a> 查询。</p>
 	EventCondition *AlarmPolicyEventCondition `json:"EventCondition,omitnil,omitempty" name:"EventCondition"`
 
-	// 通知规则 Id 列表，由 [DescribeAlarmNotices](https://cloud.tencent.com/document/product/248/51280) 获得
+	// <p>通知规则 Id 列表，由 <a href="https://cloud.tencent.com/document/product/248/51280">DescribeAlarmNotices</a> 获得</p>
 	NoticeIds []*string `json:"NoticeIds,omitnil,omitempty" name:"NoticeIds"`
 
-	// 触发任务列表
+	// <p>触发任务列表</p>
 	TriggerTasks []*AlarmPolicyTriggerTask `json:"TriggerTasks,omitnil,omitempty" name:"TriggerTasks"`
 
-	// 全局过滤条件
+	// <p>全局过滤条件</p>
 	Filter *AlarmPolicyFilter `json:"Filter,omitnil,omitempty" name:"Filter"`
 
-	// 聚合维度列表，指定按哪些维度 key 来做 group by
+	// <p>聚合维度列表，指定按哪些维度 key 来做 group by</p>
 	GroupBy []*string `json:"GroupBy,omitnil,omitempty" name:"GroupBy"`
 
-	// 模板绑定的标签
+	// <p>是否绑定全部对象。如果是的话，不需要再传filter或者调用BindPolicyObject，0=否，1=是，默认为否</p><p>取值范围：[0, 1]</p><p>默认值：0</p><p>不是所有策略类型都支持绑定全部对象</p>
+	IsBindAll *int64 `json:"IsBindAll,omitnil,omitempty" name:"IsBindAll"`
+
+	// <p>模板绑定的标签</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 日志告警信息
+	// <p>日志告警信息</p>
 	LogAlarmReqInfo *LogAlarmReq `json:"LogAlarmReqInfo,omitnil,omitempty" name:"LogAlarmReqInfo"`
 
-	// 告警分级通知规则配置
+	// <p>告警分级通知规则配置</p>
 	HierarchicalNotices []*AlarmHierarchicalNotice `json:"HierarchicalNotices,omitnil,omitempty" name:"HierarchicalNotices"`
 
-	// 迁移策略专用字段，0-走鉴权逻辑，1-跳过鉴权逻辑
+	// <p>迁移策略专用字段，0-走鉴权逻辑，1-跳过鉴权逻辑</p>
 	MigrateFlag *int64 `json:"MigrateFlag,omitnil,omitempty" name:"MigrateFlag"`
 
-	// 事件配置的告警
+	// <p>事件配置的告警</p>
 	EbSubject *string `json:"EbSubject,omitnil,omitempty" name:"EbSubject"`
 
-	// 附加告警内容
+	// <p>附加告警内容</p>
 	AdditionalAlarmContent *string `json:"AdditionalAlarmContent,omitnil,omitempty" name:"AdditionalAlarmContent"`
 
-	// 通知模板绑定信息
+	// <p>通知模板绑定信息</p>
 	NoticeContentTmplBindInfos []*NoticeContentTmplBindInfo `json:"NoticeContentTmplBindInfos,omitnil,omitempty" name:"NoticeContentTmplBindInfos"`
 }
 
 type CreateAlarmPolicyRequest struct {
 	*tchttp.BaseRequest
 	
-	// 固定值，为"monitor"
+	// <p>固定值，为&quot;monitor&quot;</p>
 	Module *string `json:"Module,omitnil,omitempty" name:"Module"`
 
-	// 策略名称，不超过60字符
+	// <p>策略名称，不超过60字符</p>
 	PolicyName *string `json:"PolicyName,omitnil,omitempty" name:"PolicyName"`
 
-	// 监控类型 MT_QCE=云产品监控
+	// <p>监控类型 MT_QCE=云产品监控</p>
 	MonitorType *string `json:"MonitorType,omitnil,omitempty" name:"MonitorType"`
 
-	// 告警策略类型，由 [DescribeAllNamespaces](https://cloud.tencent.com/document/product/248/48683) 获得。对于云产品监控，取接口出参的 QceNamespacesNew.N.Id，例如 cvm_device
+	// <p>告警策略类型，由 <a href="https://cloud.tencent.com/document/product/248/48683">DescribeAllNamespaces</a> 获得。对于云产品监控，取接口出参的 QceNamespacesNew.N.Id，例如 cvm_device</p>
 	Namespace *string `json:"Namespace,omitnil,omitempty" name:"Namespace"`
 
-	// 备注，不超过100字符，仅支持中英文、数字、下划线、-
+	// <p>备注，不超过100字符，仅支持中英文、数字、下划线、-</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 是否启用 0=停用 1=启用，可不传 默认为1
+	// <p>是否启用 0=停用 1=启用，可不传 默认为1</p>
 	Enable *int64 `json:"Enable,omitnil,omitempty" name:"Enable"`
 
-	// 项目 Id，对于区分项目的产品必须传入非 -1 的值。 -1=无项目 0=默认项目，如不传 默认为 -1。支持的项目 Id 可以在控制台 [账号中心-项目管理](https://console.cloud.tencent.com/project) 中查看。
+	// <p>项目 Id，对于区分项目的产品必须传入非 -1 的值。 -1=无项目 0=默认项目，如不传 默认为 -1。支持的项目 Id 可以在控制台 <a href="https://console.cloud.tencent.com/project">账号中心-项目管理</a> 中查看。</p>
 	ProjectId *int64 `json:"ProjectId,omitnil,omitempty" name:"ProjectId"`
 
-	// 触发条件模板 Id，该参数与 Condition 参数二选一。如果策略绑定触发条件模板，则传该参数；否则不传该参数，而是传 Condition 参数。触发条件模板 Id 可以从 [DescribeConditionsTemplateList](https://cloud.tencent.com/document/api/248/70250) 接口获取。
+	// <p>触发条件模板 Id，该参数与 Condition 参数二选一。如果策略绑定触发条件模板，则传该参数；否则不传该参数，而是传 Condition 参数。触发条件模板 Id 可以从 <a href="https://cloud.tencent.com/document/api/248/70250">DescribeConditionsTemplateList</a> 接口获取。</p>
 	ConditionTemplateId *int64 `json:"ConditionTemplateId,omitnil,omitempty" name:"ConditionTemplateId"`
 
-	// 指标触发条件，支持的指标可以从 [DescribeAlarmMetrics](https://cloud.tencent.com/document/product/248/51283) 查询。
+	// <p>指标触发条件，支持的指标可以从 <a href="https://cloud.tencent.com/document/product/248/51283">DescribeAlarmMetrics</a> 查询。</p>
 	Condition *AlarmPolicyCondition `json:"Condition,omitnil,omitempty" name:"Condition"`
 
-	// 事件触发条件，支持的事件可以从 [DescribeAlarmEvents](https://cloud.tencent.com/document/product/248/51284) 查询。
+	// <p>事件触发条件，支持的事件可以从 <a href="https://cloud.tencent.com/document/product/248/51284">DescribeAlarmEvents</a> 查询。</p>
 	EventCondition *AlarmPolicyEventCondition `json:"EventCondition,omitnil,omitempty" name:"EventCondition"`
 
-	// 通知规则 Id 列表，由 [DescribeAlarmNotices](https://cloud.tencent.com/document/product/248/51280) 获得
+	// <p>通知规则 Id 列表，由 <a href="https://cloud.tencent.com/document/product/248/51280">DescribeAlarmNotices</a> 获得</p>
 	NoticeIds []*string `json:"NoticeIds,omitnil,omitempty" name:"NoticeIds"`
 
-	// 触发任务列表
+	// <p>触发任务列表</p>
 	TriggerTasks []*AlarmPolicyTriggerTask `json:"TriggerTasks,omitnil,omitempty" name:"TriggerTasks"`
 
-	// 全局过滤条件
+	// <p>全局过滤条件</p>
 	Filter *AlarmPolicyFilter `json:"Filter,omitnil,omitempty" name:"Filter"`
 
-	// 聚合维度列表，指定按哪些维度 key 来做 group by
+	// <p>聚合维度列表，指定按哪些维度 key 来做 group by</p>
 	GroupBy []*string `json:"GroupBy,omitnil,omitempty" name:"GroupBy"`
 
-	// 模板绑定的标签
+	// <p>是否绑定全部对象。如果是的话，不需要再传filter或者调用BindPolicyObject，0=否，1=是，默认为否</p><p>取值范围：[0, 1]</p><p>默认值：0</p><p>不是所有策略类型都支持绑定全部对象</p>
+	IsBindAll *int64 `json:"IsBindAll,omitnil,omitempty" name:"IsBindAll"`
+
+	// <p>模板绑定的标签</p>
 	Tags []*Tag `json:"Tags,omitnil,omitempty" name:"Tags"`
 
-	// 日志告警信息
+	// <p>日志告警信息</p>
 	LogAlarmReqInfo *LogAlarmReq `json:"LogAlarmReqInfo,omitnil,omitempty" name:"LogAlarmReqInfo"`
 
-	// 告警分级通知规则配置
+	// <p>告警分级通知规则配置</p>
 	HierarchicalNotices []*AlarmHierarchicalNotice `json:"HierarchicalNotices,omitnil,omitempty" name:"HierarchicalNotices"`
 
-	// 迁移策略专用字段，0-走鉴权逻辑，1-跳过鉴权逻辑
+	// <p>迁移策略专用字段，0-走鉴权逻辑，1-跳过鉴权逻辑</p>
 	MigrateFlag *int64 `json:"MigrateFlag,omitnil,omitempty" name:"MigrateFlag"`
 
-	// 事件配置的告警
+	// <p>事件配置的告警</p>
 	EbSubject *string `json:"EbSubject,omitnil,omitempty" name:"EbSubject"`
 
-	// 附加告警内容
+	// <p>附加告警内容</p>
 	AdditionalAlarmContent *string `json:"AdditionalAlarmContent,omitnil,omitempty" name:"AdditionalAlarmContent"`
 
-	// 通知模板绑定信息
+	// <p>通知模板绑定信息</p>
 	NoticeContentTmplBindInfos []*NoticeContentTmplBindInfo `json:"NoticeContentTmplBindInfos,omitnil,omitempty" name:"NoticeContentTmplBindInfos"`
 }
 
@@ -1618,6 +1624,7 @@ func (r *CreateAlarmPolicyRequest) FromJsonString(s string) error {
 	delete(f, "TriggerTasks")
 	delete(f, "Filter")
 	delete(f, "GroupBy")
+	delete(f, "IsBindAll")
 	delete(f, "Tags")
 	delete(f, "LogAlarmReqInfo")
 	delete(f, "HierarchicalNotices")
@@ -1633,10 +1640,10 @@ func (r *CreateAlarmPolicyRequest) FromJsonString(s string) error {
 
 // Predefined struct for user
 type CreateAlarmPolicyResponseParams struct {
-	// 告警策略 ID
+	// <p>告警策略 ID</p>
 	PolicyId *string `json:"PolicyId,omitnil,omitempty" name:"PolicyId"`
 
-	// 可用于实例、实例组的绑定和解绑接口（[BindingPolicyObject](https://cloud.tencent.com/document/product/248/40421)、[UnBindingAllPolicyObject](https://cloud.tencent.com/document/product/248/40568)、[UnBindingPolicyObject](https://cloud.tencent.com/document/product/248/40567)）的策略 ID
+	// <p>可用于实例、实例组的绑定和解绑接口（<a href="https://cloud.tencent.com/document/product/248/40421">BindingPolicyObject</a>、<a href="https://cloud.tencent.com/document/product/248/40568">UnBindingAllPolicyObject</a>、<a href="https://cloud.tencent.com/document/product/248/40567">UnBindingPolicyObject</a>）的策略 ID</p>
 	OriginId *string `json:"OriginId,omitnil,omitempty" name:"OriginId"`
 
 	// 唯一请求 ID，由服务端生成，每次请求都会返回（若请求因其他原因未能抵达服务端，则该次请求不会获得 RequestId）。定位问题时需要提供该次请求的 RequestId。

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20230616/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20230616/models.go
@@ -2227,11 +2227,14 @@ type ExtMetric struct {
 }
 
 type FeiShuRobotNoticeTmpl struct {
-	// 内容模板
+	// <p>内容模板</p>
 	ContentTmpl *string `json:"ContentTmpl,omitnil,omitempty" name:"ContentTmpl"`
 
-	// 标题模板
+	// <p>标题模板</p>
 	TitleTmpl *string `json:"TitleTmpl,omitnil,omitempty" name:"TitleTmpl"`
+
+	// <p>通知内容模版标题自定义颜色</p>
+	TitleColor *RobotNoticeTitleColor `json:"TitleColor,omitnil,omitempty" name:"TitleColor"`
 }
 
 type FeiShuRobotNoticeTmplMatcher struct {
@@ -3887,6 +3890,25 @@ type ResourceMapInfo struct {
 	// <p>总实例数</p>
 	// 注意：此字段可能返回 null，表示取不到有效值。
 	InstanceCount *int64 `json:"InstanceCount,omitnil,omitempty" name:"InstanceCount"`
+}
+
+type RobotNoticeTitleColor struct {
+	// <p>通知内容模版自定义标题颜色默认颜色</p>
+	Default *string `json:"Default,omitnil,omitempty" name:"Default"`
+
+	// <p>通知内容模版自定义标题颜色规则，label 匹配设置颜色</p>
+	Rules []*RobotNoticeTitleColorRules `json:"Rules,omitnil,omitempty" name:"Rules"`
+}
+
+type RobotNoticeTitleColorRules struct {
+	// <p>通知内容模版自定义颜色 Label 匹配的 Key</p>
+	Key *string `json:"Key,omitnil,omitempty" name:"Key"`
+
+	// <p>通知内容模版自定义颜色 Label 匹配的 Value</p>
+	Value *string `json:"Value,omitnil,omitempty" name:"Value"`
+
+	// <p>通知内容模版自定义颜色</p>
+	Color *string `json:"Color,omitnil,omitempty" name:"Color"`
 }
 
 type Rule struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1360,7 +1360,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mariadb/v20170312
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb v1.3.141
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/mongodb/v20190725
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.170
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.3.171
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20230616

--- a/website/docs/r/monitor_alarm_policy.html.markdown
+++ b/website/docs/r/monitor_alarm_policy.html.markdown
@@ -294,6 +294,38 @@ resource "tencentcloud_monitor_alarm_policy" "foo" {
 }
 ```
 
+### alarm policy binding all objects
+
+```hcl
+resource "tencentcloud_monitor_alarm_policy" "foo" {
+  policy_name  = "tf-policy-bind-all"
+  monitor_type = "MT_QCE"
+  enable       = 1
+  project_id   = 0
+  namespace    = "cvm_device"
+  is_bind_all  = 1
+
+  conditions {
+    is_union_rule = 1
+    rules {
+      metric_name      = "CpuUsage"
+      period           = 60
+      operator         = "ge"
+      value            = "89.9"
+      continue_period  = 1
+      notice_frequency = 3600
+      is_power_notice  = 0
+    }
+  }
+
+  event_conditions {
+    metric_name = "ping_unreachable"
+  }
+
+  notice_ids = [tencentcloud_monitor_alarm_notice.foo.id]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -308,6 +340,7 @@ The following arguments are supported:
 * `filter` - (Optional, List) Global filters.
 * `group_by` - (Optional, Set: [`String`]) Aggregate dimension list, specify which dimension keys to use for group by.
 * `hierarchical_notices` - (Optional, List) Alarm hierarchical notice rules configuration.
+* `is_bind_all` - (Optional, Int, ForceNew) Whether to bind all objects. If yes, no need to pass `filter` or call `BindPolicyObject`. Valid values: `0` (no, default), `1` (yes). Not all policy types support binding all objects. Immutable after creation.
 * `notice_content_tmpl_bind_infos` - (Optional, List) Notice content template binding info.
 * `notice_ids` - (Optional, List: [`String`]) List of notification rule IDs.
 * `policy_tag` - (Optional, List, ForceNew) Policy tag to bind object.


### PR DESCRIPTION
## Description

Add the `is_bind_all` parameter to the `tencentcloud_monitor_alarm_policy` resource to support specifying whether an alarm policy binds to all objects at creation time.

- Add `is_bind_all` (TypeInt, Optional, ForceNew, valid values: 0/1) schema field
- Pass `IsBindAll` to the `CreateAlarmPolicy` API request when set by the user
- Read `IsBindAll` from the `DescribeAlarmPolicy` API response for state refresh
- Add unit test cases using gomonkey mock approach
- Update resource documentation

The parameter is immutable after creation (ForceNew) because no Modify API supports updating `IsBindAll`. Fully backward compatible — the new parameter is Optional and defaults to not being set.