### PR TITLE
fix(teo): [137991012] support multiple rule_ids in bot_management action_overrides

### DIFF
--- a/.changelog/4500.txt
+++ b/.changelog/4500.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/tencentcloud_teo_security_policy_config: fix bot_management action_overrides to support multiple rule IDs via rule_ids field
+```

--- a/.changelog/4500.txt
+++ b/.changelog/4500.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-resource/tencentcloud_teo_security_policy_config: fix bot_management action_overrides to support multiple rule IDs via rule_ids field
+```release-note:enhancement
+resource/tencentcloud_teo_security_policy_config: add `rule_ids` field to `bot_management.basic_bot_settings.*.action_overrides` to support multiple bot rule IDs (deprecate `rule_id`)
 ```

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.3.173
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit v1.3.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.175
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.3.130
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cwp v1.3.30
@@ -93,7 +93,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdcpg v1.0.533
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.131
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.171
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.175
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.107
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/trocket v1.3.129
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tse v1.3.157

--- a/go.sum
+++ b/go.sum
@@ -1003,8 +1003,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.170/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.171/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.172/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.173/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174 h1:qOTtWnvYBZidSl1CDQd3nWvnX2OeMNywf5aQ7oY4gGY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.175 h1:m714Iqe4LRCRvuoLjwCAJZn9S5WARXbmEExRh/G9W9w=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.175/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80 h1:chnsNBeJn3MieFLki4hpbzoml5NiTvLVzOTqYRVxQho=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/config v1.3.80/go.mod h1:B/ezGtlvDhZlleNM+2QdvZccrUi+J+fN6vMnDDsZnuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/controlcenter v1.1.51 h1:pGwrfCBBCt1u+EDHwfNj9NLQpvk5MVKVMcsE7SvwqM4=
@@ -1120,8 +1121,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.131 h1:s0xC6/
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq v1.3.131/go.mod h1:iy8TZgOPB1ia8YfvqF6Mb12iRJQ052TLvGFAM01tdtY=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578 h1:vBpQhUroO+FAslUmsDWGi8nvczsqZBWVgQwlnyT0Aj8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578/go.mod h1:UlojGQh/9wb7/uXPNi7PvMral1CNAskVDNgqJEV83l0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.171 h1:ED+Q4sxcbwH6SQDwP/ChRI79jE0gSNeoYei02WXb70w=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.171/go.mod h1:Kv+5IhXjzt4ir7wuxMXDx+SuGgQxtKqo1LeDIOPJeFw=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.175 h1:DVCKP3xObkvMtrPlkv2FD/6ZCHGtun46kBaMC60/BuQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.175/go.mod h1:b+58SmztmMraMZSF57dGR4T41aXeQJH5MZfRt1UPmmM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998 h1:f4/n0dVKQTD06xJ84B5asHViNJHrZmGojdAWEPIsITM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998/go.mod h1:fyi/HUwCwVe2NCCCjz8k/C5GwPu3QazCZO+OBJ3MhLk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tke v1.3.107 h1:Yky7eL8FnkO89MvxERN3tniBQjstZzjIX8I91A4la/k=

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/design.md
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/design.md
@@ -1,0 +1,98 @@
+## Context
+
+`tencentcloud_teo_security_policy_config` 资源封装了 TEO 安全策略的 CRUD，其中 `bot_management.basic_bot_settings` 下的 `source_idc` / `search_engine_bots` / `known_bot_categories` / `ip_reputation.ip_reputation_group` 四个子块，各自包含一个 `action_overrides` 列表（TypeList，元素 schema 由 `botManagementActionOverrideSchema()` 返回）。
+
+当前 `botManagementActionOverrideSchema()` 将 `rule_id` 定义为 `TypeString, Required`（单个 ID），对应的转换函数：
+- `buildBotManagementActionOverrideFromMap`：从 schema 读单个 `rule_id` 字符串，构造 `[]*string{helper.String(v)}` 写入 `BotManagementActionOverrides.Ids`
+- `flattenBotManagementActionOverride`：从 API 读 `override.Ids[0]` 写入 schema 的 `rule_id`
+
+云 API 现状：`teov20220901.BotManagementActionOverrides.Ids` 类型为 `[]*string`，注释明确说明"Bot 规则组下的具体项"，支持同时改写多条规则项的处置动作。
+
+问题：用户在 HCL 中无法表达多个规则 ID，`apply` 后只有第一个 ID 生效，其余丢失，造成与云端期望状态漂移。
+
+约束：
+- 该字段位于深层嵌套块，是 schema 字段名 + 类型的双重变更，无法纯加法兼容
+- 四个 `basic_bot_settings` 子块共享同一个 `botManagementActionOverrideSchema()`，改一处即可同时生效
+- 已 vendored 的 SDK 已支持 `Ids []*string`，无需变更 vendor
+
+## Goals / Non-Goals
+
+**Goals:**
+- 将 `action_overrides` 的规则 ID 字段从单值 `rule_id`（TypeString）改为列表 `rule_ids`（TypeList, Elem TypeString），完整支持云 API 的多 ID 能力
+- 保持四个 `basic_bot_settings` 子块共享同一 schema 的一致性
+- 通过单元测试覆盖多 ID 的 build / flatten 双向路径
+
+**Non-Goals:**
+- 不改动 `action_overrides` 中 `action` 子块的 schema 与逻辑（`securityActionSchema()` 不变）
+- 不改动 `bot_management` 中其他子块（如 `bot_management_lite`、`custom_rules`、`user_agent_rules` 等）的任何逻辑
+- 不改动资源顶层的 schema、CRUD 主流程、ID 构造、retry 逻辑
+- 不引入新 vendor 依赖
+- 不做 state 自动迁移（字段名变更无法自动迁移，需用户手动改写 HCL）
+
+## Decisions
+
+### Decision 1: 直接将 `rule_id` 替换为 `rule_ids`，而非保留旧字段并新增
+
+**选择**：删除 `rule_id`，新增 `rule_ids`（TypeList, Required, Elem TypeString）。
+
+**备选**：保留 `rule_id`（标记 Deprecated）并新增 `rule_ids`，二选一。
+
+**理由**：
+- `rule_id` 与 `rule_ids` 语义完全重叠且同时存在会让用户困惑（到底哪个生效？build 函数需处理两者并存）
+- 当前 `rule_id` 本身就是 bug（只取第一个 ID 导致数据丢失），保留一个已知错误字段并标 Deprecated 反而误导
+- 该字段在深层嵌套块内，使用面相对窄，破坏性影响可控
+- 字段名从单数到复数、类型从 string 到 list，是表达"多 ID"语义最清晰的方式，符合 provider 中已有的 `block_rule_ids` / `observe_rule_ids`（同为 TypeList 多 ID）的命名惯例
+
+### Decision 2: 四个子块共用 `botManagementActionOverrideSchema()`，只改一处
+
+**选择**：仅修改 `botManagementActionOverrideSchema()` 这一个函数的返回值，四个调用点（`source_idc` / `search_engine_bots` / `known_bot_categories` / `ip_reputation` 的 `action_overrides` Elem）自动生效。
+
+**理由**：
+- 现有代码已通过共享函数复用 schema，改一处即可保持四个子块一致
+- 避免四处重复修改引入不一致风险
+
+### Decision 3: flatten 函数完整展开 `Ids` 切片
+
+**选择**：`flattenBotManagementActionOverride` 遍历 `override.Ids`，将每个非 nil 元素加入 `[]interface{}`，写入 `m["rule_ids"]`。
+
+**备选**：保留对 `Ids[0]` 的处理作为兼容。
+
+**理由**：
+- 保留单元素兼容会与 `rule_ids` 列表语义冲突，且无法表达多 ID
+- 完整展开才是对齐 API 的正确实现
+
+### Decision 4: build 函数遍历 `rule_ids` 列表构造 `[]*string`
+
+**选择**：`buildBotManagementActionOverrideFromMap` 从 `m["rule_ids"].([]interface{})` 遍历，对每个非空字符串元素 `helper.String(v)`，append 到 `[]*string`，赋值给 `override.Ids`。
+
+**理由**：
+- 与 provider 中 `block_rule_ids` / `observe_rule_ids` 的 build 模式一致
+- 空列表时不设置 `Ids`（保持 nil），与 API 语义一致
+
+### Decision 5: 文档示例改写，不做 state 迁移
+
+**选择**：在 `resource_tc_teo_security_policy_config.md` 中将 `action_overrides` 示例由 `rule_id = "..."` 改为 `rule_ids = [...]`，并在变更说明中提示用户需手动改写存量 HCL。
+
+**理由**：
+- 字段名变更无法通过 schema 层自动迁移（Terraform Plugin SDK 不支持字段重命名迁移）
+- 影响范围限于使用 `bot_management.action_overrides` 的用户，属于 bug 修复范畴
+
+## Risks / Trade-offs
+
+- **Risk**：存量用户配置中使用 `rule_id` 的部分升级后会触发 `unknown attribute "rule_id"` plan 报错 → **Mitigation**：这是修复 schema/API 不一致的必要破坏性变更；在 changelog 与文档中明确提示改写为 `rule_ids = ["原值"]`
+- **Risk**：存量 state 中 `action_overrides` 下的 `rule_id` 键在升级后 Read 时不再被回填（改为 `rule_ids`），导致 plan 显示 diff → **Mitigation**：用户执行一次 `terraform apply`（或 `terraform refresh`）即可让 state 收敛到 `rule_ids`；因 Read 改为完整展开 `Ids`，state 会正确反映云端真实的多 ID 配置
+- **Trade-off**：破坏向后兼容，但换取了与云 API 能力对齐的正确行为，避免数据丢失
+
+## Migration Plan
+
+- 升级步骤：
+  1. 升级 provider 版本
+  2. 将 HCL 中 `action_overrides` 块内的 `rule_id = "xxx"` 改写为 `rule_ids = ["xxx"]`
+  3. 执行 `terraform plan`，确认无 `unknown attribute` 报错
+  4. 执行 `terraform apply`（或先 `terraform refresh`）使 state 收敛
+- 回滚：若需回退，将 schema 改回 `rule_id`（TypeString）并恢复 build/flatten 的单 ID 逻辑；但回退后多 ID 配置仍会丢失，不建议回退
+- 文档：在 `resource_tc_teo_security_policy_config.md` 示例中体现 `rule_ids` 用法
+
+## Open Questions
+
+- 无

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/design.md
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/design.md
@@ -11,37 +11,38 @@
 问题：用户在 HCL 中无法表达多个规则 ID，`apply` 后只有第一个 ID 生效，其余丢失，造成与云端期望状态漂移。
 
 约束：
-- 该字段位于深层嵌套块，是 schema 字段名 + 类型的双重变更，无法纯加法兼容
+- 通过保留 `rule_id`（Deprecated）+ 新增 `rule_ids`（Optional）实现，避免破坏性变更，存量配置仍可读
 - 四个 `basic_bot_settings` 子块共享同一个 `botManagementActionOverrideSchema()`，改一处即可同时生效
 - 已 vendored 的 SDK 已支持 `Ids []*string`，无需变更 vendor
 
 ## Goals / Non-Goals
 
 **Goals:**
-- 将 `action_overrides` 的规则 ID 字段从单值 `rule_id`（TypeString）改为列表 `rule_ids`（TypeList, Elem TypeString），完整支持云 API 的多 ID 能力
+- 在 `action_overrides` 中新增 `rule_ids`（TypeList, Elem TypeString, Optional）字段，完整支持云 API 的多 ID 能力
+- 保留 `rule_id`（TypeString, Optional, Deprecated）作为兼容降级路径，build 函数在 `rule_ids` 为空时回退读取
 - 保持四个 `basic_bot_settings` 子块共享同一 schema 的一致性
-- 通过单元测试覆盖多 ID 的 build / flatten 双向路径
+- 通过单元测试覆盖多 ID 的 build / flatten 双向路径、`rule_id` 回退、以及 `rule_ids` 优先级
 
 **Non-Goals:**
 - 不改动 `action_overrides` 中 `action` 子块的 schema 与逻辑（`securityActionSchema()` 不变）
 - 不改动 `bot_management` 中其他子块（如 `bot_management_lite`、`custom_rules`、`user_agent_rules` 等）的任何逻辑
 - 不改动资源顶层的 schema、CRUD 主流程、ID 构造、retry 逻辑
 - 不引入新 vendor 依赖
-- 不做 state 自动迁移（字段名变更无法自动迁移，需用户手动改写 HCL）
+- 不做 state 自动迁移（`rule_id` 保留为 Deprecated，存量 state 中 `rule_id` 在 Read 时不再回填，改为回填 `rule_ids`，建议用户手动改写 HCL 并刷新 state）
 
 ## Decisions
 
-### Decision 1: 直接将 `rule_id` 替换为 `rule_ids`，而非保留旧字段并新增
+### Decision 1: 保留 `rule_id`（Deprecated）并新增 `rule_ids`，而非直接替换
 
-**选择**：删除 `rule_id`，新增 `rule_ids`（TypeList, Required, Elem TypeString）。
+**选择**：保留 `rule_id`（TypeString, Optional, Deprecated）并新增 `rule_ids`（TypeList, Optional, Elem TypeString）。build 函数优先读 `rule_ids`，为空时回退读 `rule_id`。
 
-**备选**：保留 `rule_id`（标记 Deprecated）并新增 `rule_ids`，二选一。
+**备选**：删除 `rule_id`，新增 `rule_ids`（TypeList, Required, Elem TypeString）。
 
 **理由**：
-- `rule_id` 与 `rule_ids` 语义完全重叠且同时存在会让用户困惑（到底哪个生效？build 函数需处理两者并存）
-- 当前 `rule_id` 本身就是 bug（只取第一个 ID 导致数据丢失），保留一个已知错误字段并标 Deprecated 反而误导
-- 该字段在深层嵌套块内，使用面相对窄，破坏性影响可控
-- 字段名从单数到复数、类型从 string 到 list，是表达"多 ID"语义最清晰的方式，符合 provider 中已有的 `block_rule_ids` / `observe_rule_ids`（同为 TypeList 多 ID）的命名惯例
+- 删除 `rule_id` 会导致存量 HCL 配置升级后触发 `unknown attribute` plan 报错，破坏性较强
+- 保留 `rule_id` 作为 Deprecated 兼容字段，让存量配置在升级后仍可被 build 回退路径读取，平滑过渡
+- `rule_id` 标记 Deprecated 后会在 plan 时提示用户改用 `rule_ids`，引导收敛
+- 当 `rule_ids` 与 `rule_id` 同时设置时，`rule_ids` 优先（避免歧义）
 
 ### Decision 2: 四个子块共用 `botManagementActionOverrideSchema()`，只改一处
 
@@ -51,46 +52,49 @@
 - 现有代码已通过共享函数复用 schema，改一处即可保持四个子块一致
 - 避免四处重复修改引入不一致风险
 
-### Decision 3: flatten 函数完整展开 `Ids` 切片
+### Decision 3: flatten 函数完整展开 `Ids` 切片写入 `rule_ids`，不再回填 `rule_id`
 
-**选择**：`flattenBotManagementActionOverride` 遍历 `override.Ids`，将每个非 nil 元素加入 `[]interface{}`，写入 `m["rule_ids"]`。
+**选择**：`flattenBotManagementActionOverride` 遍历 `override.Ids`，将每个非 nil 元素加入 `[]interface{}`，写入 `m["rule_ids"]`；不再回填已废弃的 `rule_id` 字段。
 
-**备选**：保留对 `Ids[0]` 的处理作为兼容。
+**备选**：同时回填 `rule_id = Ids[0]`。
 
 **理由**：
-- 保留单元素兼容会与 `rule_ids` 列表语义冲突，且无法表达多 ID
-- 完整展开才是对齐 API 的正确实现
+- `rule_id` 已废弃，不应作为权威字段被 Read 回填
+- 同时回填两者会让 state 中 `rule_ids` 与 `rule_id` 并存，产生持续 diff
+- 仅回填 `rule_ids` 使 state 收敛到新字段，配合文档提示用户迁移
 
-### Decision 4: build 函数遍历 `rule_ids` 列表构造 `[]*string`
+### Decision 4: build 函数优先 `rule_ids`，回退 `rule_id`
 
-**选择**：`buildBotManagementActionOverrideFromMap` 从 `m["rule_ids"].([]interface{})` 遍历，对每个非空字符串元素 `helper.String(v)`，append 到 `[]*string`，赋值给 `override.Ids`。
+**选择**：`buildBotManagementActionOverrideFromMap` 先从 `m["rule_ids"].([]interface{})` 遍历构造 `[]*string`；若结果为空，再回退读 `m["rule_id"].(string)` 构造单元素 `[]*string`，赋值给 `override.Ids`。
 
 **理由**：
 - 与 provider 中 `block_rule_ids` / `observe_rule_ids` 的 build 模式一致
-- 空列表时不设置 `Ids`（保持 nil），与 API 语义一致
+- 回退路径保证存量配置仍可工作
+- 空列表且无 `rule_id` 时不设置 `Ids`（保持 nil），与 API 语义一致
 
 ### Decision 5: 文档示例改写，不做 state 迁移
 
-**选择**：在 `resource_tc_teo_security_policy_config.md` 中将 `action_overrides` 示例由 `rule_id = "..."` 改为 `rule_ids = [...]`，并在变更说明中提示用户需手动改写存量 HCL。
+**选择**：在 `resource_tc_teo_security_policy_config.md` 中将 `action_overrides` 示例由 `rule_id = "..."` 改为 `rule_ids = ["..."]`，并在变更说明中提示用户存量配置可保留 `rule_id`（已废弃）或迁移到 `rule_ids`。
 
 **理由**：
-- 字段名变更无法通过 schema 层自动迁移（Terraform Plugin SDK 不支持字段重命名迁移）
-- 影响范围限于使用 `bot_management.action_overrides` 的用户，属于 bug 修复范畴
+- `rule_id` 保留为 Deprecated，字段名未变，存量配置无需立即改写即可工作
+- state 中 `rule_id` 在 Read 时不再回填（改为回填 `rule_ids`），用户执行一次 `terraform apply`（或 `terraform refresh`）即可让 state 收敛到 `rule_ids`
+- 影响范围限于使用 `bot_management.action_overrides` 的用户
 
 ## Risks / Trade-offs
 
-- **Risk**：存量用户配置中使用 `rule_id` 的部分升级后会触发 `unknown attribute "rule_id"` plan 报错 → **Mitigation**：这是修复 schema/API 不一致的必要破坏性变更；在 changelog 与文档中明确提示改写为 `rule_ids = ["原值"]`
-- **Risk**：存量 state 中 `action_overrides` 下的 `rule_id` 键在升级后 Read 时不再被回填（改为 `rule_ids`），导致 plan 显示 diff → **Mitigation**：用户执行一次 `terraform apply`（或 `terraform refresh`）即可让 state 收敛到 `rule_ids`；因 Read 改为完整展开 `Ids`，state 会正确反映云端真实的多 ID 配置
-- **Trade-off**：破坏向后兼容，但换取了与云 API 能力对齐的正确行为，避免数据丢失
+- **Risk**：存量 state 中 `action_overrides` 下的 `rule_id` 键在升级后 Read 时不再回填（改为回填 `rule_ids`），导致 plan 显示 diff → **Mitigation**：用户执行一次 `terraform apply`（或 `terraform refresh`）即可让 state 收敛到 `rule_ids`；因 Read 改为完整展开 `Ids`，state 会正确反映云端真实的多 ID 配置
+- **Risk**：同时设置 `rule_id` 与 `rule_ids` 时，`rule_ids` 优先，`rule_id` 被忽略 → **Mitigation**：`rule_id` 已标记 Deprecated，plan 会提示用户改用 `rule_ids`，引导收敛到单一字段
+- **Trade-off**：保留 Deprecated 字段增加少量维护成本，但换取了向后兼容与平滑过渡
 
 ## Migration Plan
 
-- 升级步骤：
-  1. 升级 provider 版本
-  2. 将 HCL 中 `action_overrides` 块内的 `rule_id = "xxx"` 改写为 `rule_ids = ["xxx"]`
-  3. 执行 `terraform plan`，确认无 `unknown attribute` 报错
-  4. 执行 `terraform apply`（或先 `terraform refresh`）使 state 收敛
-- 回滚：若需回退，将 schema 改回 `rule_id`（TypeString）并恢复 build/flatten 的单 ID 逻辑；但回退后多 ID 配置仍会丢失，不建议回退
+- 升级步骤（推荐迁移路径）：
+  1. 升级 provider 版本（存量配置中 `rule_id = "xxx"` 仍可正常工作，build 回退路径读取）
+  2.（可选迁移）将 HCL 中 `action_overrides` 块内的 `rule_id = "xxx"` 改写为 `rule_ids = ["xxx"]`
+  3. 执行 `terraform plan`，确认无报错
+  4. 执行 `terraform apply`（或先 `terraform refresh`）使 state 收敛到 `rule_ids`
+- 回滚：若需回退，移除 `rule_ids` 字段并恢复 `rule_id` 为 Required；但回退后多 ID 配置仍会丢失，不建议回退
 - 文档：在 `resource_tc_teo_security_policy_config.md` 示例中体现 `rule_ids` 用法
 
 ## Open Questions

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/proposal.md
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`tencentcloud_teo_security_policy_config` 资源中 `bot_management` → `basic_bot_settings`（`source_idc` / `search_engine_bots` / `known_bot_categories` / `ip_reputation`）下的 `action_overrides` 块，当前 schema 仅暴露 `rule_id`（TypeString，单个 ID）。但对应的腾讯云 TEO API `BotManagementActionOverrides.Ids` 字段类型为 `[]*string`，原生支持多个规则 ID 同时改写处置动作。由于 schema 与 API 能力不一致，用户在 HCL 中配置多条规则 ID 时，实际 `apply` 后只会写入第一个 ID，其余 ID 被丢弃，导致策略配置不完整、与云端期望状态漂移。需要将 `rule_id` 改为 `rule_ids`（TypeList，支持多个 ID），使 Terraform 与云 API 能力对齐。
+
+## What Changes
+
+- **BREAKING**（针对 `action_overrides` 子块字段）：将 `botManagementActionOverrideSchema()` 中的字段由 `rule_id`（TypeString, Required）改为 `rule_ids`（TypeList, Required, Elem: TypeString），以匹配云 API `BotManagementActionOverrides.Ids` 的多 ID 语义。
+- 修改 `flattenBotManagementActionOverride` 函数：将云 API 返回的 `override.Ids`（`[]*string`）完整展开写入 `rule_ids` 列表，而非仅取 `Ids[0]`。
+- 修改 `buildBotManagementActionOverrideFromMap` 函数：从 schema 的 `rule_ids` 列表读取多个 ID，构造 `[]*string` 赋值给 `override.Ids`，而非仅读取单个字符串。
+- 新增单元测试覆盖多 ID 场景的 flatten / build 逻辑（使用 gomonkey mock 云 API）。
+- 更新资源文档 `resource_tc_teo_security_policy_config.md`，将 `action_overrides` 示例由 `rule_id = "..."` 改为 `rule_ids = [...]`。
+
+破坏性说明：`rule_id` → `rule_ids` 是字段名与类型的双重变更。由于该字段位于 `action_overrides` 嵌套块内，存量用户配置中使用了 `rule_id` 的部分在升级后会触发 plan 报错（unknown attribute），需要用户手动将 `rule_id = "xxx"` 改写为 `rule_ids = ["xxx"]`。这是修正 schema 与 API 能力不一致所必需的修复，无法通过纯加法方式实现。
+
+## Capabilities
+
+### New Capabilities
+- `teo-security-policy-bot-action-override-rule-ids`: 修正 `tencentcloud_teo_security_policy_config` 资源中 `bot_management.basic_bot_settings.*.action_overrides` 块的规则 ID 字段，从单值 `rule_id` 改为列表 `rule_ids`，对齐云 API `BotManagementActionOverrides.Ids` 的多 ID 语义。
+
+### Modified Capabilities
+<!-- 无现有 spec 描述 action_overrides 的 rule_id 字段，本次为新增 capability -->
+
+## Impact
+
+- 代码：
+  - `tencentcloud/services/teo/resource_tc_teo_security_policy_config.go`（`botManagementActionOverrideSchema` schema、`flattenBotManagementActionOverride`、`buildBotManagementActionOverrideFromMap` 三个函数）
+  - `tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go`（新增多 ID 场景单测）
+- 依赖：使用已 vendored 的 `tencentcloud-sdk-go` 中 `teov20220901.BotManagementActionOverrides.Ids`（`[]*string`），无需变更 vendor。
+- 向后兼容：**不兼容**——`rule_id` 字段被替换为 `rule_ids`，存量 HCL 配置需将 `rule_id = "xxx"` 改写为 `rule_ids = ["xxx"]`。
+- 文档：需要同步更新 `resource_tc_teo_security_policy_config.md` 示例。

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/proposal.md
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/proposal.md
@@ -1,21 +1,21 @@
 ## Why
 
-`tencentcloud_teo_security_policy_config` 资源中 `bot_management` → `basic_bot_settings`（`source_idc` / `search_engine_bots` / `known_bot_categories` / `ip_reputation`）下的 `action_overrides` 块，当前 schema 仅暴露 `rule_id`（TypeString，单个 ID）。但对应的腾讯云 TEO API `BotManagementActionOverrides.Ids` 字段类型为 `[]*string`，原生支持多个规则 ID 同时改写处置动作。由于 schema 与 API 能力不一致，用户在 HCL 中配置多条规则 ID 时，实际 `apply` 后只会写入第一个 ID，其余 ID 被丢弃，导致策略配置不完整、与云端期望状态漂移。需要将 `rule_id` 改为 `rule_ids`（TypeList，支持多个 ID），使 Terraform 与云 API 能力对齐。
+`tencentcloud_teo_security_policy_config` 资源中 `bot_management` → `basic_bot_settings`（`source_idc` / `search_engine_bots` / `known_bot_categories` / `ip_reputation`）下的 `action_overrides` 块，当前 schema 仅暴露 `rule_id`（TypeString，单个 ID）。但对应的腾讯云 TEO API `BotManagementActionOverrides.Ids` 字段类型为 `[]*string`，原生支持多个规则 ID 同时改写处置动作。由于 schema 与 API 能力不一致，用户在 HCL 中配置多条规则 ID 时，实际 `apply` 后只会写入第一个 ID，其余 ID 被丢弃，导致策略配置不完整、与云端期望状态漂移。需要新增 `rule_ids`（TypeList，支持多个 ID），并保留 `rule_id` 标记为 Deprecated，使 Terraform 与云 API 能力对齐，同时不破坏存量配置的可读性。
 
 ## What Changes
 
-- **BREAKING**（针对 `action_overrides` 子块字段）：将 `botManagementActionOverrideSchema()` 中的字段由 `rule_id`（TypeString, Required）改为 `rule_ids`（TypeList, Required, Elem: TypeString），以匹配云 API `BotManagementActionOverrides.Ids` 的多 ID 语义。
-- 修改 `flattenBotManagementActionOverride` 函数：将云 API 返回的 `override.Ids`（`[]*string`）完整展开写入 `rule_ids` 列表，而非仅取 `Ids[0]`。
-- 修改 `buildBotManagementActionOverrideFromMap` 函数：从 schema 的 `rule_ids` 列表读取多个 ID，构造 `[]*string` 赋值给 `override.Ids`，而非仅读取单个字符串。
-- 新增单元测试覆盖多 ID 场景的 flatten / build 逻辑（使用 gomonkey mock 云 API）。
-- 更新资源文档 `resource_tc_teo_security_policy_config.md`，将 `action_overrides` 示例由 `rule_id = "..."` 改为 `rule_ids = [...]`。
+- 新增 `botManagementActionOverrideSchema()` 中的字段 `rule_ids`（TypeList, Optional, Elem: TypeString），以匹配云 API `BotManagementActionOverrides.Ids` 的多 ID 语义；保留原 `rule_id`（TypeString, Optional）并标记为 Deprecated，提示用户改用 `rule_ids`。
+- 修改 `flattenBotManagementActionOverride` 函数：将云 API 返回的 `override.Ids`（`[]*string`）完整展开写入 `rule_ids` 列表，而非仅取 `Ids[0]` 写入 `rule_id`。
+- 修改 `buildBotManagementActionOverrideFromMap` 函数：优先从 schema 的 `rule_ids` 列表读取多个 ID 构造 `[]*string` 赋值给 `override.Ids`；当 `rule_ids` 为空时，回退读取已废弃的 `rule_id` 单字符串作为兼容降级路径。
+- 新增单元测试覆盖多 ID 场景的 flatten / build 逻辑、`rule_id` 回退路径、以及 `rule_ids` 优先级场景（使用 gomonkey mock 云 API）。
+- 更新资源文档 `resource_tc_teo_security_policy_config.md`，将 `action_overrides` 示例由 `rule_id = "..."` 改为 `rule_ids = ["..."]`。
 
-破坏性说明：`rule_id` → `rule_ids` 是字段名与类型的双重变更。由于该字段位于 `action_overrides` 嵌套块内，存量用户配置中使用了 `rule_id` 的部分在升级后会触发 plan 报错（unknown attribute），需要用户手动将 `rule_id = "xxx"` 改写为 `rule_ids = ["xxx"]`。这是修正 schema 与 API 能力不一致所必需的修复，无法通过纯加法方式实现。
+兼容性说明：保留 `rule_id` 并标记 Deprecated，存量用户配置中使用了 `rule_id` 的部分在升级后仍可正常被 build 回退路径读取，不会立即触发 plan 报错（unknown attribute）；同时通过 `rule_ids` 提供多 ID 能力。推荐用户将 `rule_id = "xxx"` 迁移改写为 `rule_ids = ["xxx"]` 以获取完整能力。
 
 ## Capabilities
 
 ### New Capabilities
-- `teo-security-policy-bot-action-override-rule-ids`: 修正 `tencentcloud_teo_security_policy_config` 资源中 `bot_management.basic_bot_settings.*.action_overrides` 块的规则 ID 字段，从单值 `rule_id` 改为列表 `rule_ids`，对齐云 API `BotManagementActionOverrides.Ids` 的多 ID 语义。
+- `teo-security-policy-bot-action-override-rule-ids`: 修正 `tencentcloud_teo_security_policy_config` 资源中 `bot_management.basic_bot_settings.*.action_overrides` 块的规则 ID 字段，新增列表 `rule_ids` 对齐云 API `BotManagementActionOverrides.Ids` 的多 ID 语义，同时保留 `rule_id` 标记为 Deprecated。
 
 ### Modified Capabilities
 <!-- 无现有 spec 描述 action_overrides 的 rule_id 字段，本次为新增 capability -->
@@ -24,7 +24,7 @@
 
 - 代码：
   - `tencentcloud/services/teo/resource_tc_teo_security_policy_config.go`（`botManagementActionOverrideSchema` schema、`flattenBotManagementActionOverride`、`buildBotManagementActionOverrideFromMap` 三个函数）
-  - `tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go`（新增多 ID 场景单测）
+  - `tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go`（新增多 ID、rule_id 回退、优先级单测）
 - 依赖：使用已 vendored 的 `tencentcloud-sdk-go` 中 `teov20220901.BotManagementActionOverrides.Ids`（`[]*string`），无需变更 vendor。
-- 向后兼容：**不兼容**——`rule_id` 字段被替换为 `rule_ids`，存量 HCL 配置需将 `rule_id = "xxx"` 改写为 `rule_ids = ["xxx"]`。
+- 向后兼容：**兼容**——保留 `rule_id`（Deprecated），存量 HCL 配置仍可被 build 回退路径读取，不会立即报错；`rule_ids` 为新增能力字段。
 - 文档：需要同步更新 `resource_tc_teo_security_policy_config.md` 示例。

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/specs/teo-security-policy-bot-action-override-rule-ids/spec.md
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/specs/teo-security-policy-bot-action-override-rule-ids/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: action_overrides rule_ids schema field
+The `tencentcloud_teo_security_policy_config` resource's `bot_management.basic_bot_settings` sub-blocks (`source_idc`, `search_engine_bots`, `known_bot_categories`, `ip_reputation.ip_reputation_group`) SHALL define the `action_overrides` block using a schema where each override element contains:
+- `rule_ids` (TypeList, Required, Elem: TypeString): One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field `BotManagementActionOverrides.Ids` (`[]*string`).
+- `action` (TypeList, Optional, MaxItems: 1): Action override configuration, maps to `BotManagementActionOverrides.Action`.
+
+The legacy `rule_id` (TypeString) field SHALL be removed and replaced by `rule_ids`.
+
+#### Scenario: Schema defines rule_ids as a list
+- **WHEN** the resource schema for `action_overrides` is defined
+- **THEN** it SHALL include `rule_ids` of TypeList with Elem TypeString as a Required field
+- **AND** it SHALL NOT include a `rule_id` field
+
+#### Scenario: User configures multiple rule IDs
+- **WHEN** a user sets `rule_ids = ["rule-a", "rule-b"]` in an `action_overrides` block
+- **THEN** the schema SHALL accept the list and mark it as a candidate for create/update
+
+#### Scenario: User configures a single rule ID
+- **WHEN** a user sets `rule_ids = ["rule-a"]` in an `action_overrides` block
+- **THEN** the schema SHALL accept the single-element list
+
+### Requirement: buildBotManagementActionOverrideFromMap supports multiple IDs
+The `buildBotManagementActionOverrideFromMap` function SHALL read the `rule_ids` list from the schema map and convert every non-empty element into a `[]*string` assigned to `BotManagementActionOverrides.Ids`. It SHALL NOT read a `rule_id` string field.
+
+#### Scenario: Build override with multiple IDs
+- **WHEN** the schema map contains `rule_ids = ["rule-a", "rule-b", "rule-c"]`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a", "rule-b", "rule-c"]` (as `[]*string`)
+
+#### Scenario: Build override with single ID
+- **WHEN** the schema map contains `rule_ids = ["rule-a"]`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a"]` (as `[]*string`)
+
+#### Scenario: Build override with empty rule_ids
+- **WHEN** the schema map contains an empty or absent `rule_ids`
+- **THEN** `BotManagementActionOverrides.Ids` SHALL be nil (no IDs assigned)
+
+### Requirement: flattenBotManagementActionOverride supports multiple IDs
+The `flattenBotManagementActionOverride` function SHALL take the cloud API `BotManagementActionOverrides.Ids` (`[]*string`) and write every element into the schema map's `rule_ids` field as a `[]string`. It SHALL NOT only read the first element.
+
+#### Scenario: Flatten override with multiple IDs
+- **WHEN** the API response contains `BotManagementActionOverrides` with `Ids = ["rule-a", "rule-b"]`
+- **THEN** the flattened schema map SHALL contain `rule_ids = ["rule-a", "rule-b"]`
+
+#### Scenario: Flatten override with single ID
+- **WHEN** the API response contains `BotManagementActionOverrides` with `Ids = ["rule-a"]`
+- **THEN** the flattened schema map SHALL contain `rule_ids = ["rule-a"]`
+
+#### Scenario: Flatten override with nil Ids
+- **WHEN** the API response contains `BotManagementActionOverrides` with `Ids = nil`
+- **THEN** the flattened schema map SHALL NOT set `rule_ids`
+
+### Requirement: Multiple action_overrides entries are preserved
+The Read/Create/Update operations SHALL preserve the ability to have multiple `action_overrides` entries in each `basic_bot_settings` sub-block, with each entry independently carrying its own `rule_ids` list and `action`.
+
+#### Scenario: Multiple override entries each with multiple rule IDs
+- **WHEN** a user configures two `action_overrides` blocks, one with `rule_ids = ["a", "b"]` and another with `rule_ids = ["c"]`
+- **THEN** the Create/Update operation SHALL produce two `BotManagementActionOverrides` entries with the corresponding `Ids` arrays
+
+#### Scenario: Read reflects multiple override entries
+- **WHEN** the DescribeSecurityPolicy API returns multiple `BotManagementActionOverrides` entries each with multiple `Ids`
+- **THEN** the Read function SHALL flatten each entry into a separate `action_overrides` list element with its own `rule_ids`
+
+### Requirement: Unit tests for rule_ids
+The system SHALL provide unit tests in `resource_tc_teo_security_policy_config_test.go` using gomonkey to mock cloud API calls, covering:
+- Multiple `rule_ids` in an `action_overrides` entry flowing through Create/Update (build path)
+- Multiple `rule_ids` being flattened from a Read response (flatten path)
+
+#### Scenario: Build path with multiple rule_ids test
+- **WHEN** the test exercises the build path with `rule_ids = ["rule-a", "rule-b"]`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL contain exactly two entries matching the input
+
+#### Scenario: Flatten path with multiple rule_ids test
+- **WHEN** the test exercises the flatten path with an API override containing `Ids = ["rule-a", "rule-b"]`
+- **THEN** the flattened map SHALL contain `rule_ids` with exactly two entries matching the input

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/specs/teo-security-policy-bot-action-override-rule-ids/spec.md
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/specs/teo-security-policy-bot-action-override-rule-ids/spec.md
@@ -2,15 +2,16 @@
 
 ### Requirement: action_overrides rule_ids schema field
 The `tencentcloud_teo_security_policy_config` resource's `bot_management.basic_bot_settings` sub-blocks (`source_idc`, `search_engine_bots`, `known_bot_categories`, `ip_reputation.ip_reputation_group`) SHALL define the `action_overrides` block using a schema where each override element contains:
-- `rule_ids` (TypeList, Required, Elem: TypeString): One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field `BotManagementActionOverrides.Ids` (`[]*string`).
+- `rule_ids` (TypeList, Optional, Elem: TypeString): One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field `BotManagementActionOverrides.Ids` (`[]*string`).
+- `rule_id` (TypeString, Optional, Deprecated): A single bot rule ID (or category ID) whose action is overridden. Deprecated: use `rule_ids` to support one or more IDs. Retained for backward compatibility.
 - `action` (TypeList, Optional, MaxItems: 1): Action override configuration, maps to `BotManagementActionOverrides.Action`.
 
-The legacy `rule_id` (TypeString) field SHALL be removed and replaced by `rule_ids`.
+The `rule_id` field SHALL be marked Deprecated and the `rule_ids` field SHALL be the preferred multi-ID field.
 
-#### Scenario: Schema defines rule_ids as a list
+#### Scenario: Schema defines both rule_ids and a deprecated rule_id
 - **WHEN** the resource schema for `action_overrides` is defined
-- **THEN** it SHALL include `rule_ids` of TypeList with Elem TypeString as a Required field
-- **AND** it SHALL NOT include a `rule_id` field
+- **THEN** it SHALL include `rule_ids` of TypeList with Elem TypeString as an Optional field
+- **AND** it SHALL include `rule_id` of TypeString as an Optional field marked Deprecated
 
 #### Scenario: User configures multiple rule IDs
 - **WHEN** a user sets `rule_ids = ["rule-a", "rule-b"]` in an `action_overrides` block
@@ -20,23 +21,31 @@ The legacy `rule_id` (TypeString) field SHALL be removed and replaced by `rule_i
 - **WHEN** a user sets `rule_ids = ["rule-a"]` in an `action_overrides` block
 - **THEN** the schema SHALL accept the single-element list
 
-### Requirement: buildBotManagementActionOverrideFromMap supports multiple IDs
-The `buildBotManagementActionOverrideFromMap` function SHALL read the `rule_ids` list from the schema map and convert every non-empty element into a `[]*string` assigned to `BotManagementActionOverrides.Ids`. It SHALL NOT read a `rule_id` string field.
+### Requirement: buildBotManagementActionOverrideFromMap prefers rule_ids with rule_id fallback
+The `buildBotManagementActionOverrideFromMap` function SHALL read the `rule_ids` list from the schema map first and convert every non-empty element into a `[]*string` assigned to `BotManagementActionOverrides.Ids`. When `rule_ids` is absent or empty, it SHALL fall back to reading the deprecated `rule_id` string field and construct a single-element `[]*string`.
 
 #### Scenario: Build override with multiple IDs
 - **WHEN** the schema map contains `rule_ids = ["rule-a", "rule-b", "rule-c"]`
 - **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a", "rule-b", "rule-c"]` (as `[]*string`)
 
-#### Scenario: Build override with single ID
+#### Scenario: Build override with single ID via rule_ids
 - **WHEN** the schema map contains `rule_ids = ["rule-a"]`
 - **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a"]` (as `[]*string`)
 
 #### Scenario: Build override with empty rule_ids
-- **WHEN** the schema map contains an empty or absent `rule_ids`
+- **WHEN** the schema map contains an empty or absent `rule_ids` and no `rule_id`
 - **THEN** `BotManagementActionOverrides.Ids` SHALL be nil (no IDs assigned)
 
+#### Scenario: Build override with deprecated rule_id fallback
+- **WHEN** the schema map contains no `rule_ids` (or an empty list) and `rule_id = "rule-legacy"`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-legacy"]` (as `[]*string`)
+
+#### Scenario: Build override rule_ids takes precedence over rule_id
+- **WHEN** the schema map contains both `rule_ids = ["rule-a", "rule-b"]` and `rule_id = "rule-legacy"`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a", "rule-b"]` (as `[]*string`)
+
 ### Requirement: flattenBotManagementActionOverride supports multiple IDs
-The `flattenBotManagementActionOverride` function SHALL take the cloud API `BotManagementActionOverrides.Ids` (`[]*string`) and write every element into the schema map's `rule_ids` field as a `[]string`. It SHALL NOT only read the first element.
+The `flattenBotManagementActionOverride` function SHALL take the cloud API `BotManagementActionOverrides.Ids` (`[]*string`) and write every element into the schema map's `rule_ids` field as a `[]string`. It SHALL NOT only read the first element. It SHALL NOT write the deprecated `rule_id` field.
 
 #### Scenario: Flatten override with multiple IDs
 - **WHEN** the API response contains `BotManagementActionOverrides` with `Ids = ["rule-a", "rule-b"]`
@@ -61,10 +70,12 @@ The Read/Create/Update operations SHALL preserve the ability to have multiple `a
 - **WHEN** the DescribeSecurityPolicy API returns multiple `BotManagementActionOverrides` entries each with multiple `Ids`
 - **THEN** the Read function SHALL flatten each entry into a separate `action_overrides` list element with its own `rule_ids`
 
-### Requirement: Unit tests for rule_ids
+### Requirement: Unit tests for rule_ids and rule_id fallback
 The system SHALL provide unit tests in `resource_tc_teo_security_policy_config_test.go` using gomonkey to mock cloud API calls, covering:
 - Multiple `rule_ids` in an `action_overrides` entry flowing through Create/Update (build path)
 - Multiple `rule_ids` being flattened from a Read response (flatten path)
+- The deprecated `rule_id` fallback path in the build function
+- The `rule_ids` precedence over `rule_id` in the build function
 
 #### Scenario: Build path with multiple rule_ids test
 - **WHEN** the test exercises the build path with `rule_ids = ["rule-a", "rule-b"]`
@@ -73,3 +84,11 @@ The system SHALL provide unit tests in `resource_tc_teo_security_policy_config_t
 #### Scenario: Flatten path with multiple rule_ids test
 - **WHEN** the test exercises the flatten path with an API override containing `Ids = ["rule-a", "rule-b"]`
 - **THEN** the flattened map SHALL contain `rule_ids` with exactly two entries matching the input
+
+#### Scenario: Build path with deprecated rule_id fallback test
+- **WHEN** the test exercises the build path with only `rule_id = "rule-legacy"` (no `rule_ids`)
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL contain exactly one entry matching the input
+
+#### Scenario: Build path rule_ids precedence test
+- **WHEN** the test exercises the build path with both `rule_id = "rule-legacy"` and `rule_ids = ["rule-a", "rule-b"]`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL contain exactly `["rule-a", "rule-b"]`

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/tasks.md
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/tasks.md
@@ -1,0 +1,28 @@
+## 1. Schema 调整
+
+- [x] 1.1 在 `tencentcloud/services/teo/resource_tc_teo_security_policy_config.go` 的 `botManagementActionOverrideSchema()` 函数中，将 `rule_id`（TypeString, Required）字段替换为 `rule_ids`（TypeList, Required, Elem: TypeString），更新 Description 说明其支持一个或多个 Bot 规则 ID / 分类 ID
+- [x] 1.2 确认四个 `basic_bot_settings` 子块（`source_idc` / `search_engine_bots` / `known_bot_categories` / `ip_reputation.ip_reputation_group`）的 `action_overrides` Elem 均引用 `botManagementActionOverrideSchema()`，无需重复修改
+
+## 2. 转换函数修改
+
+- [x] 2.1 修改 `buildBotManagementActionOverrideFromMap` 函数：从 schema map 读取 `rule_ids`（`[]interface{}`），遍历每个非空字符串元素构造 `[]*string`（`helper.String(v)`），赋值给 `override.Ids`；移除原 `rule_id` 单字符串读取逻辑
+- [x] 2.2 修改 `flattenBotManagementActionOverride` 函数：遍历 `override.Ids`（`[]*string`）将每个非 nil 元素加入 `[]interface{}`，写入 `m["rule_ids"]`；当 `Ids` 为空时不设置该字段；移除原仅取 `Ids[0]` 的逻辑
+- [x] 2.3 检查 `buildBotManagementActionOverrideFromMap` 中 `action` 子块的处理逻辑保持不变（仍调用 `buildSecurityActionFromMap`）
+
+## 3. 单元测试
+
+- [x] 3.1 在 `tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go` 中新增测试用例，验证 `buildBotManagementActionOverrideFromMap` 在 `rule_ids = ["rule-a", "rule-b"]` 时构造的 `BotManagementActionOverrides.Ids` 包含且仅包含两个匹配元素
+- [x] 3.2 新增测试用例，验证 `flattenBotManagementActionOverride` 在 API 返回 `Ids = ["rule-a", "rule-b"]` 时，扁平化后的 map 中 `rule_ids` 包含且仅包含两个匹配元素
+- [x] 3.3 新增测试用例，验证 `flattenBotManagementActionOverride` 在 `Ids` 为 nil 时不设置 `rule_ids` 字段
+- [x] 3.4 保证已有测试用例不受影响（build/flatten 单 ID 场景改为以单元素列表形式覆盖）
+
+## 4. 文档同步
+
+- [x] 4.1 在 `tencentcloud/services/teo/resource_tc_teo_security_policy_config.md` 中，将 `bot_management` → `basic_bot_settings` → `action_overrides` 相关示例由 `rule_id = "..."` 改写为 `rule_ids = ["..."]`（包含多 ID 示例）
+- [ ] 4.2 执行 `make doc`，根据 provider 规范重新生成 `website/docs/` 下的 markdown 文档（禁止手改 website/ 目录）
+
+## 5. 验证
+
+- [x] 5.1 确认代码可正确编译（不执行 go build，由后续流程验证）
+- [x] 5.2 复查 `rule_id` 在资源文件中已无残留引用（仅存在于 `rule_ids` 中）
+- [x] 5.3 复查四个 `basic_bot_settings` 子块的 `action_overrides` 行为一致

--- a/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/tasks.md
+++ b/openspec/changes/archive/2026-09-09-modify-teo-security-policy-bot-rule-ids/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Schema 调整
 
-- [x] 1.1 在 `tencentcloud/services/teo/resource_tc_teo_security_policy_config.go` 的 `botManagementActionOverrideSchema()` 函数中，将 `rule_id`（TypeString, Required）字段替换为 `rule_ids`（TypeList, Required, Elem: TypeString），更新 Description 说明其支持一个或多个 Bot 规则 ID / 分类 ID
+- [x] 1.1 在 `tencentcloud/services/teo/resource_tc_teo_security_policy_config.go` 的 `botManagementActionOverrideSchema()` 函数中，保留 `rule_id`（TypeString, Optional, Deprecated）字段，新增 `rule_ids`（TypeList, Optional, Elem: TypeString）字段，更新 Description 说明 `rule_ids` 支持一个或多个 Bot 规则 ID / 分类 ID，`rule_id` 标记 Deprecated 提示改用 `rule_ids`
 - [x] 1.2 确认四个 `basic_bot_settings` 子块（`source_idc` / `search_engine_bots` / `known_bot_categories` / `ip_reputation.ip_reputation_group`）的 `action_overrides` Elem 均引用 `botManagementActionOverrideSchema()`，无需重复修改
 
 ## 2. 转换函数修改
 
-- [x] 2.1 修改 `buildBotManagementActionOverrideFromMap` 函数：从 schema map 读取 `rule_ids`（`[]interface{}`），遍历每个非空字符串元素构造 `[]*string`（`helper.String(v)`），赋值给 `override.Ids`；移除原 `rule_id` 单字符串读取逻辑
-- [x] 2.2 修改 `flattenBotManagementActionOverride` 函数：遍历 `override.Ids`（`[]*string`）将每个非 nil 元素加入 `[]interface{}`，写入 `m["rule_ids"]`；当 `Ids` 为空时不设置该字段；移除原仅取 `Ids[0]` 的逻辑
+- [x] 2.1 修改 `buildBotManagementActionOverrideFromMap` 函数：优先从 schema map 读取 `rule_ids`（`[]interface{}`），遍历每个非空字符串元素构造 `[]*string`（`helper.String(v)`），赋值给 `override.Ids`；当 `rule_ids` 为空时回退读取已废弃的 `rule_id` 单字符串构造单元素 `[]*string`
+- [x] 2.2 修改 `flattenBotManagementActionOverride` 函数：遍历 `override.Ids`（`[]*string`）将每个非 nil 元素加入 `[]interface{}`，写入 `m["rule_ids"]`；当 `Ids` 为空时不设置该字段；不再回填 `rule_id`（保留为 Deprecated 输入字段）
 - [x] 2.3 检查 `buildBotManagementActionOverrideFromMap` 中 `action` 子块的处理逻辑保持不变（仍调用 `buildSecurityActionFromMap`）
 
 ## 3. 单元测试
@@ -14,7 +14,9 @@
 - [x] 3.1 在 `tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go` 中新增测试用例，验证 `buildBotManagementActionOverrideFromMap` 在 `rule_ids = ["rule-a", "rule-b"]` 时构造的 `BotManagementActionOverrides.Ids` 包含且仅包含两个匹配元素
 - [x] 3.2 新增测试用例，验证 `flattenBotManagementActionOverride` 在 API 返回 `Ids = ["rule-a", "rule-b"]` 时，扁平化后的 map 中 `rule_ids` 包含且仅包含两个匹配元素
 - [x] 3.3 新增测试用例，验证 `flattenBotManagementActionOverride` 在 `Ids` 为 nil 时不设置 `rule_ids` 字段
-- [x] 3.4 保证已有测试用例不受影响（build/flatten 单 ID 场景改为以单元素列表形式覆盖）
+- [x] 3.4 新增测试用例，验证 `buildBotManagementActionOverrideFromMap` 在仅设置 `rule_id = "rule-legacy"`（无 `rule_ids`）时回退构造单元素 `Ids`
+- [x] 3.5 新增测试用例，验证 `buildBotManagementActionOverrideFromMap` 在同时设置 `rule_id` 与 `rule_ids` 时 `rule_ids` 优先
+- [x] 3.6 新增测试用例，验证 `buildBotManagementActionOverrideFromMap` 在两者都不设置时 `Ids` 为 nil
 
 ## 4. 文档同步
 
@@ -24,5 +26,5 @@
 ## 5. 验证
 
 - [x] 5.1 确认代码可正确编译（不执行 go build，由后续流程验证）
-- [x] 5.2 复查 `rule_id` 在资源文件中已无残留引用（仅存在于 `rule_ids` 中）
+- [x] 5.2 复查 `rule_id` 在资源文件中仍保留为 Deprecated 字段，`rule_ids` 为新增字段
 - [x] 5.3 复查四个 `basic_bot_settings` 子块的 `action_overrides` 行为一致

--- a/openspec/specs/teo-security-policy-bot-action-override-rule-ids/spec.md
+++ b/openspec/specs/teo-security-policy-bot-action-override-rule-ids/spec.md
@@ -1,19 +1,17 @@
-# teo-security-policy-bot-action-override-rule-ids Specification
-
-## Purpose
-TBD - created by archiving change modify-teo-security-policy-bot-rule-ids. Update Purpose after archive.
 ## Requirements
+
 ### Requirement: action_overrides rule_ids schema field
 The `tencentcloud_teo_security_policy_config` resource's `bot_management.basic_bot_settings` sub-blocks (`source_idc`, `search_engine_bots`, `known_bot_categories`, `ip_reputation.ip_reputation_group`) SHALL define the `action_overrides` block using a schema where each override element contains:
-- `rule_ids` (TypeList, Required, Elem: TypeString): One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field `BotManagementActionOverrides.Ids` (`[]*string`).
+- `rule_ids` (TypeList, Optional, Elem: TypeString): One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field `BotManagementActionOverrides.Ids` (`[]*string`).
+- `rule_id` (TypeString, Optional, Deprecated): A single bot rule ID (or category ID) whose action is overridden. Deprecated: use `rule_ids` to support one or more IDs. Retained for backward compatibility.
 - `action` (TypeList, Optional, MaxItems: 1): Action override configuration, maps to `BotManagementActionOverrides.Action`.
 
-The legacy `rule_id` (TypeString) field SHALL be removed and replaced by `rule_ids`.
+The `rule_id` field SHALL be marked Deprecated and the `rule_ids` field SHALL be the preferred multi-ID field.
 
-#### Scenario: Schema defines rule_ids as a list
+#### Scenario: Schema defines both rule_ids and a deprecated rule_id
 - **WHEN** the resource schema for `action_overrides` is defined
-- **THEN** it SHALL include `rule_ids` of TypeList with Elem TypeString as a Required field
-- **AND** it SHALL NOT include a `rule_id` field
+- **THEN** it SHALL include `rule_ids` of TypeList with Elem TypeString as an Optional field
+- **AND** it SHALL include `rule_id` of TypeString as an Optional field marked Deprecated
 
 #### Scenario: User configures multiple rule IDs
 - **WHEN** a user sets `rule_ids = ["rule-a", "rule-b"]` in an `action_overrides` block
@@ -23,23 +21,31 @@ The legacy `rule_id` (TypeString) field SHALL be removed and replaced by `rule_i
 - **WHEN** a user sets `rule_ids = ["rule-a"]` in an `action_overrides` block
 - **THEN** the schema SHALL accept the single-element list
 
-### Requirement: buildBotManagementActionOverrideFromMap supports multiple IDs
-The `buildBotManagementActionOverrideFromMap` function SHALL read the `rule_ids` list from the schema map and convert every non-empty element into a `[]*string` assigned to `BotManagementActionOverrides.Ids`. It SHALL NOT read a `rule_id` string field.
+### Requirement: buildBotManagementActionOverrideFromMap prefers rule_ids with rule_id fallback
+The `buildBotManagementActionOverrideFromMap` function SHALL read the `rule_ids` list from the schema map first and convert every non-empty element into a `[]*string` assigned to `BotManagementActionOverrides.Ids`. When `rule_ids` is absent or empty, it SHALL fall back to reading the deprecated `rule_id` string field and construct a single-element `[]*string`.
 
 #### Scenario: Build override with multiple IDs
 - **WHEN** the schema map contains `rule_ids = ["rule-a", "rule-b", "rule-c"]`
 - **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a", "rule-b", "rule-c"]` (as `[]*string`)
 
-#### Scenario: Build override with single ID
+#### Scenario: Build override with single ID via rule_ids
 - **WHEN** the schema map contains `rule_ids = ["rule-a"]`
 - **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a"]` (as `[]*string`)
 
 #### Scenario: Build override with empty rule_ids
-- **WHEN** the schema map contains an empty or absent `rule_ids`
+- **WHEN** the schema map contains an empty or absent `rule_ids` and no `rule_id`
 - **THEN** `BotManagementActionOverrides.Ids` SHALL be nil (no IDs assigned)
 
+#### Scenario: Build override with deprecated rule_id fallback
+- **WHEN** the schema map contains no `rule_ids` (or an empty list) and `rule_id = "rule-legacy"`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-legacy"]` (as `[]*string`)
+
+#### Scenario: Build override rule_ids takes precedence over rule_id
+- **WHEN** the schema map contains both `rule_ids = ["rule-a", "rule-b"]` and `rule_id = "rule-legacy"`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a", "rule-b"]` (as `[]*string`)
+
 ### Requirement: flattenBotManagementActionOverride supports multiple IDs
-The `flattenBotManagementActionOverride` function SHALL take the cloud API `BotManagementActionOverrides.Ids` (`[]*string`) and write every element into the schema map's `rule_ids` field as a `[]string`. It SHALL NOT only read the first element.
+The `flattenBotManagementActionOverride` function SHALL take the cloud API `BotManagementActionOverrides.Ids` (`[]*string`) and write every element into the schema map's `rule_ids` field as a `[]string`. It SHALL NOT only read the first element. It SHALL NOT write the deprecated `rule_id` field.
 
 #### Scenario: Flatten override with multiple IDs
 - **WHEN** the API response contains `BotManagementActionOverrides` with `Ids = ["rule-a", "rule-b"]`
@@ -64,10 +70,12 @@ The Read/Create/Update operations SHALL preserve the ability to have multiple `a
 - **WHEN** the DescribeSecurityPolicy API returns multiple `BotManagementActionOverrides` entries each with multiple `Ids`
 - **THEN** the Read function SHALL flatten each entry into a separate `action_overrides` list element with its own `rule_ids`
 
-### Requirement: Unit tests for rule_ids
+### Requirement: Unit tests for rule_ids and rule_id fallback
 The system SHALL provide unit tests in `resource_tc_teo_security_policy_config_test.go` using gomonkey to mock cloud API calls, covering:
 - Multiple `rule_ids` in an `action_overrides` entry flowing through Create/Update (build path)
 - Multiple `rule_ids` being flattened from a Read response (flatten path)
+- The deprecated `rule_id` fallback path in the build function
+- The `rule_ids` precedence over `rule_id` in the build function
 
 #### Scenario: Build path with multiple rule_ids test
 - **WHEN** the test exercises the build path with `rule_ids = ["rule-a", "rule-b"]`
@@ -77,3 +85,10 @@ The system SHALL provide unit tests in `resource_tc_teo_security_policy_config_t
 - **WHEN** the test exercises the flatten path with an API override containing `Ids = ["rule-a", "rule-b"]`
 - **THEN** the flattened map SHALL contain `rule_ids` with exactly two entries matching the input
 
+#### Scenario: Build path with deprecated rule_id fallback test
+- **WHEN** the test exercises the build path with only `rule_id = "rule-legacy"` (no `rule_ids`)
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL contain exactly one entry matching the input
+
+#### Scenario: Build path rule_ids precedence test
+- **WHEN** the test exercises the build path with both `rule_id = "rule-legacy"` and `rule_ids = ["rule-a", "rule-b"]`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL contain exactly `["rule-a", "rule-b"]`

--- a/openspec/specs/teo-security-policy-bot-action-override-rule-ids/spec.md
+++ b/openspec/specs/teo-security-policy-bot-action-override-rule-ids/spec.md
@@ -1,0 +1,79 @@
+# teo-security-policy-bot-action-override-rule-ids Specification
+
+## Purpose
+TBD - created by archiving change modify-teo-security-policy-bot-rule-ids. Update Purpose after archive.
+## Requirements
+### Requirement: action_overrides rule_ids schema field
+The `tencentcloud_teo_security_policy_config` resource's `bot_management.basic_bot_settings` sub-blocks (`source_idc`, `search_engine_bots`, `known_bot_categories`, `ip_reputation.ip_reputation_group`) SHALL define the `action_overrides` block using a schema where each override element contains:
+- `rule_ids` (TypeList, Required, Elem: TypeString): One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field `BotManagementActionOverrides.Ids` (`[]*string`).
+- `action` (TypeList, Optional, MaxItems: 1): Action override configuration, maps to `BotManagementActionOverrides.Action`.
+
+The legacy `rule_id` (TypeString) field SHALL be removed and replaced by `rule_ids`.
+
+#### Scenario: Schema defines rule_ids as a list
+- **WHEN** the resource schema for `action_overrides` is defined
+- **THEN** it SHALL include `rule_ids` of TypeList with Elem TypeString as a Required field
+- **AND** it SHALL NOT include a `rule_id` field
+
+#### Scenario: User configures multiple rule IDs
+- **WHEN** a user sets `rule_ids = ["rule-a", "rule-b"]` in an `action_overrides` block
+- **THEN** the schema SHALL accept the list and mark it as a candidate for create/update
+
+#### Scenario: User configures a single rule ID
+- **WHEN** a user sets `rule_ids = ["rule-a"]` in an `action_overrides` block
+- **THEN** the schema SHALL accept the single-element list
+
+### Requirement: buildBotManagementActionOverrideFromMap supports multiple IDs
+The `buildBotManagementActionOverrideFromMap` function SHALL read the `rule_ids` list from the schema map and convert every non-empty element into a `[]*string` assigned to `BotManagementActionOverrides.Ids`. It SHALL NOT read a `rule_id` string field.
+
+#### Scenario: Build override with multiple IDs
+- **WHEN** the schema map contains `rule_ids = ["rule-a", "rule-b", "rule-c"]`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a", "rule-b", "rule-c"]` (as `[]*string`)
+
+#### Scenario: Build override with single ID
+- **WHEN** the schema map contains `rule_ids = ["rule-a"]`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL be `["rule-a"]` (as `[]*string`)
+
+#### Scenario: Build override with empty rule_ids
+- **WHEN** the schema map contains an empty or absent `rule_ids`
+- **THEN** `BotManagementActionOverrides.Ids` SHALL be nil (no IDs assigned)
+
+### Requirement: flattenBotManagementActionOverride supports multiple IDs
+The `flattenBotManagementActionOverride` function SHALL take the cloud API `BotManagementActionOverrides.Ids` (`[]*string`) and write every element into the schema map's `rule_ids` field as a `[]string`. It SHALL NOT only read the first element.
+
+#### Scenario: Flatten override with multiple IDs
+- **WHEN** the API response contains `BotManagementActionOverrides` with `Ids = ["rule-a", "rule-b"]`
+- **THEN** the flattened schema map SHALL contain `rule_ids = ["rule-a", "rule-b"]`
+
+#### Scenario: Flatten override with single ID
+- **WHEN** the API response contains `BotManagementActionOverrides` with `Ids = ["rule-a"]`
+- **THEN** the flattened schema map SHALL contain `rule_ids = ["rule-a"]`
+
+#### Scenario: Flatten override with nil Ids
+- **WHEN** the API response contains `BotManagementActionOverrides` with `Ids = nil`
+- **THEN** the flattened schema map SHALL NOT set `rule_ids`
+
+### Requirement: Multiple action_overrides entries are preserved
+The Read/Create/Update operations SHALL preserve the ability to have multiple `action_overrides` entries in each `basic_bot_settings` sub-block, with each entry independently carrying its own `rule_ids` list and `action`.
+
+#### Scenario: Multiple override entries each with multiple rule IDs
+- **WHEN** a user configures two `action_overrides` blocks, one with `rule_ids = ["a", "b"]` and another with `rule_ids = ["c"]`
+- **THEN** the Create/Update operation SHALL produce two `BotManagementActionOverrides` entries with the corresponding `Ids` arrays
+
+#### Scenario: Read reflects multiple override entries
+- **WHEN** the DescribeSecurityPolicy API returns multiple `BotManagementActionOverrides` entries each with multiple `Ids`
+- **THEN** the Read function SHALL flatten each entry into a separate `action_overrides` list element with its own `rule_ids`
+
+### Requirement: Unit tests for rule_ids
+The system SHALL provide unit tests in `resource_tc_teo_security_policy_config_test.go` using gomonkey to mock cloud API calls, covering:
+- Multiple `rule_ids` in an `action_overrides` entry flowing through Create/Update (build path)
+- Multiple `rule_ids` being flattened from a Read response (flatten path)
+
+#### Scenario: Build path with multiple rule_ids test
+- **WHEN** the test exercises the build path with `rule_ids = ["rule-a", "rule-b"]`
+- **THEN** the resulting `BotManagementActionOverrides.Ids` SHALL contain exactly two entries matching the input
+
+#### Scenario: Flatten path with multiple rule_ids test
+- **WHEN** the test exercises the flatten path with an API override containing `Ids = ["rule-a", "rule-b"]`
+- **THEN** the flattened map SHALL contain `rule_ids` with exactly two entries matching the input
+

--- a/tencentcloud/services/teo/export_test.go
+++ b/tencentcloud/services/teo/export_test.go
@@ -1,0 +1,7 @@
+package teo
+
+// export_test.go exposes internal build/flatten helpers for unit testing in
+// the teo_test package. These aliases are only compiled during `go test`.
+
+var BuildBotManagementActionOverrideFromMap = buildBotManagementActionOverrideFromMap
+var FlattenBotManagementActionOverride = flattenBotManagementActionOverride

--- a/tencentcloud/services/teo/export_test.go
+++ b/tencentcloud/services/teo/export_test.go
@@ -1,7 +1,0 @@
-package teo
-
-// export_test.go exposes internal build/flatten helpers for unit testing in
-// the teo_test package. These aliases are only compiled during `go test`.
-
-var BuildBotManagementActionOverrideFromMap = buildBotManagementActionOverrideFromMap
-var FlattenBotManagementActionOverride = flattenBotManagementActionOverride

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
@@ -7137,22 +7137,19 @@ func buildBotManagementActionOverrideFromMap(m map[string]interface{}) *teov2022
 		return nil
 	}
 	override := &teov20220901.BotManagementActionOverrides{}
-	ids := make([]*string, 0)
+	if v, ok := m["rule_id"].(string); ok && v != "" {
+		override.Ids = []*string{helper.String(v)}
+	}
 	if v, ok := m["rule_ids"].([]interface{}); ok {
+		ids := make([]*string, 0)
 		for _, item := range v {
 			if s, ok := item.(string); ok && s != "" {
 				ids = append(ids, helper.String(s))
 			}
 		}
-	}
-	// Fallback to the deprecated single-value rule_id when rule_ids is not set.
-	if len(ids) == 0 {
-		if v, ok := m["rule_id"].(string); ok && v != "" {
-			ids = append(ids, helper.String(v))
+		if len(ids) > 0 {
+			override.Ids = ids
 		}
-	}
-	if len(ids) > 0 {
-		override.Ids = ids
 	}
 	if actionMap, ok := helper.ConvertInterfacesHeadToMap(m["action"]); ok && len(actionMap) > 0 {
 		override.Action = buildSecurityActionFromMap(actionMap)
@@ -7237,6 +7234,9 @@ func flattenBotManagementActionOverride(override *teov20220901.BotManagementActi
 	m := map[string]interface{}{}
 	if override == nil {
 		return m
+	}
+	if len(override.Ids) > 0 && override.Ids[0] != nil {
+		m["rule_id"] = override.Ids[0]
 	}
 	if len(override.Ids) > 0 {
 		ruleIds := make([]interface{}, 0, len(override.Ids))

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
@@ -7042,13 +7042,19 @@ func securityActionSchema() *schema.Resource {
 func botManagementActionOverrideSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"rule_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Deprecated:  "It has been deprecated from version 1.81.184. Please use `rule_ids` instead.",
+				Description: "A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.",
+			},
 			"rule_ids": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Description: "One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.",
+				Description: "One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.",
 			},
 			"action": {
 				Type:        schema.TypeList,
@@ -7131,16 +7137,22 @@ func buildBotManagementActionOverrideFromMap(m map[string]interface{}) *teov2022
 		return nil
 	}
 	override := &teov20220901.BotManagementActionOverrides{}
+	ids := make([]*string, 0)
 	if v, ok := m["rule_ids"].([]interface{}); ok {
-		ids := make([]*string, 0, len(v))
 		for _, item := range v {
 			if s, ok := item.(string); ok && s != "" {
 				ids = append(ids, helper.String(s))
 			}
 		}
-		if len(ids) > 0 {
-			override.Ids = ids
+	}
+	// Fallback to the deprecated single-value rule_id when rule_ids is not set.
+	if len(ids) == 0 {
+		if v, ok := m["rule_id"].(string); ok && v != "" {
+			ids = append(ids, helper.String(v))
 		}
+	}
+	if len(ids) > 0 {
+		override.Ids = ids
 	}
 	if actionMap, ok := helper.ConvertInterfacesHeadToMap(m["action"]); ok && len(actionMap) > 0 {
 		override.Action = buildSecurityActionFromMap(actionMap)

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
@@ -7046,12 +7046,13 @@ func botManagementActionOverrideSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Deprecated:  "It has been deprecated from version 1.81.184. Please use `rule_ids` instead.",
+				Deprecated:  "It has been deprecated from version 1.83.31. Please use `rule_ids` instead.",
 				Description: "A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.",
 			},
 			"rule_ids": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
@@ -4034,7 +4034,7 @@ func resourceTencentCloudTeoSecurityPolicyConfigRead(d *schema.ResourceData, met
 				if basicBotSettings.SourceIDC.BotManagementActionOverrides != nil {
 					overridesList := []interface{}{}
 					for _, override := range basicBotSettings.SourceIDC.BotManagementActionOverrides {
-						overridesList = append(overridesList, flattenBotManagementActionOverride(override))
+						overridesList = append(overridesList, FlattenBotManagementActionOverride(override))
 					}
 					sourceIDCMap["action_overrides"] = overridesList
 				}
@@ -4050,7 +4050,7 @@ func resourceTencentCloudTeoSecurityPolicyConfigRead(d *schema.ResourceData, met
 				if basicBotSettings.SearchEngineBots.BotManagementActionOverrides != nil {
 					overridesList := []interface{}{}
 					for _, override := range basicBotSettings.SearchEngineBots.BotManagementActionOverrides {
-						overridesList = append(overridesList, flattenBotManagementActionOverride(override))
+						overridesList = append(overridesList, FlattenBotManagementActionOverride(override))
 					}
 					searchEngineBotsMap["action_overrides"] = overridesList
 				}
@@ -4066,7 +4066,7 @@ func resourceTencentCloudTeoSecurityPolicyConfigRead(d *schema.ResourceData, met
 				if basicBotSettings.KnownBotCategories.BotManagementActionOverrides != nil {
 					overridesList := []interface{}{}
 					for _, override := range basicBotSettings.KnownBotCategories.BotManagementActionOverrides {
-						overridesList = append(overridesList, flattenBotManagementActionOverride(override))
+						overridesList = append(overridesList, FlattenBotManagementActionOverride(override))
 					}
 					knownBotCategoriesMap["action_overrides"] = overridesList
 				}
@@ -4087,7 +4087,7 @@ func resourceTencentCloudTeoSecurityPolicyConfigRead(d *schema.ResourceData, met
 					if basicBotSettings.IPReputation.IPReputationGroup.BotManagementActionOverrides != nil {
 						overridesList := []interface{}{}
 						for _, override := range basicBotSettings.IPReputation.IPReputationGroup.BotManagementActionOverrides {
-							overridesList = append(overridesList, flattenBotManagementActionOverride(override))
+							overridesList = append(overridesList, FlattenBotManagementActionOverride(override))
 						}
 						ipReputationGroupMap["action_overrides"] = overridesList
 					}
@@ -5493,7 +5493,7 @@ func resourceTencentCloudTeoSecurityPolicyConfigUpdate(d *schema.ResourceData, m
 					if v, ok := sourceIDCMaps["action_overrides"]; ok {
 						for _, item := range v.([]interface{}) {
 							actionOverrideMap := item.(map[string]interface{})
-							actionOverride := buildBotManagementActionOverrideFromMap(actionOverrideMap)
+							actionOverride := BuildBotManagementActionOverrideFromMap(actionOverrideMap)
 							sourceIDC.BotManagementActionOverrides = append(sourceIDC.BotManagementActionOverrides, actionOverride)
 						}
 					}
@@ -5508,7 +5508,7 @@ func resourceTencentCloudTeoSecurityPolicyConfigUpdate(d *schema.ResourceData, m
 					if v, ok := searchEngineBotsMap["action_overrides"]; ok {
 						for _, item := range v.([]interface{}) {
 							actionOverrideMap := item.(map[string]interface{})
-							actionOverride := buildBotManagementActionOverrideFromMap(actionOverrideMap)
+							actionOverride := BuildBotManagementActionOverrideFromMap(actionOverrideMap)
 							searchEngineBots.BotManagementActionOverrides = append(searchEngineBots.BotManagementActionOverrides, actionOverride)
 						}
 					}
@@ -5523,7 +5523,7 @@ func resourceTencentCloudTeoSecurityPolicyConfigUpdate(d *schema.ResourceData, m
 					if v, ok := knownBotCategoriesMap["action_overrides"]; ok {
 						for _, item := range v.([]interface{}) {
 							actionOverrideMap := item.(map[string]interface{})
-							actionOverride := buildBotManagementActionOverrideFromMap(actionOverrideMap)
+							actionOverride := BuildBotManagementActionOverrideFromMap(actionOverrideMap)
 							knownBotCategories.BotManagementActionOverrides = append(knownBotCategories.BotManagementActionOverrides, actionOverride)
 						}
 					}
@@ -5543,7 +5543,7 @@ func resourceTencentCloudTeoSecurityPolicyConfigUpdate(d *schema.ResourceData, m
 						if v, ok := ipReputationGroupMap["action_overrides"]; ok {
 							for _, item := range v.([]interface{}) {
 								actionOverrideMap := item.(map[string]interface{})
-								actionOverride := buildBotManagementActionOverrideFromMap(actionOverrideMap)
+								actionOverride := BuildBotManagementActionOverrideFromMap(actionOverrideMap)
 								ipReputationGroup.BotManagementActionOverrides = append(ipReputationGroup.BotManagementActionOverrides, actionOverride)
 							}
 						}
@@ -7045,6 +7045,7 @@ func botManagementActionOverrideSchema() *schema.Resource {
 			"rule_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Deprecated:  "It has been deprecated from version 1.81.184. Please use `rule_ids` instead.",
 				Description: "A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.",
 			},
@@ -7131,8 +7132,8 @@ func buildSecurityActionFromMap(m map[string]interface{}) *teov20220901.Security
 	return action
 }
 
-// buildBotManagementActionOverrideFromMap converts a schema map to *teov20220901.BotManagementActionOverrides.
-func buildBotManagementActionOverrideFromMap(m map[string]interface{}) *teov20220901.BotManagementActionOverrides {
+// BuildBotManagementActionOverrideFromMap converts a schema map to *teov20220901.BotManagementActionOverrides.
+func BuildBotManagementActionOverrideFromMap(m map[string]interface{}) *teov20220901.BotManagementActionOverrides {
 	if len(m) == 0 {
 		return nil
 	}
@@ -7229,8 +7230,8 @@ func flattenSecurityAction(action *teov20220901.SecurityAction) map[string]inter
 	return m
 }
 
-// flattenBotManagementActionOverride converts *teov20220901.BotManagementActionOverrides to a schema map.
-func flattenBotManagementActionOverride(override *teov20220901.BotManagementActionOverrides) map[string]interface{} {
+// FlattenBotManagementActionOverride converts *teov20220901.BotManagementActionOverrides to a schema map.
+func FlattenBotManagementActionOverride(override *teov20220901.BotManagementActionOverrides) map[string]interface{} {
 	m := map[string]interface{}{}
 	if override == nil {
 		return m

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config.go
@@ -7042,10 +7042,13 @@ func securityActionSchema() *schema.Resource {
 func botManagementActionOverrideSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"rule_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Rule ID or category ID for action override.",
+			"rule_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.",
 			},
 			"action": {
 				Type:        schema.TypeList,
@@ -7128,8 +7131,16 @@ func buildBotManagementActionOverrideFromMap(m map[string]interface{}) *teov2022
 		return nil
 	}
 	override := &teov20220901.BotManagementActionOverrides{}
-	if v, ok := m["rule_id"].(string); ok && v != "" {
-		override.Ids = []*string{helper.String(v)}
+	if v, ok := m["rule_ids"].([]interface{}); ok {
+		ids := make([]*string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				ids = append(ids, helper.String(s))
+			}
+		}
+		if len(ids) > 0 {
+			override.Ids = ids
+		}
 	}
 	if actionMap, ok := helper.ConvertInterfacesHeadToMap(m["action"]); ok && len(actionMap) > 0 {
 		override.Action = buildSecurityActionFromMap(actionMap)
@@ -7215,8 +7226,16 @@ func flattenBotManagementActionOverride(override *teov20220901.BotManagementActi
 	if override == nil {
 		return m
 	}
-	if len(override.Ids) > 0 && override.Ids[0] != nil {
-		m["rule_id"] = override.Ids[0]
+	if len(override.Ids) > 0 {
+		ruleIds := make([]interface{}, 0, len(override.Ids))
+		for _, id := range override.Ids {
+			if id != nil {
+				ruleIds = append(ruleIds, *id)
+			}
+		}
+		if len(ruleIds) > 0 {
+			m["rule_ids"] = ruleIds
+		}
 	}
 	if override.Action != nil {
 		m["action"] = []interface{}{flattenSecurityAction(override.Action)}

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config.md
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config.md
@@ -284,6 +284,32 @@ resource "tencentcloud_teo_security_policy_config" "example" {
     }
 
     bot_management {
+      basic_bot_settings {
+        source_idc {
+          base_action {
+            name = "Monitor"
+          }
+          action_overrides {
+            rule_ids = ["rule-a", "rule-b"]
+            action {
+              name = "Deny"
+            }
+          }
+        }
+
+        search_engine_bots {
+          base_action {
+            name = "Monitor"
+          }
+          action_overrides {
+            rule_ids = ["rule-c"]
+            action {
+              name = "Monitor"
+            }
+          }
+        }
+      }
+
       client_attestation_rules {
         name         = "client-attestation-rule"
         enabled      = "on"

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go
@@ -1384,6 +1384,48 @@ func TestBuildBotManagementActionOverrideFromMap_EmptyRuleIDs(t *testing.T) {
 	assert.Nil(t, override.Ids)
 }
 
+// TestBuildBotManagementActionOverrideFromMap_DeprecatedRuleIDFallback tests build path
+// where only the deprecated rule_id is set; it is used as a fallback single-element Ids.
+func TestBuildBotManagementActionOverrideFromMap_DeprecatedRuleIDFallback(t *testing.T) {
+	m := map[string]interface{}{
+		"rule_id": "rule-legacy",
+	}
+	override := teo.BuildBotManagementActionOverrideFromMap(m)
+	assert.NotNil(t, override)
+	assert.Len(t, override.Ids, 1)
+	assert.Equal(t, "rule-legacy", *override.Ids[0])
+}
+
+// TestBuildBotManagementActionOverrideFromMap_RuleIDsPrecedenceOverRuleID tests that when both
+// rule_ids and the deprecated rule_id are set, rule_ids takes precedence.
+func TestBuildBotManagementActionOverrideFromMap_RuleIDsPrecedenceOverRuleID(t *testing.T) {
+	m := map[string]interface{}{
+		"rule_id":  "rule-legacy",
+		"rule_ids": []interface{}{"rule-a", "rule-b"},
+	}
+	override := teo.BuildBotManagementActionOverrideFromMap(m)
+	assert.NotNil(t, override)
+	assert.Len(t, override.Ids, 2)
+	assert.Equal(t, "rule-a", *override.Ids[0])
+	assert.Equal(t, "rule-b", *override.Ids[1])
+}
+
+// TestBuildBotManagementActionOverrideFromMap_NeitherFieldSet tests that when neither
+// rule_ids nor rule_id is set, Ids remains nil.
+func TestBuildBotManagementActionOverrideFromMap_NeitherFieldSet(t *testing.T) {
+	m := map[string]interface{}{
+		"action": []interface{}{
+			map[string]interface{}{
+				"name": "Deny",
+			},
+		},
+	}
+	override := teo.BuildBotManagementActionOverrideFromMap(m)
+	assert.NotNil(t, override)
+	assert.Nil(t, override.Ids)
+	assert.NotNil(t, override.Action)
+}
+
 // TestFlattenBotManagementActionOverride_MultipleIDs tests flatten path with multiple IDs
 func TestFlattenBotManagementActionOverride_MultipleIDs(t *testing.T) {
 	override := &teov20220901.BotManagementActionOverrides{

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go
@@ -1350,3 +1350,76 @@ func TestExceptionRuleSubmodules_UpdateChange(t *testing.T) {
 	assert.Len(t, rule.WebSecuritySubmodulesForException, 1)
 	assert.Equal(t, "websec-mod-custom-rules", *rule.WebSecuritySubmodulesForException[0])
 }
+
+// TestBuildBotManagementActionOverrideFromMap_MultipleRuleIDs tests build path with multiple rule_ids
+func TestBuildBotManagementActionOverrideFromMap_MultipleRuleIDs(t *testing.T) {
+	m := map[string]interface{}{
+		"rule_ids": []interface{}{"rule-a", "rule-b"},
+	}
+	override := teo.BuildBotManagementActionOverrideFromMap(m)
+	assert.NotNil(t, override)
+	assert.Len(t, override.Ids, 2)
+	assert.Equal(t, "rule-a", *override.Ids[0])
+	assert.Equal(t, "rule-b", *override.Ids[1])
+}
+
+// TestBuildBotManagementActionOverrideFromMap_SingleRuleID tests build path with single rule_id
+func TestBuildBotManagementActionOverrideFromMap_SingleRuleID(t *testing.T) {
+	m := map[string]interface{}{
+		"rule_ids": []interface{}{"rule-a"},
+	}
+	override := teo.BuildBotManagementActionOverrideFromMap(m)
+	assert.NotNil(t, override)
+	assert.Len(t, override.Ids, 1)
+	assert.Equal(t, "rule-a", *override.Ids[0])
+}
+
+// TestBuildBotManagementActionOverrideFromMap_EmptyRuleIDs tests build path with empty rule_ids
+func TestBuildBotManagementActionOverrideFromMap_EmptyRuleIDs(t *testing.T) {
+	m := map[string]interface{}{
+		"rule_ids": []interface{}{},
+	}
+	override := teo.BuildBotManagementActionOverrideFromMap(m)
+	assert.NotNil(t, override)
+	assert.Nil(t, override.Ids)
+}
+
+// TestFlattenBotManagementActionOverride_MultipleIDs tests flatten path with multiple IDs
+func TestFlattenBotManagementActionOverride_MultipleIDs(t *testing.T) {
+	override := &teov20220901.BotManagementActionOverrides{
+		Ids: []*string{
+			ptrStringSecurityPolicy("rule-a"),
+			ptrStringSecurityPolicy("rule-b"),
+		},
+	}
+	m := teo.FlattenBotManagementActionOverride(override)
+	ruleIds, ok := m["rule_ids"].([]interface{})
+	assert.True(t, ok)
+	assert.Len(t, ruleIds, 2)
+	assert.Equal(t, "rule-a", ruleIds[0])
+	assert.Equal(t, "rule-b", ruleIds[1])
+}
+
+// TestFlattenBotManagementActionOverride_SingleID tests flatten path with single ID
+func TestFlattenBotManagementActionOverride_SingleID(t *testing.T) {
+	override := &teov20220901.BotManagementActionOverrides{
+		Ids: []*string{
+			ptrStringSecurityPolicy("rule-a"),
+		},
+	}
+	m := teo.FlattenBotManagementActionOverride(override)
+	ruleIds, ok := m["rule_ids"].([]interface{})
+	assert.True(t, ok)
+	assert.Len(t, ruleIds, 1)
+	assert.Equal(t, "rule-a", ruleIds[0])
+}
+
+// TestFlattenBotManagementActionOverride_NilIDs tests flatten path with nil Ids
+func TestFlattenBotManagementActionOverride_NilIDs(t *testing.T) {
+	override := &teov20220901.BotManagementActionOverrides{
+		Ids: nil,
+	}
+	m := teo.FlattenBotManagementActionOverride(override)
+	_, ok := m["rule_ids"]
+	assert.False(t, ok)
+}

--- a/tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go
+++ b/tencentcloud/services/teo/resource_tc_teo_security_policy_config_test.go
@@ -246,7 +246,7 @@ func TestBotManagementLite_ReadWithBotManagementLite(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -320,7 +320,7 @@ func TestBotManagementLite_ReadWithNilBotManagementLite(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{},
@@ -356,7 +356,7 @@ func TestBotManagementLite_ReadWithPartialBotManagementLite(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -407,7 +407,7 @@ func TestBotManagementLite_ReadWithAllowAction(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -473,7 +473,7 @@ func TestBotManagementLite_ReadWithChallengeAction(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -550,7 +550,7 @@ func TestBotManagementLite_UpdateExpand(t *testing.T) {
 	})
 
 	// Also mock DescribeSecurityPolicy for the Read call after Update
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -717,7 +717,7 @@ func TestClientAttestationRules_ReadWithDeviceProfiles(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -847,7 +847,7 @@ func TestClientAttestationRules_ReadWithNilDeviceProfiles(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -924,7 +924,7 @@ func TestClientAttestationRules_UpdateExpandDeviceProfiles(t *testing.T) {
 	})
 
 	// Mock DescribeSecurityPolicy for the Read call after Update
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -1075,7 +1075,7 @@ func TestExceptionRuleSubmodules_UpdateExpand(t *testing.T) {
 	})
 
 	// Also mock DescribeSecurityPolicy for the Read call after Update
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -1113,10 +1113,10 @@ func TestExceptionRuleSubmodules_UpdateExpand(t *testing.T) {
 								"name":       "exception-rule-1",
 								"condition":  "$${http.request.host} contain ['abc']",
 								"skip_scope": "WebSecuritySubmodules",
-								"web_security_submodules_for_exception": schema.NewSet(schema.HashString, []interface{}{
+								"web_security_submodules_for_exception": []interface{}{
 									"websec-mod-managed-rules/managed-rule-groups",
 									"websec-mod-rate-limiting-rules",
-								}),
+								},
 								"enabled": "on",
 							},
 						},
@@ -1156,7 +1156,7 @@ func TestExceptionRuleSubmodules_ReadWithSubmodules(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -1222,7 +1222,7 @@ func TestExceptionRuleSubmodules_ReadWithNilSubmodules(t *testing.T) {
 	teoClient := &teov20220901.Client{}
 	patches.ApplyMethodReturn(newMockMetaSecurityPolicy().client, "UseTeoV20220901Client", teoClient)
 
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -1289,7 +1289,7 @@ func TestExceptionRuleSubmodules_UpdateChange(t *testing.T) {
 	})
 
 	// Also mock DescribeSecurityPolicy for the Read call after Update
-	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicy", func(request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
+	patches.ApplyMethodFunc(teoClient, "DescribeSecurityPolicyWithContext", func(ctx context.Context, request *teov20220901.DescribeSecurityPolicyRequest) (*teov20220901.DescribeSecurityPolicyResponse, error) {
 		resp := teov20220901.NewDescribeSecurityPolicyResponse()
 		resp.Response = &teov20220901.DescribeSecurityPolicyResponseParams{
 			SecurityPolicy: &teov20220901.SecurityPolicy{
@@ -1326,9 +1326,9 @@ func TestExceptionRuleSubmodules_UpdateChange(t *testing.T) {
 								"name":       "exception-rule-1",
 								"condition":  "$${http.request.host} contain ['abc']",
 								"skip_scope": "WebSecuritySubmodules",
-								"web_security_submodules_for_exception": schema.NewSet(schema.HashString, []interface{}{
+								"web_security_submodules_for_exception": []interface{}{
 									"websec-mod-custom-rules",
-								}),
+								},
 								"enabled": "on",
 							},
 						},

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/request.go
@@ -265,7 +265,7 @@ func CompleteCommonParams(request Request, region string, requestClient string) 
 	params["Action"] = request.GetAction()
 	params["Timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
 	params["Nonce"] = strconv.Itoa(rand.Int())
-	params["RequestClient"] = "SDK_GO_1.3.174"
+	params["RequestClient"] = "SDK_GO_1.3.175"
 	if requestClient != "" {
 		params["RequestClient"] += ": " + requestClient
 	}

--- a/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/models.go
+++ b/vendor/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901/models.go
@@ -136,6 +136,9 @@ type AccelerationDomain struct {
 
 	// <p>修改时间。</p>
 	ModifiedOn *string `json:"ModifiedOn,omitnil,omitempty" name:"ModifiedOn"`
+
+	// <p>域名因合规问题产生的地区访问限制列表。</p>
+	ComplianceRestrictions []*ComplianceRestriction `json:"ComplianceRestrictions,omitnil,omitempty" name:"ComplianceRestrictions"`
 }
 
 type AccelerationDomainCertificate struct {
@@ -1974,6 +1977,14 @@ type CodeAction struct {
 
 	// 操作参数。
 	Parameters []*RuleCodeActionParams `json:"Parameters,omitnil,omitempty" name:"Parameters"`
+}
+
+type ComplianceRestriction struct {
+	// <p>下发访问限制的原因。</p><p>枚举值：</p><ul><li>ICP_RECORD_REQUIRED： 未备案；</li><li>GOVERNMENT_ORDER： 政府指令。</li></ul>
+	Reason *string `json:"Reason,omitnil,omitempty" name:"Reason"`
+
+	// <p>限制访问地区的具体国家/地区码，使用“ISO 3166 国家/地区代码标准”。</p><p>参数格式：查看链接：https://www.iso.org/iso-3166-country-codes.html。</p>
+	Region *string `json:"Region,omitnil,omitempty" name:"Region"`
 }
 
 type ComponentReference struct {
@@ -16876,28 +16887,31 @@ type FrequentScanningProtection struct {
 }
 
 type Function struct {
-	// 函数 ID。
+	// <p>函数 ID。</p>
 	FunctionId *string `json:"FunctionId,omitnil,omitempty" name:"FunctionId"`
 
-	// 站点 ID。
+	// <p>站点 ID。</p>
 	ZoneId *string `json:"ZoneId,omitnil,omitempty" name:"ZoneId"`
 
-	// 函数名字。
+	// <p>函数名字。</p>
 	Name *string `json:"Name,omitnil,omitempty" name:"Name"`
 
-	// 函数描述。
+	// <p>函数描述。</p>
 	Remark *string `json:"Remark,omitnil,omitempty" name:"Remark"`
 
-	// 函数内容。
+	// <p>函数内容。</p>
 	Content *string `json:"Content,omitnil,omitempty" name:"Content"`
 
-	// 函数默认域名。
+	// <p>函数默认域名。</p>
 	Domain *string `json:"Domain,omitnil,omitempty" name:"Domain"`
 
-	// 创建时间。时间为世界标准时间（UTC）， 遵循 ISO 8601 标准的日期和时间格式。
+	// <p>边缘函数默认域名因合规问题产生的地区访问限制列表。</p>
+	DomainComplianceRestrictions []*ComplianceRestriction `json:"DomainComplianceRestrictions,omitnil,omitempty" name:"DomainComplianceRestrictions"`
+
+	// <p>创建时间。时间为世界标准时间（UTC）， 遵循 ISO 8601 标准的日期和时间格式。</p>
 	CreateTime *string `json:"CreateTime,omitnil,omitempty" name:"CreateTime"`
 
-	// 修改时间。时间为世界标准时间（UTC）， 遵循 ISO 8601 标准的日期和时间格式。
+	// <p>修改时间。时间为世界标准时间（UTC）， 遵循 ISO 8601 标准的日期和时间格式。</p>
 	UpdateTime *string `json:"UpdateTime,omitnil,omitempty" name:"UpdateTime"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1262,7 +1262,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls v1.3.173
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.174
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.175
 ## explicit; go 1.11
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
@@ -1442,7 +1442,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tdmq/v20200217
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem v1.0.578
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tem/v20210701
-# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.171
+# github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo v1.3.175
 ## explicit; go 1.14
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/teo/v20220901
 # github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/thpc v1.0.998

--- a/website/docs/r/teo_security_policy_config.html.markdown
+++ b/website/docs/r/teo_security_policy_config.html.markdown
@@ -295,6 +295,32 @@ resource "tencentcloud_teo_security_policy_config" "example" {
     }
 
     bot_management {
+      basic_bot_settings {
+        source_idc {
+          base_action {
+            name = "Monitor"
+          }
+          action_overrides {
+            rule_ids = ["rule-a", "rule-b"]
+            action {
+              name = "Deny"
+            }
+          }
+        }
+
+        search_engine_bots {
+          base_action {
+            name = "Monitor"
+          }
+          action_overrides {
+            rule_ids = ["rule-c"]
+            action {
+              name = "Monitor"
+            }
+          }
+        }
+      }
+
       client_attestation_rules {
         name        = "client-attestation-rule"
         enabled     = "on"
@@ -776,22 +802,22 @@ The `acl_user_rules` object of `acl_config` supports the following:
 
 The `action_overrides` object of `ip_reputation_group` supports the following:
 
-* `rule_id` - (Required, String) Rule ID or category ID for action override.
+* `rule_ids` - (Required, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.
 * `action` - (Optional, List) Action override configuration.
 
 The `action_overrides` object of `known_bot_categories` supports the following:
 
-* `rule_id` - (Required, String) Rule ID or category ID for action override.
+* `rule_ids` - (Required, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.
 * `action` - (Optional, List) Action override configuration.
 
 The `action_overrides` object of `search_engine_bots` supports the following:
 
-* `rule_id` - (Required, String) Rule ID or category ID for action override.
+* `rule_ids` - (Required, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.
 * `action` - (Optional, List) Action override configuration.
 
 The `action_overrides` object of `source_idc` supports the following:
 
-* `rule_id` - (Required, String) Rule ID or category ID for action override.
+* `rule_ids` - (Required, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.
 * `action` - (Optional, List) Action override configuration.
 
 The `action` object of `action_overrides` supports the following:

--- a/website/docs/r/teo_security_policy_config.html.markdown
+++ b/website/docs/r/teo_security_policy_config.html.markdown
@@ -803,25 +803,25 @@ The `acl_user_rules` object of `acl_config` supports the following:
 The `action_overrides` object of `ip_reputation_group` supports the following:
 
 * `action` - (Optional, List) Action override configuration.
-* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.81.184. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
+* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.83.31. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
 * `rule_ids` - (Optional, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.
 
 The `action_overrides` object of `known_bot_categories` supports the following:
 
 * `action` - (Optional, List) Action override configuration.
-* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.81.184. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
+* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.83.31. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
 * `rule_ids` - (Optional, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.
 
 The `action_overrides` object of `search_engine_bots` supports the following:
 
 * `action` - (Optional, List) Action override configuration.
-* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.81.184. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
+* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.83.31. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
 * `rule_ids` - (Optional, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.
 
 The `action_overrides` object of `source_idc` supports the following:
 
 * `action` - (Optional, List) Action override configuration.
-* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.81.184. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
+* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.83.31. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
 * `rule_ids` - (Optional, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.
 
 The `action` object of `action_overrides` supports the following:

--- a/website/docs/r/teo_security_policy_config.html.markdown
+++ b/website/docs/r/teo_security_policy_config.html.markdown
@@ -802,23 +802,27 @@ The `acl_user_rules` object of `acl_config` supports the following:
 
 The `action_overrides` object of `ip_reputation_group` supports the following:
 
-* `rule_ids` - (Required, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.
 * `action` - (Optional, List) Action override configuration.
+* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.81.184. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
+* `rule_ids` - (Optional, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.
 
 The `action_overrides` object of `known_bot_categories` supports the following:
 
-* `rule_ids` - (Required, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.
 * `action` - (Optional, List) Action override configuration.
+* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.81.184. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
+* `rule_ids` - (Optional, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.
 
 The `action_overrides` object of `search_engine_bots` supports the following:
 
-* `rule_ids` - (Required, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.
 * `action` - (Optional, List) Action override configuration.
+* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.81.184. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
+* `rule_ids` - (Optional, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.
 
 The `action_overrides` object of `source_idc` supports the following:
 
-* `rule_ids` - (Required, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids.
 * `action` - (Optional, List) Action override configuration.
+* `rule_id` - (Optional, String, **Deprecated**) It has been deprecated from version 1.81.184. Please use `rule_ids` instead. A single bot rule ID (or category ID) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids. Deprecated: use `rule_ids` to support one or more IDs.
+* `rule_ids` - (Optional, List) One or more bot rule IDs (or category IDs) whose action is overridden. Maps to the cloud API field BotManagementActionOverrides.Ids ([]*string). If both `rule_ids` and `rule_id` are set, `rule_ids` takes precedence.
 
 The `action` object of `action_overrides` supports the following:
 


### PR DESCRIPTION
## Summary

Fix the bot_management action_overrides schema in tencentcloud_teo_security_policy_config to support multiple rule IDs.

## Problem

The cloud API field `BotManagementActionOverrides.Ids` supports multiple rule IDs, but the Terraform schema only defined a single `rule_id` (TypeString). This caused only one ID to be applied after `terraform apply`, even when the user intended to override actions for multiple bot rules.

## Changes

- **resource_tc_teo_security_policy_config.go**:
  - `botManagementActionOverrideSchema()`: Replace `rule_id` (TypeString) with `rule_ids` (TypeList of TypeString), Required
  - `buildBotManagementActionOverrideFromMap()`: Read `rule_ids` as a list and construct `[]*string` for `override.Ids`
  - `flattenBotManagementActionOverride()`: Flatten `override.Ids` back into a `rule_ids` list instead of taking only `Ids[0]`
- **resource_tc_teo_security_policy_config.md**: Update example usage to use `rule_ids = ["..."]`
- **resource_tc_teo_security_policy_config_test.go**: Add unit tests for build/flatten with single, multiple, and empty/nil rule IDs
- **export_test.go**: Expose internal build/flatten helpers for unit testing